### PR TITLE
[Backup] `az backup restore restore-azurefileshare`: Add `--target-rg-name` parameter to specify the resource group of the destination storage account

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/backup/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/_params.py
@@ -381,8 +381,8 @@ def load_arguments(self, _):
         c.argument('target_folder', options_list=['--target-folder'], help='Destination folder to which content will be restored. To restore content to root , leave the folder name empty')
         c.argument('target_storage_account', options_list=['--target-storage-account'], help='Destination storage account to which content will be restored')
         c.argument('target_resource_group_name',
-                    options_list=['--target-resource-group-name', '--target-rg-name'],
-                    help='Resource group of the destination storage account to which the content will be restored, needed if it is different from the vault resource group')
+                   options_list=['--target-resource-group-name', '--target-rg-name'],
+                   help='Resource group of the destination storage account to which the content will be restored, needed if it is different from the vault resource group')
 
     with self.argument_context('backup restore restore-azurefiles') as c:
         c.argument('resolve_conflict', resolve_conflict_type)

--- a/src/azure-cli/azure/cli/command_modules/backup/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/_params.py
@@ -380,6 +380,9 @@ def load_arguments(self, _):
         c.argument('target_file_share', options_list=['--target-file-share'], help='Destination file share to which content will be restored')
         c.argument('target_folder', options_list=['--target-folder'], help='Destination folder to which content will be restored. To restore content to root , leave the folder name empty')
         c.argument('target_storage_account', options_list=['--target-storage-account'], help='Destination storage account to which content will be restored')
+        c.argument('target_resource_group_name',
+                    options_list=['--target-resource-group-name', '--target-rg-name'],
+                    help='Resource group of the destination storage account to which the content will be restored, needed if it is different from the vault resource group')
 
     with self.argument_context('backup restore restore-azurefiles') as c:
         c.argument('resolve_conflict', resolve_conflict_type)

--- a/src/azure-cli/azure/cli/command_modules/backup/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom.py
@@ -656,6 +656,11 @@ def enable_protection_for_vm(cmd, client, resource_group_name, vault_name, vm, p
     vault = vaults_cf(cmd.cli_ctx).get(resource_group_name, vault_name)
     policy = show_policy(protection_policies_cf(cmd.cli_ctx), resource_group_name, vault_name, policy_name)
 
+    logger.warning('Ignite (November) 2023 onwards Virtual Machine deployments will default to Trusted Launch configuration. '
+                   'You need to ensure Policy Name used with "az backup protection enable-for-vm" command is of type Enhanced '
+                   'Policy for Trusted Launch VMs. Non-Trusted Launch Virtual Machines will not be impacted by this change. '
+                   'To know more about default change and Trusted Launch, please visit https://aka.ms/TLaD.')
+
     # throw error if policy has more than 1000 protected VMs.
     if policy.properties.protected_items_count >= 1000:
         raise CLIError("Cannot configure backup for more than 1000 VMs per policy")

--- a/src/azure-cli/azure/cli/command_modules/backup/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom.py
@@ -656,10 +656,11 @@ def enable_protection_for_vm(cmd, client, resource_group_name, vault_name, vm, p
     vault = vaults_cf(cmd.cli_ctx).get(resource_group_name, vault_name)
     policy = show_policy(protection_policies_cf(cmd.cli_ctx), resource_group_name, vault_name, policy_name)
 
-    logger.warning('Ignite (November) 2023 onwards Virtual Machine deployments will default to Trusted Launch configuration. '
-                   'You need to ensure Policy Name used with "az backup protection enable-for-vm" command is of type Enhanced '
-                   'Policy for Trusted Launch VMs. Non-Trusted Launch Virtual Machines will not be impacted by this change. '
-                   'To know more about default change and Trusted Launch, please visit https://aka.ms/TLaD.')
+    logger.warning('Ignite (November) 2023 onwards Virtual Machine deployments using PS and CLI will default to '
+                   'security type Trusted Launch configuration. Please ensure Policy Name used with "az backup '
+                   'protection enable-for-vm" command is of type Enhanced Policy for Trusted Launch VMs. Non-Trusted '
+                   'Launch Virtual Machines will not be impacted by this change. To know more about default change '
+                   'and Trusted Launch, please visit https://aka.ms/TLaD.')
 
     # throw error if policy has more than 1000 protected VMs.
     if policy.properties.protected_items_count >= 1000:

--- a/src/azure-cli/azure/cli/command_modules/backup/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom.py
@@ -657,7 +657,7 @@ def enable_protection_for_vm(cmd, client, resource_group_name, vault_name, vm, p
     policy = show_policy(protection_policies_cf(cmd.cli_ctx), resource_group_name, vault_name, policy_name)
 
     logger.warning('Ignite (November) 2023 onwards Virtual Machine deployments using PS and CLI will default to '
-                   'security type Trusted Launch configuration. Please ensure Policy Name used with "az backup '
+                   'security type Trusted Launch. Please ensure Policy Name used with "az backup '
                    'protection enable-for-vm" command is of type Enhanced Policy for Trusted Launch VMs. Non-Trusted '
                    'Launch Virtual Machines will not be impacted by this change. To know more about default change '
                    'and Trusted Launch, please visit https://aka.ms/TLaD.')

--- a/src/azure-cli/azure/cli/command_modules/backup/custom_afs.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom_afs.py
@@ -171,7 +171,8 @@ def _try_get_protectable_item_for_afs(cli_ctx, vault_name, resource_group_name, 
 
 def restore_AzureFileShare(cmd, client, resource_group_name, vault_name, rp_name, item, restore_mode,
                            resolve_conflict, restore_request_type, source_file_type=None, source_file_path=None,
-                           target_storage_account_name=None, target_file_share_name=None, target_folder=None):
+                           target_storage_account_name=None, target_file_share_name=None, target_folder=None,
+                           target_resource_group_name=None):
 
     container_uri = helper.get_protection_container_uri_from_id(item.id)
     item_uri = helper.get_protected_item_uri_from_id(item.id)
@@ -201,7 +202,9 @@ def restore_AzureFileShare(cmd, client, resource_group_name, vault_name, rp_name
                                                        target_folder_path=target_folder))
 
     if restore_mode == "AlternateLocation":
-        target_sa_name, target_sa_rg = helper.get_resource_name_and_rg(resource_group_name, target_storage_account_name)
+        if target_resource_group_name is None:
+            target_resource_group_name = resource_group_name
+        target_sa_name, target_sa_rg = helper.get_resource_name_and_rg(target_resource_group_name, target_storage_account_name)
         target_details = TargetAFSRestoreInfo()
         target_details.name = target_file_share_name
         target_details.target_resource_id = _get_storage_account_id(cmd.cli_ctx, target_sa_name, target_sa_rg)

--- a/src/azure-cli/azure/cli/command_modules/backup/custom_afs.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom_afs.py
@@ -204,7 +204,9 @@ def restore_AzureFileShare(cmd, client, resource_group_name, vault_name, rp_name
     if restore_mode == "AlternateLocation":
         if target_resource_group_name is None:
             target_resource_group_name = resource_group_name
-        target_sa_name, target_sa_rg = helper.get_resource_name_and_rg(target_resource_group_name, target_storage_account_name)
+        target_sa_name, target_sa_rg = helper.get_resource_name_and_rg(
+            target_resource_group_name,
+            target_storage_account_name)
         target_details = TargetAFSRestoreInfo()
         target_details.name = target_file_share_name
         target_details.target_resource_id = _get_storage_account_id(cmd.cli_ctx, target_sa_name, target_sa_rg)

--- a/src/azure-cli/azure/cli/command_modules/backup/custom_afs.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom_afs.py
@@ -177,15 +177,16 @@ def restore_AzureFileShare(cmd, client, resource_group_name, vault_name, rp_name
     container_uri = helper.get_protection_container_uri_from_id(item.id)
     item_uri = helper.get_protected_item_uri_from_id(item.id)
 
-    sa_name = item.properties.container_name
+    # sa_name = item.properties.container_name
 
     afs_restore_request = AzureFileShareRestoreRequest()
     target_details = None
 
     afs_restore_request.copy_options = resolve_conflict
     afs_restore_request.recovery_type = restore_mode
-    afs_restore_request.source_resource_id = _get_storage_account_id(cmd.cli_ctx, sa_name.split(';')[-1],
-                                                                     sa_name.split(';')[-2])
+    afs_restore_request.source_resource_id = _get_storage_account_id(cmd.cli_ctx,
+                                                                     item.properties.container_name.split(';')[-1],
+                                                                     item.properties.container_name.split(';')[-2])
     afs_restore_request.restore_request_type = restore_request_type
 
     restore_file_specs = None

--- a/src/azure-cli/azure/cli/command_modules/backup/custom_base.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom_base.py
@@ -448,7 +448,7 @@ def enable_for_azurefileshare(cmd, client, resource_group_name, vault_name, poli
 
 def restore_azurefileshare(cmd, client, resource_group_name, vault_name, rp_name, container_name, item_name,
                            restore_mode, resolve_conflict, target_storage_account=None, target_file_share=None,
-                           target_folder=None):
+                           target_folder=None, target_resource_group_name=None):
     backup_management_type = "AzureStorage"
     workload_type = "AzureFileShare"
     items_client = backup_protected_items_cf(cmd.cli_ctx)
@@ -462,12 +462,13 @@ def restore_azurefileshare(cmd, client, resource_group_name, vault_name, rp_name
     return custom_afs.restore_AzureFileShare(cmd, client, resource_group_name, vault_name, rp_name, item, restore_mode,
                                              resolve_conflict, "FullShareRestore",
                                              target_storage_account_name=target_storage_account,
-                                             target_file_share_name=target_file_share, target_folder=target_folder)
+                                             target_file_share_name=target_file_share, target_folder=target_folder,
+                                             target_resource_group_name=target_resource_group_name)
 
 
 def restore_azurefiles(cmd, client, resource_group_name, vault_name, rp_name, container_name, item_name, restore_mode,
                        resolve_conflict, target_storage_account=None, target_file_share=None, target_folder=None,
-                       source_file_type=None, source_file_path=None,):
+                       source_file_type=None, source_file_path=None):
     backup_management_type = "AzureStorage"
     workload_type = "AzureFileShare"
     items_client = backup_protected_items_cf(cmd.cli_ctx)

--- a/src/azure-cli/azure/cli/command_modules/backup/tests/latest/recordings/test_afs_backup_container.yaml
+++ b/src/azure-cli/azure/cli/command_modules/backup/tests/latest/recordings/test_afs_backup_container.yaml
@@ -13,7 +13,8 @@ interactions:
       ParameterSetName:
       - -n -g --location
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2023-02-01
   response:
@@ -29,7 +30,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:06:48 GMT
+      - Wed, 16 Aug 2023 09:25:54 GMT
       expires:
       - '-1'
       pragma:
@@ -64,15 +65,16 @@ interactions:
       ParameterSetName:
       - -n -g --location
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2023-02-01
   response:
     body:
-      string: '{"location":"eastus2euap","name":"clitest-vault000002","etag":"W/\"datetime''2023-05-17T12%3A06%3A53.4065427Z''\"","properties":{"provisioningState":"Provisioning","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}},"publicNetworkAccess":"Enabled","restoreSettings":{"crossSubscriptionRestoreSettings":{"crossSubscriptionRestoreState":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+      string: '{"location":"eastus2euap","name":"clitest-vault000002","etag":"W/\"datetime''2023-08-16T09%3A25%3A55.7735645Z''\"","properties":{"provisioningState":"Provisioning","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}},"publicNetworkAccess":"Enabled","restoreSettings":{"crossSubscriptionRestoreSettings":{"crossSubscriptionRestoreState":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NzsxZDJhM2Q1Mi04MmYxLTQ5ZDMtODAyNy1lNDZkMjdiMWIwNzU=?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NzswMmYwZWY3Ni0wMWMxLTQ0NDQtOGVhNC0yNzAzNmViMzUzM2E=?api-version=2023-02-01
       cache-control:
       - no-cache
       content-length:
@@ -80,7 +82,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:06:54 GMT
+      - Wed, 16 Aug 2023 09:25:55 GMT
       expires:
       - '-1'
       pragma:
@@ -91,8 +93,10 @@ interactions:
       - max-age=31536000; includeSubDomains
       x-content-type-options:
       - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=12f8ea5c-1212-449e-b31c-0a574f43076e/centraluseuap/80ff3cca-1736-4a37-a1c8-f86de46c9180
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '298'
     status:
       code: 201
       message: Created
@@ -110,17 +114,18 @@ interactions:
       ParameterSetName:
       - -n -g --location
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NzsxZDJhM2Q1Mi04MmYxLTQ5ZDMtODAyNy1lNDZkMjdiMWIwNzU=?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NzswMmYwZWY3Ni0wMWMxLTQ0NDQtOGVhNC0yNzAzNmViMzUzM2E=?api-version=2023-02-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NzsxZDJhM2Q1Mi04MmYxLTQ5ZDMtODAyNy1lNDZkMjdiMWIwNzU=\",\r\n
-        \ \"name\": \"MjA0NzsxZDJhM2Q1Mi04MmYxLTQ5ZDMtODAyNy1lNDZkMjdiMWIwNzU=\",\r\n
-        \ \"status\": \"InProgress\"\r\n}"
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NzswMmYwZWY3Ni0wMWMxLTQ0NDQtOGVhNC0yNzAzNmViMzUzM2E=\"\
+        ,\r\n  \"name\": \"MjA0NzswMmYwZWY3Ni0wMWMxLTQ0NDQtOGVhNC0yNzAzNmViMzUzM2E=\"\
+        ,\r\n  \"status\": \"InProgress\"\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NzsxZDJhM2Q1Mi04MmYxLTQ5ZDMtODAyNy1lNDZkMjdiMWIwNzU=?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NzswMmYwZWY3Ni0wMWMxLTQ0NDQtOGVhNC0yNzAzNmViMzUzM2E=?api-version=2023-02-01
       cache-control:
       - no-cache
       content-length:
@@ -128,11 +133,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:06:55 GMT
+      - Wed, 16 Aug 2023 09:25:56 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationResults/MjA0NzsxZDJhM2Q1Mi04MmYxLTQ5ZDMtODAyNy1lNDZkMjdiMWIwNzU=?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationResults/MjA0NzswMmYwZWY3Ni0wMWMxLTQ0NDQtOGVhNC0yNzAzNmViMzUzM2E=?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -162,66 +167,15 @@ interactions:
       ParameterSetName:
       - -n -g --location
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NzsxZDJhM2Q1Mi04MmYxLTQ5ZDMtODAyNy1lNDZkMjdiMWIwNzU=?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NzswMmYwZWY3Ni0wMWMxLTQ0NDQtOGVhNC0yNzAzNmViMzUzM2E=?api-version=2023-02-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NzsxZDJhM2Q1Mi04MmYxLTQ5ZDMtODAyNy1lNDZkMjdiMWIwNzU=\",\r\n
-        \ \"name\": \"MjA0NzsxZDJhM2Q1Mi04MmYxLTQ5ZDMtODAyNy1lNDZkMjdiMWIwNzU=\",\r\n
-        \ \"status\": \"InProgress\"\r\n}"
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NzsxZDJhM2Q1Mi04MmYxLTQ5ZDMtODAyNy1lNDZkMjdiMWIwNzU=?api-version=2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '334'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:07:55 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationResults/MjA0NzsxZDJhM2Q1Mi04MmYxLTQ5ZDMtODAyNy1lNDZkMjdiMWIwNzU=?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup vault create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --location
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NzsxZDJhM2Q1Mi04MmYxLTQ5ZDMtODAyNy1lNDZkMjdiMWIwNzU=?api-version=2023-02-01
-  response:
-    body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NzsxZDJhM2Q1Mi04MmYxLTQ5ZDMtODAyNy1lNDZkMjdiMWIwNzU=\",\r\n
-        \ \"name\": \"MjA0NzsxZDJhM2Q1Mi04MmYxLTQ5ZDMtODAyNy1lNDZkMjdiMWIwNzU=\",\r\n
-        \ \"status\": \"Succeeded\"\r\n}"
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NzswMmYwZWY3Ni0wMWMxLTQ0NDQtOGVhNC0yNzAzNmViMzUzM2E=\"\
+        ,\r\n  \"name\": \"MjA0NzswMmYwZWY3Ni0wMWMxLTQ0NDQtOGVhNC0yNzAzNmViMzUzM2E=\"\
+        ,\r\n  \"status\": \"Succeeded\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -230,7 +184,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:56 GMT
+      - Wed, 16 Aug 2023 09:26:56 GMT
       expires:
       - '-1'
       pragma:
@@ -262,12 +216,13 @@ interactions:
       ParameterSetName:
       - -n -g --location
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2023-02-01
   response:
     body:
-      string: '{"location":"eastus2euap","name":"clitest-vault000002","etag":"W/\"datetime''2023-05-17T12%3A07%3A57.0122832Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","backupStorageVersion":"Unassigned","monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}},"securitySettings":{"immutabilitySettings":null,"softDeleteSettings":{"softDeleteRetentionPeriodInDays":14,"softDeleteState":"Enabled"},"multiUserAuthorization":"Disabled"},"publicNetworkAccess":"Enabled","restoreSettings":{"crossSubscriptionRestoreSettings":{"crossSubscriptionRestoreState":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+      string: '{"location":"eastus2euap","name":"clitest-vault000002","etag":"W/\"datetime''2023-08-16T09%3A25%3A56.4943047Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","backupStorageVersion":"Unassigned","monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}},"securitySettings":{"immutabilitySettings":null,"softDeleteSettings":{"softDeleteRetentionPeriodInDays":14,"softDeleteState":"Enabled"},"multiUserAuthorization":"Disabled"},"publicNetworkAccess":"Enabled","restoreSettings":{"crossSubscriptionRestoreSettings":{"crossSubscriptionRestoreState":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
     headers:
       cache-control:
       - no-cache
@@ -276,7 +231,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:56 GMT
+      - Wed, 16 Aug 2023 09:26:56 GMT
       expires:
       - '-1'
       pragma:
@@ -291,6 +246,156 @@ interactions:
       - Accept-Encoding
       x-content-type-options:
       - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault backup-properties set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --soft-delete-feature-state
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupconfig/vaultconfig?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupconfig/vaultconfig","name":"vaultconfig","type":"Microsoft.RecoveryServices/vaults/backupconfig","properties":{"enhancedSecurityState":"Enabled","softDeleteFeatureState":"Enabled","softDeleteRetentionPeriodInDays":14,"isSoftDeleteFeatureStateEditable":true}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '419'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:26:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '299'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault backup-properties set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --soft-delete-feature-state
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupResourceGuardProxies?api-version=2023-02-01
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:26:59 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"enhancedSecurityState": "Enabled", "softDeleteFeatureState":
+      "Disabled"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault backup-properties set
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '90'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -n -g --soft-delete-feature-state
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: PATCH
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupconfig/vaultconfig?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupconfig/vaultconfig","name":"vaultconfig","type":"Microsoft.RecoveryServices/vaults/backupconfig","properties":{"enhancedSecurityState":"Enabled","softDeleteFeatureState":"Disabled","softDeleteRetentionPeriodInDays":14,"isSoftDeleteFeatureStateEditable":true}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '420'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:27:00 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1197'
     status:
       code: 200
       message: OK
@@ -310,12 +415,13 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-storage/21.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003/listKeys?api-version=2022-09-01&$expand=kerb
   response:
     body:
-      string: '{"keys":[{"creationTime":"2023-05-17T12:08:59.6554204Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2023-05-17T12:08:59.6554204Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
+      string: '{"keys":[{"creationTime":"2023-08-16T09:27:02.7815711Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2023-08-16T09:27:02.7815711Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
     headers:
       cache-control:
       - no-cache
@@ -324,7 +430,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 17 May 2023 12:09:23 GMT
+      - Wed, 16 Aug 2023 09:27:25 GMT
       expires:
       - '-1'
       pragma:
@@ -340,7 +446,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11997'
     status:
       code: 200
       message: OK
@@ -358,21 +464,22 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-storage/21.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","name":"clitest000003","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"keyCreationTime":{"key1":"2023-05-17T12:08:59.6554204Z","key2":"2023-05-17T12:08:59.6554204Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-05-17T12:09:00.0460253Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-05-17T12:09:00.0460253Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-05-17T12:08:59.5773042Z","primaryEndpoints":{"blob":"https://clitest000003.blob.core.windows.net/","queue":"https://clitest000003.queue.core.windows.net/","table":"https://clitest000003.table.core.windows.net/","file":"https://clitest000003.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","name":"clitest000003","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"keyCreationTime":{"key1":"2023-08-16T09:27:02.7815711Z","key2":"2023-08-16T09:27:02.7815711Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-08-16T09:27:03.2034940Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-08-16T09:27:03.2034940Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-08-16T09:27:02.7034212Z","primaryEndpoints":{"blob":"https://clitest000003.blob.core.windows.net/","queue":"https://clitest000003.queue.core.windows.net/","table":"https://clitest000003.table.core.windows.net/","file":"https://clitest000003.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1280'
+      - '1316'
       content-type:
       - application/json
       date:
-      - Wed, 17 May 2023 12:09:24 GMT
+      - Wed, 16 Aug 2023 09:27:25 GMT
       expires:
       - '-1'
       pragma:
@@ -406,9 +513,10 @@ interactions:
       ParameterSetName:
       - --name --quota --connection-string
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-storage-file-share/12.12.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-storage-file-share/12.12.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Wed, 17 May 2023 12:09:23 GMT
+      - Wed, 16 Aug 2023 09:27:27 GMT
       x-ms-share-quota:
       - '1'
       x-ms-version:
@@ -422,11 +530,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:09:24 GMT
+      - Wed, 16 Aug 2023 09:27:27 GMT
       etag:
-      - '"0x8DB56CF8EC65A10"'
+      - '"0x8DB9E3B0239A518"'
       last-modified:
-      - Wed, 17 May 2023 12:09:25 GMT
+      - Wed, 16 Aug 2023 09:27:28 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
@@ -448,13 +556,13 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T19:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T19:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
@@ -463,7 +571,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:09:26 GMT
+      - Wed, 16 Aug 2023 09:27:28 GMT
       expires:
       - '-1'
       pragma:
@@ -479,16 +587,16 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '298'
     status:
       code: 200
       message: OK
 - request:
     body: '{"properties": {"protectedItemsCount": 0, "backupManagementType": "AzureStorage",
       "workLoadType": "AzureFileShare", "schedulePolicy": {"schedulePolicyType": "SimpleSchedulePolicy",
-      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2023-05-17T22:00:00.000Z"],
+      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2023-08-16T19:00:00.000Z"],
       "scheduleWeeklyFrequency": 0}, "retentionPolicy": {"retentionPolicyType": "LongTermRetentionPolicy",
-      "dailySchedule": {"retentionTimes": ["2023-05-17T22:00:00.000Z"], "retentionDuration":
+      "dailySchedule": {"retentionTimes": ["2023-08-16T19:00:00.000Z"], "retentionDuration":
       {"count": 30, "durationType": "Days"}}}, "timeZone": "UTC"}}'
     headers:
       Accept:
@@ -506,22 +614,22 @@ interactions:
       ParameterSetName:
       - -g -v --policy -n --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","name":"clitest-item000005","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","name":"clitest-item000005","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","workLoadType":"AzureFileShare","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T19:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T19:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '719'
+      - '751'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:09:28 GMT
+      - Wed, 16 Aug 2023 09:27:30 GMT
       expires:
       - '-1'
       pragma:
@@ -537,7 +645,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1195'
+      - '1196'
     status:
       code: 200
       message: OK
@@ -555,8 +663,8 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+status+eq+%27Registered%27
   response:
@@ -570,7 +678,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:09:28 GMT
+      - Wed, 16 Aug 2023 09:27:31 GMT
       expires:
       - '-1'
       pragma:
@@ -586,7 +694,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '299'
     status:
       code: 200
       message: OK
@@ -604,22 +712,22 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","name":"StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"adiguptecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/adigupt-ecy-rg/providers/Microsoft.Storage/storageAccounts/adiguptecy"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg2yfprhyqds;clitesttz6sdom2jatwnfac4","name":"StorageContainer;Storage;clitest.rg2yfprhyqds;clitesttz6sdom2jatwnfac4","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesttz6sdom2jatwnfac4","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg2yfprhyqds/providers/Microsoft.Storage/storageAccounts/clitesttz6sdom2jatwnfac4"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx;clitest5g7td7ozjqq2b6ccr","name":"StorageContainer;Storage;clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx;clitest5g7td7ozjqq2b6ccr","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest5g7td7ozjqq2b6ccr","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx/providers/Microsoft.Storage/storageAccounts/clitest5g7td7ozjqq2b6ccr"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","name":"StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontusebvtaksecycansa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DonotUse-Blobs-BVT-EACAN-RG/providers/Microsoft.Storage/storageAccounts/dontusebvtaksecycansa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","name":"StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"iaasextstoreecy1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.czr/providers/Microsoft.Storage/storageAccounts/iaasextstoreecy1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","name":"StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesaksdonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-clitest-rg/providers/Microsoft.Storage/storageAccounts/clitesaksdonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"bloboprestorecontainers","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/bloboprestorecontainers"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopall","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopall"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopcontainer","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopcontainer"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopprefix","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopprefix"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG;zubairsaecy","name":"StorageContainer;Storage;zubairRG;zubairsaecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Storage/storageAccounts/zubairsaecy"}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","name":"StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"adiguptecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/adigupt-ecy-rg/providers/Microsoft.Storage/storageAccounts/adiguptecy"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","name":"StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontusebvtaksecycansa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DonotUse-Blobs-BVT-EACAN-RG/providers/Microsoft.Storage/storageAccounts/dontusebvtaksecycansa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","name":"StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"iaasextstoreecy1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.czr/providers/Microsoft.Storage/storageAccounts/iaasextstoreecy1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","name":"StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesaksdonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-clitest-rg/providers/Microsoft.Storage/storageAccounts/clitesaksdonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"bloboprestorecontainers","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/bloboprestorecontainers"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopall","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopall"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopcontainer","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopcontainer"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopprefix","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopprefix"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG2;zubairsaecy2","name":"StorageContainer;Storage;zubairRG2;zubairsaecy2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy2","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG2/providers/Microsoft.Storage/storageAccounts/zubairsaecy2"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG;zubairsaecy","name":"StorageContainer;Storage;zubairRG;zubairsaecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Storage/storageAccounts/zubairsaecy"}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '8530'
+      - '7516'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:09:29 GMT
+      - Wed, 16 Aug 2023 09:27:33 GMT
       expires:
       - '-1'
       pragma:
@@ -635,7 +743,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '299'
     status:
       code: 200
       message: OK
@@ -655,8 +763,8 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/refreshContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
@@ -664,17 +772,17 @@ interactions:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/f73d0c5d-8fea-4a52-bdac-2145101e5ffc?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/e7e04218-6afd-4e5c-8ef9-dccec76d73f5?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:09:30 GMT
+      - Wed, 16 Aug 2023 09:27:34 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/f73d0c5d-8fea-4a52-bdac-2145101e5ffc?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/e7e04218-6afd-4e5c-8ef9-dccec76d73f5?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -684,7 +792,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1196'
     status:
       code: 202
       message: Accepted
@@ -702,10 +810,10 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/f73d0c5d-8fea-4a52-bdac-2145101e5ffc?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/e7e04218-6afd-4e5c-8ef9-dccec76d73f5?api-version=2023-02-01
   response:
     body:
       string: ''
@@ -715,11 +823,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:09:31 GMT
+      - Wed, 16 Aug 2023 09:27:35 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/f73d0c5d-8fea-4a52-bdac-2145101e5ffc?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/e7e04218-6afd-4e5c-8ef9-dccec76d73f5?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -747,10 +855,10 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/f73d0c5d-8fea-4a52-bdac-2145101e5ffc?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/e7e04218-6afd-4e5c-8ef9-dccec76d73f5?api-version=2023-02-01
   response:
     body:
       string: ''
@@ -760,11 +868,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:09:36 GMT
+      - Wed, 16 Aug 2023 09:27:40 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/f73d0c5d-8fea-4a52-bdac-2145101e5ffc?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/e7e04218-6afd-4e5c-8ef9-dccec76d73f5?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -792,10 +900,10 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/f73d0c5d-8fea-4a52-bdac-2145101e5ffc?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/e7e04218-6afd-4e5c-8ef9-dccec76d73f5?api-version=2023-02-01
   response:
     body:
       string: ''
@@ -803,7 +911,7 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Wed, 17 May 2023 12:09:42 GMT
+      - Wed, 16 Aug 2023 09:27:46 GMT
       expires:
       - '-1'
       pragma:
@@ -833,22 +941,22 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","name":"StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"adiguptecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/adigupt-ecy-rg/providers/Microsoft.Storage/storageAccounts/adiguptecy"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg2yfprhyqds;clitesttz6sdom2jatwnfac4","name":"StorageContainer;Storage;clitest.rg2yfprhyqds;clitesttz6sdom2jatwnfac4","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesttz6sdom2jatwnfac4","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg2yfprhyqds/providers/Microsoft.Storage/storageAccounts/clitesttz6sdom2jatwnfac4"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest000003","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx;clitest5g7td7ozjqq2b6ccr","name":"StorageContainer;Storage;clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx;clitest5g7td7ozjqq2b6ccr","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest5g7td7ozjqq2b6ccr","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx/providers/Microsoft.Storage/storageAccounts/clitest5g7td7ozjqq2b6ccr"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","name":"StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontusebvtaksecycansa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DonotUse-Blobs-BVT-EACAN-RG/providers/Microsoft.Storage/storageAccounts/dontusebvtaksecycansa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","name":"StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"iaasextstoreecy1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.czr/providers/Microsoft.Storage/storageAccounts/iaasextstoreecy1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","name":"StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesaksdonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-clitest-rg/providers/Microsoft.Storage/storageAccounts/clitesaksdonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"bloboprestorecontainers","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/bloboprestorecontainers"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopall","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopall"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopcontainer","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopcontainer"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopprefix","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopprefix"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG;zubairsaecy","name":"StorageContainer;Storage;zubairRG;zubairsaecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Storage/storageAccounts/zubairsaecy"}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","name":"StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"adiguptecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/adigupt-ecy-rg/providers/Microsoft.Storage/storageAccounts/adiguptecy"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgl7ufwgcue4;clitestropgruks4gtf2d2ty","name":"StorageContainer;Storage;clitest.rgl7ufwgcue4;clitestropgruks4gtf2d2ty","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestropgruks4gtf2d2ty","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgl7ufwgcue4/providers/Microsoft.Storage/storageAccounts/clitestropgruks4gtf2d2ty"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest000003","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","name":"StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontusebvtaksecycansa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DonotUse-Blobs-BVT-EACAN-RG/providers/Microsoft.Storage/storageAccounts/dontusebvtaksecycansa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","name":"StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"iaasextstoreecy1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.czr/providers/Microsoft.Storage/storageAccounts/iaasextstoreecy1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","name":"StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesaksdonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-clitest-rg/providers/Microsoft.Storage/storageAccounts/clitesaksdonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"bloboprestorecontainers","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/bloboprestorecontainers"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopall","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopall"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopcontainer","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopcontainer"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopprefix","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopprefix"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG2;zubairsaecy2","name":"StorageContainer;Storage;zubairRG2;zubairsaecy2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy2","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG2/providers/Microsoft.Storage/storageAccounts/zubairsaecy2"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG;zubairsaecy","name":"StorageContainer;Storage;zubairRG;zubairsaecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Storage/storageAccounts/zubairsaecy"}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '9242'
+      - '8996'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:09:42 GMT
+      - Wed, 16 Aug 2023 09:27:47 GMT
       expires:
       - '-1'
       pragma:
@@ -887,8 +995,8 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003?api-version=2023-02-01
   response:
@@ -896,7 +1004,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/8a7c5a43-b8a0-4c2f-b3dd-3755566cb869?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/1c85529e-2ec9-4dd2-b0dc-40e7fe7b2629?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -904,11 +1012,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:09:44 GMT
+      - Wed, 16 Aug 2023 09:27:48 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/8a7c5a43-b8a0-4c2f-b3dd-3755566cb869?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/1c85529e-2ec9-4dd2-b0dc-40e7fe7b2629?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -918,7 +1026,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1193'
     status:
       code: 202
       message: Accepted
@@ -936,16 +1044,16 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/8a7c5a43-b8a0-4c2f-b3dd-3755566cb869?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/1c85529e-2ec9-4dd2-b0dc-40e7fe7b2629?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/8a7c5a43-b8a0-4c2f-b3dd-3755566cb869?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/1c85529e-2ec9-4dd2-b0dc-40e7fe7b2629?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -953,256 +1061,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:09:44 GMT
+      - Wed, 16 Aug 2023 09:27:49 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/8a7c5a43-b8a0-4c2f-b3dd-3755566cb869?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/8a7c5a43-b8a0-4c2f-b3dd-3755566cb869?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/8a7c5a43-b8a0-4c2f-b3dd-3755566cb869?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:49 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/8a7c5a43-b8a0-4c2f-b3dd-3755566cb869?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '296'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/8a7c5a43-b8a0-4c2f-b3dd-3755566cb869?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","protectedItemCount":0,"acquireStorageAccountLock":"Acquire","friendlyName":"clitest000003","backupManagementType":"AzureStorage","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"StorageContainer","protectableObjectType":"StorageContainer"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '763'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:55 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '295'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectableItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+workloadType+eq+%27AzureFileShare%27
-  response:
-    body:
-      string: '{"value":[]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '12'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:56 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/inquire?api-version=2023-02-01&%24filter=workloadType+eq+%27AzureFileShare%27
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/fc96aae9-51f8-41f2-bec7-e831fc5b83b6?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Wed, 17 May 2023 12:09:56 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/fc96aae9-51f8-41f2-bec7-e831fc5b83b6?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/fc96aae9-51f8-41f2-bec7-e831fc5b83b6?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/fc96aae9-51f8-41f2-bec7-e831fc5b83b6?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:58 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/fc96aae9-51f8-41f2-bec7-e831fc5b83b6?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/1c85529e-2ec9-4dd2-b0dc-40e7fe7b2629?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -1230,16 +1093,16 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/fc96aae9-51f8-41f2-bec7-e831fc5b83b6?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/1c85529e-2ec9-4dd2-b0dc-40e7fe7b2629?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/fc96aae9-51f8-41f2-bec7-e831fc5b83b6?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/1c85529e-2ec9-4dd2-b0dc-40e7fe7b2629?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -1247,11 +1110,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:03 GMT
+      - Wed, 16 Aug 2023 09:27:55 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/fc96aae9-51f8-41f2-bec7-e831fc5b83b6?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/1c85529e-2ec9-4dd2-b0dc-40e7fe7b2629?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -1279,20 +1142,28 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/fc96aae9-51f8-41f2-bec7-e831fc5b83b6?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/1c85529e-2ec9-4dd2-b0dc-40e7fe7b2629?api-version=2023-02-01
   response:
     body:
-      string: ''
+      string: '{}'
     headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/1c85529e-2ec9-4dd2-b0dc-40e7fe7b2629?api-version=2019-05-13-preview
       cache-control:
       - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:08 GMT
+      - Wed, 16 Aug 2023 09:28:01 GMT
       expires:
       - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/1c85529e-2ec9-4dd2-b0dc-40e7fe7b2629?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -1304,8 +1175,8 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '297'
     status:
-      code: 204
-      message: No Content
+      code: 202
+      message: Accepted
 - request:
     body: null
     headers:
@@ -1320,22 +1191,218 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectableItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+workloadType+eq+%27AzureFileShare%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/1c85529e-2ec9-4dd2-b0dc-40e7fe7b2629?api-version=2023-02-01
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectableItems/azurefileshare;9aab449eeb0a587b1a0bad3ba3fbfd73eb85468b78342621fda665235d35d88b","name":"azurefileshare;9aab449eeb0a587b1a0bad3ba3fbfd73eb85468b78342621fda665235d35d88b","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"parentContainerFabricId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","parentContainerFriendlyName":"clitest000003","azureFileShareType":"XSMB","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","protectableItemType":"AzureFileShare","friendlyName":"clitest-item000004","protectionState":"NotProtected"}}]}'
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/1c85529e-2ec9-4dd2-b0dc-40e7fe7b2629?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:28:06 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/1c85529e-2ec9-4dd2-b0dc-40e7fe7b2629?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '296'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/1c85529e-2ec9-4dd2-b0dc-40e7fe7b2629?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/1c85529e-2ec9-4dd2-b0dc-40e7fe7b2629?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:28:11 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/1c85529e-2ec9-4dd2-b0dc-40e7fe7b2629?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '295'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/1c85529e-2ec9-4dd2-b0dc-40e7fe7b2629?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/1c85529e-2ec9-4dd2-b0dc-40e7fe7b2629?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:28:17 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/1c85529e-2ec9-4dd2-b0dc-40e7fe7b2629?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '294'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/1c85529e-2ec9-4dd2-b0dc-40e7fe7b2629?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/1c85529e-2ec9-4dd2-b0dc-40e7fe7b2629?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:28:22 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/1c85529e-2ec9-4dd2-b0dc-40e7fe7b2629?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '293'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/1c85529e-2ec9-4dd2-b0dc-40e7fe7b2629?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","protectedItemCount":0,"acquireStorageAccountLock":"Acquire","friendlyName":"clitest000003","backupManagementType":"AzureStorage","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"StorageContainer","protectableObjectType":"StorageContainer"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '983'
+      - '763'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:09 GMT
+      - Wed, 16 Aug 2023 09:28:28 GMT
       expires:
       - '-1'
       pragma:
@@ -1351,7 +1418,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '292'
     status:
       code: 200
       message: OK
@@ -1369,22 +1436,71 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectableItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+workloadType+eq+%27AzureFileShare%27
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","name":"clitest-item000005","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectableItems/azurefileshare;e507b8700265f2adcfcf47abf6a9e732db86b73363c1f002236ab1bbbdf3f377","name":"azurefileshare;e507b8700265f2adcfcf47abf6a9e732db86b73363c1f002236ab1bbbdf3f377","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"parentContainerFabricId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","parentContainerFriendlyName":"clitest000003","azureFileShareType":"XSMB","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","protectableItemType":"AzureFileShare","friendlyName":"clitest-item000004","protectionState":"NotProtected"}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '719'
+      - '983'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:11 GMT
+      - Wed, 16 Aug 2023 09:28:29 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '297'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","name":"clitest-item000005","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","workLoadType":"AzureFileShare","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T19:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T19:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '751'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:28:29 GMT
       expires:
       - '-1'
       pragma:
@@ -1424,26 +1540,26 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/azurefileshare%3B9aab449eeb0a587b1a0bad3ba3fbfd73eb85468b78342621fda665235d35d88b?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/azurefileshare%3Be507b8700265f2adcfcf47abf6a9e732db86b73363c1f002236ab1bbbdf3f377?api-version=2023-02-01
   response:
     body:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectedItems/azurefileshare;9aab449eeb0a587b1a0bad3ba3fbfd73eb85468b78342621fda665235d35d88b/operationsStatus/5dad2d36-1ea0-4e36-8b30-0faeaf959dd7?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectedItems/azurefileshare;e507b8700265f2adcfcf47abf6a9e732db86b73363c1f002236ab1bbbdf3f377/operationsStatus/363465af-8fd5-4366-a22e-bdcb26bbb513?api-version=2023-02-01
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:10:12 GMT
+      - Wed, 16 Aug 2023 09:28:32 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectedItems/azurefileshare;9aab449eeb0a587b1a0bad3ba3fbfd73eb85468b78342621fda665235d35d88b/operationResults/5dad2d36-1ea0-4e36-8b30-0faeaf959dd7?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectedItems/azurefileshare;e507b8700265f2adcfcf47abf6a9e732db86b73363c1f002236ab1bbbdf3f377/operationResults/363465af-8fd5-4366-a22e-bdcb26bbb513?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -1453,7 +1569,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1198'
     status:
       code: 202
       message: Accepted
@@ -1471,13 +1587,13 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5dad2d36-1ea0-4e36-8b30-0faeaf959dd7?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/363465af-8fd5-4366-a22e-bdcb26bbb513?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"5dad2d36-1ea0-4e36-8b30-0faeaf959dd7","name":"5dad2d36-1ea0-4e36-8b30-0faeaf959dd7","status":"InProgress","startTime":"2023-05-17T12:10:12.6052823Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"363465af-8fd5-4366-a22e-bdcb26bbb513","name":"363465af-8fd5-4366-a22e-bdcb26bbb513","status":"InProgress","startTime":"2023-08-16T09:28:31.9386678Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -1486,7 +1602,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:13 GMT
+      - Wed, 16 Aug 2023 09:28:33 GMT
       expires:
       - '-1'
       pragma:
@@ -1520,13 +1636,13 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5dad2d36-1ea0-4e36-8b30-0faeaf959dd7?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/363465af-8fd5-4366-a22e-bdcb26bbb513?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"5dad2d36-1ea0-4e36-8b30-0faeaf959dd7","name":"5dad2d36-1ea0-4e36-8b30-0faeaf959dd7","status":"InProgress","startTime":"2023-05-17T12:10:12.6052823Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"363465af-8fd5-4366-a22e-bdcb26bbb513","name":"363465af-8fd5-4366-a22e-bdcb26bbb513","status":"InProgress","startTime":"2023-08-16T09:28:31.9386678Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -1535,56 +1651,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:19 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5dad2d36-1ea0-4e36-8b30-0faeaf959dd7?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"5dad2d36-1ea0-4e36-8b30-0faeaf959dd7","name":"5dad2d36-1ea0-4e36-8b30-0faeaf959dd7","status":"InProgress","startTime":"2023-05-17T12:10:12.6052823Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:10:24 GMT
+      - Wed, 16 Aug 2023 09:28:38 GMT
       expires:
       - '-1'
       pragma:
@@ -1618,13 +1685,13 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5dad2d36-1ea0-4e36-8b30-0faeaf959dd7?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/363465af-8fd5-4366-a22e-bdcb26bbb513?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"5dad2d36-1ea0-4e36-8b30-0faeaf959dd7","name":"5dad2d36-1ea0-4e36-8b30-0faeaf959dd7","status":"InProgress","startTime":"2023-05-17T12:10:12.6052823Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"363465af-8fd5-4366-a22e-bdcb26bbb513","name":"363465af-8fd5-4366-a22e-bdcb26bbb513","status":"InProgress","startTime":"2023-08-16T09:28:31.9386678Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -1633,56 +1700,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:30 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '296'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5dad2d36-1ea0-4e36-8b30-0faeaf959dd7?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"5dad2d36-1ea0-4e36-8b30-0faeaf959dd7","name":"5dad2d36-1ea0-4e36-8b30-0faeaf959dd7","status":"InProgress","startTime":"2023-05-17T12:10:12.6052823Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:10:35 GMT
+      - Wed, 16 Aug 2023 09:28:44 GMT
       expires:
       - '-1'
       pragma:
@@ -1716,13 +1734,13 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5dad2d36-1ea0-4e36-8b30-0faeaf959dd7?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/363465af-8fd5-4366-a22e-bdcb26bbb513?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"5dad2d36-1ea0-4e36-8b30-0faeaf959dd7","name":"5dad2d36-1ea0-4e36-8b30-0faeaf959dd7","status":"InProgress","startTime":"2023-05-17T12:10:12.6052823Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"363465af-8fd5-4366-a22e-bdcb26bbb513","name":"363465af-8fd5-4366-a22e-bdcb26bbb513","status":"InProgress","startTime":"2023-08-16T09:28:31.9386678Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -1731,56 +1749,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:41 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '294'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5dad2d36-1ea0-4e36-8b30-0faeaf959dd7?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"5dad2d36-1ea0-4e36-8b30-0faeaf959dd7","name":"5dad2d36-1ea0-4e36-8b30-0faeaf959dd7","status":"InProgress","startTime":"2023-05-17T12:10:12.6052823Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:10:46 GMT
+      - Wed, 16 Aug 2023 09:28:49 GMT
       expires:
       - '-1'
       pragma:
@@ -1814,13 +1783,13 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5dad2d36-1ea0-4e36-8b30-0faeaf959dd7?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/363465af-8fd5-4366-a22e-bdcb26bbb513?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"5dad2d36-1ea0-4e36-8b30-0faeaf959dd7","name":"5dad2d36-1ea0-4e36-8b30-0faeaf959dd7","status":"InProgress","startTime":"2023-05-17T12:10:12.6052823Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"363465af-8fd5-4366-a22e-bdcb26bbb513","name":"363465af-8fd5-4366-a22e-bdcb26bbb513","status":"InProgress","startTime":"2023-08-16T09:28:31.9386678Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -1829,56 +1798,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:52 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '292'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5dad2d36-1ea0-4e36-8b30-0faeaf959dd7?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"5dad2d36-1ea0-4e36-8b30-0faeaf959dd7","name":"5dad2d36-1ea0-4e36-8b30-0faeaf959dd7","status":"Succeeded","startTime":"2023-05-17T12:10:12.6052823Z","endTime":"2023-05-17T12:10:12.6052823Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"d93f8d7e-f938-4f23-9758-0b9196e15eef"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:10:57 GMT
+      - Wed, 16 Aug 2023 09:28:54 GMT
       expires:
       - '-1'
       pragma:
@@ -1912,24 +1832,22 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/d93f8d7e-f938-4f23-9758-0b9196e15eef?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/363465af-8fd5-4366-a22e-bdcb26bbb513?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/d93f8d7e-f938-4f23-9758-0b9196e15eef","name":"d93f8d7e-f938-4f23-9758-0b9196e15eef","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT41.4467842S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
-        Share Name":"clitest-item000004","Storage Account Name":"clitest000003","Policy
-        Name":"clitest-item000005"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"ConfigureBackup","status":"Completed","startTime":"2023-05-17T12:10:12.6052823Z","endTime":"2023-05-17T12:10:54.0520665Z","activityId":"ab848b62-f4ab-11ed-988a-c8f750f92764"}}'
+      string: '{"id":"363465af-8fd5-4366-a22e-bdcb26bbb513","name":"363465af-8fd5-4366-a22e-bdcb26bbb513","status":"InProgress","startTime":"2023-08-16T09:28:31.9386678Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '897'
+      - '188'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:58 GMT
+      - Wed, 16 Aug 2023 09:29:00 GMT
       expires:
       - '-1'
       pragma:
@@ -1945,7 +1863,205 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '148'
+      - '289'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/363465af-8fd5-4366-a22e-bdcb26bbb513?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"363465af-8fd5-4366-a22e-bdcb26bbb513","name":"363465af-8fd5-4366-a22e-bdcb26bbb513","status":"InProgress","startTime":"2023-08-16T09:28:31.9386678Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:29:04 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '288'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/363465af-8fd5-4366-a22e-bdcb26bbb513?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"363465af-8fd5-4366-a22e-bdcb26bbb513","name":"363465af-8fd5-4366-a22e-bdcb26bbb513","status":"InProgress","startTime":"2023-08-16T09:28:31.9386678Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:29:10 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '287'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/363465af-8fd5-4366-a22e-bdcb26bbb513?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"363465af-8fd5-4366-a22e-bdcb26bbb513","name":"363465af-8fd5-4366-a22e-bdcb26bbb513","status":"Succeeded","startTime":"2023-08-16T09:28:31.9386678Z","endTime":"2023-08-16T09:28:31.9386678Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"0422e2e3-ff70-4e23-b25e-6a36817afcc2"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:29:16 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '286'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/0422e2e3-ff70-4e23-b25e-6a36817afcc2?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/0422e2e3-ff70-4e23-b25e-6a36817afcc2","name":"0422e2e3-ff70-4e23-b25e-6a36817afcc2","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT41.3707752S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
+        Share Name":"clitest-item000004","Storage Account Name":"clitest000003","Policy
+        Name":"clitest-item000005"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"ConfigureBackup","status":"Completed","startTime":"2023-08-16T09:28:31.9386678Z","endTime":"2023-08-16T09:29:13.309443Z","activityId":"1ff3a016-3c17-11ee-9bbd-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '896'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:29:17 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '149'
     status:
       code: 200
       message: OK
@@ -1965,12 +2081,13 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-storage/21.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000007/listKeys?api-version=2022-09-01&$expand=kerb
   response:
     body:
-      string: '{"keys":[{"creationTime":"2023-05-17T12:11:01.7814307Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2023-05-17T12:11:01.7814307Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
+      string: '{"keys":[{"creationTime":"2023-08-16T09:29:19.3185397Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2023-08-16T09:29:19.3185397Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
     headers:
       cache-control:
       - no-cache
@@ -1979,7 +2096,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 17 May 2023 12:11:24 GMT
+      - Wed, 16 Aug 2023 09:29:42 GMT
       expires:
       - '-1'
       pragma:
@@ -1995,7 +2112,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11994'
     status:
       code: 200
       message: OK
@@ -2013,21 +2130,22 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-storage/21.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000007?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000007","name":"clitest000007","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"keyCreationTime":{"key1":"2023-05-17T12:11:01.7814307Z","key2":"2023-05-17T12:11:01.7814307Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-05-17T12:11:01.7969398Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-05-17T12:11:01.7969398Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-05-17T12:11:01.6875742Z","primaryEndpoints":{"blob":"https://clitest000007.blob.core.windows.net/","queue":"https://clitest000007.queue.core.windows.net/","table":"https://clitest000007.table.core.windows.net/","file":"https://clitest000007.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000007","name":"clitest000007","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"keyCreationTime":{"key1":"2023-08-16T09:29:19.3185397Z","key2":"2023-08-16T09:29:19.3185397Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-08-16T09:29:19.3185397Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-08-16T09:29:19.3185397Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-08-16T09:29:19.2247775Z","primaryEndpoints":{"blob":"https://clitest000007.blob.core.windows.net/","queue":"https://clitest000007.queue.core.windows.net/","table":"https://clitest000007.table.core.windows.net/","file":"https://clitest000007.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1280'
+      - '1316'
       content-type:
       - application/json
       date:
-      - Wed, 17 May 2023 12:11:25 GMT
+      - Wed, 16 Aug 2023 09:29:42 GMT
       expires:
       - '-1'
       pragma:
@@ -2061,9 +2179,10 @@ interactions:
       ParameterSetName:
       - --name --quota --connection-string
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-storage-file-share/12.12.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-storage-file-share/12.12.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Wed, 17 May 2023 12:11:24 GMT
+      - Wed, 16 Aug 2023 09:29:43 GMT
       x-ms-share-quota:
       - '1'
       x-ms-version:
@@ -2077,11 +2196,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:11:26 GMT
+      - Wed, 16 Aug 2023 09:29:43 GMT
       etag:
-      - '"0x8DB56CFD729FCCA"'
+      - '"0x8DB9E3B53609B15"'
       last-modified:
-      - Wed, 17 May 2023 12:11:27 GMT
+      - Wed, 16 Aug 2023 09:29:44 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
@@ -2103,8 +2222,8 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+status+eq+%27Registered%27
   response:
@@ -2118,7 +2237,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:11:28 GMT
+      - Wed, 16 Aug 2023 09:29:45 GMT
       expires:
       - '-1'
       pragma:
@@ -2152,22 +2271,22 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","name":"StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"adiguptecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/adigupt-ecy-rg/providers/Microsoft.Storage/storageAccounts/adiguptecy"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg2yfprhyqds;clitesttz6sdom2jatwnfac4","name":"StorageContainer;Storage;clitest.rg2yfprhyqds;clitesttz6sdom2jatwnfac4","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesttz6sdom2jatwnfac4","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg2yfprhyqds/providers/Microsoft.Storage/storageAccounts/clitesttz6sdom2jatwnfac4"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgaphtzd4b6w;clitest2e4uvoffeuotuhhkv","name":"StorageContainer;Storage;clitest.rgaphtzd4b6w;clitest2e4uvoffeuotuhhkv","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest2e4uvoffeuotuhhkv","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgaphtzd4b6w/providers/Microsoft.Storage/storageAccounts/clitest2e4uvoffeuotuhhkv"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx;clitest5g7td7ozjqq2b6ccr","name":"StorageContainer;Storage;clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx;clitest5g7td7ozjqq2b6ccr","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest5g7td7ozjqq2b6ccr","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx/providers/Microsoft.Storage/storageAccounts/clitest5g7td7ozjqq2b6ccr"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgt7y3m2jxoj;clitest4ok6wrvjr5q6texyd","name":"StorageContainer;Storage;clitest.rgt7y3m2jxoj;clitest4ok6wrvjr5q6texyd","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest4ok6wrvjr5q6texyd","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgt7y3m2jxoj/providers/Microsoft.Storage/storageAccounts/clitest4ok6wrvjr5q6texyd"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rguojke4c6gf;clitestid5t5zlxfktv7il2t","name":"StorageContainer;Storage;clitest.rguojke4c6gf;clitestid5t5zlxfktv7il2t","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestid5t5zlxfktv7il2t","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rguojke4c6gf/providers/Microsoft.Storage/storageAccounts/clitestid5t5zlxfktv7il2t"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","name":"StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontusebvtaksecycansa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DonotUse-Blobs-BVT-EACAN-RG/providers/Microsoft.Storage/storageAccounts/dontusebvtaksecycansa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","name":"StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"iaasextstoreecy1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.czr/providers/Microsoft.Storage/storageAccounts/iaasextstoreecy1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","name":"StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesaksdonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-clitest-rg/providers/Microsoft.Storage/storageAccounts/clitesaksdonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"bloboprestorecontainers","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/bloboprestorecontainers"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopall","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopall"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopcontainer","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopcontainer"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopprefix","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopprefix"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG;zubairsaecy","name":"StorageContainer;Storage;zubairRG;zubairsaecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Storage/storageAccounts/zubairsaecy"}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","name":"StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"adiguptecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/adigupt-ecy-rg/providers/Microsoft.Storage/storageAccounts/adiguptecy"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","name":"StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontusebvtaksecycansa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DonotUse-Blobs-BVT-EACAN-RG/providers/Microsoft.Storage/storageAccounts/dontusebvtaksecycansa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","name":"StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"iaasextstoreecy1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.czr/providers/Microsoft.Storage/storageAccounts/iaasextstoreecy1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","name":"StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesaksdonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-clitest-rg/providers/Microsoft.Storage/storageAccounts/clitesaksdonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"bloboprestorecontainers","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/bloboprestorecontainers"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopall","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopall"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopcontainer","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopcontainer"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopprefix","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopprefix"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG2;zubairsaecy2","name":"StorageContainer;Storage;zubairRG2;zubairsaecy2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy2","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG2/providers/Microsoft.Storage/storageAccounts/zubairsaecy2"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG;zubairsaecy","name":"StorageContainer;Storage;zubairRG;zubairsaecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Storage/storageAccounts/zubairsaecy"}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '10834'
+      - '7516'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:11:29 GMT
+      - Wed, 16 Aug 2023 09:29:46 GMT
       expires:
       - '-1'
       pragma:
@@ -2183,7 +2302,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '297'
     status:
       code: 200
       message: OK
@@ -2203,8 +2322,8 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/refreshContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
@@ -2212,17 +2331,17 @@ interactions:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/177921b5-5d58-429c-b0b7-5d59c070a433?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/c6f612f8-7ef9-488e-8a40-afed20db757e?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:11:31 GMT
+      - Wed, 16 Aug 2023 09:29:48 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/177921b5-5d58-429c-b0b7-5d59c070a433?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/c6f612f8-7ef9-488e-8a40-afed20db757e?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -2232,7 +2351,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
     status:
       code: 202
       message: Accepted
@@ -2250,10 +2369,10 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/177921b5-5d58-429c-b0b7-5d59c070a433?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/c6f612f8-7ef9-488e-8a40-afed20db757e?api-version=2023-02-01
   response:
     body:
       string: ''
@@ -2263,11 +2382,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:11:31 GMT
+      - Wed, 16 Aug 2023 09:29:49 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/177921b5-5d58-429c-b0b7-5d59c070a433?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/c6f612f8-7ef9-488e-8a40-afed20db757e?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -2277,7 +2396,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '293'
     status:
       code: 202
       message: Accepted
@@ -2295,10 +2414,10 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/177921b5-5d58-429c-b0b7-5d59c070a433?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/c6f612f8-7ef9-488e-8a40-afed20db757e?api-version=2023-02-01
   response:
     body:
       string: ''
@@ -2308,11 +2427,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:11:37 GMT
+      - Wed, 16 Aug 2023 09:29:54 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/177921b5-5d58-429c-b0b7-5d59c070a433?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/c6f612f8-7ef9-488e-8a40-afed20db757e?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -2322,7 +2441,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '292'
     status:
       code: 202
       message: Accepted
@@ -2340,10 +2459,10 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/177921b5-5d58-429c-b0b7-5d59c070a433?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/c6f612f8-7ef9-488e-8a40-afed20db757e?api-version=2023-02-01
   response:
     body:
       string: ''
@@ -2351,7 +2470,7 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Wed, 17 May 2023 12:11:42 GMT
+      - Wed, 16 Aug 2023 09:30:00 GMT
       expires:
       - '-1'
       pragma:
@@ -2363,7 +2482,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
+      - '291'
     status:
       code: 204
       message: No Content
@@ -2381,22 +2500,22 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","name":"StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"adiguptecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/adigupt-ecy-rg/providers/Microsoft.Storage/storageAccounts/adiguptecy"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg2yfprhyqds;clitesttz6sdom2jatwnfac4","name":"StorageContainer;Storage;clitest.rg2yfprhyqds;clitesttz6sdom2jatwnfac4","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesttz6sdom2jatwnfac4","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg2yfprhyqds/providers/Microsoft.Storage/storageAccounts/clitesttz6sdom2jatwnfac4"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg000001;clitest000007","name":"StorageContainer;Storage;clitest.rg000001;clitest000007","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest000007","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000007"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgaphtzd4b6w;clitest2e4uvoffeuotuhhkv","name":"StorageContainer;Storage;clitest.rgaphtzd4b6w;clitest2e4uvoffeuotuhhkv","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest2e4uvoffeuotuhhkv","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgaphtzd4b6w/providers/Microsoft.Storage/storageAccounts/clitest2e4uvoffeuotuhhkv"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx;clitest5g7td7ozjqq2b6ccr","name":"StorageContainer;Storage;clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx;clitest5g7td7ozjqq2b6ccr","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest5g7td7ozjqq2b6ccr","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx/providers/Microsoft.Storage/storageAccounts/clitest5g7td7ozjqq2b6ccr"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgt7y3m2jxoj;clitest4ok6wrvjr5q6texyd","name":"StorageContainer;Storage;clitest.rgt7y3m2jxoj;clitest4ok6wrvjr5q6texyd","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest4ok6wrvjr5q6texyd","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgt7y3m2jxoj/providers/Microsoft.Storage/storageAccounts/clitest4ok6wrvjr5q6texyd"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rguojke4c6gf;clitestid5t5zlxfktv7il2t","name":"StorageContainer;Storage;clitest.rguojke4c6gf;clitestid5t5zlxfktv7il2t","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestid5t5zlxfktv7il2t","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rguojke4c6gf/providers/Microsoft.Storage/storageAccounts/clitestid5t5zlxfktv7il2t"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","name":"StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontusebvtaksecycansa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DonotUse-Blobs-BVT-EACAN-RG/providers/Microsoft.Storage/storageAccounts/dontusebvtaksecycansa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","name":"StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"iaasextstoreecy1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.czr/providers/Microsoft.Storage/storageAccounts/iaasextstoreecy1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","name":"StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesaksdonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-clitest-rg/providers/Microsoft.Storage/storageAccounts/clitesaksdonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"bloboprestorecontainers","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/bloboprestorecontainers"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopall","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopall"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopcontainer","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopcontainer"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopprefix","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopprefix"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG;zubairsaecy","name":"StorageContainer;Storage;zubairRG;zubairsaecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Storage/storageAccounts/zubairsaecy"}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","name":"StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"adiguptecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/adigupt-ecy-rg/providers/Microsoft.Storage/storageAccounts/adiguptecy"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg000001;clitest000007","name":"StorageContainer;Storage;clitest.rg000001;clitest000007","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest000007","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000007"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","name":"StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontusebvtaksecycansa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DonotUse-Blobs-BVT-EACAN-RG/providers/Microsoft.Storage/storageAccounts/dontusebvtaksecycansa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","name":"StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"iaasextstoreecy1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.czr/providers/Microsoft.Storage/storageAccounts/iaasextstoreecy1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","name":"StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesaksdonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-clitest-rg/providers/Microsoft.Storage/storageAccounts/clitesaksdonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"bloboprestorecontainers","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/bloboprestorecontainers"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopall","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopall"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopcontainer","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopcontainer"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopprefix","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopprefix"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG2;zubairsaecy2","name":"StorageContainer;Storage;zubairRG2;zubairsaecy2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy2","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG2/providers/Microsoft.Storage/storageAccounts/zubairsaecy2"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG;zubairsaecy","name":"StorageContainer;Storage;zubairRG;zubairsaecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Storage/storageAccounts/zubairsaecy"}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '11546'
+      - '8228'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:11:44 GMT
+      - Wed, 16 Aug 2023 09:30:01 GMT
       expires:
       - '-1'
       pragma:
@@ -2435,8 +2554,8 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007?api-version=2023-02-01
   response:
@@ -2444,7 +2563,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationsStatus/c52009ab-c953-4a38-a7da-17f8c8a6b887?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationsStatus/803bdfab-9604-4d5f-9926-7cfb015294c2?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -2452,11 +2571,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:11:46 GMT
+      - Wed, 16 Aug 2023 09:30:02 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationResults/c52009ab-c953-4a38-a7da-17f8c8a6b887?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationResults/803bdfab-9604-4d5f-9926-7cfb015294c2?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -2466,7 +2585,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1196'
+      - '1198'
     status:
       code: 202
       message: Accepted
@@ -2484,16 +2603,16 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007/operationResults/c52009ab-c953-4a38-a7da-17f8c8a6b887?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007/operationResults/803bdfab-9604-4d5f-9926-7cfb015294c2?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationsStatus/c52009ab-c953-4a38-a7da-17f8c8a6b887?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationsStatus/803bdfab-9604-4d5f-9926-7cfb015294c2?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -2501,11 +2620,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:11:47 GMT
+      - Wed, 16 Aug 2023 09:30:03 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationResults/c52009ab-c953-4a38-a7da-17f8c8a6b887?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationResults/803bdfab-9604-4d5f-9926-7cfb015294c2?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -2533,16 +2652,16 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007/operationResults/c52009ab-c953-4a38-a7da-17f8c8a6b887?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007/operationResults/803bdfab-9604-4d5f-9926-7cfb015294c2?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationsStatus/c52009ab-c953-4a38-a7da-17f8c8a6b887?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationsStatus/803bdfab-9604-4d5f-9926-7cfb015294c2?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -2550,11 +2669,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:11:53 GMT
+      - Wed, 16 Aug 2023 09:30:09 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationResults/c52009ab-c953-4a38-a7da-17f8c8a6b887?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationResults/803bdfab-9604-4d5f-9926-7cfb015294c2?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -2582,10 +2701,255 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007/operationResults/c52009ab-c953-4a38-a7da-17f8c8a6b887?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007/operationResults/803bdfab-9604-4d5f-9926-7cfb015294c2?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationsStatus/803bdfab-9604-4d5f-9926-7cfb015294c2?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:30:14 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationResults/803bdfab-9604-4d5f-9926-7cfb015294c2?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '297'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007/operationResults/803bdfab-9604-4d5f-9926-7cfb015294c2?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationsStatus/803bdfab-9604-4d5f-9926-7cfb015294c2?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:30:20 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationResults/803bdfab-9604-4d5f-9926-7cfb015294c2?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '296'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007/operationResults/803bdfab-9604-4d5f-9926-7cfb015294c2?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationsStatus/803bdfab-9604-4d5f-9926-7cfb015294c2?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:30:24 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationResults/803bdfab-9604-4d5f-9926-7cfb015294c2?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '294'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007/operationResults/803bdfab-9604-4d5f-9926-7cfb015294c2?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationsStatus/803bdfab-9604-4d5f-9926-7cfb015294c2?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:30:30 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationResults/803bdfab-9604-4d5f-9926-7cfb015294c2?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '292'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007/operationResults/803bdfab-9604-4d5f-9926-7cfb015294c2?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationsStatus/803bdfab-9604-4d5f-9926-7cfb015294c2?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:30:36 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationResults/803bdfab-9604-4d5f-9926-7cfb015294c2?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '290'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007/operationResults/803bdfab-9604-4d5f-9926-7cfb015294c2?api-version=2023-02-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007","name":"StorageContainer;Storage;clitest.rg000001;clitest000007","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000007","protectedItemCount":0,"acquireStorageAccountLock":"Acquire","friendlyName":"clitest000007","backupManagementType":"AzureStorage","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"StorageContainer","protectableObjectType":"StorageContainer"}}'
@@ -2597,738 +2961,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:11:58 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectableItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+workloadType+eq+%27AzureFileShare%27
-  response:
-    body:
-      string: '{"value":[]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '12'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:12:00 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007/inquire?api-version=2023-02-01&%24filter=workloadType+eq+%27AzureFileShare%27
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationsStatus/9d444496-12f9-43ac-befd-4f2dc53a6b10?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Wed, 17 May 2023 12:12:00 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationResults/9d444496-12f9-43ac-befd-4f2dc53a6b10?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007/operationResults/9d444496-12f9-43ac-befd-4f2dc53a6b10?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationsStatus/9d444496-12f9-43ac-befd-4f2dc53a6b10?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:12:01 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationResults/9d444496-12f9-43ac-befd-4f2dc53a6b10?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '287'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007/operationResults/9d444496-12f9-43ac-befd-4f2dc53a6b10?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationsStatus/9d444496-12f9-43ac-befd-4f2dc53a6b10?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:12:07 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationResults/9d444496-12f9-43ac-befd-4f2dc53a6b10?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '286'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007/operationResults/9d444496-12f9-43ac-befd-4f2dc53a6b10?api-version=2023-02-01
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      date:
-      - Wed, 17 May 2023 12:12:13 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '285'
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectableItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+workloadType+eq+%27AzureFileShare%27
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000007/protectableItems/azurefileshare;f6ad1e906ad7f1d8e330babc98fe3a756f4a8ceca2c10b420444d31e2c6530fd","name":"azurefileshare;f6ad1e906ad7f1d8e330babc98fe3a756f4a8ceca2c10b420444d31e2c6530fd","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"parentContainerFabricId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000007","parentContainerFriendlyName":"clitest000007","azureFileShareType":"XSMB","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","protectableItemType":"AzureFileShare","friendlyName":"clitest-item000008","protectionState":"NotProtected"}}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '983'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:12:13 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","name":"clitest-item000005","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":1}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '719'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:12:14 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"protectedItemType": "AzureFileShareProtectedItem", "sourceResourceId":
-      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000007",
-      "policyId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005"}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '430'
-      Content-Type:
-      - application/json
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer%3Bstorage%3Bclitest.rg000001%3Bclitest000007/protectedItems/azurefileshare%3Bf6ad1e906ad7f1d8e330babc98fe3a756f4a8ceca2c10b420444d31e2c6530fd?api-version=2023-02-01
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000007/protectedItems/azurefileshare;f6ad1e906ad7f1d8e330babc98fe3a756f4a8ceca2c10b420444d31e2c6530fd/operationsStatus/24af185c-63c3-4793-978c-ae37c9b30cc5?api-version=2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Wed, 17 May 2023 12:12:16 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000007/protectedItems/azurefileshare;f6ad1e906ad7f1d8e330babc98fe3a756f4a8ceca2c10b420444d31e2c6530fd/operationResults/24af185c-63c3-4793-978c-ae37c9b30cc5?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1189'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/24af185c-63c3-4793-978c-ae37c9b30cc5?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"24af185c-63c3-4793-978c-ae37c9b30cc5","name":"24af185c-63c3-4793-978c-ae37c9b30cc5","status":"InProgress","startTime":"2023-05-17T12:12:16.3368076Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:12:17 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/24af185c-63c3-4793-978c-ae37c9b30cc5?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"24af185c-63c3-4793-978c-ae37c9b30cc5","name":"24af185c-63c3-4793-978c-ae37c9b30cc5","status":"InProgress","startTime":"2023-05-17T12:12:16.3368076Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:12:23 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/24af185c-63c3-4793-978c-ae37c9b30cc5?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"24af185c-63c3-4793-978c-ae37c9b30cc5","name":"24af185c-63c3-4793-978c-ae37c9b30cc5","status":"InProgress","startTime":"2023-05-17T12:12:16.3368076Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:12:28 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '295'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/24af185c-63c3-4793-978c-ae37c9b30cc5?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"24af185c-63c3-4793-978c-ae37c9b30cc5","name":"24af185c-63c3-4793-978c-ae37c9b30cc5","status":"InProgress","startTime":"2023-05-17T12:12:16.3368076Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:12:34 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '293'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/24af185c-63c3-4793-978c-ae37c9b30cc5?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"24af185c-63c3-4793-978c-ae37c9b30cc5","name":"24af185c-63c3-4793-978c-ae37c9b30cc5","status":"InProgress","startTime":"2023-05-17T12:12:16.3368076Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:12:39 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '291'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/24af185c-63c3-4793-978c-ae37c9b30cc5?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"24af185c-63c3-4793-978c-ae37c9b30cc5","name":"24af185c-63c3-4793-978c-ae37c9b30cc5","status":"InProgress","startTime":"2023-05-17T12:12:16.3368076Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:12:45 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '289'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/24af185c-63c3-4793-978c-ae37c9b30cc5?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"24af185c-63c3-4793-978c-ae37c9b30cc5","name":"24af185c-63c3-4793-978c-ae37c9b30cc5","status":"InProgress","startTime":"2023-05-17T12:12:16.3368076Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:12:51 GMT
+      - Wed, 16 Aug 2023 09:30:41 GMT
       expires:
       - '-1'
       pragma:
@@ -3362,13 +2995,164 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/24af185c-63c3-4793-978c-ae37c9b30cc5?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectableItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+workloadType+eq+%27AzureFileShare%27
   response:
     body:
-      string: '{"id":"24af185c-63c3-4793-978c-ae37c9b30cc5","name":"24af185c-63c3-4793-978c-ae37c9b30cc5","status":"InProgress","startTime":"2023-05-17T12:12:16.3368076Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000007/protectableItems/azurefileshare;7a4d1a0415368473a0b96eabff013d9ad9cb1bf9618e79ef742a9188aa5fac36","name":"azurefileshare;7a4d1a0415368473a0b96eabff013d9ad9cb1bf9618e79ef742a9188aa5fac36","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"parentContainerFabricId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000007","parentContainerFriendlyName":"clitest000007","azureFileShareType":"XSMB","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","protectableItemType":"AzureFileShare","friendlyName":"clitest-item000008","protectionState":"NotProtected"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '983'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:30:43 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '298'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","name":"clitest-item000005","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","workLoadType":"AzureFileShare","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T19:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T19:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":1}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '751'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:30:43 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '293'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"protectedItemType": "AzureFileShareProtectedItem", "sourceResourceId":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000007",
+      "policyId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '430'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer%3Bstorage%3Bclitest.rg000001%3Bclitest000007/protectedItems/azurefileshare%3B7a4d1a0415368473a0b96eabff013d9ad9cb1bf9618e79ef742a9188aa5fac36?api-version=2023-02-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000007/protectedItems/azurefileshare;7a4d1a0415368473a0b96eabff013d9ad9cb1bf9618e79ef742a9188aa5fac36/operationsStatus/8f01362b-746d-49ae-9698-b844c9149378?api-version=2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Wed, 16 Aug 2023 09:30:45 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000007/protectedItems/azurefileshare;7a4d1a0415368473a0b96eabff013d9ad9cb1bf9618e79ef742a9188aa5fac36/operationResults/8f01362b-746d-49ae-9698-b844c9149378?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1196'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8f01362b-746d-49ae-9698-b844c9149378?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"8f01362b-746d-49ae-9698-b844c9149378","name":"8f01362b-746d-49ae-9698-b844c9149378","status":"InProgress","startTime":"2023-08-16T09:30:45.5843803Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -3377,7 +3161,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:12:56 GMT
+      - Wed, 16 Aug 2023 09:30:46 GMT
       expires:
       - '-1'
       pragma:
@@ -3393,7 +3177,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '287'
+      - '280'
     status:
       code: 200
       message: OK
@@ -3411,13 +3195,356 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/24af185c-63c3-4793-978c-ae37c9b30cc5?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8f01362b-746d-49ae-9698-b844c9149378?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"24af185c-63c3-4793-978c-ae37c9b30cc5","name":"24af185c-63c3-4793-978c-ae37c9b30cc5","status":"Succeeded","startTime":"2023-05-17T12:12:16.3368076Z","endTime":"2023-05-17T12:12:16.3368076Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"6cc095a8-e09a-4099-bbd2-f33aa5dc7147"}}'
+      string: '{"id":"8f01362b-746d-49ae-9698-b844c9149378","name":"8f01362b-746d-49ae-9698-b844c9149378","status":"InProgress","startTime":"2023-08-16T09:30:45.5843803Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:30:52 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '279'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8f01362b-746d-49ae-9698-b844c9149378?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"8f01362b-746d-49ae-9698-b844c9149378","name":"8f01362b-746d-49ae-9698-b844c9149378","status":"InProgress","startTime":"2023-08-16T09:30:45.5843803Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:30:57 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '277'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8f01362b-746d-49ae-9698-b844c9149378?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"8f01362b-746d-49ae-9698-b844c9149378","name":"8f01362b-746d-49ae-9698-b844c9149378","status":"InProgress","startTime":"2023-08-16T09:30:45.5843803Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:31:02 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '275'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8f01362b-746d-49ae-9698-b844c9149378?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"8f01362b-746d-49ae-9698-b844c9149378","name":"8f01362b-746d-49ae-9698-b844c9149378","status":"InProgress","startTime":"2023-08-16T09:30:45.5843803Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:31:08 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '273'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8f01362b-746d-49ae-9698-b844c9149378?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"8f01362b-746d-49ae-9698-b844c9149378","name":"8f01362b-746d-49ae-9698-b844c9149378","status":"InProgress","startTime":"2023-08-16T09:30:45.5843803Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:31:13 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '271'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8f01362b-746d-49ae-9698-b844c9149378?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"8f01362b-746d-49ae-9698-b844c9149378","name":"8f01362b-746d-49ae-9698-b844c9149378","status":"InProgress","startTime":"2023-08-16T09:30:45.5843803Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:31:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '269'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8f01362b-746d-49ae-9698-b844c9149378?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"8f01362b-746d-49ae-9698-b844c9149378","name":"8f01362b-746d-49ae-9698-b844c9149378","status":"InProgress","startTime":"2023-08-16T09:30:45.5843803Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:31:24 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '267'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8f01362b-746d-49ae-9698-b844c9149378?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"8f01362b-746d-49ae-9698-b844c9149378","name":"8f01362b-746d-49ae-9698-b844c9149378","status":"Succeeded","startTime":"2023-08-16T09:30:45.5843803Z","endTime":"2023-08-16T09:30:45.5843803Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"e2c4293f-2ced-423d-b029-205a0d002d69"}}'
     headers:
       cache-control:
       - no-cache
@@ -3426,7 +3553,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:13:03 GMT
+      - Wed, 16 Aug 2023 09:31:29 GMT
       expires:
       - '-1'
       pragma:
@@ -3442,7 +3569,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '286'
+      - '265'
     status:
       code: 200
       message: OK
@@ -3460,15 +3587,15 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/6cc095a8-e09a-4099-bbd2-f33aa5dc7147?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/e2c4293f-2ced-423d-b029-205a0d002d69?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/6cc095a8-e09a-4099-bbd2-f33aa5dc7147","name":"6cc095a8-e09a-4099-bbd2-f33aa5dc7147","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT41.3729448S","storageAccountName":"clitest000007","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/e2c4293f-2ced-423d-b029-205a0d002d69","name":"e2c4293f-2ced-423d-b029-205a0d002d69","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT41.3678042S","storageAccountName":"clitest000007","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
         Share Name":"clitest-item000008","Storage Account Name":"clitest000007","Policy
-        Name":"clitest-item000005"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"ConfigureBackup","status":"Completed","startTime":"2023-05-17T12:12:16.3523808Z","endTime":"2023-05-17T12:12:57.7253256Z","activityId":"f22fcc77-f4ab-11ed-ae7f-c8f750f92764"}}'
+        Name":"clitest-item000005"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"ConfigureBackup","status":"Completed","startTime":"2023-08-16T09:30:45.5843803Z","endTime":"2023-08-16T09:31:26.9521845Z","activityId":"6f713d88-3c17-11ee-87f7-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
@@ -3477,7 +3604,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:13:03 GMT
+      - Wed, 16 Aug 2023 09:31:31 GMT
       expires:
       - '-1'
       pragma:
@@ -3511,8 +3638,8 @@ interactions:
       ParameterSetName:
       - -n -v -g --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+friendlyName+eq+%27clitest000007%27+and+status+eq+%27Registered%27
   response:
@@ -3526,7 +3653,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:13:04 GMT
+      - Wed, 16 Aug 2023 09:31:32 GMT
       expires:
       - '-1'
       pragma:
@@ -3542,7 +3669,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '298'
     status:
       code: 200
       message: OK
@@ -3560,13 +3687,13 @@ interactions:
       ParameterSetName:
       - -n -v -g
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+status+eq+%27Registered%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007","name":"StorageContainer;Storage;clitest.rg000001;clitest000007","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000007","protectedItemCount":1,"acquireStorageAccountLock":"Acquire","friendlyName":"clitest000007","backupManagementType":"AzureStorage","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"StorageContainer","protectableObjectType":"StorageContainer"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","protectedItemCount":1,"acquireStorageAccountLock":"Acquire","friendlyName":"clitest000003","backupManagementType":"AzureStorage","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"StorageContainer","protectableObjectType":"StorageContainer"}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","protectedItemCount":1,"acquireStorageAccountLock":"Acquire","friendlyName":"clitest000003","backupManagementType":"AzureStorage","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"StorageContainer","protectableObjectType":"StorageContainer"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007","name":"StorageContainer;Storage;clitest.rg000001;clitest000007","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000007","protectedItemCount":1,"acquireStorageAccountLock":"Acquire","friendlyName":"clitest000007","backupManagementType":"AzureStorage","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"StorageContainer","protectableObjectType":"StorageContainer"}}]}'
     headers:
       cache-control:
       - no-cache
@@ -3575,7 +3702,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:13:05 GMT
+      - Wed, 16 Aug 2023 09:31:33 GMT
       expires:
       - '-1'
       pragma:
@@ -3591,7 +3718,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '296'
     status:
       code: 200
       message: OK
@@ -3609,13 +3736,13 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+status+eq+%27Registered%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007","name":"StorageContainer;Storage;clitest.rg000001;clitest000007","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000007","protectedItemCount":1,"acquireStorageAccountLock":"Acquire","friendlyName":"clitest000007","backupManagementType":"AzureStorage","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"StorageContainer","protectableObjectType":"StorageContainer"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","protectedItemCount":1,"acquireStorageAccountLock":"Acquire","friendlyName":"clitest000003","backupManagementType":"AzureStorage","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"StorageContainer","protectableObjectType":"StorageContainer"}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","protectedItemCount":1,"acquireStorageAccountLock":"Acquire","friendlyName":"clitest000003","backupManagementType":"AzureStorage","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"StorageContainer","protectableObjectType":"StorageContainer"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007","name":"StorageContainer;Storage;clitest.rg000001;clitest000007","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000007","protectedItemCount":1,"acquireStorageAccountLock":"Acquire","friendlyName":"clitest000007","backupManagementType":"AzureStorage","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"StorageContainer","protectableObjectType":"StorageContainer"}}]}'
     headers:
       cache-control:
       - no-cache
@@ -3624,7 +3751,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:13:06 GMT
+      - Wed, 16 Aug 2023 09:31:34 GMT
       expires:
       - '-1'
       pragma:
@@ -3658,13 +3785,13 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --backup-management-type --delete-backup-data --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000007/protectedItems/AzureFileShare;f6ad1e906ad7f1d8e330babc98fe3a756f4a8ceca2c10b420444d31e2c6530fd","name":"AzureFileShare;f6ad1e906ad7f1d8e330babc98fe3a756f4a8ceca2c10b420444d31e2c6530fd","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000008","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000007","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000007","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;9aab449eeb0a587b1a0bad3ba3fbfd73eb85468b78342621fda665235d35d88b","name":"AzureFileShare;9aab449eeb0a587b1a0bad3ba3fbfd73eb85468b78342621fda665235d35d88b","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;e507b8700265f2adcfcf47abf6a9e732db86b73363c1f002236ab1bbbdf3f377","name":"AzureFileShare;e507b8700265f2adcfcf47abf6a9e732db86b73363c1f002236ab1bbbdf3f377","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000007/protectedItems/AzureFileShare;7a4d1a0415368473a0b96eabff013d9ad9cb1bf9618e79ef742a9188aa5fac36","name":"AzureFileShare;7a4d1a0415368473a0b96eabff013d9ad9cb1bf9618e79ef742a9188aa5fac36","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000008","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000007","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000007","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
     headers:
       cache-control:
       - no-cache
@@ -3673,250 +3800,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:13:06 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupResourceGuardProxies?api-version=2023-02-01
-  response:
-    body:
-      string: '{"value":[]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '12'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:13:07 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3B9aab449eeb0a587b1a0bad3ba3fbfd73eb85468b78342621fda665235d35d88b?api-version=2023-02-01
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/cc202042-bd78-4ed5-aa6c-b5eae6dcaa5d?api-version=2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Wed, 17 May 2023 12:13:08 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/cc202042-bd78-4ed5-aa6c-b5eae6dcaa5d?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-deletes:
-      - '14998'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/cc202042-bd78-4ed5-aa6c-b5eae6dcaa5d?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"cc202042-bd78-4ed5-aa6c-b5eae6dcaa5d","name":"cc202042-bd78-4ed5-aa6c-b5eae6dcaa5d","status":"InProgress","startTime":"2023-05-17T12:13:08.8747865Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:13:08 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/cc202042-bd78-4ed5-aa6c-b5eae6dcaa5d?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"cc202042-bd78-4ed5-aa6c-b5eae6dcaa5d","name":"cc202042-bd78-4ed5-aa6c-b5eae6dcaa5d","status":"InProgress","startTime":"2023-05-17T12:13:08.8747865Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:13:15 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/cc202042-bd78-4ed5-aa6c-b5eae6dcaa5d?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"cc202042-bd78-4ed5-aa6c-b5eae6dcaa5d","name":"cc202042-bd78-4ed5-aa6c-b5eae6dcaa5d","status":"InProgress","startTime":"2023-05-17T12:13:08.8747865Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:13:20 GMT
+      - Wed, 16 Aug 2023 09:31:35 GMT
       expires:
       - '-1'
       pragma:
@@ -3950,13 +3834,109 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --backup-management-type --delete-backup-data --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/cc202042-bd78-4ed5-aa6c-b5eae6dcaa5d?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupResourceGuardProxies?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"cc202042-bd78-4ed5-aa6c-b5eae6dcaa5d","name":"cc202042-bd78-4ed5-aa6c-b5eae6dcaa5d","status":"InProgress","startTime":"2023-05-17T12:13:08.8747865Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:31:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3Be507b8700265f2adcfcf47abf6a9e732db86b73363c1f002236ab1bbbdf3f377?api-version=2023-02-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/9bcce7c4-ad09-41be-b7d7-fe8f9fbb452e?api-version=2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Wed, 16 Aug 2023 09:31:38 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/9bcce7c4-ad09-41be-b7d7-fe8f9fbb452e?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14997'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/9bcce7c4-ad09-41be-b7d7-fe8f9fbb452e?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"9bcce7c4-ad09-41be-b7d7-fe8f9fbb452e","name":"9bcce7c4-ad09-41be-b7d7-fe8f9fbb452e","status":"InProgress","startTime":"2023-08-16T09:31:39.0069147Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -3965,7 +3945,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:13:26 GMT
+      - Wed, 16 Aug 2023 09:31:39 GMT
       expires:
       - '-1'
       pragma:
@@ -3981,7 +3961,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '296'
+      - '290'
     status:
       code: 200
       message: OK
@@ -3999,13 +3979,160 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --backup-management-type --delete-backup-data --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/cc202042-bd78-4ed5-aa6c-b5eae6dcaa5d?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/9bcce7c4-ad09-41be-b7d7-fe8f9fbb452e?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"cc202042-bd78-4ed5-aa6c-b5eae6dcaa5d","name":"cc202042-bd78-4ed5-aa6c-b5eae6dcaa5d","status":"Succeeded","startTime":"2023-05-17T12:13:08.8747865Z","endTime":"2023-05-17T12:13:08.8747865Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"ac0ec90d-9c1e-4def-b8d3-55954034d7c7"}}'
+      string: '{"id":"9bcce7c4-ad09-41be-b7d7-fe8f9fbb452e","name":"9bcce7c4-ad09-41be-b7d7-fe8f9fbb452e","status":"InProgress","startTime":"2023-08-16T09:31:39.0069147Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:31:45 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '289'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/9bcce7c4-ad09-41be-b7d7-fe8f9fbb452e?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"9bcce7c4-ad09-41be-b7d7-fe8f9fbb452e","name":"9bcce7c4-ad09-41be-b7d7-fe8f9fbb452e","status":"InProgress","startTime":"2023-08-16T09:31:39.0069147Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:31:50 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '288'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/9bcce7c4-ad09-41be-b7d7-fe8f9fbb452e?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"9bcce7c4-ad09-41be-b7d7-fe8f9fbb452e","name":"9bcce7c4-ad09-41be-b7d7-fe8f9fbb452e","status":"InProgress","startTime":"2023-08-16T09:31:39.0069147Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:31:55 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '286'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/9bcce7c4-ad09-41be-b7d7-fe8f9fbb452e?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"9bcce7c4-ad09-41be-b7d7-fe8f9fbb452e","name":"9bcce7c4-ad09-41be-b7d7-fe8f9fbb452e","status":"Succeeded","startTime":"2023-08-16T09:31:39.0069147Z","endTime":"2023-08-16T09:31:39.0069147Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"01b9fe26-7370-4374-9323-b713ea758a07"}}'
     headers:
       cache-control:
       - no-cache
@@ -4014,7 +4141,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:13:31 GMT
+      - Wed, 16 Aug 2023 09:32:01 GMT
       expires:
       - '-1'
       pragma:
@@ -4030,7 +4157,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '295'
+      - '284'
     status:
       code: 200
       message: OK
@@ -4048,14 +4175,14 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --backup-management-type --delete-backup-data --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/ac0ec90d-9c1e-4def-b8d3-55954034d7c7?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/01b9fe26-7370-4374-9323-b713ea758a07?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/ac0ec90d-9c1e-4def-b8d3-55954034d7c7","name":"ac0ec90d-9c1e-4def-b8d3-55954034d7c7","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT20.8970697S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
-        Share Name":"clitest-item000004","Storage Account Name":"clitest000003"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"DeleteBackupData","status":"Completed","startTime":"2023-05-17T12:13:08.8747865Z","endTime":"2023-05-17T12:13:29.7718562Z","activityId":"2d50b6e2-f4ac-11ed-8618-c8f750f92764"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/01b9fe26-7370-4374-9323-b713ea758a07","name":"01b9fe26-7370-4374-9323-b713ea758a07","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT21.0295736S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
+        Share Name":"clitest-item000004","Storage Account Name":"clitest000003"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"DeleteBackupData","status":"Completed","startTime":"2023-08-16T09:31:39.0069147Z","endTime":"2023-08-16T09:32:00.0364883Z","activityId":"b1960e77-3c17-11ee-9496-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
@@ -4064,7 +4191,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:13:32 GMT
+      - Wed, 16 Aug 2023 09:32:02 GMT
       expires:
       - '-1'
       pragma:
@@ -4098,13 +4225,13 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --backup-management-type --delete-backup-data --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000007/protectedItems/AzureFileShare;f6ad1e906ad7f1d8e330babc98fe3a756f4a8ceca2c10b420444d31e2c6530fd","name":"AzureFileShare;f6ad1e906ad7f1d8e330babc98fe3a756f4a8ceca2c10b420444d31e2c6530fd","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000008","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000007","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000007","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000007/protectedItems/AzureFileShare;7a4d1a0415368473a0b96eabff013d9ad9cb1bf9618e79ef742a9188aa5fac36","name":"AzureFileShare;7a4d1a0415368473a0b96eabff013d9ad9cb1bf9618e79ef742a9188aa5fac36","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000008","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000007","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000007","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
     headers:
       cache-control:
       - no-cache
@@ -4113,299 +4240,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:13:32 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupResourceGuardProxies?api-version=2023-02-01
-  response:
-    body:
-      string: '{"value":[]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '12'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:13:34 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000007/protectedItems/AzureFileShare%3Bf6ad1e906ad7f1d8e330babc98fe3a756f4a8ceca2c10b420444d31e2c6530fd?api-version=2023-02-01
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/6d9d8e6c-e01a-42af-a2cc-c962e5aeb926?api-version=2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Wed, 17 May 2023 12:13:35 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/6d9d8e6c-e01a-42af-a2cc-c962e5aeb926?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-deletes:
-      - '14998'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/6d9d8e6c-e01a-42af-a2cc-c962e5aeb926?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"6d9d8e6c-e01a-42af-a2cc-c962e5aeb926","name":"6d9d8e6c-e01a-42af-a2cc-c962e5aeb926","status":"InProgress","startTime":"2023-05-17T12:13:35.8716751Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:13:36 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/6d9d8e6c-e01a-42af-a2cc-c962e5aeb926?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"6d9d8e6c-e01a-42af-a2cc-c962e5aeb926","name":"6d9d8e6c-e01a-42af-a2cc-c962e5aeb926","status":"InProgress","startTime":"2023-05-17T12:13:35.8716751Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:13:41 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/6d9d8e6c-e01a-42af-a2cc-c962e5aeb926?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"6d9d8e6c-e01a-42af-a2cc-c962e5aeb926","name":"6d9d8e6c-e01a-42af-a2cc-c962e5aeb926","status":"InProgress","startTime":"2023-05-17T12:13:35.8716751Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:13:47 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/6d9d8e6c-e01a-42af-a2cc-c962e5aeb926?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"6d9d8e6c-e01a-42af-a2cc-c962e5aeb926","name":"6d9d8e6c-e01a-42af-a2cc-c962e5aeb926","status":"InProgress","startTime":"2023-05-17T12:13:35.8716751Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:13:53 GMT
+      - Wed, 16 Aug 2023 09:32:04 GMT
       expires:
       - '-1'
       pragma:
@@ -4439,22 +4274,118 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --backup-management-type --delete-backup-data --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/6d9d8e6c-e01a-42af-a2cc-c962e5aeb926?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupResourceGuardProxies?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"6d9d8e6c-e01a-42af-a2cc-c962e5aeb926","name":"6d9d8e6c-e01a-42af-a2cc-c962e5aeb926","status":"Succeeded","startTime":"2023-05-17T12:13:35.8716751Z","endTime":"2023-05-17T12:13:35.8716751Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"5fe293c4-9ec9-480a-bef6-3fab9d818391"}}'
+      string: '{"value":[]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '12'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:13:59 GMT
+      - Wed, 16 Aug 2023 09:32:05 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000007/protectedItems/AzureFileShare%3B7a4d1a0415368473a0b96eabff013d9ad9cb1bf9618e79ef742a9188aa5fac36?api-version=2023-02-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b6cf7327-ae9d-4fd0-99ec-c08e7e103b54?api-version=2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Wed, 16 Aug 2023 09:32:06 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/b6cf7327-ae9d-4fd0-99ec-c08e7e103b54?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14997'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b6cf7327-ae9d-4fd0-99ec-c08e7e103b54?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"b6cf7327-ae9d-4fd0-99ec-c08e7e103b54","name":"b6cf7327-ae9d-4fd0-99ec-c08e7e103b54","status":"InProgress","startTime":"2023-08-16T09:32:06.7171325Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:32:08 GMT
       expires:
       - '-1'
       pragma:
@@ -4470,7 +4401,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '295'
+      - '262'
     status:
       code: 200
       message: OK
@@ -4488,23 +4419,22 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --backup-management-type --delete-backup-data --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/5fe293c4-9ec9-480a-bef6-3fab9d818391?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b6cf7327-ae9d-4fd0-99ec-c08e7e103b54?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/5fe293c4-9ec9-480a-bef6-3fab9d818391","name":"5fe293c4-9ec9-480a-bef6-3fab9d818391","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT20.9366543S","storageAccountName":"clitest000007","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
-        Share Name":"clitest-item000008","Storage Account Name":"clitest000007"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"DeleteBackupData","status":"Completed","startTime":"2023-05-17T12:13:35.8716751Z","endTime":"2023-05-17T12:13:56.8083294Z","activityId":"3d1f4467-f4ac-11ed-a090-c8f750f92764"}}'
+      string: '{"id":"b6cf7327-ae9d-4fd0-99ec-c08e7e103b54","name":"b6cf7327-ae9d-4fd0-99ec-c08e7e103b54","status":"InProgress","startTime":"2023-08-16T09:32:06.7171325Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '863'
+      - '188'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:14:00 GMT
+      - Wed, 16 Aug 2023 09:32:12 GMT
       expires:
       - '-1'
       pragma:
@@ -4520,7 +4450,204 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '148'
+      - '261'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b6cf7327-ae9d-4fd0-99ec-c08e7e103b54?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"b6cf7327-ae9d-4fd0-99ec-c08e7e103b54","name":"b6cf7327-ae9d-4fd0-99ec-c08e7e103b54","status":"InProgress","startTime":"2023-08-16T09:32:06.7171325Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:32:17 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '260'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b6cf7327-ae9d-4fd0-99ec-c08e7e103b54?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"b6cf7327-ae9d-4fd0-99ec-c08e7e103b54","name":"b6cf7327-ae9d-4fd0-99ec-c08e7e103b54","status":"InProgress","startTime":"2023-08-16T09:32:06.7171325Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:32:24 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '259'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b6cf7327-ae9d-4fd0-99ec-c08e7e103b54?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"b6cf7327-ae9d-4fd0-99ec-c08e7e103b54","name":"b6cf7327-ae9d-4fd0-99ec-c08e7e103b54","status":"Succeeded","startTime":"2023-08-16T09:32:06.7171325Z","endTime":"2023-08-16T09:32:06.7171325Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"63f25584-5fdf-4fe5-9081-86857d249038"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:32:28 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '258'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/63f25584-5fdf-4fe5-9081-86857d249038?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/63f25584-5fdf-4fe5-9081-86857d249038","name":"63f25584-5fdf-4fe5-9081-86857d249038","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT20.9598124S","storageAccountName":"clitest000007","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
+        Share Name":"clitest-item000008","Storage Account Name":"clitest000007"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"DeleteBackupData","status":"Completed","startTime":"2023-08-16T09:32:06.7171325Z","endTime":"2023-08-16T09:32:27.6769449Z","activityId":"c22da842-3c17-11ee-8bc7-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '863'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:32:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '147'
     status:
       code: 200
       message: OK
@@ -4538,8 +4665,8 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+friendlyName+eq+%27clitest000003%27+and+status+eq+%27Registered%27
   response:
@@ -4553,7 +4680,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:14:00 GMT
+      - Wed, 16 Aug 2023 09:32:34 GMT
       expires:
       - '-1'
       pragma:
@@ -4569,7 +4696,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '297'
     status:
       code: 200
       message: OK
@@ -4589,8 +4716,8 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003?api-version=2023-02-01
   response:
@@ -4598,17 +4725,17 @@ interactions:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/751fef42-a469-4485-95d7-b9f4a7416666?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:14:02 GMT
+      - Wed, 16 Aug 2023 09:32:35 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/751fef42-a469-4485-95d7-b9f4a7416666?fabricName=Azure?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/7244bd3e-d1da-4c31-940a-acecf94aff39?fabricName=Azure?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -4618,7 +4745,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-deletes:
-      - '14999'
+      - '14996'
     status:
       code: 202
       message: Accepted
@@ -4636,16 +4763,16 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/751fef42-a469-4485-95d7-b9f4a7416666?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/751fef42-a469-4485-95d7-b9f4a7416666?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -4653,11 +4780,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:14:03 GMT
+      - Wed, 16 Aug 2023 09:32:36 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/751fef42-a469-4485-95d7-b9f4a7416666?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -4667,7 +4794,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '283'
     status:
       code: 202
       message: Accepted
@@ -4685,16 +4812,16 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/751fef42-a469-4485-95d7-b9f4a7416666?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/751fef42-a469-4485-95d7-b9f4a7416666?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -4702,11 +4829,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:14:10 GMT
+      - Wed, 16 Aug 2023 09:32:41 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/751fef42-a469-4485-95d7-b9f4a7416666?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -4716,7 +4843,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '282'
     status:
       code: 202
       message: Accepted
@@ -4734,16 +4861,16 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/751fef42-a469-4485-95d7-b9f4a7416666?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/751fef42-a469-4485-95d7-b9f4a7416666?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -4751,11 +4878,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:14:15 GMT
+      - Wed, 16 Aug 2023 09:32:46 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/751fef42-a469-4485-95d7-b9f4a7416666?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -4765,7 +4892,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
+      - '281'
     status:
       code: 202
       message: Accepted
@@ -4783,16 +4910,16 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/751fef42-a469-4485-95d7-b9f4a7416666?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/751fef42-a469-4485-95d7-b9f4a7416666?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -4800,11 +4927,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:14:20 GMT
+      - Wed, 16 Aug 2023 09:32:52 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/751fef42-a469-4485-95d7-b9f4a7416666?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -4814,7 +4941,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '296'
+      - '280'
     status:
       code: 202
       message: Accepted
@@ -4832,10 +4959,500 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/751fef42-a469-4485-95d7-b9f4a7416666?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:32:58 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '279'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:33:03 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '278'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:33:08 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '277'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:33:14 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '276'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:33:19 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '275'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:33:25 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '274'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:33:30 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '273'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:33:35 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '272'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:33:41 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '271'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:33:47 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '270'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/7244bd3e-d1da-4c31-940a-acecf94aff39?api-version=2023-02-01
   response:
     body:
       string: ''
@@ -4843,7 +5460,7 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Wed, 17 May 2023 12:14:26 GMT
+      - Wed, 16 Aug 2023 09:33:51 GMT
       expires:
       - '-1'
       pragma:
@@ -4855,7 +5472,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '295'
+      - '269'
     status:
       code: 204
       message: No Content
@@ -4873,8 +5490,8 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+friendlyName+eq+%27clitest000007%27+and+status+eq+%27Registered%27
   response:
@@ -4888,7 +5505,878 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:14:27 GMT
+      - Wed, 16 Aug 2023 09:33:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '295'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007?api-version=2023-02-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Wed, 16 Aug 2023 09:33:54 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/ddb6e16f-1015-4dc2-9b87-d60aed17a850?fabricName=Azure?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14996'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007/operationResults/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationsStatus/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:33:55 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationResults/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '276'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007/operationResults/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationsStatus/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:34:01 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationResults/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '275'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007/operationResults/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationsStatus/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:34:06 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationResults/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '274'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007/operationResults/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationsStatus/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:34:11 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationResults/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '273'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007/operationResults/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationsStatus/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:34:17 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationResults/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '272'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007/operationResults/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationsStatus/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:34:23 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationResults/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '271'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007/operationResults/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationsStatus/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:34:27 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationResults/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '270'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007/operationResults/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationsStatus/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:34:33 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationResults/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '269'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007/operationResults/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationsStatus/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:34:38 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationResults/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '268'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007/operationResults/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationsStatus/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:34:44 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationResults/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '267'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007/operationResults/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationsStatus/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:34:49 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationResults/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '266'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007/operationResults/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationsStatus/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:34:54 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationResults/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '265'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007/operationResults/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationsStatus/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:35:01 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationResults/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '264'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007/operationResults/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationsStatus/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:35:06 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationResults/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '263'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007/operationResults/ddb6e16f-1015-4dc2-9b87-d60aed17a850?api-version=2023-02-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      date:
+      - Wed, 16 Aug 2023 09:35:11 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '262'
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - lock list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/locks?api-version=2016-09-01
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:36:52 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --container-name --item-name --backup-management-type --workload-type
+        --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+itemType+eq+%27AzureFileShare%27
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:36:53 GMT
       expires:
       - '-1'
       pragma:
@@ -4919,266 +6407,25 @@ interactions:
       - backup container unregister
       Connection:
       - keep-alive
-      Content-Length:
-      - '0'
       ParameterSetName:
-      - -g -v -c --yes --backup-management-type
+      - --vault-name --resource-group --container-name --backup-management-type --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007?api-version=2023-02-01
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/a3f778f0-e03b-43df-a203-403be1c384a0?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Wed, 17 May 2023 12:14:28 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/a3f778f0-e03b-43df-a203-403be1c384a0?fabricName=Azure?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-deletes:
-      - '14999'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container unregister
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c --yes --backup-management-type
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007/operationResults/a3f778f0-e03b-43df-a203-403be1c384a0?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+friendlyName+eq+%27clitest000007%27+and+status+eq+%27Registered%27
   response:
     body:
-      string: '{}'
+      string: '{"value":[]}'
     headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationsStatus/a3f778f0-e03b-43df-a203-403be1c384a0?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
-      - '2'
+      - '12'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:14:28 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationResults/a3f778f0-e03b-43df-a203-403be1c384a0?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container unregister
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c --yes --backup-management-type
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007/operationResults/a3f778f0-e03b-43df-a203-403be1c384a0?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationsStatus/a3f778f0-e03b-43df-a203-403be1c384a0?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:14:35 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationResults/a3f778f0-e03b-43df-a203-403be1c384a0?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container unregister
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c --yes --backup-management-type
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007/operationResults/a3f778f0-e03b-43df-a203-403be1c384a0?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationsStatus/a3f778f0-e03b-43df-a203-403be1c384a0?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:14:40 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationResults/a3f778f0-e03b-43df-a203-403be1c384a0?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '296'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container unregister
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c --yes --backup-management-type
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007/operationResults/a3f778f0-e03b-43df-a203-403be1c384a0?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationsStatus/a3f778f0-e03b-43df-a203-403be1c384a0?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:14:46 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000007/operationResults/a3f778f0-e03b-43df-a203-403be1c384a0?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '295'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container unregister
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c --yes --backup-management-type
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000007/operationResults/a3f778f0-e03b-43df-a203-403be1c384a0?api-version=2023-02-01
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      date:
-      - Wed, 17 May 2023 12:14:51 GMT
+      - Wed, 16 Aug 2023 09:36:54 GMT
       expires:
       - '-1'
       pragma:
@@ -5187,13 +6434,161 @@ interactions:
       - Kestrel
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '294'
     status:
-      code: 204
-      message: No Content
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - lock list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/locks?api-version=2016-09-01
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:36:55 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --container-name --item-name --backup-management-type --workload-type
+        --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+itemType+eq+%27AzureFileShare%27
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:36:57 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '293'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --vault-name --resource-group --container-name --backup-management-type --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+friendlyName+eq+%27clitest000003%27+and+status+eq+%27Registered%27
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:36:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '298'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
@@ -5208,8 +6603,8 @@ interactions:
       ParameterSetName:
       - --backup-management-type -v -g --query
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureIaasVM%27+and+status+eq+%27Registered%27
   response:
@@ -5223,7 +6618,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:16:32 GMT
+      - Wed, 16 Aug 2023 09:37:00 GMT
       expires:
       - '-1'
       pragma:
@@ -5239,7 +6634,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '292'
     status:
       code: 200
       message: OK
@@ -5259,7 +6654,8 @@ interactions:
       ParameterSetName:
       - -n -g --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2023-02-01
   response:
@@ -5271,7 +6667,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:16:39 GMT
+      - Wed, 16 Aug 2023 09:37:02 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/backup/tests/latest/recordings/test_afs_backup_item.yaml
+++ b/src/azure-cli/azure/cli/command_modules/backup/tests/latest/recordings/test_afs_backup_item.yaml
@@ -13,7 +13,8 @@ interactions:
       ParameterSetName:
       - -n -g --location
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2023-02-01
   response:
@@ -29,7 +30,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:06:47 GMT
+      - Wed, 16 Aug 2023 09:25:54 GMT
       expires:
       - '-1'
       pragma:
@@ -64,15 +65,16 @@ interactions:
       ParameterSetName:
       - -n -g --location
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2023-02-01
   response:
     body:
-      string: '{"location":"eastus2euap","name":"clitest-vault000002","etag":"W/\"datetime''2023-05-17T12%3A06%3A52.5269334Z''\"","properties":{"provisioningState":"Provisioning","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}},"publicNetworkAccess":"Enabled","restoreSettings":{"crossSubscriptionRestoreSettings":{"crossSubscriptionRestoreState":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+      string: '{"location":"eastus2euap","name":"clitest-vault000002","etag":"W/\"datetime''2023-08-16T09%3A25%3A55.8884804Z''\"","properties":{"provisioningState":"Provisioning","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}},"publicNetworkAccess":"Enabled","restoreSettings":{"crossSubscriptionRestoreSettings":{"crossSubscriptionRestoreState":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NzsyOTg0ZjZmZC1jMDNlLTRjMGEtYTg4ZS02ZDNlNDZiMzhkNzk=?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NztlM2E2NTUxYy1hMGY3LTQxZjQtYjRjYS01NTQzZGQ5NDMzOWM=?api-version=2023-02-01
       cache-control:
       - no-cache
       content-length:
@@ -80,7 +82,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:06:53 GMT
+      - Wed, 16 Aug 2023 09:25:55 GMT
       expires:
       - '-1'
       pragma:
@@ -91,8 +93,10 @@ interactions:
       - max-age=31536000; includeSubDomains
       x-content-type-options:
       - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=12f8ea5c-1212-449e-b31c-0a574f43076e/centraluseuap/6dcb68a4-5b99-4514-927f-d001860e9f7e
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
+      - '298'
     status:
       code: 201
       message: Created
@@ -110,17 +114,18 @@ interactions:
       ParameterSetName:
       - -n -g --location
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NzsyOTg0ZjZmZC1jMDNlLTRjMGEtYTg4ZS02ZDNlNDZiMzhkNzk=?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NztlM2E2NTUxYy1hMGY3LTQxZjQtYjRjYS01NTQzZGQ5NDMzOWM=?api-version=2023-02-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NzsyOTg0ZjZmZC1jMDNlLTRjMGEtYTg4ZS02ZDNlNDZiMzhkNzk=\",\r\n
-        \ \"name\": \"MjA0NzsyOTg0ZjZmZC1jMDNlLTRjMGEtYTg4ZS02ZDNlNDZiMzhkNzk=\",\r\n
-        \ \"status\": \"InProgress\"\r\n}"
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NztlM2E2NTUxYy1hMGY3LTQxZjQtYjRjYS01NTQzZGQ5NDMzOWM=\"\
+        ,\r\n  \"name\": \"MjA0NztlM2E2NTUxYy1hMGY3LTQxZjQtYjRjYS01NTQzZGQ5NDMzOWM=\"\
+        ,\r\n  \"status\": \"InProgress\"\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NzsyOTg0ZjZmZC1jMDNlLTRjMGEtYTg4ZS02ZDNlNDZiMzhkNzk=?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NztlM2E2NTUxYy1hMGY3LTQxZjQtYjRjYS01NTQzZGQ5NDMzOWM=?api-version=2023-02-01
       cache-control:
       - no-cache
       content-length:
@@ -128,11 +133,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:06:53 GMT
+      - Wed, 16 Aug 2023 09:25:56 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationResults/MjA0NzsyOTg0ZjZmZC1jMDNlLTRjMGEtYTg4ZS02ZDNlNDZiMzhkNzk=?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationResults/MjA0NztlM2E2NTUxYy1hMGY3LTQxZjQtYjRjYS01NTQzZGQ5NDMzOWM=?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -162,14 +167,68 @@ interactions:
       ParameterSetName:
       - -n -g --location
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NzsyOTg0ZjZmZC1jMDNlLTRjMGEtYTg4ZS02ZDNlNDZiMzhkNzk=?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NztlM2E2NTUxYy1hMGY3LTQxZjQtYjRjYS01NTQzZGQ5NDMzOWM=?api-version=2023-02-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NzsyOTg0ZjZmZC1jMDNlLTRjMGEtYTg4ZS02ZDNlNDZiMzhkNzk=\",\r\n
-        \ \"name\": \"MjA0NzsyOTg0ZjZmZC1jMDNlLTRjMGEtYTg4ZS02ZDNlNDZiMzhkNzk=\",\r\n
-        \ \"status\": \"Succeeded\"\r\n}"
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NztlM2E2NTUxYy1hMGY3LTQxZjQtYjRjYS01NTQzZGQ5NDMzOWM=\"\
+        ,\r\n  \"name\": \"MjA0NztlM2E2NTUxYy1hMGY3LTQxZjQtYjRjYS01NTQzZGQ5NDMzOWM=\"\
+        ,\r\n  \"status\": \"InProgress\"\r\n}"
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NztlM2E2NTUxYy1hMGY3LTQxZjQtYjRjYS01NTQzZGQ5NDMzOWM=?api-version=2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '334'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:26:56 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationResults/MjA0NztlM2E2NTUxYy1hMGY3LTQxZjQtYjRjYS01NTQzZGQ5NDMzOWM=?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --location
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NztlM2E2NTUxYy1hMGY3LTQxZjQtYjRjYS01NTQzZGQ5NDMzOWM=?api-version=2023-02-01
+  response:
+    body:
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NztlM2E2NTUxYy1hMGY3LTQxZjQtYjRjYS01NTQzZGQ5NDMzOWM=\"\
+        ,\r\n  \"name\": \"MjA0NztlM2E2NTUxYy1hMGY3LTQxZjQtYjRjYS01NTQzZGQ5NDMzOWM=\"\
+        ,\r\n  \"status\": \"Succeeded\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -178,7 +237,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:07:54 GMT
+      - Wed, 16 Aug 2023 09:27:56 GMT
       expires:
       - '-1'
       pragma:
@@ -210,12 +269,13 @@ interactions:
       ParameterSetName:
       - -n -g --location
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2023-02-01
   response:
     body:
-      string: '{"location":"eastus2euap","name":"clitest-vault000002","etag":"W/\"datetime''2023-05-17T12%3A07%3A54.1685519Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","backupStorageVersion":"Unassigned","monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}},"securitySettings":{"immutabilitySettings":null,"softDeleteSettings":{"softDeleteRetentionPeriodInDays":14,"softDeleteState":"Enabled"},"multiUserAuthorization":"Disabled"},"publicNetworkAccess":"Enabled","restoreSettings":{"crossSubscriptionRestoreSettings":{"crossSubscriptionRestoreState":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+      string: '{"location":"eastus2euap","name":"clitest-vault000002","etag":"W/\"datetime''2023-08-16T09%3A26%3A58.0347592Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","backupStorageVersion":"Unassigned","monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}},"securitySettings":{"immutabilitySettings":null,"softDeleteSettings":{"softDeleteRetentionPeriodInDays":14,"softDeleteState":"Enabled"},"multiUserAuthorization":"Disabled"},"publicNetworkAccess":"Enabled","restoreSettings":{"crossSubscriptionRestoreSettings":{"crossSubscriptionRestoreState":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
     headers:
       cache-control:
       - no-cache
@@ -224,7 +284,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:07:55 GMT
+      - Wed, 16 Aug 2023 09:27:57 GMT
       expires:
       - '-1'
       pragma:
@@ -239,6 +299,156 @@ interactions:
       - Accept-Encoding
       x-content-type-options:
       - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault backup-properties set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --soft-delete-feature-state
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupconfig/vaultconfig?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupconfig/vaultconfig","name":"vaultconfig","type":"Microsoft.RecoveryServices/vaults/backupconfig","properties":{"enhancedSecurityState":"Enabled","softDeleteFeatureState":"Enabled","softDeleteRetentionPeriodInDays":14,"isSoftDeleteFeatureStateEditable":true}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '419'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:27:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '299'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault backup-properties set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --soft-delete-feature-state
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupResourceGuardProxies?api-version=2023-02-01
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:27:59 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"enhancedSecurityState": "Enabled", "softDeleteFeatureState":
+      "Disabled"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault backup-properties set
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '90'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -n -g --soft-delete-feature-state
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: PATCH
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupconfig/vaultconfig?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupconfig/vaultconfig","name":"vaultconfig","type":"Microsoft.RecoveryServices/vaults/backupconfig","properties":{"enhancedSecurityState":"Enabled","softDeleteFeatureState":"Disabled","softDeleteRetentionPeriodInDays":14,"isSoftDeleteFeatureStateEditable":true}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '420'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:28:01 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
     status:
       code: 200
       message: OK
@@ -258,12 +468,13 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-storage/21.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003/listKeys?api-version=2022-09-01&$expand=kerb
   response:
     body:
-      string: '{"keys":[{"creationTime":"2023-05-17T12:07:59.0299578Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2023-05-17T12:07:59.0299578Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
+      string: '{"keys":[{"creationTime":"2023-08-16T09:28:03.9091060Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2023-08-16T09:28:03.9091060Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
     headers:
       cache-control:
       - no-cache
@@ -272,7 +483,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 17 May 2023 12:08:22 GMT
+      - Wed, 16 Aug 2023 09:28:27 GMT
       expires:
       - '-1'
       pragma:
@@ -306,21 +517,22 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-storage/21.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","name":"clitest000003","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"keyCreationTime":{"key1":"2023-05-17T12:07:59.0299578Z","key2":"2023-05-17T12:07:59.0299578Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-05-17T12:07:59.4205817Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-05-17T12:07:59.4205817Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-05-17T12:07:58.9361988Z","primaryEndpoints":{"blob":"https://clitest000003.blob.core.windows.net/","queue":"https://clitest000003.queue.core.windows.net/","table":"https://clitest000003.table.core.windows.net/","file":"https://clitest000003.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","name":"clitest000003","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"keyCreationTime":{"key1":"2023-08-16T09:28:03.9091060Z","key2":"2023-08-16T09:28:03.9091060Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-08-16T09:28:04.3466695Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-08-16T09:28:04.3466695Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-08-16T09:28:03.8153912Z","primaryEndpoints":{"blob":"https://clitest000003.blob.core.windows.net/","queue":"https://clitest000003.queue.core.windows.net/","table":"https://clitest000003.table.core.windows.net/","file":"https://clitest000003.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1280'
+      - '1316'
       content-type:
       - application/json
       date:
-      - Wed, 17 May 2023 12:08:23 GMT
+      - Wed, 16 Aug 2023 09:28:27 GMT
       expires:
       - '-1'
       pragma:
@@ -354,9 +566,10 @@ interactions:
       ParameterSetName:
       - --name --quota --connection-string
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-storage-file-share/12.12.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-storage-file-share/12.12.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Wed, 17 May 2023 12:08:22 GMT
+      - Wed, 16 Aug 2023 09:28:28 GMT
       x-ms-share-quota:
       - '1'
       x-ms-version:
@@ -370,11 +583,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:08:24 GMT
+      - Wed, 16 Aug 2023 09:28:29 GMT
       etag:
-      - '"0x8DB56CF6A92BAB1"'
+      - '"0x8DB9E3B26C5477F"'
       last-modified:
-      - Wed, 17 May 2023 12:08:24 GMT
+      - Wed, 16 Aug 2023 09:28:29 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
@@ -398,12 +611,13 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-storage/21.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003/listKeys?api-version=2022-09-01&$expand=kerb
   response:
     body:
-      string: '{"keys":[{"creationTime":"2023-05-17T12:07:59.0299578Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2023-05-17T12:07:59.0299578Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
+      string: '{"keys":[{"creationTime":"2023-08-16T09:28:03.9091060Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2023-08-16T09:28:03.9091060Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
     headers:
       cache-control:
       - no-cache
@@ -412,7 +626,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 17 May 2023 12:08:26 GMT
+      - Wed, 16 Aug 2023 09:28:30 GMT
       expires:
       - '-1'
       pragma:
@@ -428,7 +642,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11997'
     status:
       code: 200
       message: OK
@@ -446,21 +660,22 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-storage/21.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","name":"clitest000003","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"keyCreationTime":{"key1":"2023-05-17T12:07:59.0299578Z","key2":"2023-05-17T12:07:59.0299578Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-05-17T12:07:59.4205817Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-05-17T12:07:59.4205817Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-05-17T12:07:58.9361988Z","primaryEndpoints":{"blob":"https://clitest000003.blob.core.windows.net/","queue":"https://clitest000003.queue.core.windows.net/","table":"https://clitest000003.table.core.windows.net/","file":"https://clitest000003.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","name":"clitest000003","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"keyCreationTime":{"key1":"2023-08-16T09:28:03.9091060Z","key2":"2023-08-16T09:28:03.9091060Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-08-16T09:28:04.3466695Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-08-16T09:28:04.3466695Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-08-16T09:28:03.8153912Z","primaryEndpoints":{"blob":"https://clitest000003.blob.core.windows.net/","queue":"https://clitest000003.queue.core.windows.net/","table":"https://clitest000003.table.core.windows.net/","file":"https://clitest000003.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1280'
+      - '1316'
       content-type:
       - application/json
       date:
-      - Wed, 17 May 2023 12:08:26 GMT
+      - Wed, 16 Aug 2023 09:28:30 GMT
       expires:
       - '-1'
       pragma:
@@ -494,9 +709,10 @@ interactions:
       ParameterSetName:
       - --name --quota --connection-string
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-storage-file-share/12.12.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-storage-file-share/12.12.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Wed, 17 May 2023 12:08:25 GMT
+      - Wed, 16 Aug 2023 09:28:31 GMT
       x-ms-share-quota:
       - '1'
       x-ms-version:
@@ -510,11 +726,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:08:27 GMT
+      - Wed, 16 Aug 2023 09:28:31 GMT
       etag:
-      - '"0x8DB56CF6C4D4D32"'
+      - '"0x8DB9E3B2898FA12"'
       last-modified:
-      - Wed, 17 May 2023 12:08:27 GMT
+      - Wed, 16 Aug 2023 09:28:32 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
@@ -536,13 +752,13 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T19:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T19:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
@@ -551,7 +767,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:29 GMT
+      - Wed, 16 Aug 2023 09:28:33 GMT
       expires:
       - '-1'
       pragma:
@@ -574,9 +790,9 @@ interactions:
 - request:
     body: '{"properties": {"protectedItemsCount": 0, "backupManagementType": "AzureStorage",
       "workLoadType": "AzureFileShare", "schedulePolicy": {"schedulePolicyType": "SimpleSchedulePolicy",
-      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2023-05-17T22:00:00.000Z"],
+      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2023-08-16T19:00:00.000Z"],
       "scheduleWeeklyFrequency": 0}, "retentionPolicy": {"retentionPolicyType": "LongTermRetentionPolicy",
-      "dailySchedule": {"retentionTimes": ["2023-05-17T22:00:00.000Z"], "retentionDuration":
+      "dailySchedule": {"retentionTimes": ["2023-08-16T19:00:00.000Z"], "retentionDuration":
       {"count": 30, "durationType": "Days"}}}, "timeZone": "UTC"}}'
     headers:
       Accept:
@@ -594,22 +810,22 @@ interactions:
       ParameterSetName:
       - -g -v --policy -n --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006","name":"clitest-item000006","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006","name":"clitest-item000006","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","workLoadType":"AzureFileShare","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T19:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T19:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '719'
+      - '751'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:30 GMT
+      - Wed, 16 Aug 2023 09:28:34 GMT
       expires:
       - '-1'
       pragma:
@@ -625,7 +841,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1190'
     status:
       code: 200
       message: OK
@@ -643,13 +859,13 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T19:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T19:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
@@ -658,7 +874,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:32 GMT
+      - Wed, 16 Aug 2023 09:28:35 GMT
       expires:
       - '-1'
       pragma:
@@ -674,16 +890,16 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '298'
     status:
       code: 200
       message: OK
 - request:
     body: '{"properties": {"protectedItemsCount": 0, "backupManagementType": "AzureStorage",
       "workLoadType": "AzureFileShare", "schedulePolicy": {"schedulePolicyType": "SimpleSchedulePolicy",
-      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2023-05-17T22:00:00.000Z"],
+      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2023-08-16T19:00:00.000Z"],
       "scheduleWeeklyFrequency": 0}, "retentionPolicy": {"retentionPolicyType": "LongTermRetentionPolicy",
-      "dailySchedule": {"retentionTimes": ["2023-05-17T22:00:00.000Z"], "retentionDuration":
+      "dailySchedule": {"retentionTimes": ["2023-08-16T19:00:00.000Z"], "retentionDuration":
       {"count": 30, "durationType": "Days"}}}, "timeZone": "UTC"}}'
     headers:
       Accept:
@@ -701,22 +917,22 @@ interactions:
       ParameterSetName:
       - -g -v --policy -n --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000007?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000007","name":"clitest-item000007","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000007","name":"clitest-item000007","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","workLoadType":"AzureFileShare","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T19:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T19:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '719'
+      - '751'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:34 GMT
+      - Wed, 16 Aug 2023 09:28:37 GMT
       expires:
       - '-1'
       pragma:
@@ -732,7 +948,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1197'
     status:
       code: 200
       message: OK
@@ -750,8 +966,8 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+status+eq+%27Registered%27
   response:
@@ -765,7 +981,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:35 GMT
+      - Wed, 16 Aug 2023 09:28:38 GMT
       expires:
       - '-1'
       pragma:
@@ -781,7 +997,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '298'
     status:
       code: 200
       message: OK
@@ -799,22 +1015,251 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","name":"StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"adiguptecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/adigupt-ecy-rg/providers/Microsoft.Storage/storageAccounts/adiguptecy"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg2yfprhyqds;clitesttz6sdom2jatwnfac4","name":"StorageContainer;Storage;clitest.rg2yfprhyqds;clitesttz6sdom2jatwnfac4","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesttz6sdom2jatwnfac4","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg2yfprhyqds/providers/Microsoft.Storage/storageAccounts/clitesttz6sdom2jatwnfac4"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx;clitest5g7td7ozjqq2b6ccr","name":"StorageContainer;Storage;clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx;clitest5g7td7ozjqq2b6ccr","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest5g7td7ozjqq2b6ccr","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx/providers/Microsoft.Storage/storageAccounts/clitest5g7td7ozjqq2b6ccr"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgnochh2c3ax;clitestu2fyy2h47rugcmeo6","name":"StorageContainer;Storage;clitest.rgnochh2c3ax;clitestu2fyy2h47rugcmeo6","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestu2fyy2h47rugcmeo6","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgnochh2c3ax/providers/Microsoft.Storage/storageAccounts/clitestu2fyy2h47rugcmeo6"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgnvoelwrvnb;clitestw62rrt6h5fidon2vw","name":"StorageContainer;Storage;clitest.rgnvoelwrvnb;clitestw62rrt6h5fidon2vw","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestw62rrt6h5fidon2vw","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgnvoelwrvnb/providers/Microsoft.Storage/storageAccounts/clitestw62rrt6h5fidon2vw"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest000003","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgt7y3m2jxoj;clitest4ok6wrvjr5q6texyd","name":"StorageContainer;Storage;clitest.rgt7y3m2jxoj;clitest4ok6wrvjr5q6texyd","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest4ok6wrvjr5q6texyd","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgt7y3m2jxoj/providers/Microsoft.Storage/storageAccounts/clitest4ok6wrvjr5q6texyd"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","name":"StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontusebvtaksecycansa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DonotUse-Blobs-BVT-EACAN-RG/providers/Microsoft.Storage/storageAccounts/dontusebvtaksecycansa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","name":"StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"iaasextstoreecy1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.czr/providers/Microsoft.Storage/storageAccounts/iaasextstoreecy1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","name":"StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesaksdonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-clitest-rg/providers/Microsoft.Storage/storageAccounts/clitesaksdonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"bloboprestorecontainers","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/bloboprestorecontainers"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopall","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopall"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopcontainer","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopcontainer"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopprefix","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopprefix"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG;zubairsaecy","name":"StorageContainer;Storage;zubairRG;zubairsaecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Storage/storageAccounts/zubairsaecy"}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","name":"StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"adiguptecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/adigupt-ecy-rg/providers/Microsoft.Storage/storageAccounts/adiguptecy"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","name":"StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontusebvtaksecycansa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DonotUse-Blobs-BVT-EACAN-RG/providers/Microsoft.Storage/storageAccounts/dontusebvtaksecycansa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","name":"StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"iaasextstoreecy1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.czr/providers/Microsoft.Storage/storageAccounts/iaasextstoreecy1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","name":"StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesaksdonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-clitest-rg/providers/Microsoft.Storage/storageAccounts/clitesaksdonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"bloboprestorecontainers","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/bloboprestorecontainers"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopall","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopall"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopcontainer","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopcontainer"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopprefix","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopprefix"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG2;zubairsaecy2","name":"StorageContainer;Storage;zubairRG2;zubairsaecy2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy2","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG2/providers/Microsoft.Storage/storageAccounts/zubairsaecy2"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG;zubairsaecy","name":"StorageContainer;Storage;zubairRG;zubairsaecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Storage/storageAccounts/zubairsaecy"}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '11546'
+      - '7516'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:36 GMT
+      - Wed, 16 Aug 2023 09:28:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '298'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/refreshContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/d0b80a9f-fa18-493c-8078-75b565f46b81?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Wed, 16 Aug 2023 09:28:40 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/d0b80a9f-fa18-493c-8078-75b565f46b81?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/d0b80a9f-fa18-493c-8078-75b565f46b81?api-version=2023-02-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Wed, 16 Aug 2023 09:28:42 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/d0b80a9f-fa18-493c-8078-75b565f46b81?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '296'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/d0b80a9f-fa18-493c-8078-75b565f46b81?api-version=2023-02-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Wed, 16 Aug 2023 09:28:47 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/d0b80a9f-fa18-493c-8078-75b565f46b81?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '295'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/d0b80a9f-fa18-493c-8078-75b565f46b81?api-version=2023-02-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      date:
+      - Wed, 16 Aug 2023 09:28:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '294'
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","name":"StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"adiguptecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/adigupt-ecy-rg/providers/Microsoft.Storage/storageAccounts/adiguptecy"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest000003","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","name":"StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontusebvtaksecycansa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DonotUse-Blobs-BVT-EACAN-RG/providers/Microsoft.Storage/storageAccounts/dontusebvtaksecycansa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","name":"StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"iaasextstoreecy1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.czr/providers/Microsoft.Storage/storageAccounts/iaasextstoreecy1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","name":"StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesaksdonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-clitest-rg/providers/Microsoft.Storage/storageAccounts/clitesaksdonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"bloboprestorecontainers","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/bloboprestorecontainers"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopall","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopall"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopcontainer","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopcontainer"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopprefix","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopprefix"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG2;zubairsaecy2","name":"StorageContainer;Storage;zubairRG2;zubairsaecy2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy2","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG2/providers/Microsoft.Storage/storageAccounts/zubairsaecy2"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG;zubairsaecy","name":"StorageContainer;Storage;zubairRG;zubairsaecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Storage/storageAccounts/zubairsaecy"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '8228'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:28:53 GMT
       expires:
       - '-1'
       pragma:
@@ -853,8 +1298,8 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003?api-version=2023-02-01
   response:
@@ -862,7 +1307,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/df890d63-087b-4d80-9388-1c7ea3fb00e4?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/950fe4ee-0de3-477e-add6-fec25a361cd2?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -870,11 +1315,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:39 GMT
+      - Wed, 16 Aug 2023 09:28:55 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/df890d63-087b-4d80-9388-1c7ea3fb00e4?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/950fe4ee-0de3-477e-add6-fec25a361cd2?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -884,7 +1329,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1188'
     status:
       code: 202
       message: Accepted
@@ -902,16 +1347,16 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/df890d63-087b-4d80-9388-1c7ea3fb00e4?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/950fe4ee-0de3-477e-add6-fec25a361cd2?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/df890d63-087b-4d80-9388-1c7ea3fb00e4?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/950fe4ee-0de3-477e-add6-fec25a361cd2?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -919,11 +1364,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:39 GMT
+      - Wed, 16 Aug 2023 09:28:57 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/df890d63-087b-4d80-9388-1c7ea3fb00e4?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/950fe4ee-0de3-477e-add6-fec25a361cd2?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -933,7 +1378,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '291'
     status:
       code: 202
       message: Accepted
@@ -951,16 +1396,16 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/df890d63-087b-4d80-9388-1c7ea3fb00e4?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/950fe4ee-0de3-477e-add6-fec25a361cd2?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/df890d63-087b-4d80-9388-1c7ea3fb00e4?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/950fe4ee-0de3-477e-add6-fec25a361cd2?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -968,11 +1413,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:45 GMT
+      - Wed, 16 Aug 2023 09:29:02 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/df890d63-087b-4d80-9388-1c7ea3fb00e4?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/950fe4ee-0de3-477e-add6-fec25a361cd2?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -982,7 +1427,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '290'
     status:
       code: 202
       message: Accepted
@@ -1000,16 +1445,16 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/df890d63-087b-4d80-9388-1c7ea3fb00e4?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/950fe4ee-0de3-477e-add6-fec25a361cd2?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/df890d63-087b-4d80-9388-1c7ea3fb00e4?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/950fe4ee-0de3-477e-add6-fec25a361cd2?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -1017,11 +1462,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:50 GMT
+      - Wed, 16 Aug 2023 09:29:07 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/df890d63-087b-4d80-9388-1c7ea3fb00e4?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/950fe4ee-0de3-477e-add6-fec25a361cd2?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -1031,7 +1476,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
+      - '289'
     status:
       code: 202
       message: Accepted
@@ -1049,16 +1494,16 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/df890d63-087b-4d80-9388-1c7ea3fb00e4?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/950fe4ee-0de3-477e-add6-fec25a361cd2?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/df890d63-087b-4d80-9388-1c7ea3fb00e4?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/950fe4ee-0de3-477e-add6-fec25a361cd2?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -1066,11 +1511,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:55 GMT
+      - Wed, 16 Aug 2023 09:29:12 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/df890d63-087b-4d80-9388-1c7ea3fb00e4?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/950fe4ee-0de3-477e-add6-fec25a361cd2?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -1080,7 +1525,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '296'
+      - '288'
     status:
       code: 202
       message: Accepted
@@ -1098,16 +1543,16 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/df890d63-087b-4d80-9388-1c7ea3fb00e4?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/950fe4ee-0de3-477e-add6-fec25a361cd2?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/df890d63-087b-4d80-9388-1c7ea3fb00e4?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/950fe4ee-0de3-477e-add6-fec25a361cd2?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -1115,11 +1560,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:09:01 GMT
+      - Wed, 16 Aug 2023 09:29:18 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/df890d63-087b-4d80-9388-1c7ea3fb00e4?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/950fe4ee-0de3-477e-add6-fec25a361cd2?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -1129,7 +1574,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '295'
+      - '287'
     status:
       code: 202
       message: Accepted
@@ -1147,10 +1592,108 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/df890d63-087b-4d80-9388-1c7ea3fb00e4?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/950fe4ee-0de3-477e-add6-fec25a361cd2?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/950fe4ee-0de3-477e-add6-fec25a361cd2?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:29:23 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/950fe4ee-0de3-477e-add6-fec25a361cd2?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '286'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/950fe4ee-0de3-477e-add6-fec25a361cd2?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/950fe4ee-0de3-477e-add6-fec25a361cd2?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:29:29 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/950fe4ee-0de3-477e-add6-fec25a361cd2?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '285'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/950fe4ee-0de3-477e-add6-fec25a361cd2?api-version=2023-02-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","protectedItemCount":0,"acquireStorageAccountLock":"Acquire","friendlyName":"clitest000003","backupManagementType":"AzureStorage","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"StorageContainer","protectableObjectType":"StorageContainer"}}'
@@ -1162,689 +1705,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:09:07 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '294'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectableItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+workloadType+eq+%27AzureFileShare%27
-  response:
-    body:
-      string: '{"value":[]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '12'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:07 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/inquire?api-version=2023-02-01&%24filter=workloadType+eq+%27AzureFileShare%27
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/09bffc4b-4bb3-4a76-bf15-fb77c65b2f88?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Wed, 17 May 2023 12:09:09 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/09bffc4b-4bb3-4a76-bf15-fb77c65b2f88?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/09bffc4b-4bb3-4a76-bf15-fb77c65b2f88?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/09bffc4b-4bb3-4a76-bf15-fb77c65b2f88?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:09 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/09bffc4b-4bb3-4a76-bf15-fb77c65b2f88?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '296'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/09bffc4b-4bb3-4a76-bf15-fb77c65b2f88?api-version=2023-02-01
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      date:
-      - Wed, 17 May 2023 12:09:16 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '295'
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectableItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+workloadType+eq+%27AzureFileShare%27
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectableItems/azurefileshare;6bcfd92e6c5f11d939bb47d9ecc04df51dc0eb03a5cdf608599bd1590453feca","name":"azurefileshare;6bcfd92e6c5f11d939bb47d9ecc04df51dc0eb03a5cdf608599bd1590453feca","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"parentContainerFabricId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","parentContainerFriendlyName":"clitest000003","azureFileShareType":"XSMB","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","protectableItemType":"AzureFileShare","friendlyName":"clitest-item000005","protectionState":"NotProtected"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectableItems/azurefileshare;d7a22c5d547e60e80c985358f7b08a0f715f260d8b676e1d33b3478933fc229e","name":"azurefileshare;d7a22c5d547e60e80c985358f7b08a0f715f260d8b676e1d33b3478933fc229e","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"parentContainerFabricId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","parentContainerFriendlyName":"clitest000003","azureFileShareType":"XSMB","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","protectableItemType":"AzureFileShare","friendlyName":"clitest-item000004","protectionState":"NotProtected"}}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1955'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:18 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006","name":"clitest-item000006","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '719'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:18 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"protectedItemType": "AzureFileShareProtectedItem", "sourceResourceId":
-      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003",
-      "policyId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006"}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '430'
-      Content-Type:
-      - application/json
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/azurefileshare%3Bd7a22c5d547e60e80c985358f7b08a0f715f260d8b676e1d33b3478933fc229e?api-version=2023-02-01
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectedItems/azurefileshare;d7a22c5d547e60e80c985358f7b08a0f715f260d8b676e1d33b3478933fc229e/operationsStatus/3ffbba71-97cc-41e0-b3b4-ab50449f8d14?api-version=2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Wed, 17 May 2023 12:09:20 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectedItems/azurefileshare;d7a22c5d547e60e80c985358f7b08a0f715f260d8b676e1d33b3478933fc229e/operationResults/3ffbba71-97cc-41e0-b3b4-ab50449f8d14?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/3ffbba71-97cc-41e0-b3b4-ab50449f8d14?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"3ffbba71-97cc-41e0-b3b4-ab50449f8d14","name":"3ffbba71-97cc-41e0-b3b4-ab50449f8d14","status":"InProgress","startTime":"2023-05-17T12:09:20.2995797Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:21 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '296'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/3ffbba71-97cc-41e0-b3b4-ab50449f8d14?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"3ffbba71-97cc-41e0-b3b4-ab50449f8d14","name":"3ffbba71-97cc-41e0-b3b4-ab50449f8d14","status":"InProgress","startTime":"2023-05-17T12:09:20.2995797Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:26 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '294'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/3ffbba71-97cc-41e0-b3b4-ab50449f8d14?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"3ffbba71-97cc-41e0-b3b4-ab50449f8d14","name":"3ffbba71-97cc-41e0-b3b4-ab50449f8d14","status":"InProgress","startTime":"2023-05-17T12:09:20.2995797Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:32 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '292'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/3ffbba71-97cc-41e0-b3b4-ab50449f8d14?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"3ffbba71-97cc-41e0-b3b4-ab50449f8d14","name":"3ffbba71-97cc-41e0-b3b4-ab50449f8d14","status":"InProgress","startTime":"2023-05-17T12:09:20.2995797Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:38 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '290'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/3ffbba71-97cc-41e0-b3b4-ab50449f8d14?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"3ffbba71-97cc-41e0-b3b4-ab50449f8d14","name":"3ffbba71-97cc-41e0-b3b4-ab50449f8d14","status":"InProgress","startTime":"2023-05-17T12:09:20.2995797Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:43 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '288'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/3ffbba71-97cc-41e0-b3b4-ab50449f8d14?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"3ffbba71-97cc-41e0-b3b4-ab50449f8d14","name":"3ffbba71-97cc-41e0-b3b4-ab50449f8d14","status":"InProgress","startTime":"2023-05-17T12:09:20.2995797Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:49 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '286'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/3ffbba71-97cc-41e0-b3b4-ab50449f8d14?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"3ffbba71-97cc-41e0-b3b4-ab50449f8d14","name":"3ffbba71-97cc-41e0-b3b4-ab50449f8d14","status":"InProgress","startTime":"2023-05-17T12:09:20.2995797Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:54 GMT
+      - Wed, 16 Aug 2023 09:29:34 GMT
       expires:
       - '-1'
       pragma:
@@ -1878,220 +1739,22 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/3ffbba71-97cc-41e0-b3b4-ab50449f8d14?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"3ffbba71-97cc-41e0-b3b4-ab50449f8d14","name":"3ffbba71-97cc-41e0-b3b4-ab50449f8d14","status":"InProgress","startTime":"2023-05-17T12:09:20.2995797Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:10:00 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '283'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/3ffbba71-97cc-41e0-b3b4-ab50449f8d14?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"3ffbba71-97cc-41e0-b3b4-ab50449f8d14","name":"3ffbba71-97cc-41e0-b3b4-ab50449f8d14","status":"Succeeded","startTime":"2023-05-17T12:09:20.2995797Z","endTime":"2023-05-17T12:09:20.2995797Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"f2bbf442-0cc5-4bd6-b889-0f734af086a5"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:10:05 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '282'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2bbf442-0cc5-4bd6-b889-0f734af086a5?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2bbf442-0cc5-4bd6-b889-0f734af086a5","name":"f2bbf442-0cc5-4bd6-b889-0f734af086a5","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT41.3722867S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
-        Share Name":"clitest-item000004","Storage Account Name":"clitest000003","Policy
-        Name":"clitest-item000006"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"ConfigureBackup","status":"Completed","startTime":"2023-05-17T12:09:20.2995797Z","endTime":"2023-05-17T12:10:01.6718664Z","activityId":"8b3e6c45-f4ab-11ed-ae3b-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '897'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:10:06 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '149'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+status+eq+%27Registered%27
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","protectedItemCount":1,"acquireStorageAccountLock":"Acquire","friendlyName":"clitest000003","backupManagementType":"AzureStorage","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"StorageContainer","protectableObjectType":"StorageContainer"}}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '853'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:10:07 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectableItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+workloadType+eq+%27AzureFileShare%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectableItems/azurefileshare;6bcfd92e6c5f11d939bb47d9ecc04df51dc0eb03a5cdf608599bd1590453feca","name":"azurefileshare;6bcfd92e6c5f11d939bb47d9ecc04df51dc0eb03a5cdf608599bd1590453feca","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"parentContainerFabricId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","parentContainerFriendlyName":"clitest000003","azureFileShareType":"XSMB","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","protectableItemType":"AzureFileShare","friendlyName":"clitest-item000005","protectionState":"NotProtected"}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectableItems/azurefileshare;8f0fb7c295f1e15b03639f071968d52f6c15e14bc5d6323bd1fd3f4fd17f568b","name":"azurefileshare;8f0fb7c295f1e15b03639f071968d52f6c15e14bc5d6323bd1fd3f4fd17f568b","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"parentContainerFabricId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","parentContainerFriendlyName":"clitest000003","azureFileShareType":"XSMB","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","protectableItemType":"AzureFileShare","friendlyName":"clitest-item000005","protectionState":"NotProtected"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectableItems/azurefileshare;cedc90187291d7e86937febb5c66cd5d3fa2392853aadeeb714338ce7cb9aff3","name":"azurefileshare;cedc90187291d7e86937febb5c66cd5d3fa2392853aadeeb714338ce7cb9aff3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"parentContainerFabricId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","parentContainerFriendlyName":"clitest000003","azureFileShareType":"XSMB","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","protectableItemType":"AzureFileShare","friendlyName":"clitest-item000004","protectionState":"NotProtected"}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '983'
+      - '1955'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:08 GMT
+      - Wed, 16 Aug 2023 09:29:35 GMT
       expires:
       - '-1'
       pragma:
@@ -2125,22 +1788,22 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006","name":"clitest-item000006","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":1}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006","name":"clitest-item000006","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","workLoadType":"AzureFileShare","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T19:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T19:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '719'
+      - '751'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:09 GMT
+      - Wed, 16 Aug 2023 09:29:36 GMT
       expires:
       - '-1'
       pragma:
@@ -2156,7 +1819,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '295'
     status:
       code: 200
       message: OK
@@ -2180,26 +1843,26 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/azurefileshare%3B6bcfd92e6c5f11d939bb47d9ecc04df51dc0eb03a5cdf608599bd1590453feca?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/azurefileshare%3Bcedc90187291d7e86937febb5c66cd5d3fa2392853aadeeb714338ce7cb9aff3?api-version=2023-02-01
   response:
     body:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectedItems/azurefileshare;6bcfd92e6c5f11d939bb47d9ecc04df51dc0eb03a5cdf608599bd1590453feca/operationsStatus/8a7717c2-c0a6-4052-aacf-aad154e21dce?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectedItems/azurefileshare;cedc90187291d7e86937febb5c66cd5d3fa2392853aadeeb714338ce7cb9aff3/operationsStatus/d5a1cb2f-7ec7-4b31-9802-f4d925621306?api-version=2023-02-01
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:10:11 GMT
+      - Wed, 16 Aug 2023 09:29:38 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectedItems/azurefileshare;6bcfd92e6c5f11d939bb47d9ecc04df51dc0eb03a5cdf608599bd1590453feca/operationResults/8a7717c2-c0a6-4052-aacf-aad154e21dce?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectedItems/azurefileshare;cedc90187291d7e86937febb5c66cd5d3fa2392853aadeeb714338ce7cb9aff3/operationResults/d5a1cb2f-7ec7-4b31-9802-f4d925621306?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -2227,13 +1890,13 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8a7717c2-c0a6-4052-aacf-aad154e21dce?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/d5a1cb2f-7ec7-4b31-9802-f4d925621306?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"8a7717c2-c0a6-4052-aacf-aad154e21dce","name":"8a7717c2-c0a6-4052-aacf-aad154e21dce","status":"InProgress","startTime":"2023-05-17T12:10:10.7706684Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"d5a1cb2f-7ec7-4b31-9802-f4d925621306","name":"d5a1cb2f-7ec7-4b31-9802-f4d925621306","status":"InProgress","startTime":"2023-08-16T09:29:38.7140502Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -2242,7 +1905,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:11 GMT
+      - Wed, 16 Aug 2023 09:29:40 GMT
       expires:
       - '-1'
       pragma:
@@ -2276,13 +1939,13 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8a7717c2-c0a6-4052-aacf-aad154e21dce?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/d5a1cb2f-7ec7-4b31-9802-f4d925621306?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"8a7717c2-c0a6-4052-aacf-aad154e21dce","name":"8a7717c2-c0a6-4052-aacf-aad154e21dce","status":"InProgress","startTime":"2023-05-17T12:10:10.7706684Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"d5a1cb2f-7ec7-4b31-9802-f4d925621306","name":"d5a1cb2f-7ec7-4b31-9802-f4d925621306","status":"InProgress","startTime":"2023-08-16T09:29:38.7140502Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -2291,7 +1954,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:16 GMT
+      - Wed, 16 Aug 2023 09:29:45 GMT
       expires:
       - '-1'
       pragma:
@@ -2325,13 +1988,13 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8a7717c2-c0a6-4052-aacf-aad154e21dce?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/d5a1cb2f-7ec7-4b31-9802-f4d925621306?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"8a7717c2-c0a6-4052-aacf-aad154e21dce","name":"8a7717c2-c0a6-4052-aacf-aad154e21dce","status":"InProgress","startTime":"2023-05-17T12:10:10.7706684Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"d5a1cb2f-7ec7-4b31-9802-f4d925621306","name":"d5a1cb2f-7ec7-4b31-9802-f4d925621306","status":"InProgress","startTime":"2023-08-16T09:29:38.7140502Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -2340,7 +2003,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:21 GMT
+      - Wed, 16 Aug 2023 09:29:50 GMT
       expires:
       - '-1'
       pragma:
@@ -2374,13 +2037,13 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8a7717c2-c0a6-4052-aacf-aad154e21dce?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/d5a1cb2f-7ec7-4b31-9802-f4d925621306?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"8a7717c2-c0a6-4052-aacf-aad154e21dce","name":"8a7717c2-c0a6-4052-aacf-aad154e21dce","status":"InProgress","startTime":"2023-05-17T12:10:10.7706684Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"d5a1cb2f-7ec7-4b31-9802-f4d925621306","name":"d5a1cb2f-7ec7-4b31-9802-f4d925621306","status":"InProgress","startTime":"2023-08-16T09:29:38.7140502Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -2389,7 +2052,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:27 GMT
+      - Wed, 16 Aug 2023 09:29:55 GMT
       expires:
       - '-1'
       pragma:
@@ -2423,13 +2086,13 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8a7717c2-c0a6-4052-aacf-aad154e21dce?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/d5a1cb2f-7ec7-4b31-9802-f4d925621306?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"8a7717c2-c0a6-4052-aacf-aad154e21dce","name":"8a7717c2-c0a6-4052-aacf-aad154e21dce","status":"InProgress","startTime":"2023-05-17T12:10:10.7706684Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"d5a1cb2f-7ec7-4b31-9802-f4d925621306","name":"d5a1cb2f-7ec7-4b31-9802-f4d925621306","status":"InProgress","startTime":"2023-08-16T09:29:38.7140502Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -2438,7 +2101,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:33 GMT
+      - Wed, 16 Aug 2023 09:30:01 GMT
       expires:
       - '-1'
       pragma:
@@ -2472,13 +2135,13 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8a7717c2-c0a6-4052-aacf-aad154e21dce?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/d5a1cb2f-7ec7-4b31-9802-f4d925621306?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"8a7717c2-c0a6-4052-aacf-aad154e21dce","name":"8a7717c2-c0a6-4052-aacf-aad154e21dce","status":"InProgress","startTime":"2023-05-17T12:10:10.7706684Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"d5a1cb2f-7ec7-4b31-9802-f4d925621306","name":"d5a1cb2f-7ec7-4b31-9802-f4d925621306","status":"InProgress","startTime":"2023-08-16T09:29:38.7140502Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -2487,7 +2150,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:39 GMT
+      - Wed, 16 Aug 2023 09:30:06 GMT
       expires:
       - '-1'
       pragma:
@@ -2521,13 +2184,13 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8a7717c2-c0a6-4052-aacf-aad154e21dce?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/d5a1cb2f-7ec7-4b31-9802-f4d925621306?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"8a7717c2-c0a6-4052-aacf-aad154e21dce","name":"8a7717c2-c0a6-4052-aacf-aad154e21dce","status":"InProgress","startTime":"2023-05-17T12:10:10.7706684Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"d5a1cb2f-7ec7-4b31-9802-f4d925621306","name":"d5a1cb2f-7ec7-4b31-9802-f4d925621306","status":"InProgress","startTime":"2023-08-16T09:29:38.7140502Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -2536,7 +2199,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:44 GMT
+      - Wed, 16 Aug 2023 09:30:12 GMT
       expires:
       - '-1'
       pragma:
@@ -2570,13 +2233,13 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8a7717c2-c0a6-4052-aacf-aad154e21dce?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/d5a1cb2f-7ec7-4b31-9802-f4d925621306?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"8a7717c2-c0a6-4052-aacf-aad154e21dce","name":"8a7717c2-c0a6-4052-aacf-aad154e21dce","status":"InProgress","startTime":"2023-05-17T12:10:10.7706684Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"d5a1cb2f-7ec7-4b31-9802-f4d925621306","name":"d5a1cb2f-7ec7-4b31-9802-f4d925621306","status":"InProgress","startTime":"2023-08-16T09:29:38.7140502Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -2585,7 +2248,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:50 GMT
+      - Wed, 16 Aug 2023 09:30:18 GMT
       expires:
       - '-1'
       pragma:
@@ -2619,22 +2282,22 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8a7717c2-c0a6-4052-aacf-aad154e21dce?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/d5a1cb2f-7ec7-4b31-9802-f4d925621306?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"8a7717c2-c0a6-4052-aacf-aad154e21dce","name":"8a7717c2-c0a6-4052-aacf-aad154e21dce","status":"Succeeded","startTime":"2023-05-17T12:10:10.7706684Z","endTime":"2023-05-17T12:10:10.7706684Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"4b8cd5af-3438-4987-9d55-38cd1cbd26ac"}}'
+      string: '{"id":"d5a1cb2f-7ec7-4b31-9802-f4d925621306","name":"d5a1cb2f-7ec7-4b31-9802-f4d925621306","status":"InProgress","startTime":"2023-08-16T09:29:38.7140502Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '188'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:55 GMT
+      - Wed, 16 Aug 2023 09:30:23 GMT
       expires:
       - '-1'
       pragma:
@@ -2668,24 +2331,220 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/4b8cd5af-3438-4987-9d55-38cd1cbd26ac?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/d5a1cb2f-7ec7-4b31-9802-f4d925621306?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/4b8cd5af-3438-4987-9d55-38cd1cbd26ac","name":"4b8cd5af-3438-4987-9d55-38cd1cbd26ac","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT41.2215397S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
-        Share Name":"clitest-item000005","Storage Account Name":"clitest000003","Policy
-        Name":"clitest-item000006"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000005","backupManagementType":"AzureStorage","operation":"ConfigureBackup","status":"Completed","startTime":"2023-05-17T12:10:10.7706684Z","endTime":"2023-05-17T12:10:51.9922081Z","activityId":"c264318e-f4ab-11ed-b6dc-c8f750f92764"}}'
+      string: '{"id":"d5a1cb2f-7ec7-4b31-9802-f4d925621306","name":"d5a1cb2f-7ec7-4b31-9802-f4d925621306","status":"InProgress","startTime":"2023-08-16T09:29:38.7140502Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '897'
+      - '188'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:55 GMT
+      - Wed, 16 Aug 2023 09:30:29 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '290'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/d5a1cb2f-7ec7-4b31-9802-f4d925621306?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"d5a1cb2f-7ec7-4b31-9802-f4d925621306","name":"d5a1cb2f-7ec7-4b31-9802-f4d925621306","status":"InProgress","startTime":"2023-08-16T09:29:38.7140502Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:30:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '289'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/d5a1cb2f-7ec7-4b31-9802-f4d925621306?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"d5a1cb2f-7ec7-4b31-9802-f4d925621306","name":"d5a1cb2f-7ec7-4b31-9802-f4d925621306","status":"InProgress","startTime":"2023-08-16T09:29:38.7140502Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:30:39 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '288'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/d5a1cb2f-7ec7-4b31-9802-f4d925621306?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"d5a1cb2f-7ec7-4b31-9802-f4d925621306","name":"d5a1cb2f-7ec7-4b31-9802-f4d925621306","status":"Succeeded","startTime":"2023-08-16T09:29:38.7140502Z","endTime":"2023-08-16T09:29:38.7140502Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"920d08e4-31f3-4755-9bc3-6799b4e92afc"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:30:45 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '287'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/920d08e4-31f3-4755-9bc3-6799b4e92afc?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/920d08e4-31f3-4755-9bc3-6799b4e92afc","name":"920d08e4-31f3-4755-9bc3-6799b4e92afc","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT1M1.8037047S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
+        Share Name":"clitest-item000004","Storage Account Name":"clitest000003","Policy
+        Name":"clitest-item000006"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"ConfigureBackup","status":"Completed","startTime":"2023-08-16T09:29:38.7140502Z","endTime":"2023-08-16T09:30:40.5177549Z","activityId":"47e4176c-3c17-11ee-99ce-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '898'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:30:46 GMT
       expires:
       - '-1'
       pragma:
@@ -2713,14 +2572,706 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+status+eq+%27Registered%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","protectedItemCount":1,"acquireStorageAccountLock":"Acquire","friendlyName":"clitest000003","backupManagementType":"AzureStorage","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"StorageContainer","protectableObjectType":"StorageContainer"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '853'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:30:48 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '299'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectableItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+workloadType+eq+%27AzureFileShare%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectableItems/azurefileshare;8f0fb7c295f1e15b03639f071968d52f6c15e14bc5d6323bd1fd3f4fd17f568b","name":"azurefileshare;8f0fb7c295f1e15b03639f071968d52f6c15e14bc5d6323bd1fd3f4fd17f568b","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"parentContainerFabricId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","parentContainerFriendlyName":"clitest000003","azureFileShareType":"XSMB","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","protectableItemType":"AzureFileShare","friendlyName":"clitest-item000005","protectionState":"NotProtected"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '983'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:30:48 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '297'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006","name":"clitest-item000006","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","workLoadType":"AzureFileShare","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T19:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T19:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":1}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '751'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:30:50 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '298'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"protectedItemType": "AzureFileShareProtectedItem", "sourceResourceId":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003",
+      "policyId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '430'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/azurefileshare%3B8f0fb7c295f1e15b03639f071968d52f6c15e14bc5d6323bd1fd3f4fd17f568b?api-version=2023-02-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectedItems/azurefileshare;8f0fb7c295f1e15b03639f071968d52f6c15e14bc5d6323bd1fd3f4fd17f568b/operationsStatus/415cf633-d0fe-4580-9f2a-2b189f88359d?api-version=2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Wed, 16 Aug 2023 09:30:51 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectedItems/azurefileshare;8f0fb7c295f1e15b03639f071968d52f6c15e14bc5d6323bd1fd3f4fd17f568b/operationResults/415cf633-d0fe-4580-9f2a-2b189f88359d?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1195'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/415cf633-d0fe-4580-9f2a-2b189f88359d?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"415cf633-d0fe-4580-9f2a-2b189f88359d","name":"415cf633-d0fe-4580-9f2a-2b189f88359d","status":"InProgress","startTime":"2023-08-16T09:30:51.8514775Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:30:52 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '278'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/415cf633-d0fe-4580-9f2a-2b189f88359d?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"415cf633-d0fe-4580-9f2a-2b189f88359d","name":"415cf633-d0fe-4580-9f2a-2b189f88359d","status":"InProgress","startTime":"2023-08-16T09:30:51.8514775Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:30:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '276'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/415cf633-d0fe-4580-9f2a-2b189f88359d?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"415cf633-d0fe-4580-9f2a-2b189f88359d","name":"415cf633-d0fe-4580-9f2a-2b189f88359d","status":"InProgress","startTime":"2023-08-16T09:30:51.8514775Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:31:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '274'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/415cf633-d0fe-4580-9f2a-2b189f88359d?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"415cf633-d0fe-4580-9f2a-2b189f88359d","name":"415cf633-d0fe-4580-9f2a-2b189f88359d","status":"InProgress","startTime":"2023-08-16T09:30:51.8514775Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:31:09 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '272'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/415cf633-d0fe-4580-9f2a-2b189f88359d?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"415cf633-d0fe-4580-9f2a-2b189f88359d","name":"415cf633-d0fe-4580-9f2a-2b189f88359d","status":"InProgress","startTime":"2023-08-16T09:30:51.8514775Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:31:13 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '270'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/415cf633-d0fe-4580-9f2a-2b189f88359d?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"415cf633-d0fe-4580-9f2a-2b189f88359d","name":"415cf633-d0fe-4580-9f2a-2b189f88359d","status":"InProgress","startTime":"2023-08-16T09:30:51.8514775Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:31:20 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '268'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/415cf633-d0fe-4580-9f2a-2b189f88359d?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"415cf633-d0fe-4580-9f2a-2b189f88359d","name":"415cf633-d0fe-4580-9f2a-2b189f88359d","status":"InProgress","startTime":"2023-08-16T09:30:51.8514775Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:31:24 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '266'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/415cf633-d0fe-4580-9f2a-2b189f88359d?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"415cf633-d0fe-4580-9f2a-2b189f88359d","name":"415cf633-d0fe-4580-9f2a-2b189f88359d","status":"InProgress","startTime":"2023-08-16T09:30:51.8514775Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:31:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '264'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/415cf633-d0fe-4580-9f2a-2b189f88359d?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"415cf633-d0fe-4580-9f2a-2b189f88359d","name":"415cf633-d0fe-4580-9f2a-2b189f88359d","status":"Succeeded","startTime":"2023-08-16T09:30:51.8514775Z","endTime":"2023-08-16T09:30:51.8514775Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"c1790262-a429-4a3a-b681-d6f8088aff65"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:31:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '263'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/c1790262-a429-4a3a-b681-d6f8088aff65?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/c1790262-a429-4a3a-b681-d6f8088aff65","name":"c1790262-a429-4a3a-b681-d6f8088aff65","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT41.3625285S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
+        Share Name":"clitest-item000005","Storage Account Name":"clitest000003","Policy
+        Name":"clitest-item000006"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000005","backupManagementType":"AzureStorage","operation":"ConfigureBackup","status":"Completed","startTime":"2023-08-16T09:30:51.8514775Z","endTime":"2023-08-16T09:31:33.214006Z","activityId":"94a60166-3c17-11ee-9eb0-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '896'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:31:36 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '147'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
       - backup container show
       Connection:
       - keep-alive
       ParameterSetName:
       - -g -v -n --backup-management-type --query
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+friendlyName+eq+%27clitest000003%27+and+status+eq+%27Registered%27
   response:
@@ -2734,7 +3285,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:57 GMT
+      - Wed, 16 Aug 2023 09:31:38 GMT
       expires:
       - '-1'
       pragma:
@@ -2750,7 +3301,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '295'
     status:
       code: 200
       message: OK
@@ -2768,13 +3319,13 @@ interactions:
       ParameterSetName:
       - -g -v -c -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;6bcfd92e6c5f11d939bb47d9ecc04df51dc0eb03a5cdf608599bd1590453feca","name":"AzureFileShare;6bcfd92e6c5f11d939bb47d9ecc04df51dc0eb03a5cdf608599bd1590453feca","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000005","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;d7a22c5d547e60e80c985358f7b08a0f715f260d8b676e1d33b3478933fc229e","name":"AzureFileShare;d7a22c5d547e60e80c985358f7b08a0f715f260d8b676e1d33b3478933fc229e","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;8f0fb7c295f1e15b03639f071968d52f6c15e14bc5d6323bd1fd3f4fd17f568b","name":"AzureFileShare;8f0fb7c295f1e15b03639f071968d52f6c15e14bc5d6323bd1fd3f4fd17f568b","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000005","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;cedc90187291d7e86937febb5c66cd5d3fa2392853aadeeb714338ce7cb9aff3","name":"AzureFileShare;cedc90187291d7e86937febb5c66cd5d3fa2392853aadeeb714338ce7cb9aff3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
     headers:
       cache-control:
       - no-cache
@@ -2783,7 +3334,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:58 GMT
+      - Wed, 16 Aug 2023 09:31:40 GMT
       expires:
       - '-1'
       pragma:
@@ -2799,7 +3350,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '296'
     status:
       code: 200
       message: OK
@@ -2817,13 +3368,13 @@ interactions:
       ParameterSetName:
       - -g -v -c -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3Bd7a22c5d547e60e80c985358f7b08a0f715f260d8b676e1d33b3478933fc229e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3Bcedc90187291d7e86937febb5c66cd5d3fa2392853aadeeb714338ce7cb9aff3?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;d7a22c5d547e60e80c985358f7b08a0f715f260d8b676e1d33b3478933fc229e","name":"AzureFileShare;d7a22c5d547e60e80c985358f7b08a0f715f260d8b676e1d33b3478933fc229e","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","extendedInfo":{"recoveryPointCount":0,"policyState":"Consistent","resourceState":"Active","resourceStateSyncTime":"2023-05-17T12:10:01.4374136Z"},"protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;cedc90187291d7e86937febb5c66cd5d3fa2392853aadeeb714338ce7cb9aff3","name":"AzureFileShare;cedc90187291d7e86937febb5c66cd5d3fa2392853aadeeb714338ce7cb9aff3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","extendedInfo":{"recoveryPointCount":0,"policyState":"Consistent","resourceState":"Active","resourceStateSyncTime":"2023-08-16T09:30:40.2990023Z"},"protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}'
     headers:
       cache-control:
       - no-cache
@@ -2832,7 +3383,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:59 GMT
+      - Wed, 16 Aug 2023 09:31:41 GMT
       expires:
       - '-1'
       pragma:
@@ -2866,13 +3417,13 @@ interactions:
       ParameterSetName:
       - -g -v -c
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;6bcfd92e6c5f11d939bb47d9ecc04df51dc0eb03a5cdf608599bd1590453feca","name":"AzureFileShare;6bcfd92e6c5f11d939bb47d9ecc04df51dc0eb03a5cdf608599bd1590453feca","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000005","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;d7a22c5d547e60e80c985358f7b08a0f715f260d8b676e1d33b3478933fc229e","name":"AzureFileShare;d7a22c5d547e60e80c985358f7b08a0f715f260d8b676e1d33b3478933fc229e","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;8f0fb7c295f1e15b03639f071968d52f6c15e14bc5d6323bd1fd3f4fd17f568b","name":"AzureFileShare;8f0fb7c295f1e15b03639f071968d52f6c15e14bc5d6323bd1fd3f4fd17f568b","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000005","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;cedc90187291d7e86937febb5c66cd5d3fa2392853aadeeb714338ce7cb9aff3","name":"AzureFileShare;cedc90187291d7e86937febb5c66cd5d3fa2392853aadeeb714338ce7cb9aff3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
     headers:
       cache-control:
       - no-cache
@@ -2881,7 +3432,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:59 GMT
+      - Wed, 16 Aug 2023 09:31:42 GMT
       expires:
       - '-1'
       pragma:
@@ -2897,7 +3448,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '295'
     status:
       code: 200
       message: OK
@@ -2915,13 +3466,13 @@ interactions:
       ParameterSetName:
       - -g -v -c
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;6bcfd92e6c5f11d939bb47d9ecc04df51dc0eb03a5cdf608599bd1590453feca","name":"AzureFileShare;6bcfd92e6c5f11d939bb47d9ecc04df51dc0eb03a5cdf608599bd1590453feca","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000005","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;d7a22c5d547e60e80c985358f7b08a0f715f260d8b676e1d33b3478933fc229e","name":"AzureFileShare;d7a22c5d547e60e80c985358f7b08a0f715f260d8b676e1d33b3478933fc229e","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;8f0fb7c295f1e15b03639f071968d52f6c15e14bc5d6323bd1fd3f4fd17f568b","name":"AzureFileShare;8f0fb7c295f1e15b03639f071968d52f6c15e14bc5d6323bd1fd3f4fd17f568b","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000005","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;cedc90187291d7e86937febb5c66cd5d3fa2392853aadeeb714338ce7cb9aff3","name":"AzureFileShare;cedc90187291d7e86937febb5c66cd5d3fa2392853aadeeb714338ce7cb9aff3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
     headers:
       cache-control:
       - no-cache
@@ -2930,7 +3481,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:11:00 GMT
+      - Wed, 16 Aug 2023 09:31:43 GMT
       expires:
       - '-1'
       pragma:
@@ -2946,7 +3497,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '296'
     status:
       code: 200
       message: OK
@@ -2964,13 +3515,13 @@ interactions:
       ParameterSetName:
       - -g -v -c
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;6bcfd92e6c5f11d939bb47d9ecc04df51dc0eb03a5cdf608599bd1590453feca","name":"AzureFileShare;6bcfd92e6c5f11d939bb47d9ecc04df51dc0eb03a5cdf608599bd1590453feca","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000005","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;d7a22c5d547e60e80c985358f7b08a0f715f260d8b676e1d33b3478933fc229e","name":"AzureFileShare;d7a22c5d547e60e80c985358f7b08a0f715f260d8b676e1d33b3478933fc229e","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;8f0fb7c295f1e15b03639f071968d52f6c15e14bc5d6323bd1fd3f4fd17f568b","name":"AzureFileShare;8f0fb7c295f1e15b03639f071968d52f6c15e14bc5d6323bd1fd3f4fd17f568b","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000005","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;cedc90187291d7e86937febb5c66cd5d3fa2392853aadeeb714338ce7cb9aff3","name":"AzureFileShare;cedc90187291d7e86937febb5c66cd5d3fa2392853aadeeb714338ce7cb9aff3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
     headers:
       cache-control:
       - no-cache
@@ -2979,105 +3530,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:11:01 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup item set-policy
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -n -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;6bcfd92e6c5f11d939bb47d9ecc04df51dc0eb03a5cdf608599bd1590453feca","name":"AzureFileShare;6bcfd92e6c5f11d939bb47d9ecc04df51dc0eb03a5cdf608599bd1590453feca","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000005","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;d7a22c5d547e60e80c985358f7b08a0f715f260d8b676e1d33b3478933fc229e","name":"AzureFileShare;d7a22c5d547e60e80c985358f7b08a0f715f260d8b676e1d33b3478933fc229e","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '2945'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:11:01 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup item set-policy
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -n -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000007?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000007","name":"clitest-item000007","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '719'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:11:02 GMT
+      - Wed, 16 Aug 2023 09:31:44 GMT
       expires:
       - '-1'
       pragma:
@@ -3111,8 +3564,106 @@ interactions:
       ParameterSetName:
       - -g -v -c -n -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;8f0fb7c295f1e15b03639f071968d52f6c15e14bc5d6323bd1fd3f4fd17f568b","name":"AzureFileShare;8f0fb7c295f1e15b03639f071968d52f6c15e14bc5d6323bd1fd3f4fd17f568b","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000005","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;cedc90187291d7e86937febb5c66cd5d3fa2392853aadeeb714338ce7cb9aff3","name":"AzureFileShare;cedc90187291d7e86937febb5c66cd5d3fa2392853aadeeb714338ce7cb9aff3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2945'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:31:46 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '294'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup item set-policy
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -n -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000007?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000007","name":"clitest-item000007","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","workLoadType":"AzureFileShare","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T19:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T19:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '751'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:31:47 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '295'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup item set-policy
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -n -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupResourceGuardProxies?api-version=2023-02-01
   response:
@@ -3126,7 +3677,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:11:03 GMT
+      - Wed, 16 Aug 2023 09:31:48 GMT
       expires:
       - '-1'
       pragma:
@@ -3164,26 +3715,26 @@ interactions:
       ParameterSetName:
       - -g -v -c -n -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3Bd7a22c5d547e60e80c985358f7b08a0f715f260d8b676e1d33b3478933fc229e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3Bcedc90187291d7e86937febb5c66cd5d3fa2392853aadeeb714338ce7cb9aff3?api-version=2023-02-01
   response:
     body:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;d7a22c5d547e60e80c985358f7b08a0f715f260d8b676e1d33b3478933fc229e/operationsStatus/5a9b8f3c-e17f-4b6d-89e5-8f8ceeed21c9?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;cedc90187291d7e86937febb5c66cd5d3fa2392853aadeeb714338ce7cb9aff3/operationsStatus/aa8e337a-2745-464e-81ba-a866bbf4527e?api-version=2023-02-01
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:11:04 GMT
+      - Wed, 16 Aug 2023 09:31:49 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;d7a22c5d547e60e80c985358f7b08a0f715f260d8b676e1d33b3478933fc229e/operationResults/5a9b8f3c-e17f-4b6d-89e5-8f8ceeed21c9?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;cedc90187291d7e86937febb5c66cd5d3fa2392853aadeeb714338ce7cb9aff3/operationResults/aa8e337a-2745-464e-81ba-a866bbf4527e?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -3193,7 +3744,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1194'
     status:
       code: 202
       message: Accepted
@@ -3211,13 +3762,13 @@ interactions:
       ParameterSetName:
       - -g -v -c -n -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5a9b8f3c-e17f-4b6d-89e5-8f8ceeed21c9?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/aa8e337a-2745-464e-81ba-a866bbf4527e?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"5a9b8f3c-e17f-4b6d-89e5-8f8ceeed21c9","name":"5a9b8f3c-e17f-4b6d-89e5-8f8ceeed21c9","status":"InProgress","startTime":"2023-05-17T12:11:04.9127019Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"aa8e337a-2745-464e-81ba-a866bbf4527e","name":"aa8e337a-2745-464e-81ba-a866bbf4527e","status":"InProgress","startTime":"2023-08-16T09:31:50.3271612Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -3226,7 +3777,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:11:04 GMT
+      - Wed, 16 Aug 2023 09:31:51 GMT
       expires:
       - '-1'
       pragma:
@@ -3242,7 +3793,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '287'
     status:
       code: 200
       message: OK
@@ -3260,13 +3811,13 @@ interactions:
       ParameterSetName:
       - -g -v -c -n -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5a9b8f3c-e17f-4b6d-89e5-8f8ceeed21c9?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/aa8e337a-2745-464e-81ba-a866bbf4527e?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"5a9b8f3c-e17f-4b6d-89e5-8f8ceeed21c9","name":"5a9b8f3c-e17f-4b6d-89e5-8f8ceeed21c9","status":"InProgress","startTime":"2023-05-17T12:11:04.9127019Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"aa8e337a-2745-464e-81ba-a866bbf4527e","name":"aa8e337a-2745-464e-81ba-a866bbf4527e","status":"InProgress","startTime":"2023-08-16T09:31:50.3271612Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -3275,7 +3826,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:11:11 GMT
+      - Wed, 16 Aug 2023 09:31:56 GMT
       expires:
       - '-1'
       pragma:
@@ -3291,7 +3842,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
+      - '285'
     status:
       code: 200
       message: OK
@@ -3309,13 +3860,13 @@ interactions:
       ParameterSetName:
       - -g -v -c -n -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5a9b8f3c-e17f-4b6d-89e5-8f8ceeed21c9?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/aa8e337a-2745-464e-81ba-a866bbf4527e?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"5a9b8f3c-e17f-4b6d-89e5-8f8ceeed21c9","name":"5a9b8f3c-e17f-4b6d-89e5-8f8ceeed21c9","status":"InProgress","startTime":"2023-05-17T12:11:04.9127019Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"aa8e337a-2745-464e-81ba-a866bbf4527e","name":"aa8e337a-2745-464e-81ba-a866bbf4527e","status":"InProgress","startTime":"2023-08-16T09:31:50.3271612Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -3324,7 +3875,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:11:16 GMT
+      - Wed, 16 Aug 2023 09:32:01 GMT
       expires:
       - '-1'
       pragma:
@@ -3340,7 +3891,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '296'
+      - '283'
     status:
       code: 200
       message: OK
@@ -3358,13 +3909,13 @@ interactions:
       ParameterSetName:
       - -g -v -c -n -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5a9b8f3c-e17f-4b6d-89e5-8f8ceeed21c9?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/aa8e337a-2745-464e-81ba-a866bbf4527e?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"5a9b8f3c-e17f-4b6d-89e5-8f8ceeed21c9","name":"5a9b8f3c-e17f-4b6d-89e5-8f8ceeed21c9","status":"InProgress","startTime":"2023-05-17T12:11:04.9127019Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"aa8e337a-2745-464e-81ba-a866bbf4527e","name":"aa8e337a-2745-464e-81ba-a866bbf4527e","status":"InProgress","startTime":"2023-08-16T09:31:50.3271612Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -3373,7 +3924,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:11:21 GMT
+      - Wed, 16 Aug 2023 09:32:07 GMT
       expires:
       - '-1'
       pragma:
@@ -3389,7 +3940,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '295'
+      - '282'
     status:
       code: 200
       message: OK
@@ -3407,13 +3958,13 @@ interactions:
       ParameterSetName:
       - -g -v -c -n -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5a9b8f3c-e17f-4b6d-89e5-8f8ceeed21c9?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/aa8e337a-2745-464e-81ba-a866bbf4527e?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"5a9b8f3c-e17f-4b6d-89e5-8f8ceeed21c9","name":"5a9b8f3c-e17f-4b6d-89e5-8f8ceeed21c9","status":"InProgress","startTime":"2023-05-17T12:11:04.9127019Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"aa8e337a-2745-464e-81ba-a866bbf4527e","name":"aa8e337a-2745-464e-81ba-a866bbf4527e","status":"InProgress","startTime":"2023-08-16T09:31:50.3271612Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -3422,7 +3973,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:11:27 GMT
+      - Wed, 16 Aug 2023 09:32:12 GMT
       expires:
       - '-1'
       pragma:
@@ -3438,7 +3989,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '294'
+      - '281'
     status:
       code: 200
       message: OK
@@ -3456,13 +4007,13 @@ interactions:
       ParameterSetName:
       - -g -v -c -n -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5a9b8f3c-e17f-4b6d-89e5-8f8ceeed21c9?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/aa8e337a-2745-464e-81ba-a866bbf4527e?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"5a9b8f3c-e17f-4b6d-89e5-8f8ceeed21c9","name":"5a9b8f3c-e17f-4b6d-89e5-8f8ceeed21c9","status":"InProgress","startTime":"2023-05-17T12:11:04.9127019Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"aa8e337a-2745-464e-81ba-a866bbf4527e","name":"aa8e337a-2745-464e-81ba-a866bbf4527e","status":"InProgress","startTime":"2023-08-16T09:31:50.3271612Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -3471,7 +4022,254 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:11:32 GMT
+      - Wed, 16 Aug 2023 09:32:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '280'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup item set-policy
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -n -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/aa8e337a-2745-464e-81ba-a866bbf4527e?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"aa8e337a-2745-464e-81ba-a866bbf4527e","name":"aa8e337a-2745-464e-81ba-a866bbf4527e","status":"InProgress","startTime":"2023-08-16T09:31:50.3271612Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:32:23 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '279'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup item set-policy
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -n -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/aa8e337a-2745-464e-81ba-a866bbf4527e?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"aa8e337a-2745-464e-81ba-a866bbf4527e","name":"aa8e337a-2745-464e-81ba-a866bbf4527e","status":"InProgress","startTime":"2023-08-16T09:31:50.3271612Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:32:29 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '278'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup item set-policy
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -n -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/aa8e337a-2745-464e-81ba-a866bbf4527e?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"aa8e337a-2745-464e-81ba-a866bbf4527e","name":"aa8e337a-2745-464e-81ba-a866bbf4527e","status":"Succeeded","startTime":"2023-08-16T09:31:50.3271612Z","endTime":"2023-08-16T09:31:50.3271612Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"e9dba853-f801-45e5-b635-1484ca9802b3"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:32:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '277'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup item set-policy
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -n -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/e9dba853-f801-45e5-b635-1484ca9802b3?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/e9dba853-f801-45e5-b635-1484ca9802b3","name":"e9dba853-f801-45e5-b635-1484ca9802b3","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT41.0507568S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
+        Share Name":"clitest-item000004","Storage Account Name":"clitest000003","Policy
+        Name":"clitest-item000007"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"ConfigureBackup","status":"Completed","startTime":"2023-08-16T09:31:50.3271612Z","endTime":"2023-08-16T09:32:31.377918Z","activityId":"b7996be2-3c17-11ee-ab62-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '896'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:32:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '145'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup item show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;8f0fb7c295f1e15b03639f071968d52f6c15e14bc5d6323bd1fd3f4fd17f568b","name":"AzureFileShare;8f0fb7c295f1e15b03639f071968d52f6c15e14bc5d6323bd1fd3f4fd17f568b","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000005","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;cedc90187291d7e86937febb5c66cd5d3fa2392853aadeeb714338ce7cb9aff3","name":"AzureFileShare;cedc90187291d7e86937febb5c66cd5d3fa2392853aadeeb714338ce7cb9aff3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000007","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2945'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:32:37 GMT
       expires:
       - '-1'
       pragma:
@@ -3499,28 +4297,28 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - backup item set-policy
+      - backup protection disable
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -v -c -n -p
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5a9b8f3c-e17f-4b6d-89e5-8f8ceeed21c9?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
     body:
-      string: '{"id":"5a9b8f3c-e17f-4b6d-89e5-8f8ceeed21c9","name":"5a9b8f3c-e17f-4b6d-89e5-8f8ceeed21c9","status":"InProgress","startTime":"2023-05-17T12:11:04.9127019Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;8f0fb7c295f1e15b03639f071968d52f6c15e14bc5d6323bd1fd3f4fd17f568b","name":"AzureFileShare;8f0fb7c295f1e15b03639f071968d52f6c15e14bc5d6323bd1fd3f4fd17f568b","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000005","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;cedc90187291d7e86937febb5c66cd5d3fa2392853aadeeb714338ce7cb9aff3","name":"AzureFileShare;cedc90187291d7e86937febb5c66cd5d3fa2392853aadeeb714338ce7cb9aff3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000007","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '2945'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:11:38 GMT
+      - Wed, 16 Aug 2023 09:32:38 GMT
       expires:
       - '-1'
       pragma:
@@ -3548,261 +4346,14 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - backup item set-policy
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -n -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5a9b8f3c-e17f-4b6d-89e5-8f8ceeed21c9?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"5a9b8f3c-e17f-4b6d-89e5-8f8ceeed21c9","name":"5a9b8f3c-e17f-4b6d-89e5-8f8ceeed21c9","status":"InProgress","startTime":"2023-05-17T12:11:04.9127019Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:11:44 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '291'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup item set-policy
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -n -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5a9b8f3c-e17f-4b6d-89e5-8f8ceeed21c9?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"5a9b8f3c-e17f-4b6d-89e5-8f8ceeed21c9","name":"5a9b8f3c-e17f-4b6d-89e5-8f8ceeed21c9","status":"Succeeded","startTime":"2023-05-17T12:11:04.9127019Z","endTime":"2023-05-17T12:11:04.9127019Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"22f8700b-faf8-4f4c-87bd-c0519c13eacd"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:11:50 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '290'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup item set-policy
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -n -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/22f8700b-faf8-4f4c-87bd-c0519c13eacd?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/22f8700b-faf8-4f4c-87bd-c0519c13eacd","name":"22f8700b-faf8-4f4c-87bd-c0519c13eacd","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT40.9906982S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
-        Share Name":"clitest-item000004","Storage Account Name":"clitest000003","Policy
-        Name":"clitest-item000007"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"ConfigureBackup","status":"Completed","startTime":"2023-05-17T12:11:04.9127019Z","endTime":"2023-05-17T12:11:45.9034001Z","activityId":"e32451ca-f4ab-11ed-9eae-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '897'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:11:50 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '149'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup item show
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;6bcfd92e6c5f11d939bb47d9ecc04df51dc0eb03a5cdf608599bd1590453feca","name":"AzureFileShare;6bcfd92e6c5f11d939bb47d9ecc04df51dc0eb03a5cdf608599bd1590453feca","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000005","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;d7a22c5d547e60e80c985358f7b08a0f715f260d8b676e1d33b3478933fc229e","name":"AzureFileShare;d7a22c5d547e60e80c985358f7b08a0f715f260d8b676e1d33b3478933fc229e","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000007","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '2945'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:11:51 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
       - backup protection disable
       Connection:
       - keep-alive
       ParameterSetName:
       - -g -v -c -i --backup-management-type --delete-backup-data --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;6bcfd92e6c5f11d939bb47d9ecc04df51dc0eb03a5cdf608599bd1590453feca","name":"AzureFileShare;6bcfd92e6c5f11d939bb47d9ecc04df51dc0eb03a5cdf608599bd1590453feca","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000005","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;d7a22c5d547e60e80c985358f7b08a0f715f260d8b676e1d33b3478933fc229e","name":"AzureFileShare;d7a22c5d547e60e80c985358f7b08a0f715f260d8b676e1d33b3478933fc229e","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000007","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '2945'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:11:51 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupResourceGuardProxies?api-version=2023-02-01
   response:
@@ -3816,7 +4367,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:11:52 GMT
+      - Wed, 16 Aug 2023 09:32:39 GMT
       expires:
       - '-1'
       pragma:
@@ -3850,26 +4401,26 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --backup-management-type --delete-backup-data --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3Bd7a22c5d547e60e80c985358f7b08a0f715f260d8b676e1d33b3478933fc229e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3Bcedc90187291d7e86937febb5c66cd5d3fa2392853aadeeb714338ce7cb9aff3?api-version=2023-02-01
   response:
     body:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3f6a298-8285-4f8a-a1f4-7f23fffafacd?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/f7ab29b0-0be6-435d-aeef-d2970bab84c7?api-version=2023-02-01
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:11:55 GMT
+      - Wed, 16 Aug 2023 09:32:41 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/b3f6a298-8285-4f8a-a1f4-7f23fffafacd?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/f7ab29b0-0be6-435d-aeef-d2970bab84c7?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -3879,7 +4430,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-deletes:
-      - '14999'
+      - '14995'
     status:
       code: 202
       message: Accepted
@@ -3897,13 +4448,13 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --backup-management-type --delete-backup-data --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3f6a298-8285-4f8a-a1f4-7f23fffafacd?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/f7ab29b0-0be6-435d-aeef-d2970bab84c7?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"b3f6a298-8285-4f8a-a1f4-7f23fffafacd","name":"b3f6a298-8285-4f8a-a1f4-7f23fffafacd","status":"InProgress","startTime":"2023-05-17T12:11:54.9435948Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"f7ab29b0-0be6-435d-aeef-d2970bab84c7","name":"f7ab29b0-0be6-435d-aeef-d2970bab84c7","status":"InProgress","startTime":"2023-08-16T09:32:41.0852051Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -3912,7 +4463,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:11:55 GMT
+      - Wed, 16 Aug 2023 09:32:42 GMT
       expires:
       - '-1'
       pragma:
@@ -3928,7 +4479,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '285'
     status:
       code: 200
       message: OK
@@ -3946,13 +4497,13 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --backup-management-type --delete-backup-data --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3f6a298-8285-4f8a-a1f4-7f23fffafacd?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/f7ab29b0-0be6-435d-aeef-d2970bab84c7?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"b3f6a298-8285-4f8a-a1f4-7f23fffafacd","name":"b3f6a298-8285-4f8a-a1f4-7f23fffafacd","status":"InProgress","startTime":"2023-05-17T12:11:54.9435948Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"f7ab29b0-0be6-435d-aeef-d2970bab84c7","name":"f7ab29b0-0be6-435d-aeef-d2970bab84c7","status":"InProgress","startTime":"2023-08-16T09:32:41.0852051Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -3961,7 +4512,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:12:00 GMT
+      - Wed, 16 Aug 2023 09:32:47 GMT
       expires:
       - '-1'
       pragma:
@@ -3977,7 +4528,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '284'
     status:
       code: 200
       message: OK
@@ -3995,13 +4546,13 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --backup-management-type --delete-backup-data --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3f6a298-8285-4f8a-a1f4-7f23fffafacd?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/f7ab29b0-0be6-435d-aeef-d2970bab84c7?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"b3f6a298-8285-4f8a-a1f4-7f23fffafacd","name":"b3f6a298-8285-4f8a-a1f4-7f23fffafacd","status":"InProgress","startTime":"2023-05-17T12:11:54.9435948Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"f7ab29b0-0be6-435d-aeef-d2970bab84c7","name":"f7ab29b0-0be6-435d-aeef-d2970bab84c7","status":"InProgress","startTime":"2023-08-16T09:32:41.0852051Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4010,7 +4561,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:12:06 GMT
+      - Wed, 16 Aug 2023 09:32:52 GMT
       expires:
       - '-1'
       pragma:
@@ -4026,7 +4577,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
+      - '283'
     status:
       code: 200
       message: OK
@@ -4044,13 +4595,13 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --backup-management-type --delete-backup-data --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3f6a298-8285-4f8a-a1f4-7f23fffafacd?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/f7ab29b0-0be6-435d-aeef-d2970bab84c7?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"b3f6a298-8285-4f8a-a1f4-7f23fffafacd","name":"b3f6a298-8285-4f8a-a1f4-7f23fffafacd","status":"InProgress","startTime":"2023-05-17T12:11:54.9435948Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"f7ab29b0-0be6-435d-aeef-d2970bab84c7","name":"f7ab29b0-0be6-435d-aeef-d2970bab84c7","status":"InProgress","startTime":"2023-08-16T09:32:41.0852051Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4059,7 +4610,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:12:12 GMT
+      - Wed, 16 Aug 2023 09:32:58 GMT
       expires:
       - '-1'
       pragma:
@@ -4075,7 +4626,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '296'
+      - '282'
     status:
       code: 200
       message: OK
@@ -4093,13 +4644,13 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --backup-management-type --delete-backup-data --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3f6a298-8285-4f8a-a1f4-7f23fffafacd?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/f7ab29b0-0be6-435d-aeef-d2970bab84c7?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"b3f6a298-8285-4f8a-a1f4-7f23fffafacd","name":"b3f6a298-8285-4f8a-a1f4-7f23fffafacd","status":"Succeeded","startTime":"2023-05-17T12:11:54.9435948Z","endTime":"2023-05-17T12:11:54.9435948Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"639b0d0e-deae-4a4d-abfb-6c5ea416584e"}}'
+      string: '{"id":"f7ab29b0-0be6-435d-aeef-d2970bab84c7","name":"f7ab29b0-0be6-435d-aeef-d2970bab84c7","status":"Succeeded","startTime":"2023-08-16T09:32:41.0852051Z","endTime":"2023-08-16T09:32:41.0852051Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"44b5edad-27fc-4a37-9a85-dd51e63e9bba"}}'
     headers:
       cache-control:
       - no-cache
@@ -4108,7 +4659,546 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:12:18 GMT
+      - Wed, 16 Aug 2023 09:33:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '281'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/44b5edad-27fc-4a37-9a85-dd51e63e9bba?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/44b5edad-27fc-4a37-9a85-dd51e63e9bba","name":"44b5edad-27fc-4a37-9a85-dd51e63e9bba","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT21.0177201S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
+        Share Name":"clitest-item000004","Storage Account Name":"clitest000003"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"DeleteBackupData","status":"Completed","startTime":"2023-08-16T09:32:41.0852051Z","endTime":"2023-08-16T09:33:02.1029252Z","activityId":"d6a5062b-3c17-11ee-84b2-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '863'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:33:04 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '148'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;8f0fb7c295f1e15b03639f071968d52f6c15e14bc5d6323bd1fd3f4fd17f568b","name":"AzureFileShare;8f0fb7c295f1e15b03639f071968d52f6c15e14bc5d6323bd1fd3f4fd17f568b","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000005","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1478'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:33:05 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '291'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupResourceGuardProxies?api-version=2023-02-01
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:33:06 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3B8f0fb7c295f1e15b03639f071968d52f6c15e14bc5d6323bd1fd3f4fd17f568b?api-version=2023-02-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c31d2bd0-f878-4839-9240-d24f86036151?api-version=2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Wed, 16 Aug 2023 09:33:08 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/c31d2bd0-f878-4839-9240-d24f86036151?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14994'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c31d2bd0-f878-4839-9240-d24f86036151?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"c31d2bd0-f878-4839-9240-d24f86036151","name":"c31d2bd0-f878-4839-9240-d24f86036151","status":"InProgress","startTime":"2023-08-16T09:33:08.8308039Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:33:09 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '276'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c31d2bd0-f878-4839-9240-d24f86036151?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"c31d2bd0-f878-4839-9240-d24f86036151","name":"c31d2bd0-f878-4839-9240-d24f86036151","status":"InProgress","startTime":"2023-08-16T09:33:08.8308039Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:33:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '275'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c31d2bd0-f878-4839-9240-d24f86036151?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"c31d2bd0-f878-4839-9240-d24f86036151","name":"c31d2bd0-f878-4839-9240-d24f86036151","status":"InProgress","startTime":"2023-08-16T09:33:08.8308039Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:33:20 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '274'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c31d2bd0-f878-4839-9240-d24f86036151?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"c31d2bd0-f878-4839-9240-d24f86036151","name":"c31d2bd0-f878-4839-9240-d24f86036151","status":"InProgress","startTime":"2023-08-16T09:33:08.8308039Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:33:26 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '273'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c31d2bd0-f878-4839-9240-d24f86036151?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"c31d2bd0-f878-4839-9240-d24f86036151","name":"c31d2bd0-f878-4839-9240-d24f86036151","status":"Succeeded","startTime":"2023-08-16T09:33:08.8308039Z","endTime":"2023-08-16T09:33:08.8308039Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"28222798-d78f-4f4f-a20c-28e050b6f348"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:33:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '272'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/28222798-d78f-4f4f-a20c-28e050b6f348?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/28222798-d78f-4f4f-a20c-28e050b6f348","name":"28222798-d78f-4f4f-a20c-28e050b6f348","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT21.0059907S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
+        Share Name":"clitest-item000005","Storage Account Name":"clitest000003"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000005","backupManagementType":"AzureStorage","operation":"DeleteBackupData","status":"Completed","startTime":"2023-08-16T09:33:08.8308039Z","endTime":"2023-08-16T09:33:29.8367946Z","activityId":"e72ec333-3c17-11ee-99d5-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '863'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:33:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '146'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+friendlyName+eq+%27clitest000003%27+and+status+eq+%27Registered%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","protectedItemCount":0,"acquireStorageAccountLock":"Acquire","friendlyName":"clitest000003","backupManagementType":"AzureStorage","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"StorageContainer","protectableObjectType":"StorageContainer"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '853'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:33:33 GMT
       expires:
       - '-1'
       pragma:
@@ -4136,545 +5226,6 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/639b0d0e-deae-4a4d-abfb-6c5ea416584e?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/639b0d0e-deae-4a4d-abfb-6c5ea416584e","name":"639b0d0e-deae-4a4d-abfb-6c5ea416584e","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT20.9184556S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
-        Share Name":"clitest-item000004","Storage Account Name":"clitest000003"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"DeleteBackupData","status":"Completed","startTime":"2023-05-17T12:11:54.9435948Z","endTime":"2023-05-17T12:12:15.8620504Z","activityId":"00d661cf-f4ac-11ed-8aff-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '863'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:12:18 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '149'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;6bcfd92e6c5f11d939bb47d9ecc04df51dc0eb03a5cdf608599bd1590453feca","name":"AzureFileShare;6bcfd92e6c5f11d939bb47d9ecc04df51dc0eb03a5cdf608599bd1590453feca","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000005","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000006","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1478'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:12:19 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupResourceGuardProxies?api-version=2023-02-01
-  response:
-    body:
-      string: '{"value":[]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '12'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:12:20 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3B6bcfd92e6c5f11d939bb47d9ecc04df51dc0eb03a5cdf608599bd1590453feca?api-version=2023-02-01
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c60c5e25-6f41-4c68-abf8-0307c5856bd0?api-version=2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Wed, 17 May 2023 12:12:22 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/c60c5e25-6f41-4c68-abf8-0307c5856bd0?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-deletes:
-      - '14999'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c60c5e25-6f41-4c68-abf8-0307c5856bd0?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"c60c5e25-6f41-4c68-abf8-0307c5856bd0","name":"c60c5e25-6f41-4c68-abf8-0307c5856bd0","status":"InProgress","startTime":"2023-05-17T12:12:22.0809376Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:12:22 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c60c5e25-6f41-4c68-abf8-0307c5856bd0?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"c60c5e25-6f41-4c68-abf8-0307c5856bd0","name":"c60c5e25-6f41-4c68-abf8-0307c5856bd0","status":"InProgress","startTime":"2023-05-17T12:12:22.0809376Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:12:27 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '296'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c60c5e25-6f41-4c68-abf8-0307c5856bd0?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"c60c5e25-6f41-4c68-abf8-0307c5856bd0","name":"c60c5e25-6f41-4c68-abf8-0307c5856bd0","status":"InProgress","startTime":"2023-05-17T12:12:22.0809376Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:12:33 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '294'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c60c5e25-6f41-4c68-abf8-0307c5856bd0?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"c60c5e25-6f41-4c68-abf8-0307c5856bd0","name":"c60c5e25-6f41-4c68-abf8-0307c5856bd0","status":"InProgress","startTime":"2023-05-17T12:12:22.0809376Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:12:39 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '291'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c60c5e25-6f41-4c68-abf8-0307c5856bd0?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"c60c5e25-6f41-4c68-abf8-0307c5856bd0","name":"c60c5e25-6f41-4c68-abf8-0307c5856bd0","status":"Succeeded","startTime":"2023-05-17T12:12:22.0809376Z","endTime":"2023-05-17T12:12:22.0809376Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"c0613f87-46ae-453d-8c5d-51efcd839add"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:12:45 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '289'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/c0613f87-46ae-453d-8c5d-51efcd839add?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/c0613f87-46ae-453d-8c5d-51efcd839add","name":"c0613f87-46ae-453d-8c5d-51efcd839add","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT20.8909515S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
-        Share Name":"clitest-item000005","Storage Account Name":"clitest000003"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000005","backupManagementType":"AzureStorage","operation":"DeleteBackupData","status":"Completed","startTime":"2023-05-17T12:12:22.0809376Z","endTime":"2023-05-17T12:12:42.9718891Z","activityId":"115bc6c9-f4ac-11ed-be94-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '863'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:12:46 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '149'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container unregister
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c --yes --backup-management-type
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+friendlyName+eq+%27clitest000003%27+and+status+eq+%27Registered%27
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","protectedItemCount":0,"acquireStorageAccountLock":"Acquire","friendlyName":"clitest000003","backupManagementType":"AzureStorage","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"StorageContainer","protectableObjectType":"StorageContainer"}}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '853'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:12:46 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
       - backup container unregister
       Connection:
       - keep-alive
@@ -4683,8 +5234,8 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003?api-version=2023-02-01
   response:
@@ -4692,17 +5243,17 @@ interactions:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/670973e9-bfe6-4074-b037-2571313dcab9?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:12:47 GMT
+      - Wed, 16 Aug 2023 09:33:34 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/670973e9-bfe6-4074-b037-2571313dcab9?fabricName=Azure?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/bdf7f516-fd7e-4894-8d79-e5efb98293ea?fabricName=Azure?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -4730,16 +5281,16 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/670973e9-bfe6-4074-b037-2571313dcab9?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/670973e9-bfe6-4074-b037-2571313dcab9?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -4747,11 +5298,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:12:48 GMT
+      - Wed, 16 Aug 2023 09:33:35 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/670973e9-bfe6-4074-b037-2571313dcab9?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -4761,7 +5312,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '284'
     status:
       code: 202
       message: Accepted
@@ -4779,16 +5330,16 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/670973e9-bfe6-4074-b037-2571313dcab9?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/670973e9-bfe6-4074-b037-2571313dcab9?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -4796,11 +5347,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:12:54 GMT
+      - Wed, 16 Aug 2023 09:33:41 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/670973e9-bfe6-4074-b037-2571313dcab9?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -4810,7 +5361,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '283'
     status:
       code: 202
       message: Accepted
@@ -4828,16 +5379,16 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/670973e9-bfe6-4074-b037-2571313dcab9?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/670973e9-bfe6-4074-b037-2571313dcab9?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -4845,11 +5396,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:12:59 GMT
+      - Wed, 16 Aug 2023 09:33:46 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/670973e9-bfe6-4074-b037-2571313dcab9?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -4859,7 +5410,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
+      - '282'
     status:
       code: 202
       message: Accepted
@@ -4877,16 +5428,16 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/670973e9-bfe6-4074-b037-2571313dcab9?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/670973e9-bfe6-4074-b037-2571313dcab9?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -4894,11 +5445,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:13:05 GMT
+      - Wed, 16 Aug 2023 09:33:52 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/670973e9-bfe6-4074-b037-2571313dcab9?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -4908,7 +5459,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '296'
+      - '281'
     status:
       code: 202
       message: Accepted
@@ -4926,10 +5477,598 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/670973e9-bfe6-4074-b037-2571313dcab9?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:33:58 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '280'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:34:02 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '279'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:34:08 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '278'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:34:14 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '277'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:34:19 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '276'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:34:25 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '275'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:34:30 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '274'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:34:36 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '273'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:34:40 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '272'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:34:46 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '271'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:34:52 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '270'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:34:57 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '269'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/bdf7f516-fd7e-4894-8d79-e5efb98293ea?api-version=2023-02-01
   response:
     body:
       string: ''
@@ -4937,7 +6076,7 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Wed, 17 May 2023 12:13:10 GMT
+      - Wed, 16 Aug 2023 09:35:02 GMT
       expires:
       - '-1'
       pragma:
@@ -4949,7 +6088,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '295'
+      - '268'
     status:
       code: 204
       message: No Content
@@ -4961,16 +6100,16 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - backup container list
+      - lock list
       Connection:
       - keep-alive
       ParameterSetName:
-      - --backup-management-type -v -g --query
+      - -g
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureIaasVM%27+and+status+eq+%27Registered%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/locks?api-version=2016-09-01
   response:
     body:
       string: '{"value":[]}'
@@ -4982,7 +6121,53 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:14:52 GMT
+      - Wed, 16 Aug 2023 09:36:43 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --container-name --item-name --backup-management-type --workload-type
+        --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+itemType+eq+%27AzureFileShare%27
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:36:44 GMT
       expires:
       - '-1'
       pragma:
@@ -4998,7 +6183,249 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '295'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --vault-name --resource-group --container-name --backup-management-type --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+friendlyName+eq+%27clitest000003%27+and+status+eq+%27Registered%27
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:36:46 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '294'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - lock list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/locks?api-version=2016-09-01
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:36:48 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --container-name --item-name --backup-management-type --workload-type
+        --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+itemType+eq+%27AzureFileShare%27
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:36:49 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '294'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --vault-name --resource-group --container-name --backup-management-type --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+friendlyName+eq+%27clitest000003%27+and+status+eq+%27Registered%27
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:36:49 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '293'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type -v -g --query
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureIaasVM%27+and+status+eq+%27Registered%27
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:36:51 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '293'
     status:
       code: 200
       message: OK
@@ -5018,7 +6445,8 @@ interactions:
       ParameterSetName:
       - -n -g --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2023-02-01
   response:
@@ -5030,7 +6458,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:14:59 GMT
+      - Wed, 16 Aug 2023 09:36:54 GMT
       expires:
       - '-1'
       pragma:
@@ -5042,7 +6470,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '49'
+      - '48'
     status:
       code: 200
       message: OK

--- a/src/azure-cli/azure/cli/command_modules/backup/tests/latest/recordings/test_afs_backup_policy.yaml
+++ b/src/azure-cli/azure/cli/command_modules/backup/tests/latest/recordings/test_afs_backup_policy.yaml
@@ -13,7 +13,8 @@ interactions:
       ParameterSetName:
       - -n -g --location
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2023-02-01
   response:
@@ -29,7 +30,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:06:46 GMT
+      - Wed, 16 Aug 2023 09:25:55 GMT
       expires:
       - '-1'
       pragma:
@@ -64,15 +65,16 @@ interactions:
       ParameterSetName:
       - -n -g --location
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2023-02-01
   response:
     body:
-      string: '{"location":"eastus2euap","name":"clitest-vault000002","etag":"W/\"datetime''2023-05-17T12%3A06%3A52.3680042Z''\"","properties":{"provisioningState":"Provisioning","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}},"publicNetworkAccess":"Enabled","restoreSettings":{"crossSubscriptionRestoreSettings":{"crossSubscriptionRestoreState":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+      string: '{"location":"eastus2euap","name":"clitest-vault000002","etag":"W/\"datetime''2023-08-16T09%3A25%3A56.2917203Z''\"","properties":{"provisioningState":"Provisioning","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}},"publicNetworkAccess":"Enabled","restoreSettings":{"crossSubscriptionRestoreSettings":{"crossSubscriptionRestoreState":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0Nzs0YzI3OGFmYi0zNzRiLTQ3ZGYtOGJhYS0zNWQzZTZiY2FlYzM=?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NztlYzZmZDFlZS1jNjNjLTRmZjgtOGM5NC03NmViMzQ4ODliZmU=?api-version=2023-02-01
       cache-control:
       - no-cache
       content-length:
@@ -80,7 +82,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:06:54 GMT
+      - Wed, 16 Aug 2023 09:25:56 GMT
       expires:
       - '-1'
       pragma:
@@ -91,8 +93,10 @@ interactions:
       - max-age=31536000; includeSubDomains
       x-content-type-options:
       - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=12f8ea5c-1212-449e-b31c-0a574f43076e/centraluseuap/4e13841f-ce51-4428-8f1a-193c6a395337
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '298'
     status:
       code: 201
       message: Created
@@ -110,14 +114,68 @@ interactions:
       ParameterSetName:
       - -n -g --location
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0Nzs0YzI3OGFmYi0zNzRiLTQ3ZGYtOGJhYS0zNWQzZTZiY2FlYzM=?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NztlYzZmZDFlZS1jNjNjLTRmZjgtOGM5NC03NmViMzQ4ODliZmU=?api-version=2023-02-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0Nzs0YzI3OGFmYi0zNzRiLTQ3ZGYtOGJhYS0zNWQzZTZiY2FlYzM=\",\r\n
-        \ \"name\": \"MjA0Nzs0YzI3OGFmYi0zNzRiLTQ3ZGYtOGJhYS0zNWQzZTZiY2FlYzM=\",\r\n
-        \ \"status\": \"Succeeded\"\r\n}"
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NztlYzZmZDFlZS1jNjNjLTRmZjgtOGM5NC03NmViMzQ4ODliZmU=\"\
+        ,\r\n  \"name\": \"MjA0NztlYzZmZDFlZS1jNjNjLTRmZjgtOGM5NC03NmViMzQ4ODliZmU=\"\
+        ,\r\n  \"status\": \"InProgress\"\r\n}"
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NztlYzZmZDFlZS1jNjNjLTRmZjgtOGM5NC03NmViMzQ4ODliZmU=?api-version=2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '334'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:25:56 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationResults/MjA0NztlYzZmZDFlZS1jNjNjLTRmZjgtOGM5NC03NmViMzQ4ODliZmU=?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --location
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NztlYzZmZDFlZS1jNjNjLTRmZjgtOGM5NC03NmViMzQ4ODliZmU=?api-version=2023-02-01
+  response:
+    body:
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NztlYzZmZDFlZS1jNjNjLTRmZjgtOGM5NC03NmViMzQ4ODliZmU=\"\
+        ,\r\n  \"name\": \"MjA0NztlYzZmZDFlZS1jNjNjLTRmZjgtOGM5NC03NmViMzQ4ODliZmU=\"\
+        ,\r\n  \"status\": \"Succeeded\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -126,7 +184,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:06:54 GMT
+      - Wed, 16 Aug 2023 09:26:56 GMT
       expires:
       - '-1'
       pragma:
@@ -158,21 +216,22 @@ interactions:
       ParameterSetName:
       - -n -g --location
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2023-02-01
   response:
     body:
-      string: '{"location":"eastus2euap","name":"clitest-vault000002","etag":"W/\"datetime''2023-05-17T12%3A06%3A53.991386Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","backupStorageVersion":"Unassigned","monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}},"securitySettings":{"immutabilitySettings":null,"softDeleteSettings":{"softDeleteRetentionPeriodInDays":14,"softDeleteState":"Enabled"},"multiUserAuthorization":"Disabled"},"publicNetworkAccess":"Enabled","restoreSettings":{"crossSubscriptionRestoreSettings":{"crossSubscriptionRestoreState":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+      string: '{"location":"eastus2euap","name":"clitest-vault000002","etag":"W/\"datetime''2023-08-16T09%3A26%3A57.0150834Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","backupStorageVersion":"Unassigned","monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}},"securitySettings":{"immutabilitySettings":null,"softDeleteSettings":{"softDeleteRetentionPeriodInDays":14,"softDeleteState":"Enabled"},"multiUserAuthorization":"Disabled"},"publicNetworkAccess":"Enabled","restoreSettings":{"crossSubscriptionRestoreSettings":{"crossSubscriptionRestoreState":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '961'
+      - '962'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:06:55 GMT
+      - Wed, 16 Aug 2023 09:26:57 GMT
       expires:
       - '-1'
       pragma:
@@ -187,6 +246,156 @@ interactions:
       - Accept-Encoding
       x-content-type-options:
       - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault backup-properties set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --soft-delete-feature-state
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupconfig/vaultconfig?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupconfig/vaultconfig","name":"vaultconfig","type":"Microsoft.RecoveryServices/vaults/backupconfig","properties":{"enhancedSecurityState":"Enabled","softDeleteFeatureState":"Enabled","softDeleteRetentionPeriodInDays":14,"isSoftDeleteFeatureStateEditable":true}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '419'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:26:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '298'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault backup-properties set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --soft-delete-feature-state
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupResourceGuardProxies?api-version=2023-02-01
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:26:59 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"enhancedSecurityState": "Enabled", "softDeleteFeatureState":
+      "Disabled"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault backup-properties set
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '90'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -n -g --soft-delete-feature-state
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: PATCH
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupconfig/vaultconfig?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupconfig/vaultconfig","name":"vaultconfig","type":"Microsoft.RecoveryServices/vaults/backupconfig","properties":{"enhancedSecurityState":"Enabled","softDeleteFeatureState":"Disabled","softDeleteRetentionPeriodInDays":14,"isSoftDeleteFeatureStateEditable":true}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '420'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:27:00 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1197'
     status:
       code: 200
       message: OK
@@ -206,12 +415,13 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-storage/21.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003/listKeys?api-version=2022-09-01&$expand=kerb
   response:
     body:
-      string: '{"keys":[{"creationTime":"2023-05-17T12:07:00.9357454Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2023-05-17T12:07:00.9357454Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
+      string: '{"keys":[{"creationTime":"2023-08-16T09:27:03.0940593Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2023-08-16T09:27:03.0940593Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
     headers:
       cache-control:
       - no-cache
@@ -220,7 +430,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 17 May 2023 12:07:24 GMT
+      - Wed, 16 Aug 2023 09:27:26 GMT
       expires:
       - '-1'
       pragma:
@@ -236,7 +446,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11996'
     status:
       code: 200
       message: OK
@@ -254,21 +464,22 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-storage/21.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","name":"clitest000003","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"keyCreationTime":{"key1":"2023-05-17T12:07:00.9357454Z","key2":"2023-05-17T12:07:00.9357454Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-05-17T12:07:01.3576700Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-05-17T12:07:01.3576700Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-05-17T12:07:00.8419909Z","primaryEndpoints":{"blob":"https://clitest000003.blob.core.windows.net/","queue":"https://clitest000003.queue.core.windows.net/","table":"https://clitest000003.table.core.windows.net/","file":"https://clitest000003.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","name":"clitest000003","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"keyCreationTime":{"key1":"2023-08-16T09:27:03.0940593Z","key2":"2023-08-16T09:27:03.0940593Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-08-16T09:27:03.5003233Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-08-16T09:27:03.5003233Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-08-16T09:27:03.0003041Z","primaryEndpoints":{"blob":"https://clitest000003.blob.core.windows.net/","queue":"https://clitest000003.queue.core.windows.net/","table":"https://clitest000003.table.core.windows.net/","file":"https://clitest000003.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1280'
+      - '1316'
       content-type:
       - application/json
       date:
-      - Wed, 17 May 2023 12:07:25 GMT
+      - Wed, 16 Aug 2023 09:27:26 GMT
       expires:
       - '-1'
       pragma:
@@ -302,9 +513,10 @@ interactions:
       ParameterSetName:
       - --name --quota --connection-string
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-storage-file-share/12.12.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-storage-file-share/12.12.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Wed, 17 May 2023 12:07:24 GMT
+      - Wed, 16 Aug 2023 09:27:27 GMT
       x-ms-share-quota:
       - '1'
       x-ms-version:
@@ -318,11 +530,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:07:26 GMT
+      - Wed, 16 Aug 2023 09:27:28 GMT
       etag:
-      - '"0x8DB56CF48176606"'
+      - '"0x8DB9E3B026DA69E"'
       last-modified:
-      - Wed, 17 May 2023 12:07:27 GMT
+      - Wed, 16 Aug 2023 09:27:28 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
@@ -344,13 +556,13 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T19:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T19:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
@@ -359,7 +571,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:07:30 GMT
+      - Wed, 16 Aug 2023 09:27:28 GMT
       expires:
       - '-1'
       pragma:
@@ -375,16 +587,16 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '297'
     status:
       code: 200
       message: OK
 - request:
     body: '{"properties": {"protectedItemsCount": 0, "backupManagementType": "AzureStorage",
       "workLoadType": "AzureFileShare", "schedulePolicy": {"schedulePolicyType": "SimpleSchedulePolicy",
-      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2023-05-17T22:00:00.000Z"],
+      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2023-08-16T19:00:00.000Z"],
       "scheduleWeeklyFrequency": 0}, "retentionPolicy": {"retentionPolicyType": "LongTermRetentionPolicy",
-      "dailySchedule": {"retentionTimes": ["2023-05-17T22:00:00.000Z"], "retentionDuration":
+      "dailySchedule": {"retentionTimes": ["2023-08-16T19:00:00.000Z"], "retentionDuration":
       {"count": 30, "durationType": "Days"}}}, "timeZone": "UTC"}}'
     headers:
       Accept:
@@ -402,22 +614,22 @@ interactions:
       ParameterSetName:
       - -g -v --policy -n --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","name":"clitest-item000005","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","name":"clitest-item000005","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","workLoadType":"AzureFileShare","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T19:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T19:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '719'
+      - '751'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:07:32 GMT
+      - Wed, 16 Aug 2023 09:27:31 GMT
       expires:
       - '-1'
       pragma:
@@ -433,7 +645,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1194'
     status:
       code: 200
       message: OK
@@ -451,8 +663,8 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+status+eq+%27Registered%27
   response:
@@ -466,7 +678,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:07:34 GMT
+      - Wed, 16 Aug 2023 09:27:32 GMT
       expires:
       - '-1'
       pragma:
@@ -482,7 +694,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '298'
     status:
       code: 200
       message: OK
@@ -500,22 +712,22 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","name":"StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"adiguptecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/adigupt-ecy-rg/providers/Microsoft.Storage/storageAccounts/adiguptecy"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg2yfprhyqds;clitesttz6sdom2jatwnfac4","name":"StorageContainer;Storage;clitest.rg2yfprhyqds;clitesttz6sdom2jatwnfac4","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesttz6sdom2jatwnfac4","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg2yfprhyqds/providers/Microsoft.Storage/storageAccounts/clitesttz6sdom2jatwnfac4"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgcg55fjw6oydcqxadogkryma2vngbhcbisbtwvzrlednvwxiqdh5vw4j7ltte2nacv;clitestle63ytisykbtb4afs","name":"StorageContainer;Storage;clitest.rgcg55fjw6oydcqxadogkryma2vngbhcbisbtwvzrlednvwxiqdh5vw4j7ltte2nacv;clitestle63ytisykbtb4afs","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestle63ytisykbtb4afs","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgcg55fjw6oydcqxadogkryma2vngbhcbisbtwvzrlednvwxiqdh5vw4j7ltte2nacv/providers/Microsoft.Storage/storageAccounts/clitestle63ytisykbtb4afs"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx;clitest5g7td7ozjqq2b6ccr","name":"StorageContainer;Storage;clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx;clitest5g7td7ozjqq2b6ccr","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest5g7td7ozjqq2b6ccr","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx/providers/Microsoft.Storage/storageAccounts/clitest5g7td7ozjqq2b6ccr"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rglhjd23gmd22yjo46bvchsudoznlqkhubppep3t6sillavnqqy7ioqnd5cmz66wupg;clitestyg5bffz6esoe2kj6r","name":"StorageContainer;Storage;clitest.rglhjd23gmd22yjo46bvchsudoznlqkhubppep3t6sillavnqqy7ioqnd5cmz66wupg;clitestyg5bffz6esoe2kj6r","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestyg5bffz6esoe2kj6r","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rglhjd23gmd22yjo46bvchsudoznlqkhubppep3t6sillavnqqy7ioqnd5cmz66wupg/providers/Microsoft.Storage/storageAccounts/clitestyg5bffz6esoe2kj6r"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rguab7asrflt;clitestfdfvj5rqbl2gzzi3b","name":"StorageContainer;Storage;clitest.rguab7asrflt;clitestfdfvj5rqbl2gzzi3b","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestfdfvj5rqbl2gzzi3b","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rguab7asrflt/providers/Microsoft.Storage/storageAccounts/clitestfdfvj5rqbl2gzzi3b"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","name":"StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontusebvtaksecycansa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DonotUse-Blobs-BVT-EACAN-RG/providers/Microsoft.Storage/storageAccounts/dontusebvtaksecycansa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","name":"StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"iaasextstoreecy1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.czr/providers/Microsoft.Storage/storageAccounts/iaasextstoreecy1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","name":"StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesaksdonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-clitest-rg/providers/Microsoft.Storage/storageAccounts/clitesaksdonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"bloboprestorecontainers","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/bloboprestorecontainers"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopall","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopall"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopcontainer","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopcontainer"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopprefix","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopprefix"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG;zubairsaecy","name":"StorageContainer;Storage;zubairRG;zubairsaecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Storage/storageAccounts/zubairsaecy"}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","name":"StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"adiguptecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/adigupt-ecy-rg/providers/Microsoft.Storage/storageAccounts/adiguptecy"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","name":"StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontusebvtaksecycansa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DonotUse-Blobs-BVT-EACAN-RG/providers/Microsoft.Storage/storageAccounts/dontusebvtaksecycansa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","name":"StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"iaasextstoreecy1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.czr/providers/Microsoft.Storage/storageAccounts/iaasextstoreecy1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","name":"StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesaksdonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-clitest-rg/providers/Microsoft.Storage/storageAccounts/clitesaksdonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"bloboprestorecontainers","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/bloboprestorecontainers"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopall","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopall"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopcontainer","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopcontainer"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopprefix","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopprefix"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG2;zubairsaecy2","name":"StorageContainer;Storage;zubairRG2;zubairsaecy2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy2","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG2/providers/Microsoft.Storage/storageAccounts/zubairsaecy2"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG;zubairsaecy","name":"StorageContainer;Storage;zubairRG;zubairsaecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Storage/storageAccounts/zubairsaecy"}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '11164'
+      - '7516'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:07:35 GMT
+      - Wed, 16 Aug 2023 09:27:33 GMT
       expires:
       - '-1'
       pragma:
@@ -531,7 +743,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '298'
     status:
       code: 200
       message: OK
@@ -551,8 +763,8 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/refreshContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
@@ -560,17 +772,17 @@ interactions:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/892751bc-c24a-48d1-8290-7eeb4bf3b43e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/995f9df2-c1d7-4d50-bf45-d1518b747bdb?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:07:37 GMT
+      - Wed, 16 Aug 2023 09:27:34 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/892751bc-c24a-48d1-8290-7eeb4bf3b43e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/995f9df2-c1d7-4d50-bf45-d1518b747bdb?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -598,10 +810,10 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/892751bc-c24a-48d1-8290-7eeb4bf3b43e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/995f9df2-c1d7-4d50-bf45-d1518b747bdb?api-version=2023-02-01
   response:
     body:
       string: ''
@@ -611,11 +823,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:07:38 GMT
+      - Wed, 16 Aug 2023 09:27:35 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/892751bc-c24a-48d1-8290-7eeb4bf3b43e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/995f9df2-c1d7-4d50-bf45-d1518b747bdb?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -625,7 +837,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '296'
     status:
       code: 202
       message: Accepted
@@ -643,10 +855,10 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/892751bc-c24a-48d1-8290-7eeb4bf3b43e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/995f9df2-c1d7-4d50-bf45-d1518b747bdb?api-version=2023-02-01
   response:
     body:
       string: ''
@@ -656,11 +868,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:07:44 GMT
+      - Wed, 16 Aug 2023 09:27:41 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/892751bc-c24a-48d1-8290-7eeb4bf3b43e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/995f9df2-c1d7-4d50-bf45-d1518b747bdb?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -670,7 +882,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '295'
     status:
       code: 202
       message: Accepted
@@ -688,10 +900,10 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/892751bc-c24a-48d1-8290-7eeb4bf3b43e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/995f9df2-c1d7-4d50-bf45-d1518b747bdb?api-version=2023-02-01
   response:
     body:
       string: ''
@@ -699,7 +911,7 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Wed, 17 May 2023 12:07:49 GMT
+      - Wed, 16 Aug 2023 09:27:46 GMT
       expires:
       - '-1'
       pragma:
@@ -711,7 +923,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
+      - '294'
     status:
       code: 204
       message: No Content
@@ -729,22 +941,22 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","name":"StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"adiguptecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/adigupt-ecy-rg/providers/Microsoft.Storage/storageAccounts/adiguptecy"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg2yfprhyqds;clitesttz6sdom2jatwnfac4","name":"StorageContainer;Storage;clitest.rg2yfprhyqds;clitesttz6sdom2jatwnfac4","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesttz6sdom2jatwnfac4","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg2yfprhyqds/providers/Microsoft.Storage/storageAccounts/clitesttz6sdom2jatwnfac4"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest000003","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx;clitest5g7td7ozjqq2b6ccr","name":"StorageContainer;Storage;clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx;clitest5g7td7ozjqq2b6ccr","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest5g7td7ozjqq2b6ccr","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx/providers/Microsoft.Storage/storageAccounts/clitest5g7td7ozjqq2b6ccr"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","name":"StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontusebvtaksecycansa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DonotUse-Blobs-BVT-EACAN-RG/providers/Microsoft.Storage/storageAccounts/dontusebvtaksecycansa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","name":"StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"iaasextstoreecy1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.czr/providers/Microsoft.Storage/storageAccounts/iaasextstoreecy1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","name":"StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesaksdonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-clitest-rg/providers/Microsoft.Storage/storageAccounts/clitesaksdonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"bloboprestorecontainers","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/bloboprestorecontainers"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopall","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopall"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopcontainer","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopcontainer"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopprefix","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopprefix"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG;zubairsaecy","name":"StorageContainer;Storage;zubairRG;zubairsaecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Storage/storageAccounts/zubairsaecy"}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","name":"StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"adiguptecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/adigupt-ecy-rg/providers/Microsoft.Storage/storageAccounts/adiguptecy"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest000003","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgzoyjagb5eb;clitestamxx27lkbfywib4s6","name":"StorageContainer;Storage;clitest.rgzoyjagb5eb;clitestamxx27lkbfywib4s6","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestamxx27lkbfywib4s6","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgzoyjagb5eb/providers/Microsoft.Storage/storageAccounts/clitestamxx27lkbfywib4s6"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","name":"StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontusebvtaksecycansa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DonotUse-Blobs-BVT-EACAN-RG/providers/Microsoft.Storage/storageAccounts/dontusebvtaksecycansa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","name":"StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"iaasextstoreecy1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.czr/providers/Microsoft.Storage/storageAccounts/iaasextstoreecy1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","name":"StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesaksdonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-clitest-rg/providers/Microsoft.Storage/storageAccounts/clitesaksdonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"bloboprestorecontainers","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/bloboprestorecontainers"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopall","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopall"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopcontainer","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopcontainer"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopprefix","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopprefix"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG2;zubairsaecy2","name":"StorageContainer;Storage;zubairRG2;zubairsaecy2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy2","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG2/providers/Microsoft.Storage/storageAccounts/zubairsaecy2"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG;zubairsaecy","name":"StorageContainer;Storage;zubairRG;zubairsaecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Storage/storageAccounts/zubairsaecy"}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '9242'
+      - '8996'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:07:51 GMT
+      - Wed, 16 Aug 2023 09:27:47 GMT
       expires:
       - '-1'
       pragma:
@@ -760,7 +972,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '296'
     status:
       code: 200
       message: OK
@@ -783,8 +995,8 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003?api-version=2023-02-01
   response:
@@ -792,7 +1004,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/a37e5cee-c55d-445a-bdd7-1fafd9910f2b?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/00b7c707-a591-4756-b9e9-c3f96284c74d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -800,11 +1012,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:07:52 GMT
+      - Wed, 16 Aug 2023 09:27:49 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/a37e5cee-c55d-445a-bdd7-1fafd9910f2b?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/00b7c707-a591-4756-b9e9-c3f96284c74d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -814,7 +1026,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1192'
     status:
       code: 202
       message: Accepted
@@ -832,16 +1044,16 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/a37e5cee-c55d-445a-bdd7-1fafd9910f2b?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/00b7c707-a591-4756-b9e9-c3f96284c74d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/a37e5cee-c55d-445a-bdd7-1fafd9910f2b?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/00b7c707-a591-4756-b9e9-c3f96284c74d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -849,60 +1061,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:07:53 GMT
+      - Wed, 16 Aug 2023 09:27:50 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/a37e5cee-c55d-445a-bdd7-1fafd9910f2b?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/a37e5cee-c55d-445a-bdd7-1fafd9910f2b?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/a37e5cee-c55d-445a-bdd7-1fafd9910f2b?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:07:58 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/a37e5cee-c55d-445a-bdd7-1fafd9910f2b?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/00b7c707-a591-4756-b9e9-c3f96284c74d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -930,16 +1093,16 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/a37e5cee-c55d-445a-bdd7-1fafd9910f2b?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/00b7c707-a591-4756-b9e9-c3f96284c74d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/a37e5cee-c55d-445a-bdd7-1fafd9910f2b?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/00b7c707-a591-4756-b9e9-c3f96284c74d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -947,11 +1110,60 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:04 GMT
+      - Wed, 16 Aug 2023 09:27:55 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/a37e5cee-c55d-445a-bdd7-1fafd9910f2b?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/00b7c707-a591-4756-b9e9-c3f96284c74d?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '295'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/00b7c707-a591-4756-b9e9-c3f96284c74d?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/00b7c707-a591-4756-b9e9-c3f96284c74d?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:28:01 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/00b7c707-a591-4756-b9e9-c3f96284c74d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -979,16 +1191,16 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/a37e5cee-c55d-445a-bdd7-1fafd9910f2b?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/00b7c707-a591-4756-b9e9-c3f96284c74d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/a37e5cee-c55d-445a-bdd7-1fafd9910f2b?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/00b7c707-a591-4756-b9e9-c3f96284c74d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -996,11 +1208,60 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:09 GMT
+      - Wed, 16 Aug 2023 09:28:06 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/a37e5cee-c55d-445a-bdd7-1fafd9910f2b?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/00b7c707-a591-4756-b9e9-c3f96284c74d?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '293'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/00b7c707-a591-4756-b9e9-c3f96284c74d?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/00b7c707-a591-4756-b9e9-c3f96284c74d?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:28:11 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/00b7c707-a591-4756-b9e9-c3f96284c74d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -1028,16 +1289,16 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/a37e5cee-c55d-445a-bdd7-1fafd9910f2b?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/00b7c707-a591-4756-b9e9-c3f96284c74d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/a37e5cee-c55d-445a-bdd7-1fafd9910f2b?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/00b7c707-a591-4756-b9e9-c3f96284c74d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -1045,11 +1306,60 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:15 GMT
+      - Wed, 16 Aug 2023 09:28:17 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/a37e5cee-c55d-445a-bdd7-1fafd9910f2b?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/00b7c707-a591-4756-b9e9-c3f96284c74d?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '291'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/00b7c707-a591-4756-b9e9-c3f96284c74d?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/00b7c707-a591-4756-b9e9-c3f96284c74d?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:28:22 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/00b7c707-a591-4756-b9e9-c3f96284c74d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -1077,10 +1387,108 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/a37e5cee-c55d-445a-bdd7-1fafd9910f2b?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/00b7c707-a591-4756-b9e9-c3f96284c74d?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/00b7c707-a591-4756-b9e9-c3f96284c74d?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:28:28 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/00b7c707-a591-4756-b9e9-c3f96284c74d?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '289'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/00b7c707-a591-4756-b9e9-c3f96284c74d?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/00b7c707-a591-4756-b9e9-c3f96284c74d?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:28:33 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/00b7c707-a591-4756-b9e9-c3f96284c74d?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '288'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/00b7c707-a591-4756-b9e9-c3f96284c74d?api-version=2023-02-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","protectedItemCount":0,"acquireStorageAccountLock":"Acquire","friendlyName":"clitest000003","backupManagementType":"AzureStorage","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"StorageContainer","protectableObjectType":"StorageContainer"}}'
@@ -1092,1685 +1500,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:20 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '288'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectableItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+workloadType+eq+%27AzureFileShare%27
-  response:
-    body:
-      string: '{"value":[]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '12'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:08:21 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/inquire?api-version=2023-02-01&%24filter=workloadType+eq+%27AzureFileShare%27
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/fb19a266-ce77-4ae6-8723-8f63d8e26192?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Wed, 17 May 2023 12:08:23 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/fb19a266-ce77-4ae6-8723-8f63d8e26192?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/fb19a266-ce77-4ae6-8723-8f63d8e26192?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/fb19a266-ce77-4ae6-8723-8f63d8e26192?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:08:25 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/fb19a266-ce77-4ae6-8723-8f63d8e26192?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/fb19a266-ce77-4ae6-8723-8f63d8e26192?api-version=2023-02-01
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      date:
-      - Wed, 17 May 2023 12:08:30 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectableItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+workloadType+eq+%27AzureFileShare%27
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectableItems/azurefileshare;6d6fac9f520ff146fa229011a68c02a027aa09210826a440fabd74c33af1298a","name":"azurefileshare;6d6fac9f520ff146fa229011a68c02a027aa09210826a440fabd74c33af1298a","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"parentContainerFabricId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","parentContainerFriendlyName":"clitest000003","azureFileShareType":"XSMB","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","protectableItemType":"AzureFileShare","friendlyName":"clitest-item000004","protectionState":"NotProtected"}}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '983'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:08:31 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","name":"clitest-item000005","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '719'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:08:32 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"protectedItemType": "AzureFileShareProtectedItem", "sourceResourceId":
-      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003",
-      "policyId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005"}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '430'
-      Content-Type:
-      - application/json
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/azurefileshare%3B6d6fac9f520ff146fa229011a68c02a027aa09210826a440fabd74c33af1298a?api-version=2023-02-01
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectedItems/azurefileshare;6d6fac9f520ff146fa229011a68c02a027aa09210826a440fabd74c33af1298a/operationsStatus/9281931d-a675-47cf-a495-8f5e026b2a69?api-version=2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Wed, 17 May 2023 12:08:34 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectedItems/azurefileshare;6d6fac9f520ff146fa229011a68c02a027aa09210826a440fabd74c33af1298a/operationResults/9281931d-a675-47cf-a495-8f5e026b2a69?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/9281931d-a675-47cf-a495-8f5e026b2a69?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"9281931d-a675-47cf-a495-8f5e026b2a69","name":"9281931d-a675-47cf-a495-8f5e026b2a69","status":"InProgress","startTime":"2023-05-17T12:08:34.3682817Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:08:34 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/9281931d-a675-47cf-a495-8f5e026b2a69?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"9281931d-a675-47cf-a495-8f5e026b2a69","name":"9281931d-a675-47cf-a495-8f5e026b2a69","status":"InProgress","startTime":"2023-05-17T12:08:34.3682817Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:08:40 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/9281931d-a675-47cf-a495-8f5e026b2a69?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"9281931d-a675-47cf-a495-8f5e026b2a69","name":"9281931d-a675-47cf-a495-8f5e026b2a69","status":"InProgress","startTime":"2023-05-17T12:08:34.3682817Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:08:45 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/9281931d-a675-47cf-a495-8f5e026b2a69?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"9281931d-a675-47cf-a495-8f5e026b2a69","name":"9281931d-a675-47cf-a495-8f5e026b2a69","status":"InProgress","startTime":"2023-05-17T12:08:34.3682817Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:08:51 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '296'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/9281931d-a675-47cf-a495-8f5e026b2a69?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"9281931d-a675-47cf-a495-8f5e026b2a69","name":"9281931d-a675-47cf-a495-8f5e026b2a69","status":"InProgress","startTime":"2023-05-17T12:08:34.3682817Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:08:56 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '295'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/9281931d-a675-47cf-a495-8f5e026b2a69?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"9281931d-a675-47cf-a495-8f5e026b2a69","name":"9281931d-a675-47cf-a495-8f5e026b2a69","status":"InProgress","startTime":"2023-05-17T12:08:34.3682817Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:03 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '294'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/9281931d-a675-47cf-a495-8f5e026b2a69?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"9281931d-a675-47cf-a495-8f5e026b2a69","name":"9281931d-a675-47cf-a495-8f5e026b2a69","status":"InProgress","startTime":"2023-05-17T12:08:34.3682817Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:08 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '293'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/9281931d-a675-47cf-a495-8f5e026b2a69?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"9281931d-a675-47cf-a495-8f5e026b2a69","name":"9281931d-a675-47cf-a495-8f5e026b2a69","status":"InProgress","startTime":"2023-05-17T12:08:34.3682817Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:13 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '292'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/9281931d-a675-47cf-a495-8f5e026b2a69?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"9281931d-a675-47cf-a495-8f5e026b2a69","name":"9281931d-a675-47cf-a495-8f5e026b2a69","status":"Succeeded","startTime":"2023-05-17T12:08:34.3682817Z","endTime":"2023-05-17T12:08:34.3682817Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"a25c9043-21fd-4187-822c-568d882a6cf4"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:19 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '291'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a25c9043-21fd-4187-822c-568d882a6cf4?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a25c9043-21fd-4187-822c-568d882a6cf4","name":"a25c9043-21fd-4187-822c-568d882a6cf4","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT41.6208351S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
-        Share Name":"clitest-item000004","Storage Account Name":"clitest000003","Policy
-        Name":"clitest-item000005"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"ConfigureBackup","status":"Completed","startTime":"2023-05-17T12:08:34.3682817Z","endTime":"2023-05-17T12:09:15.9891168Z","activityId":"66b4ac0d-f4ab-11ed-9102-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '897'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:20 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '149'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup policy list
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --backup-management-type
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","name":"clitest-item000005","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '731'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:21 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup policy show
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","name":"clitest-item000005","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":1}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '719'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:21 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"protectedItemsCount": 1, "backupManagementType": "AzureStorage",
-      "workLoadType": "AzureFileShare", "schedulePolicy": {"schedulePolicyType": "SimpleSchedulePolicy",
-      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2023-05-17T22:00:00.000Z"],
-      "scheduleWeeklyFrequency": 0}, "retentionPolicy": {"retentionPolicyType": "LongTermRetentionPolicy",
-      "dailySchedule": {"retentionTimes": ["2023-05-17T22:00:00.000Z"], "retentionDuration":
-      {"count": 25, "durationType": "Days"}}}, "timeZone": "UTC"}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup policy create
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '512'
-      Content-Type:
-      - application/json
-      ParameterSetName:
-      - -g -v --policy --name --backup-management-type
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitestafspolicy?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitestafspolicy","name":"clitestafspolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":25,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '715'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:22 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup policy show
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitestafspolicy?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitestafspolicy","name":"clitestafspolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":25,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '715'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:23 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup policy list
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --backup-management-type
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitestafspolicy","name":"clitestafspolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":25,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","name":"clitest-item000005","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1447'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:24 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup policy set
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --policy -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupResourceGuardProxies?api-version=2023-02-01
-  response:
-    body:
-      string: '{"value":[]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '12'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:25 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup policy set
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --policy -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitestafspolicy?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitestafspolicy","name":"clitestafspolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":25,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '715'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:26 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"protectedItemsCount": 0, "backupManagementType": "AzureStorage",
-      "workLoadType": "AzureFileShare", "schedulePolicy": {"schedulePolicyType": "SimpleSchedulePolicy",
-      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2023-05-17T22:00:00.000Z"],
-      "scheduleWeeklyFrequency": 0}, "retentionPolicy": {"retentionPolicyType": "LongTermRetentionPolicy",
-      "dailySchedule": {"retentionTimes": ["2023-05-17T22:00:00.000Z"], "retentionDuration":
-      {"count": 20, "durationType": "Days"}}}, "timeZone": "UTC"}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup policy set
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '512'
-      Content-Type:
-      - application/json
-      ParameterSetName:
-      - -g -v --policy -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitestafspolicy?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitestafspolicy","name":"clitestafspolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":20,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '715'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:27 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1195'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup policy show
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitestafspolicy?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitestafspolicy","name":"clitestafspolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":20,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '715'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:27 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup item list
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c --backup-management-type --query
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;6d6fac9f520ff146fa229011a68c02a027aa09210826a440fabd74c33af1298a","name":"AzureFileShare;6d6fac9f520ff146fa229011a68c02a027aa09210826a440fabd74c33af1298a","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1478'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:28 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;6d6fac9f520ff146fa229011a68c02a027aa09210826a440fabd74c33af1298a","name":"AzureFileShare;6d6fac9f520ff146fa229011a68c02a027aa09210826a440fabd74c33af1298a","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1478'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:29 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupResourceGuardProxies?api-version=2023-02-01
-  response:
-    body:
-      string: '{"value":[]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '12'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:29 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3B6d6fac9f520ff146fa229011a68c02a027aa09210826a440fabd74c33af1298a?api-version=2023-02-01
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/f5052e04-f9ad-44b5-a88a-4c90fb2d3ed4?api-version=2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Wed, 17 May 2023 12:09:31 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/f5052e04-f9ad-44b5-a88a-4c90fb2d3ed4?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-deletes:
-      - '14999'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/f5052e04-f9ad-44b5-a88a-4c90fb2d3ed4?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"f5052e04-f9ad-44b5-a88a-4c90fb2d3ed4","name":"f5052e04-f9ad-44b5-a88a-4c90fb2d3ed4","status":"InProgress","startTime":"2023-05-17T12:09:31.9289102Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:32 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '290'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/f5052e04-f9ad-44b5-a88a-4c90fb2d3ed4?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"f5052e04-f9ad-44b5-a88a-4c90fb2d3ed4","name":"f5052e04-f9ad-44b5-a88a-4c90fb2d3ed4","status":"InProgress","startTime":"2023-05-17T12:09:31.9289102Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:37 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '289'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/f5052e04-f9ad-44b5-a88a-4c90fb2d3ed4?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"f5052e04-f9ad-44b5-a88a-4c90fb2d3ed4","name":"f5052e04-f9ad-44b5-a88a-4c90fb2d3ed4","status":"InProgress","startTime":"2023-05-17T12:09:31.9289102Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:43 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '288'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/f5052e04-f9ad-44b5-a88a-4c90fb2d3ed4?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"f5052e04-f9ad-44b5-a88a-4c90fb2d3ed4","name":"f5052e04-f9ad-44b5-a88a-4c90fb2d3ed4","status":"InProgress","startTime":"2023-05-17T12:09:31.9289102Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:48 GMT
+      - Wed, 16 Aug 2023 09:28:39 GMT
       expires:
       - '-1'
       pragma:
@@ -2798,19 +1528,750 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - backup protection disable
+      - backup protection enable-for-azurefileshare
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/f5052e04-f9ad-44b5-a88a-4c90fb2d3ed4?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectableItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+workloadType+eq+%27AzureFileShare%27
   response:
     body:
-      string: '{"id":"f5052e04-f9ad-44b5-a88a-4c90fb2d3ed4","name":"f5052e04-f9ad-44b5-a88a-4c90fb2d3ed4","status":"Succeeded","startTime":"2023-05-17T12:09:31.9289102Z","endTime":"2023-05-17T12:09:31.9289102Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"85aa40c6-5e31-477f-ac30-01514a7ce1b0"}}'
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:28:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '299'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/inquire?api-version=2023-02-01&%24filter=workloadType+eq+%27AzureFileShare%27
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/d8781cd8-c124-4f04-a1bc-5175970e861b?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Wed, 16 Aug 2023 09:28:42 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/d8781cd8-c124-4f04-a1bc-5175970e861b?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/d8781cd8-c124-4f04-a1bc-5175970e861b?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/d8781cd8-c124-4f04-a1bc-5175970e861b?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:28:43 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/d8781cd8-c124-4f04-a1bc-5175970e861b?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '286'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/d8781cd8-c124-4f04-a1bc-5175970e861b?api-version=2023-02-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      date:
+      - Wed, 16 Aug 2023 09:28:48 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '285'
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectableItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+workloadType+eq+%27AzureFileShare%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectableItems/azurefileshare;0c49ad673f76b7757133bfe727ba88728f2f80a1de97cd45930c379ed57a9807","name":"azurefileshare;0c49ad673f76b7757133bfe727ba88728f2f80a1de97cd45930c379ed57a9807","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"parentContainerFabricId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","parentContainerFriendlyName":"clitest000003","azureFileShareType":"XSMB","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","protectableItemType":"AzureFileShare","friendlyName":"clitest-item000004","protectionState":"NotProtected"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '983'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:28:49 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '298'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","name":"clitest-item000005","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","workLoadType":"AzureFileShare","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T19:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T19:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '751'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:28:50 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '297'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"protectedItemType": "AzureFileShareProtectedItem", "sourceResourceId":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003",
+      "policyId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '430'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/azurefileshare%3B0c49ad673f76b7757133bfe727ba88728f2f80a1de97cd45930c379ed57a9807?api-version=2023-02-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectedItems/azurefileshare;0c49ad673f76b7757133bfe727ba88728f2f80a1de97cd45930c379ed57a9807/operationsStatus/7238b00b-fc63-4460-883d-63944c770f03?api-version=2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Wed, 16 Aug 2023 09:28:52 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectedItems/azurefileshare;0c49ad673f76b7757133bfe727ba88728f2f80a1de97cd45930c379ed57a9807/operationResults/7238b00b-fc63-4460-883d-63944c770f03?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1189'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/7238b00b-fc63-4460-883d-63944c770f03?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"7238b00b-fc63-4460-883d-63944c770f03","name":"7238b00b-fc63-4460-883d-63944c770f03","status":"InProgress","startTime":"2023-08-16T09:28:52.5221464Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:28:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '299'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/7238b00b-fc63-4460-883d-63944c770f03?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"7238b00b-fc63-4460-883d-63944c770f03","name":"7238b00b-fc63-4460-883d-63944c770f03","status":"InProgress","startTime":"2023-08-16T09:28:52.5221464Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:28:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '298'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/7238b00b-fc63-4460-883d-63944c770f03?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"7238b00b-fc63-4460-883d-63944c770f03","name":"7238b00b-fc63-4460-883d-63944c770f03","status":"InProgress","startTime":"2023-08-16T09:28:52.5221464Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:29:04 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '296'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/7238b00b-fc63-4460-883d-63944c770f03?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"7238b00b-fc63-4460-883d-63944c770f03","name":"7238b00b-fc63-4460-883d-63944c770f03","status":"InProgress","startTime":"2023-08-16T09:28:52.5221464Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:29:09 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '294'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/7238b00b-fc63-4460-883d-63944c770f03?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"7238b00b-fc63-4460-883d-63944c770f03","name":"7238b00b-fc63-4460-883d-63944c770f03","status":"InProgress","startTime":"2023-08-16T09:28:52.5221464Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:29:14 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '292'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/7238b00b-fc63-4460-883d-63944c770f03?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"7238b00b-fc63-4460-883d-63944c770f03","name":"7238b00b-fc63-4460-883d-63944c770f03","status":"InProgress","startTime":"2023-08-16T09:28:52.5221464Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:29:20 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '290'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/7238b00b-fc63-4460-883d-63944c770f03?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"7238b00b-fc63-4460-883d-63944c770f03","name":"7238b00b-fc63-4460-883d-63944c770f03","status":"InProgress","startTime":"2023-08-16T09:28:52.5221464Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:29:25 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '288'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/7238b00b-fc63-4460-883d-63944c770f03?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"7238b00b-fc63-4460-883d-63944c770f03","name":"7238b00b-fc63-4460-883d-63944c770f03","status":"InProgress","startTime":"2023-08-16T09:28:52.5221464Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:29:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '287'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/7238b00b-fc63-4460-883d-63944c770f03?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"7238b00b-fc63-4460-883d-63944c770f03","name":"7238b00b-fc63-4460-883d-63944c770f03","status":"Succeeded","startTime":"2023-08-16T09:28:52.5221464Z","endTime":"2023-08-16T09:28:52.5221464Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"6a69106f-b8b3-4969-9f91-802f1afabe24"}}'
     headers:
       cache-control:
       - no-cache
@@ -2819,7 +2280,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:09:54 GMT
+      - Wed, 16 Aug 2023 09:29:36 GMT
       expires:
       - '-1'
       pragma:
@@ -2847,29 +2308,30 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - backup protection disable
+      - backup protection enable-for-azurefileshare
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/85aa40c6-5e31-477f-ac30-01514a7ce1b0?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/6a69106f-b8b3-4969-9f91-802f1afabe24?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/85aa40c6-5e31-477f-ac30-01514a7ce1b0","name":"85aa40c6-5e31-477f-ac30-01514a7ce1b0","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT20.9228634S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
-        Share Name":"clitest-item000004","Storage Account Name":"clitest000003"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"DeleteBackupData","status":"Completed","startTime":"2023-05-17T12:09:31.9289102Z","endTime":"2023-05-17T12:09:52.8517736Z","activityId":"abd944e2-f4ab-11ed-9155-c8f750f92764"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/6a69106f-b8b3-4969-9f91-802f1afabe24","name":"6a69106f-b8b3-4969-9f91-802f1afabe24","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT41.4094364S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
+        Share Name":"clitest-item000004","Storage Account Name":"clitest000003","Policy
+        Name":"clitest-item000005"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"ConfigureBackup","status":"Completed","startTime":"2023-08-16T09:28:52.5221464Z","endTime":"2023-08-16T09:29:33.9315828Z","activityId":"202bb67b-3c17-11ee-ad22-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '863'
+      - '897'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:09:55 GMT
+      - Wed, 16 Aug 2023 09:29:37 GMT
       expires:
       - '-1'
       pragma:
@@ -2885,7 +2347,953 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '149'
+      - '147'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup policy list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","name":"clitest-item000005","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","workLoadType":"AzureFileShare","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T19:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T19:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '763'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:29:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '298'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup policy show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","name":"clitest-item000005","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","workLoadType":"AzureFileShare","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T19:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T19:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":1}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '751'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:29:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '299'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"protectedItemsCount": 1, "backupManagementType": "AzureStorage",
+      "workLoadType": "AzureFileShare", "schedulePolicy": {"schedulePolicyType": "SimpleSchedulePolicy",
+      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2023-08-16T19:00:00.000Z"],
+      "scheduleWeeklyFrequency": 0}, "retentionPolicy": {"retentionPolicyType": "LongTermRetentionPolicy",
+      "dailySchedule": {"retentionTimes": ["2023-08-16T19:00:00.000Z"], "retentionDuration":
+      {"count": 25, "durationType": "Days"}}}, "timeZone": "UTC"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup policy create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '512'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -v --policy --name --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitestafspolicy?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitestafspolicy","name":"clitestafspolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","workLoadType":"AzureFileShare","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T19:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T19:00:00Z"],"retentionDuration":{"count":25,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '747'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:29:42 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1186'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup policy show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitestafspolicy?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitestafspolicy","name":"clitestafspolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","workLoadType":"AzureFileShare","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T19:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T19:00:00Z"],"retentionDuration":{"count":25,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '747'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:29:43 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '294'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup policy list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitestafspolicy","name":"clitestafspolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","workLoadType":"AzureFileShare","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T19:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T19:00:00Z"],"retentionDuration":{"count":25,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","name":"clitest-item000005","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","workLoadType":"AzureFileShare","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T19:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T19:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1511'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:29:44 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '297'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup policy set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --policy -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupResourceGuardProxies?api-version=2023-02-01
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:29:45 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup policy set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --policy -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitestafspolicy?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitestafspolicy","name":"clitestafspolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","workLoadType":"AzureFileShare","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T19:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T19:00:00Z"],"retentionDuration":{"count":25,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '747'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:29:46 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '296'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"protectedItemsCount": 0, "backupManagementType": "AzureStorage",
+      "workLoadType": "AzureFileShare", "schedulePolicy": {"schedulePolicyType": "SimpleSchedulePolicy",
+      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2023-08-16T19:00:00.000Z"],
+      "scheduleWeeklyFrequency": 0}, "retentionPolicy": {"retentionPolicyType": "LongTermRetentionPolicy",
+      "dailySchedule": {"retentionTimes": ["2023-08-16T19:00:00.000Z"], "retentionDuration":
+      {"count": 20, "durationType": "Days"}}}, "timeZone": "UTC"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup policy set
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '512'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -v --policy -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitestafspolicy?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitestafspolicy","name":"clitestafspolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","workLoadType":"AzureFileShare","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T19:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T19:00:00Z"],"retentionDuration":{"count":20,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '747'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:29:47 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1185'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup policy show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitestafspolicy?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitestafspolicy","name":"clitestafspolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","workLoadType":"AzureFileShare","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T19:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T19:00:00Z"],"retentionDuration":{"count":20,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '747'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:29:49 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '296'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup item list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --backup-management-type --query
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;0c49ad673f76b7757133bfe727ba88728f2f80a1de97cd45930c379ed57a9807","name":"AzureFileShare;0c49ad673f76b7757133bfe727ba88728f2f80a1de97cd45930c379ed57a9807","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1478'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:29:50 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '298'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;0c49ad673f76b7757133bfe727ba88728f2f80a1de97cd45930c379ed57a9807","name":"AzureFileShare;0c49ad673f76b7757133bfe727ba88728f2f80a1de97cd45930c379ed57a9807","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1478'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:29:51 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '297'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupResourceGuardProxies?api-version=2023-02-01
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:29:52 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3B0c49ad673f76b7757133bfe727ba88728f2f80a1de97cd45930c379ed57a9807?api-version=2023-02-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ffa46961-6451-413c-9be5-8208f9ad1ea3?api-version=2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Wed, 16 Aug 2023 09:29:53 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/ffa46961-6451-413c-9be5-8208f9ad1ea3?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14998'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ffa46961-6451-413c-9be5-8208f9ad1ea3?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"ffa46961-6451-413c-9be5-8208f9ad1ea3","name":"ffa46961-6451-413c-9be5-8208f9ad1ea3","status":"InProgress","startTime":"2023-08-16T09:29:54.4382227Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:29:55 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '285'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ffa46961-6451-413c-9be5-8208f9ad1ea3?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"ffa46961-6451-413c-9be5-8208f9ad1ea3","name":"ffa46961-6451-413c-9be5-8208f9ad1ea3","status":"InProgress","startTime":"2023-08-16T09:29:54.4382227Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:30:00 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '284'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ffa46961-6451-413c-9be5-8208f9ad1ea3?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"ffa46961-6451-413c-9be5-8208f9ad1ea3","name":"ffa46961-6451-413c-9be5-8208f9ad1ea3","status":"InProgress","startTime":"2023-08-16T09:29:54.4382227Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:30:05 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '283'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ffa46961-6451-413c-9be5-8208f9ad1ea3?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"ffa46961-6451-413c-9be5-8208f9ad1ea3","name":"ffa46961-6451-413c-9be5-8208f9ad1ea3","status":"InProgress","startTime":"2023-08-16T09:29:54.4382227Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:30:11 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '282'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ffa46961-6451-413c-9be5-8208f9ad1ea3?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"ffa46961-6451-413c-9be5-8208f9ad1ea3","name":"ffa46961-6451-413c-9be5-8208f9ad1ea3","status":"Succeeded","startTime":"2023-08-16T09:29:54.4382227Z","endTime":"2023-08-16T09:29:54.4382227Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"659f7a82-ee87-4e5d-89cb-59c1c18fbfe6"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:30:16 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '281'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/659f7a82-ee87-4e5d-89cb-59c1c18fbfe6?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/659f7a82-ee87-4e5d-89cb-59c1c18fbfe6","name":"659f7a82-ee87-4e5d-89cb-59c1c18fbfe6","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT20.962309S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
+        Share Name":"clitest-item000004","Storage Account Name":"clitest000003"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"DeleteBackupData","status":"Completed","startTime":"2023-08-16T09:29:54.4382227Z","endTime":"2023-08-16T09:30:15.4005317Z","activityId":"735066f2-3c17-11ee-8166-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '862'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:30:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '146'
     status:
       code: 200
       message: OK
@@ -2903,8 +3311,8 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+friendlyName+eq+%27clitest000003%27+and+status+eq+%27Registered%27
   response:
@@ -2918,7 +3326,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:09:55 GMT
+      - Wed, 16 Aug 2023 09:30:19 GMT
       expires:
       - '-1'
       pragma:
@@ -2954,8 +3362,8 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003?api-version=2023-02-01
   response:
@@ -2963,17 +3371,17 @@ interactions:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/8e023fb5-d606-47b2-99fd-1f3b6e940e24?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:09:56 GMT
+      - Wed, 16 Aug 2023 09:30:20 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/8e023fb5-d606-47b2-99fd-1f3b6e940e24?fabricName=Azure?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/920dbc59-7cae-4895-b2d7-11af5ab5c10b?fabricName=Azure?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -3001,16 +3409,16 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/8e023fb5-d606-47b2-99fd-1f3b6e940e24?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/8e023fb5-d606-47b2-99fd-1f3b6e940e24?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -3018,11 +3426,60 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:09:57 GMT
+      - Wed, 16 Aug 2023 09:30:21 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/8e023fb5-d606-47b2-99fd-1f3b6e940e24?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '295'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:30:26 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -3050,16 +3507,16 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/8e023fb5-d606-47b2-99fd-1f3b6e940e24?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/8e023fb5-d606-47b2-99fd-1f3b6e940e24?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -3067,60 +3524,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:02 GMT
+      - Wed, 16 Aug 2023 09:30:32 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/8e023fb5-d606-47b2-99fd-1f3b6e940e24?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '292'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container unregister
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c --yes --backup-management-type
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/8e023fb5-d606-47b2-99fd-1f3b6e940e24?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/8e023fb5-d606-47b2-99fd-1f3b6e940e24?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:10:08 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/8e023fb5-d606-47b2-99fd-1f3b6e940e24?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -3148,16 +3556,16 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/8e023fb5-d606-47b2-99fd-1f3b6e940e24?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/8e023fb5-d606-47b2-99fd-1f3b6e940e24?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -3165,11 +3573,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:14 GMT
+      - Wed, 16 Aug 2023 09:30:38 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/8e023fb5-d606-47b2-99fd-1f3b6e940e24?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -3179,7 +3587,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '290'
+      - '289'
     status:
       code: 202
       message: Accepted
@@ -3197,10 +3605,500 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/8e023fb5-d606-47b2-99fd-1f3b6e940e24?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:30:43 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '287'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:30:48 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '286'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:30:54 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '285'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:31:00 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '284'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:31:05 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '283'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:31:10 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '282'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:31:16 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '281'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:31:20 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '280'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:31:26 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '279'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:31:31 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '278'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/920dbc59-7cae-4895-b2d7-11af5ab5c10b?api-version=2023-02-01
   response:
     body:
       string: ''
@@ -3208,7 +4106,7 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Wed, 17 May 2023 12:10:20 GMT
+      - Wed, 16 Aug 2023 09:31:37 GMT
       expires:
       - '-1'
       pragma:
@@ -3220,7 +4118,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '289'
+      - '277'
     status:
       code: 204
       message: No Content
@@ -3232,16 +4130,16 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - backup container list
+      - lock list
       Connection:
       - keep-alive
       ParameterSetName:
-      - --backup-management-type -v -g --query
+      - -g
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureIaasVM%27+and+status+eq+%27Registered%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/locks?api-version=2016-09-01
   response:
     body:
       string: '{"value":[]}'
@@ -3253,7 +4151,53 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:12:01 GMT
+      - Wed, 16 Aug 2023 09:33:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --container-name --item-name --backup-management-type --workload-type
+        --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+itemType+eq+%27AzureFileShare%27
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:33:19 GMT
       expires:
       - '-1'
       pragma:
@@ -3269,7 +4213,105 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '295'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --vault-name --resource-group --container-name --backup-management-type --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+friendlyName+eq+%27clitest000003%27+and+status+eq+%27Registered%27
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:33:20 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '296'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type -v -g --query
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureIaasVM%27+and+status+eq+%27Registered%27
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:33:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '296'
     status:
       code: 200
       message: OK
@@ -3289,7 +4331,8 @@ interactions:
       ParameterSetName:
       - -n -g --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2023-02-01
   response:
@@ -3301,7 +4344,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:12:09 GMT
+      - Wed, 16 Aug 2023 09:33:27 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/backup/tests/latest/recordings/test_afs_backup_protection.yaml
+++ b/src/azure-cli/azure/cli/command_modules/backup/tests/latest/recordings/test_afs_backup_protection.yaml
@@ -13,7 +13,8 @@ interactions:
       ParameterSetName:
       - -n -g --location
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2023-02-01
   response:
@@ -29,7 +30,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:06:46 GMT
+      - Wed, 16 Aug 2023 09:25:55 GMT
       expires:
       - '-1'
       pragma:
@@ -64,23 +65,24 @@ interactions:
       ParameterSetName:
       - -n -g --location
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2023-02-01
   response:
     body:
-      string: '{"location":"eastus2euap","name":"clitest-vault000002","etag":"W/\"datetime''2023-05-17T12%3A06%3A52.4239792Z''\"","properties":{"provisioningState":"Provisioning","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}},"publicNetworkAccess":"Enabled","restoreSettings":{"crossSubscriptionRestoreSettings":{"crossSubscriptionRestoreState":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+      string: '{"location":"eastus2euap","name":"clitest-vault000002","etag":"W/\"datetime''2023-08-16T09%3A25%3A56.249366Z''\"","properties":{"provisioningState":"Provisioning","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}},"publicNetworkAccess":"Enabled","restoreSettings":{"crossSubscriptionRestoreSettings":{"crossSubscriptionRestoreState":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0Nzs5ZDk1YTE5Ny0zYmFjLTQ2NmYtYWU5Mi0zZDk1NGI2ZmI0Yzg=?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0Nzs5YjIwN2Y4ZC0zNDYzLTQxZmEtODQ4OS0yNjExNDc1MjVjMzg=?api-version=2023-02-01
       cache-control:
       - no-cache
       content-length:
-      - '756'
+      - '755'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:06:54 GMT
+      - Wed, 16 Aug 2023 09:25:56 GMT
       expires:
       - '-1'
       pragma:
@@ -91,6 +93,8 @@ interactions:
       - max-age=31536000; includeSubDomains
       x-content-type-options:
       - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=12f8ea5c-1212-449e-b31c-0a574f43076e/centraluseuap/384c69bd-3755-4185-813d-db85a8bfdfc6
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '298'
     status:
@@ -110,66 +114,15 @@ interactions:
       ParameterSetName:
       - -n -g --location
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0Nzs5ZDk1YTE5Ny0zYmFjLTQ2NmYtYWU5Mi0zZDk1NGI2ZmI0Yzg=?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0Nzs5YjIwN2Y4ZC0zNDYzLTQxZmEtODQ4OS0yNjExNDc1MjVjMzg=?api-version=2023-02-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0Nzs5ZDk1YTE5Ny0zYmFjLTQ2NmYtYWU5Mi0zZDk1NGI2ZmI0Yzg=\",\r\n
-        \ \"name\": \"MjA0Nzs5ZDk1YTE5Ny0zYmFjLTQ2NmYtYWU5Mi0zZDk1NGI2ZmI0Yzg=\",\r\n
-        \ \"status\": \"InProgress\"\r\n}"
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0Nzs5ZDk1YTE5Ny0zYmFjLTQ2NmYtYWU5Mi0zZDk1NGI2ZmI0Yzg=?api-version=2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '334'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:06:54 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationResults/MjA0Nzs5ZDk1YTE5Ny0zYmFjLTQ2NmYtYWU5Mi0zZDk1NGI2ZmI0Yzg=?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup vault create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --location
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0Nzs5ZDk1YTE5Ny0zYmFjLTQ2NmYtYWU5Mi0zZDk1NGI2ZmI0Yzg=?api-version=2023-02-01
-  response:
-    body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0Nzs5ZDk1YTE5Ny0zYmFjLTQ2NmYtYWU5Mi0zZDk1NGI2ZmI0Yzg=\",\r\n
-        \ \"name\": \"MjA0Nzs5ZDk1YTE5Ny0zYmFjLTQ2NmYtYWU5Mi0zZDk1NGI2ZmI0Yzg=\",\r\n
-        \ \"status\": \"Succeeded\"\r\n}"
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0Nzs5YjIwN2Y4ZC0zNDYzLTQxZmEtODQ4OS0yNjExNDc1MjVjMzg=\"\
+        ,\r\n  \"name\": \"MjA0Nzs5YjIwN2Y4ZC0zNDYzLTQxZmEtODQ4OS0yNjExNDc1MjVjMzg=\"\
+        ,\r\n  \"status\": \"Succeeded\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -178,7 +131,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:07:54 GMT
+      - Wed, 16 Aug 2023 09:25:56 GMT
       expires:
       - '-1'
       pragma:
@@ -210,12 +163,13 @@ interactions:
       ParameterSetName:
       - -n -g --location
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2023-02-01
   response:
     body:
-      string: '{"location":"eastus2euap","name":"clitest-vault000002","etag":"W/\"datetime''2023-05-17T12%3A07%3A53.2339686Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","backupStorageVersion":"Unassigned","monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}},"securitySettings":{"immutabilitySettings":null,"softDeleteSettings":{"softDeleteRetentionPeriodInDays":14,"softDeleteState":"Enabled"},"multiUserAuthorization":"Disabled"},"publicNetworkAccess":"Enabled","restoreSettings":{"crossSubscriptionRestoreSettings":{"crossSubscriptionRestoreState":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+      string: '{"location":"eastus2euap","name":"clitest-vault000002","etag":"W/\"datetime''2023-08-16T09%3A25%3A56.6942414Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","backupStorageVersion":"Unassigned","monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}},"securitySettings":{"immutabilitySettings":null,"softDeleteSettings":{"softDeleteRetentionPeriodInDays":14,"softDeleteState":"Enabled"},"multiUserAuthorization":"Disabled"},"publicNetworkAccess":"Enabled","restoreSettings":{"crossSubscriptionRestoreSettings":{"crossSubscriptionRestoreState":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
     headers:
       cache-control:
       - no-cache
@@ -224,7 +178,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:07:55 GMT
+      - Wed, 16 Aug 2023 09:25:56 GMT
       expires:
       - '-1'
       pragma:
@@ -258,12 +212,13 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-storage/21.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003/listKeys?api-version=2022-09-01&$expand=kerb
   response:
     body:
-      string: '{"keys":[{"creationTime":"2023-05-17T12:07:58.3424705Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2023-05-17T12:07:58.3424705Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
+      string: '{"keys":[{"creationTime":"2023-08-16T09:25:59.9039680Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2023-08-16T09:25:59.9039680Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
     headers:
       cache-control:
       - no-cache
@@ -272,7 +227,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 17 May 2023 12:08:23 GMT
+      - Wed, 16 Aug 2023 09:26:23 GMT
       expires:
       - '-1'
       pragma:
@@ -306,21 +261,22 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-storage/21.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","name":"clitest000003","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"keyCreationTime":{"key1":"2023-05-17T12:07:58.3424705Z","key2":"2023-05-17T12:07:58.3424705Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-05-17T12:07:58.7330775Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-05-17T12:07:58.7330775Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-05-17T12:07:58.2487032Z","primaryEndpoints":{"blob":"https://clitest000003.blob.core.windows.net/","queue":"https://clitest000003.queue.core.windows.net/","table":"https://clitest000003.table.core.windows.net/","file":"https://clitest000003.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","name":"clitest000003","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"keyCreationTime":{"key1":"2023-08-16T09:25:59.9039680Z","key2":"2023-08-16T09:25:59.9039680Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-08-16T09:26:00.3727120Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-08-16T09:26:00.3727120Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-08-16T09:25:59.8258415Z","primaryEndpoints":{"blob":"https://clitest000003.blob.core.windows.net/","queue":"https://clitest000003.queue.core.windows.net/","table":"https://clitest000003.table.core.windows.net/","file":"https://clitest000003.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1280'
+      - '1316'
       content-type:
       - application/json
       date:
-      - Wed, 17 May 2023 12:08:24 GMT
+      - Wed, 16 Aug 2023 09:26:23 GMT
       expires:
       - '-1'
       pragma:
@@ -354,9 +310,10 @@ interactions:
       ParameterSetName:
       - --name --quota --connection-string
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-storage-file-share/12.12.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-storage-file-share/12.12.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Wed, 17 May 2023 12:08:22 GMT
+      - Wed, 16 Aug 2023 09:26:24 GMT
       x-ms-share-quota:
       - '1'
       x-ms-version:
@@ -370,11 +327,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:08:25 GMT
+      - Wed, 16 Aug 2023 09:26:24 GMT
       etag:
-      - '"0x8DB56CF6AAA5BB8"'
+      - '"0x8DB9E3ADCE28B2D"'
       last-modified:
-      - Wed, 17 May 2023 12:08:25 GMT
+      - Wed, 16 Aug 2023 09:26:25 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
@@ -396,13 +353,13 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T19:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T19:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
@@ -411,7 +368,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:26 GMT
+      - Wed, 16 Aug 2023 09:26:26 GMT
       expires:
       - '-1'
       pragma:
@@ -434,9 +391,9 @@ interactions:
 - request:
     body: '{"properties": {"protectedItemsCount": 0, "backupManagementType": "AzureStorage",
       "workLoadType": "AzureFileShare", "schedulePolicy": {"schedulePolicyType": "SimpleSchedulePolicy",
-      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2023-05-17T22:00:00.000Z"],
+      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2023-08-16T19:00:00.000Z"],
       "scheduleWeeklyFrequency": 0}, "retentionPolicy": {"retentionPolicyType": "LongTermRetentionPolicy",
-      "dailySchedule": {"retentionTimes": ["2023-05-17T22:00:00.000Z"], "retentionDuration":
+      "dailySchedule": {"retentionTimes": ["2023-08-16T19:00:00.000Z"], "retentionDuration":
       {"count": 30, "durationType": "Days"}}}, "timeZone": "UTC"}}'
     headers:
       Accept:
@@ -454,22 +411,22 @@ interactions:
       ParameterSetName:
       - -g -v --policy -n --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","name":"clitest-item000005","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","name":"clitest-item000005","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","workLoadType":"AzureFileShare","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T19:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T19:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '719'
+      - '751'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:27 GMT
+      - Wed, 16 Aug 2023 09:26:28 GMT
       expires:
       - '-1'
       pragma:
@@ -485,7 +442,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1197'
     status:
       code: 200
       message: OK
@@ -503,8 +460,8 @@ interactions:
       ParameterSetName:
       - -g -v --storage-account --azure-file-share -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+status+eq+%27Registered%27
   response:
@@ -518,7 +475,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:29 GMT
+      - Wed, 16 Aug 2023 09:26:29 GMT
       expires:
       - '-1'
       pragma:
@@ -552,22 +509,22 @@ interactions:
       ParameterSetName:
       - -g -v --storage-account --azure-file-share -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","name":"StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"adiguptecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/adigupt-ecy-rg/providers/Microsoft.Storage/storageAccounts/adiguptecy"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg2yfprhyqds;clitesttz6sdom2jatwnfac4","name":"StorageContainer;Storage;clitest.rg2yfprhyqds;clitesttz6sdom2jatwnfac4","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesttz6sdom2jatwnfac4","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg2yfprhyqds/providers/Microsoft.Storage/storageAccounts/clitesttz6sdom2jatwnfac4"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx;clitest5g7td7ozjqq2b6ccr","name":"StorageContainer;Storage;clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx;clitest5g7td7ozjqq2b6ccr","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest5g7td7ozjqq2b6ccr","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx/providers/Microsoft.Storage/storageAccounts/clitest5g7td7ozjqq2b6ccr"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","name":"StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontusebvtaksecycansa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DonotUse-Blobs-BVT-EACAN-RG/providers/Microsoft.Storage/storageAccounts/dontusebvtaksecycansa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","name":"StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"iaasextstoreecy1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.czr/providers/Microsoft.Storage/storageAccounts/iaasextstoreecy1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","name":"StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesaksdonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-clitest-rg/providers/Microsoft.Storage/storageAccounts/clitesaksdonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"bloboprestorecontainers","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/bloboprestorecontainers"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopall","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopall"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopcontainer","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopcontainer"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopprefix","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopprefix"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG;zubairsaecy","name":"StorageContainer;Storage;zubairRG;zubairsaecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Storage/storageAccounts/zubairsaecy"}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","name":"StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"adiguptecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/adigupt-ecy-rg/providers/Microsoft.Storage/storageAccounts/adiguptecy"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","name":"StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontusebvtaksecycansa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DonotUse-Blobs-BVT-EACAN-RG/providers/Microsoft.Storage/storageAccounts/dontusebvtaksecycansa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","name":"StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"iaasextstoreecy1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.czr/providers/Microsoft.Storage/storageAccounts/iaasextstoreecy1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","name":"StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesaksdonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-clitest-rg/providers/Microsoft.Storage/storageAccounts/clitesaksdonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"bloboprestorecontainers","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/bloboprestorecontainers"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopall","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopall"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopcontainer","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopcontainer"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopprefix","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopprefix"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG2;zubairsaecy2","name":"StorageContainer;Storage;zubairRG2;zubairsaecy2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy2","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG2/providers/Microsoft.Storage/storageAccounts/zubairsaecy2"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG;zubairsaecy","name":"StorageContainer;Storage;zubairRG;zubairsaecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Storage/storageAccounts/zubairsaecy"}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '8530'
+      - '7516'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:30 GMT
+      - Wed, 16 Aug 2023 09:26:30 GMT
       expires:
       - '-1'
       pragma:
@@ -603,8 +560,8 @@ interactions:
       ParameterSetName:
       - -g -v --storage-account --azure-file-share -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/refreshContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
@@ -612,17 +569,17 @@ interactions:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/c948d9b0-ea8c-4110-882b-442fe9a0dc93?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/6544a463-49ba-4c67-8691-dfb22984eb16?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:08:31 GMT
+      - Wed, 16 Aug 2023 09:26:31 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/c948d9b0-ea8c-4110-882b-442fe9a0dc93?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6544a463-49ba-4c67-8691-dfb22984eb16?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -632,7 +589,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
     status:
       code: 202
       message: Accepted
@@ -650,10 +607,10 @@ interactions:
       ParameterSetName:
       - -g -v --storage-account --azure-file-share -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/c948d9b0-ea8c-4110-882b-442fe9a0dc93?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6544a463-49ba-4c67-8691-dfb22984eb16?api-version=2023-02-01
   response:
     body:
       string: ''
@@ -663,11 +620,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:08:32 GMT
+      - Wed, 16 Aug 2023 09:26:32 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/c948d9b0-ea8c-4110-882b-442fe9a0dc93?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6544a463-49ba-4c67-8691-dfb22984eb16?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -695,10 +652,10 @@ interactions:
       ParameterSetName:
       - -g -v --storage-account --azure-file-share -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/c948d9b0-ea8c-4110-882b-442fe9a0dc93?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6544a463-49ba-4c67-8691-dfb22984eb16?api-version=2023-02-01
   response:
     body:
       string: ''
@@ -708,11 +665,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:08:38 GMT
+      - Wed, 16 Aug 2023 09:26:37 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/c948d9b0-ea8c-4110-882b-442fe9a0dc93?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6544a463-49ba-4c67-8691-dfb22984eb16?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -740,10 +697,10 @@ interactions:
       ParameterSetName:
       - -g -v --storage-account --azure-file-share -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/c948d9b0-ea8c-4110-882b-442fe9a0dc93?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6544a463-49ba-4c67-8691-dfb22984eb16?api-version=2023-02-01
   response:
     body:
       string: ''
@@ -751,7 +708,7 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Wed, 17 May 2023 12:08:44 GMT
+      - Wed, 16 Aug 2023 09:26:43 GMT
       expires:
       - '-1'
       pragma:
@@ -781,22 +738,22 @@ interactions:
       ParameterSetName:
       - -g -v --storage-account --azure-file-share -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","name":"StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"adiguptecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/adigupt-ecy-rg/providers/Microsoft.Storage/storageAccounts/adiguptecy"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg2yfprhyqds;clitesttz6sdom2jatwnfac4","name":"StorageContainer;Storage;clitest.rg2yfprhyqds;clitesttz6sdom2jatwnfac4","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesttz6sdom2jatwnfac4","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg2yfprhyqds/providers/Microsoft.Storage/storageAccounts/clitesttz6sdom2jatwnfac4"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx;clitest5g7td7ozjqq2b6ccr","name":"StorageContainer;Storage;clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx;clitest5g7td7ozjqq2b6ccr","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest5g7td7ozjqq2b6ccr","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx/providers/Microsoft.Storage/storageAccounts/clitest5g7td7ozjqq2b6ccr"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgnvoelwrvnb;clitestw62rrt6h5fidon2vw","name":"StorageContainer;Storage;clitest.rgnvoelwrvnb;clitestw62rrt6h5fidon2vw","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestw62rrt6h5fidon2vw","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgnvoelwrvnb/providers/Microsoft.Storage/storageAccounts/clitestw62rrt6h5fidon2vw"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest000003","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","name":"StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontusebvtaksecycansa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DonotUse-Blobs-BVT-EACAN-RG/providers/Microsoft.Storage/storageAccounts/dontusebvtaksecycansa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","name":"StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"iaasextstoreecy1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.czr/providers/Microsoft.Storage/storageAccounts/iaasextstoreecy1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","name":"StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesaksdonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-clitest-rg/providers/Microsoft.Storage/storageAccounts/clitesaksdonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"bloboprestorecontainers","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/bloboprestorecontainers"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopall","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopall"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopcontainer","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopcontainer"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopprefix","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopprefix"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG;zubairsaecy","name":"StorageContainer;Storage;zubairRG;zubairsaecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Storage/storageAccounts/zubairsaecy"}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","name":"StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"adiguptecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/adigupt-ecy-rg/providers/Microsoft.Storage/storageAccounts/adiguptecy"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest000003","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","name":"StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontusebvtaksecycansa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DonotUse-Blobs-BVT-EACAN-RG/providers/Microsoft.Storage/storageAccounts/dontusebvtaksecycansa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","name":"StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"iaasextstoreecy1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.czr/providers/Microsoft.Storage/storageAccounts/iaasextstoreecy1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","name":"StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesaksdonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-clitest-rg/providers/Microsoft.Storage/storageAccounts/clitesaksdonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"bloboprestorecontainers","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/bloboprestorecontainers"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopall","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopall"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopcontainer","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopcontainer"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopprefix","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopprefix"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG2;zubairsaecy2","name":"StorageContainer;Storage;zubairRG2;zubairsaecy2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy2","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG2/providers/Microsoft.Storage/storageAccounts/zubairsaecy2"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG;zubairsaecy","name":"StorageContainer;Storage;zubairRG;zubairsaecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Storage/storageAccounts/zubairsaecy"}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '10010'
+      - '8228'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:44 GMT
+      - Wed, 16 Aug 2023 09:26:44 GMT
       expires:
       - '-1'
       pragma:
@@ -812,7 +769,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '299'
     status:
       code: 200
       message: OK
@@ -835,8 +792,8 @@ interactions:
       ParameterSetName:
       - -g -v --storage-account --azure-file-share -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003?api-version=2023-02-01
   response:
@@ -844,7 +801,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/d069a347-2a0f-4649-8ae9-1106ad3d0e5e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/d01ba30c-3193-4dfa-9582-c8ad6caace9a?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -852,11 +809,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:45 GMT
+      - Wed, 16 Aug 2023 09:26:46 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/d069a347-2a0f-4649-8ae9-1106ad3d0e5e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/d01ba30c-3193-4dfa-9582-c8ad6caace9a?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -866,7 +823,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1197'
     status:
       code: 202
       message: Accepted
@@ -884,16 +841,16 @@ interactions:
       ParameterSetName:
       - -g -v --storage-account --azure-file-share -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/d069a347-2a0f-4649-8ae9-1106ad3d0e5e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/d01ba30c-3193-4dfa-9582-c8ad6caace9a?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/d069a347-2a0f-4649-8ae9-1106ad3d0e5e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/d01ba30c-3193-4dfa-9582-c8ad6caace9a?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -901,11 +858,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:46 GMT
+      - Wed, 16 Aug 2023 09:26:48 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/d069a347-2a0f-4649-8ae9-1106ad3d0e5e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/d01ba30c-3193-4dfa-9582-c8ad6caace9a?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -933,16 +890,16 @@ interactions:
       ParameterSetName:
       - -g -v --storage-account --azure-file-share -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/d069a347-2a0f-4649-8ae9-1106ad3d0e5e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/d01ba30c-3193-4dfa-9582-c8ad6caace9a?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/d069a347-2a0f-4649-8ae9-1106ad3d0e5e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/d01ba30c-3193-4dfa-9582-c8ad6caace9a?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -950,11 +907,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:52 GMT
+      - Wed, 16 Aug 2023 09:26:53 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/d069a347-2a0f-4649-8ae9-1106ad3d0e5e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/d01ba30c-3193-4dfa-9582-c8ad6caace9a?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -982,10 +939,255 @@ interactions:
       ParameterSetName:
       - -g -v --storage-account --azure-file-share -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/d069a347-2a0f-4649-8ae9-1106ad3d0e5e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/d01ba30c-3193-4dfa-9582-c8ad6caace9a?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/d01ba30c-3193-4dfa-9582-c8ad6caace9a?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:26:58 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/d01ba30c-3193-4dfa-9582-c8ad6caace9a?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '297'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/d01ba30c-3193-4dfa-9582-c8ad6caace9a?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/d01ba30c-3193-4dfa-9582-c8ad6caace9a?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:27:03 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/d01ba30c-3193-4dfa-9582-c8ad6caace9a?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '296'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/d01ba30c-3193-4dfa-9582-c8ad6caace9a?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/d01ba30c-3193-4dfa-9582-c8ad6caace9a?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:27:09 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/d01ba30c-3193-4dfa-9582-c8ad6caace9a?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '295'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/d01ba30c-3193-4dfa-9582-c8ad6caace9a?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/d01ba30c-3193-4dfa-9582-c8ad6caace9a?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:27:14 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/d01ba30c-3193-4dfa-9582-c8ad6caace9a?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '294'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/d01ba30c-3193-4dfa-9582-c8ad6caace9a?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/d01ba30c-3193-4dfa-9582-c8ad6caace9a?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:27:19 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/d01ba30c-3193-4dfa-9582-c8ad6caace9a?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '293'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/d01ba30c-3193-4dfa-9582-c8ad6caace9a?api-version=2023-02-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","protectedItemCount":0,"acquireStorageAccountLock":"Acquire","friendlyName":"clitest000003","backupManagementType":"AzureStorage","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"StorageContainer","protectableObjectType":"StorageContainer"}}'
@@ -997,738 +1199,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:57 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --storage-account --azure-file-share -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectableItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+workloadType+eq+%27AzureFileShare%27
-  response:
-    body:
-      string: '{"value":[]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '12'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:08:58 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      ParameterSetName:
-      - -g -v --storage-account --azure-file-share -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/inquire?api-version=2023-02-01&%24filter=workloadType+eq+%27AzureFileShare%27
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/2af138f5-a506-4b5f-a942-8484a5af219e?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Wed, 17 May 2023 12:08:59 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/2af138f5-a506-4b5f-a942-8484a5af219e?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --storage-account --azure-file-share -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/2af138f5-a506-4b5f-a942-8484a5af219e?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/2af138f5-a506-4b5f-a942-8484a5af219e?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:08:59 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/2af138f5-a506-4b5f-a942-8484a5af219e?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --storage-account --azure-file-share -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/2af138f5-a506-4b5f-a942-8484a5af219e?api-version=2023-02-01
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      date:
-      - Wed, 17 May 2023 12:09:06 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --storage-account --azure-file-share -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectableItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+workloadType+eq+%27AzureFileShare%27
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectableItems/azurefileshare;980e2d26bb4174c443bfac1bca2ffaff5635170927b4f9fa287548f2416b34cb","name":"azurefileshare;980e2d26bb4174c443bfac1bca2ffaff5635170927b4f9fa287548f2416b34cb","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"parentContainerFabricId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","parentContainerFriendlyName":"clitest000003","azureFileShareType":"XSMB","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","protectableItemType":"AzureFileShare","friendlyName":"clitest-item000004","protectionState":"NotProtected"}}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '983'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:06 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --storage-account --azure-file-share -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","name":"clitest-item000005","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '719'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:07 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"protectedItemType": "AzureFileShareProtectedItem", "sourceResourceId":
-      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003",
-      "policyId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005"}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '430'
-      Content-Type:
-      - application/json
-      ParameterSetName:
-      - -g -v --storage-account --azure-file-share -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/azurefileshare%3B980e2d26bb4174c443bfac1bca2ffaff5635170927b4f9fa287548f2416b34cb?api-version=2023-02-01
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectedItems/azurefileshare;980e2d26bb4174c443bfac1bca2ffaff5635170927b4f9fa287548f2416b34cb/operationsStatus/81ee2b62-13d6-4ab4-ab75-9d0a5fb53711?api-version=2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Wed, 17 May 2023 12:09:08 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectedItems/azurefileshare;980e2d26bb4174c443bfac1bca2ffaff5635170927b4f9fa287548f2416b34cb/operationResults/81ee2b62-13d6-4ab4-ab75-9d0a5fb53711?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --storage-account --azure-file-share -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/81ee2b62-13d6-4ab4-ab75-9d0a5fb53711?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"81ee2b62-13d6-4ab4-ab75-9d0a5fb53711","name":"81ee2b62-13d6-4ab4-ab75-9d0a5fb53711","status":"InProgress","startTime":"2023-05-17T12:09:08.8760546Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:09 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --storage-account --azure-file-share -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/81ee2b62-13d6-4ab4-ab75-9d0a5fb53711?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"81ee2b62-13d6-4ab4-ab75-9d0a5fb53711","name":"81ee2b62-13d6-4ab4-ab75-9d0a5fb53711","status":"InProgress","startTime":"2023-05-17T12:09:08.8760546Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:14 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --storage-account --azure-file-share -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/81ee2b62-13d6-4ab4-ab75-9d0a5fb53711?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"81ee2b62-13d6-4ab4-ab75-9d0a5fb53711","name":"81ee2b62-13d6-4ab4-ab75-9d0a5fb53711","status":"InProgress","startTime":"2023-05-17T12:09:08.8760546Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:20 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --storage-account --azure-file-share -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/81ee2b62-13d6-4ab4-ab75-9d0a5fb53711?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"81ee2b62-13d6-4ab4-ab75-9d0a5fb53711","name":"81ee2b62-13d6-4ab4-ab75-9d0a5fb53711","status":"InProgress","startTime":"2023-05-17T12:09:08.8760546Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:25 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '296'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --storage-account --azure-file-share -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/81ee2b62-13d6-4ab4-ab75-9d0a5fb53711?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"81ee2b62-13d6-4ab4-ab75-9d0a5fb53711","name":"81ee2b62-13d6-4ab4-ab75-9d0a5fb53711","status":"InProgress","startTime":"2023-05-17T12:09:08.8760546Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:31 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '295'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --storage-account --azure-file-share -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/81ee2b62-13d6-4ab4-ab75-9d0a5fb53711?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"81ee2b62-13d6-4ab4-ab75-9d0a5fb53711","name":"81ee2b62-13d6-4ab4-ab75-9d0a5fb53711","status":"InProgress","startTime":"2023-05-17T12:09:08.8760546Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:36 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '294'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --storage-account --azure-file-share -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/81ee2b62-13d6-4ab4-ab75-9d0a5fb53711?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"81ee2b62-13d6-4ab4-ab75-9d0a5fb53711","name":"81ee2b62-13d6-4ab4-ab75-9d0a5fb53711","status":"InProgress","startTime":"2023-05-17T12:09:08.8760546Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:42 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '293'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --storage-account --azure-file-share -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/81ee2b62-13d6-4ab4-ab75-9d0a5fb53711?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"81ee2b62-13d6-4ab4-ab75-9d0a5fb53711","name":"81ee2b62-13d6-4ab4-ab75-9d0a5fb53711","status":"InProgress","startTime":"2023-05-17T12:09:08.8760546Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:48 GMT
+      - Wed, 16 Aug 2023 09:27:25 GMT
       expires:
       - '-1'
       pragma:
@@ -1762,22 +1233,802 @@ interactions:
       ParameterSetName:
       - -g -v --storage-account --azure-file-share -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/81ee2b62-13d6-4ab4-ab75-9d0a5fb53711?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectableItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+workloadType+eq+%27AzureFileShare%27
   response:
     body:
-      string: '{"id":"81ee2b62-13d6-4ab4-ab75-9d0a5fb53711","name":"81ee2b62-13d6-4ab4-ab75-9d0a5fb53711","status":"Succeeded","startTime":"2023-05-17T12:09:08.8760546Z","endTime":"2023-05-17T12:09:08.8760546Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"2d117199-8f4b-4d30-8758-7fe7e8910326"}}'
+      string: '{"value":[]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '12'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:09:54 GMT
+      - Wed, 16 Aug 2023 09:27:26 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '299'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/inquire?api-version=2023-02-01&%24filter=workloadType+eq+%27AzureFileShare%27
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/d2de86f7-e1e1-4774-9ffb-ba3a1ade687b?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Wed, 16 Aug 2023 09:27:27 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/d2de86f7-e1e1-4774-9ffb-ba3a1ade687b?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1197'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/d2de86f7-e1e1-4774-9ffb-ba3a1ade687b?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/d2de86f7-e1e1-4774-9ffb-ba3a1ade687b?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:27:29 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/d2de86f7-e1e1-4774-9ffb-ba3a1ade687b?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '299'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/d2de86f7-e1e1-4774-9ffb-ba3a1ade687b?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/d2de86f7-e1e1-4774-9ffb-ba3a1ade687b?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:27:35 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/d2de86f7-e1e1-4774-9ffb-ba3a1ade687b?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '298'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/d2de86f7-e1e1-4774-9ffb-ba3a1ade687b?api-version=2023-02-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      date:
+      - Wed, 16 Aug 2023 09:27:39 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '297'
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectableItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+workloadType+eq+%27AzureFileShare%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectableItems/azurefileshare;df0275e3e674d8756d9ed13690173363cecff2ee265c42fe89940a8adfed9bf4","name":"azurefileshare;df0275e3e674d8756d9ed13690173363cecff2ee265c42fe89940a8adfed9bf4","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"parentContainerFabricId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","parentContainerFriendlyName":"clitest000003","azureFileShareType":"XSMB","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","protectableItemType":"AzureFileShare","friendlyName":"clitest-item000004","protectionState":"NotProtected"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '983'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:27:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '298'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","name":"clitest-item000005","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","workLoadType":"AzureFileShare","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T19:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T19:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '751'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:27:42 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '296'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"protectedItemType": "AzureFileShareProtectedItem", "sourceResourceId":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003",
+      "policyId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '430'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/azurefileshare%3Bdf0275e3e674d8756d9ed13690173363cecff2ee265c42fe89940a8adfed9bf4?api-version=2023-02-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectedItems/azurefileshare;df0275e3e674d8756d9ed13690173363cecff2ee265c42fe89940a8adfed9bf4/operationsStatus/04e52a8d-0428-40c6-bb0f-1ac7bd38adc6?api-version=2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Wed, 16 Aug 2023 09:27:44 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectedItems/azurefileshare;df0275e3e674d8756d9ed13690173363cecff2ee265c42fe89940a8adfed9bf4/operationResults/04e52a8d-0428-40c6-bb0f-1ac7bd38adc6?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1196'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/04e52a8d-0428-40c6-bb0f-1ac7bd38adc6?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"04e52a8d-0428-40c6-bb0f-1ac7bd38adc6","name":"04e52a8d-0428-40c6-bb0f-1ac7bd38adc6","status":"InProgress","startTime":"2023-08-16T09:27:44.384457Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:27:45 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '299'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/04e52a8d-0428-40c6-bb0f-1ac7bd38adc6?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"04e52a8d-0428-40c6-bb0f-1ac7bd38adc6","name":"04e52a8d-0428-40c6-bb0f-1ac7bd38adc6","status":"InProgress","startTime":"2023-08-16T09:27:44.384457Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:27:50 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '298'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/04e52a8d-0428-40c6-bb0f-1ac7bd38adc6?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"04e52a8d-0428-40c6-bb0f-1ac7bd38adc6","name":"04e52a8d-0428-40c6-bb0f-1ac7bd38adc6","status":"InProgress","startTime":"2023-08-16T09:27:44.384457Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:27:56 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '297'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/04e52a8d-0428-40c6-bb0f-1ac7bd38adc6?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"04e52a8d-0428-40c6-bb0f-1ac7bd38adc6","name":"04e52a8d-0428-40c6-bb0f-1ac7bd38adc6","status":"InProgress","startTime":"2023-08-16T09:27:44.384457Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:28:01 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '296'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/04e52a8d-0428-40c6-bb0f-1ac7bd38adc6?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"04e52a8d-0428-40c6-bb0f-1ac7bd38adc6","name":"04e52a8d-0428-40c6-bb0f-1ac7bd38adc6","status":"InProgress","startTime":"2023-08-16T09:27:44.384457Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:28:07 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '295'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/04e52a8d-0428-40c6-bb0f-1ac7bd38adc6?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"04e52a8d-0428-40c6-bb0f-1ac7bd38adc6","name":"04e52a8d-0428-40c6-bb0f-1ac7bd38adc6","status":"InProgress","startTime":"2023-08-16T09:27:44.384457Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:28:12 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '294'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/04e52a8d-0428-40c6-bb0f-1ac7bd38adc6?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"04e52a8d-0428-40c6-bb0f-1ac7bd38adc6","name":"04e52a8d-0428-40c6-bb0f-1ac7bd38adc6","status":"InProgress","startTime":"2023-08-16T09:27:44.384457Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:28:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '293'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/04e52a8d-0428-40c6-bb0f-1ac7bd38adc6?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"04e52a8d-0428-40c6-bb0f-1ac7bd38adc6","name":"04e52a8d-0428-40c6-bb0f-1ac7bd38adc6","status":"InProgress","startTime":"2023-08-16T09:27:44.384457Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:28:23 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '292'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/04e52a8d-0428-40c6-bb0f-1ac7bd38adc6?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"04e52a8d-0428-40c6-bb0f-1ac7bd38adc6","name":"04e52a8d-0428-40c6-bb0f-1ac7bd38adc6","status":"Succeeded","startTime":"2023-08-16T09:27:44.384457Z","endTime":"2023-08-16T09:27:44.384457Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"7a18c424-aa9c-450a-95af-295da26d5f73"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '302'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:28:28 GMT
       expires:
       - '-1'
       pragma:
@@ -1811,15 +2062,15 @@ interactions:
       ParameterSetName:
       - -g -v --storage-account --azure-file-share -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/2d117199-8f4b-4d30-8758-7fe7e8910326?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7a18c424-aa9c-450a-95af-295da26d5f73?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/2d117199-8f4b-4d30-8758-7fe7e8910326","name":"2d117199-8f4b-4d30-8758-7fe7e8910326","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT41.346172S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7a18c424-aa9c-450a-95af-295da26d5f73","name":"7a18c424-aa9c-450a-95af-295da26d5f73","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT41.5564301S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
         Share Name":"clitest-item000004","Storage Account Name":"clitest000003","Policy
-        Name":"clitest-item000005"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"ConfigureBackup","status":"Completed","startTime":"2023-05-17T12:09:08.8760546Z","endTime":"2023-05-17T12:09:50.2222266Z","activityId":"875340ba-f4ab-11ed-bb24-c8f750f92764"}}'
+        Name":"clitest-item000005"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"ConfigureBackup","status":"Completed","startTime":"2023-08-16T09:27:44.384457Z","endTime":"2023-08-16T09:28:25.9408871Z","activityId":"faaad124-3c16-11ee-81ce-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
@@ -1828,7 +2079,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:09:54 GMT
+      - Wed, 16 Aug 2023 09:28:30 GMT
       expires:
       - '-1'
       pragma:
@@ -1862,13 +2113,13 @@ interactions:
       ParameterSetName:
       - -g -v -c --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;980e2d26bb4174c443bfac1bca2ffaff5635170927b4f9fa287548f2416b34cb","name":"AzureFileShare;980e2d26bb4174c443bfac1bca2ffaff5635170927b4f9fa287548f2416b34cb","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;df0275e3e674d8756d9ed13690173363cecff2ee265c42fe89940a8adfed9bf4","name":"AzureFileShare;df0275e3e674d8756d9ed13690173363cecff2ee265c42fe89940a8adfed9bf4","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
     headers:
       cache-control:
       - no-cache
@@ -1877,7 +2128,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:09:55 GMT
+      - Wed, 16 Aug 2023 09:28:31 GMT
       expires:
       - '-1'
       pragma:
@@ -1893,7 +2144,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '299'
     status:
       code: 200
       message: OK
@@ -1911,13 +2162,13 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --backup-management-type --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;980e2d26bb4174c443bfac1bca2ffaff5635170927b4f9fa287548f2416b34cb","name":"AzureFileShare;980e2d26bb4174c443bfac1bca2ffaff5635170927b4f9fa287548f2416b34cb","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;df0275e3e674d8756d9ed13690173363cecff2ee265c42fe89940a8adfed9bf4","name":"AzureFileShare;df0275e3e674d8756d9ed13690173363cecff2ee265c42fe89940a8adfed9bf4","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
     headers:
       cache-control:
       - no-cache
@@ -1926,7 +2177,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:09:55 GMT
+      - Wed, 16 Aug 2023 09:28:32 GMT
       expires:
       - '-1'
       pragma:
@@ -1966,26 +2217,26 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --backup-management-type --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3B980e2d26bb4174c443bfac1bca2ffaff5635170927b4f9fa287548f2416b34cb?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3Bdf0275e3e674d8756d9ed13690173363cecff2ee265c42fe89940a8adfed9bf4?api-version=2023-02-01
   response:
     body:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;980e2d26bb4174c443bfac1bca2ffaff5635170927b4f9fa287548f2416b34cb/operationsStatus/845fb0c3-712c-498a-b8ab-fb206121cf42?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;df0275e3e674d8756d9ed13690173363cecff2ee265c42fe89940a8adfed9bf4/operationsStatus/d1eb6eeb-f739-49a5-97f4-8772f5480409?api-version=2023-02-01
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:09:56 GMT
+      - Wed, 16 Aug 2023 09:28:33 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;980e2d26bb4174c443bfac1bca2ffaff5635170927b4f9fa287548f2416b34cb/operationResults/845fb0c3-712c-498a-b8ab-fb206121cf42?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;df0275e3e674d8756d9ed13690173363cecff2ee265c42fe89940a8adfed9bf4/operationResults/d1eb6eeb-f739-49a5-97f4-8772f5480409?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -1995,7 +2246,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1195'
     status:
       code: 202
       message: Accepted
@@ -2013,71 +2264,22 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --backup-management-type --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/845fb0c3-712c-498a-b8ab-fb206121cf42?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/d1eb6eeb-f739-49a5-97f4-8772f5480409?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"845fb0c3-712c-498a-b8ab-fb206121cf42","name":"845fb0c3-712c-498a-b8ab-fb206121cf42","status":"InProgress","startTime":"2023-05-17T12:09:57.509853Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"d1eb6eeb-f739-49a5-97f4-8772f5480409","name":"d1eb6eeb-f739-49a5-97f4-8772f5480409","status":"InProgress","startTime":"2023-08-16T09:28:34.0287352Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '187'
+      - '188'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:09:58 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/845fb0c3-712c-498a-b8ab-fb206121cf42?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"845fb0c3-712c-498a-b8ab-fb206121cf42","name":"845fb0c3-712c-498a-b8ab-fb206121cf42","status":"InProgress","startTime":"2023-05-17T12:09:57.509853Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:10:03 GMT
+      - Wed, 16 Aug 2023 09:28:35 GMT
       expires:
       - '-1'
       pragma:
@@ -2111,71 +2313,22 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --backup-management-type --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/845fb0c3-712c-498a-b8ab-fb206121cf42?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/d1eb6eeb-f739-49a5-97f4-8772f5480409?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"845fb0c3-712c-498a-b8ab-fb206121cf42","name":"845fb0c3-712c-498a-b8ab-fb206121cf42","status":"InProgress","startTime":"2023-05-17T12:09:57.509853Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"d1eb6eeb-f739-49a5-97f4-8772f5480409","name":"d1eb6eeb-f739-49a5-97f4-8772f5480409","status":"InProgress","startTime":"2023-08-16T09:28:34.0287352Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '187'
+      - '188'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:08 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/845fb0c3-712c-498a-b8ab-fb206121cf42?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"845fb0c3-712c-498a-b8ab-fb206121cf42","name":"845fb0c3-712c-498a-b8ab-fb206121cf42","status":"InProgress","startTime":"2023-05-17T12:09:57.509853Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:10:15 GMT
+      - Wed, 16 Aug 2023 09:28:40 GMT
       expires:
       - '-1'
       pragma:
@@ -2209,22 +2362,22 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --backup-management-type --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/845fb0c3-712c-498a-b8ab-fb206121cf42?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/d1eb6eeb-f739-49a5-97f4-8772f5480409?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"845fb0c3-712c-498a-b8ab-fb206121cf42","name":"845fb0c3-712c-498a-b8ab-fb206121cf42","status":"Succeeded","startTime":"2023-05-17T12:09:57.509853Z","endTime":"2023-05-17T12:09:57.509853Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"44acd99e-d5e1-465f-b015-f155259dda23"}}'
+      string: '{"id":"d1eb6eeb-f739-49a5-97f4-8772f5480409","name":"d1eb6eeb-f739-49a5-97f4-8772f5480409","status":"InProgress","startTime":"2023-08-16T09:28:34.0287352Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '302'
+      - '188'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:20 GMT
+      - Wed, 16 Aug 2023 09:28:45 GMT
       expires:
       - '-1'
       pragma:
@@ -2240,7 +2393,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '295'
+      - '294'
     status:
       code: 200
       message: OK
@@ -2258,14 +2411,112 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --backup-management-type --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/44acd99e-d5e1-465f-b015-f155259dda23?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/d1eb6eeb-f739-49a5-97f4-8772f5480409?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/44acd99e-d5e1-465f-b015-f155259dda23","name":"44acd99e-d5e1-465f-b015-f155259dda23","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT20.7031707S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
-        Share Name":"clitest-item000004","Storage Account Name":"clitest000003"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"DisableBackup","status":"Completed","startTime":"2023-05-17T12:09:57.509853Z","endTime":"2023-05-17T12:10:18.2130237Z","activityId":"bbb5cde2-f4ab-11ed-8822-c8f750f92764"}}'
+      string: '{"id":"d1eb6eeb-f739-49a5-97f4-8772f5480409","name":"d1eb6eeb-f739-49a5-97f4-8772f5480409","status":"InProgress","startTime":"2023-08-16T09:28:34.0287352Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:28:51 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '292'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/d1eb6eeb-f739-49a5-97f4-8772f5480409?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"d1eb6eeb-f739-49a5-97f4-8772f5480409","name":"d1eb6eeb-f739-49a5-97f4-8772f5480409","status":"Succeeded","startTime":"2023-08-16T09:28:34.0287352Z","endTime":"2023-08-16T09:28:34.0287352Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"cb7fddeb-7c2a-4f5f-827a-5bd8bd24751e"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:28:55 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '290'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/cb7fddeb-7c2a-4f5f-827a-5bd8bd24751e?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/cb7fddeb-7c2a-4f5f-827a-5bd8bd24751e","name":"cb7fddeb-7c2a-4f5f-827a-5bd8bd24751e","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT20.8781138S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
+        Share Name":"clitest-item000004","Storage Account Name":"clitest000003"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"DisableBackup","status":"Completed","startTime":"2023-08-16T09:28:34.0287352Z","endTime":"2023-08-16T09:28:54.906849Z","activityId":"441ca01c-3c17-11ee-93e0-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
@@ -2274,7 +2525,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:21 GMT
+      - Wed, 16 Aug 2023 09:28:57 GMT
       expires:
       - '-1'
       pragma:
@@ -2308,13 +2559,13 @@ interactions:
       ParameterSetName:
       - -g -v -c -n --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;980e2d26bb4174c443bfac1bca2ffaff5635170927b4f9fa287548f2416b34cb","name":"AzureFileShare;980e2d26bb4174c443bfac1bca2ffaff5635170927b4f9fa287548f2416b34cb","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"ProtectionStopped","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;df0275e3e674d8756d9ed13690173363cecff2ee265c42fe89940a8adfed9bf4","name":"AzureFileShare;df0275e3e674d8756d9ed13690173363cecff2ee265c42fe89940a8adfed9bf4","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"ProtectionStopped","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
     headers:
       cache-control:
       - no-cache
@@ -2323,7 +2574,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:21 GMT
+      - Wed, 16 Aug 2023 09:28:58 GMT
       expires:
       - '-1'
       pragma:
@@ -2357,13 +2608,13 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --backup-management-type --delete-backup-data --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;980e2d26bb4174c443bfac1bca2ffaff5635170927b4f9fa287548f2416b34cb","name":"AzureFileShare;980e2d26bb4174c443bfac1bca2ffaff5635170927b4f9fa287548f2416b34cb","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"ProtectionStopped","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;df0275e3e674d8756d9ed13690173363cecff2ee265c42fe89940a8adfed9bf4","name":"AzureFileShare;df0275e3e674d8756d9ed13690173363cecff2ee265c42fe89940a8adfed9bf4","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"ProtectionStopped","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
     headers:
       cache-control:
       - no-cache
@@ -2372,201 +2623,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:22 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupResourceGuardProxies?api-version=2023-02-01
-  response:
-    body:
-      string: '{"value":[]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '12'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:10:23 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3B980e2d26bb4174c443bfac1bca2ffaff5635170927b4f9fa287548f2416b34cb?api-version=2023-02-01
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/df5d9575-8df4-4a88-8e3d-5c425bc6d096?api-version=2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Wed, 17 May 2023 12:10:23 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/df5d9575-8df4-4a88-8e3d-5c425bc6d096?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-deletes:
-      - '14998'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/df5d9575-8df4-4a88-8e3d-5c425bc6d096?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"df5d9575-8df4-4a88-8e3d-5c425bc6d096","name":"df5d9575-8df4-4a88-8e3d-5c425bc6d096","status":"InProgress","startTime":"2023-05-17T12:10:24.3321758Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:10:24 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/df5d9575-8df4-4a88-8e3d-5c425bc6d096?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"df5d9575-8df4-4a88-8e3d-5c425bc6d096","name":"df5d9575-8df4-4a88-8e3d-5c425bc6d096","status":"InProgress","startTime":"2023-05-17T12:10:24.3321758Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:10:30 GMT
+      - Wed, 16 Aug 2023 09:29:00 GMT
       expires:
       - '-1'
       pragma:
@@ -2600,13 +2657,109 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --backup-management-type --delete-backup-data --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/df5d9575-8df4-4a88-8e3d-5c425bc6d096?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupResourceGuardProxies?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"df5d9575-8df4-4a88-8e3d-5c425bc6d096","name":"df5d9575-8df4-4a88-8e3d-5c425bc6d096","status":"InProgress","startTime":"2023-05-17T12:10:24.3321758Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:29:01 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3Bdf0275e3e674d8756d9ed13690173363cecff2ee265c42fe89940a8adfed9bf4?api-version=2023-02-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e9aa1d70-8318-43aa-b782-817b9654aa15?api-version=2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Wed, 16 Aug 2023 09:29:02 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/e9aa1d70-8318-43aa-b782-817b9654aa15?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14999'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e9aa1d70-8318-43aa-b782-817b9654aa15?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"e9aa1d70-8318-43aa-b782-817b9654aa15","name":"e9aa1d70-8318-43aa-b782-817b9654aa15","status":"InProgress","startTime":"2023-08-16T09:29:03.0549661Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -2615,7 +2768,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:35 GMT
+      - Wed, 16 Aug 2023 09:29:04 GMT
       expires:
       - '-1'
       pragma:
@@ -2649,13 +2802,13 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --backup-management-type --delete-backup-data --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/df5d9575-8df4-4a88-8e3d-5c425bc6d096?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e9aa1d70-8318-43aa-b782-817b9654aa15?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"df5d9575-8df4-4a88-8e3d-5c425bc6d096","name":"df5d9575-8df4-4a88-8e3d-5c425bc6d096","status":"InProgress","startTime":"2023-05-17T12:10:24.3321758Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"e9aa1d70-8318-43aa-b782-817b9654aa15","name":"e9aa1d70-8318-43aa-b782-817b9654aa15","status":"InProgress","startTime":"2023-08-16T09:29:03.0549661Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -2664,56 +2817,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:41 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '296'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/df5d9575-8df4-4a88-8e3d-5c425bc6d096?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"df5d9575-8df4-4a88-8e3d-5c425bc6d096","name":"df5d9575-8df4-4a88-8e3d-5c425bc6d096","status":"Succeeded","startTime":"2023-05-17T12:10:24.3321758Z","endTime":"2023-05-17T12:10:24.3321758Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"4c28363d-187c-4724-b6a5-f2a929af4edf"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:10:46 GMT
+      - Wed, 16 Aug 2023 09:29:09 GMT
       expires:
       - '-1'
       pragma:
@@ -2747,23 +2851,22 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --backup-management-type --delete-backup-data --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/4c28363d-187c-4724-b6a5-f2a929af4edf?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e9aa1d70-8318-43aa-b782-817b9654aa15?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/4c28363d-187c-4724-b6a5-f2a929af4edf","name":"4c28363d-187c-4724-b6a5-f2a929af4edf","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT20.824144S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
-        Share Name":"clitest-item000004","Storage Account Name":"clitest000003"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"DeleteBackupData","status":"Completed","startTime":"2023-05-17T12:10:24.3321758Z","endTime":"2023-05-17T12:10:45.1563198Z","activityId":"cb7e5b0a-f4ab-11ed-9b73-c8f750f92764"}}'
+      string: '{"id":"e9aa1d70-8318-43aa-b782-817b9654aa15","name":"e9aa1d70-8318-43aa-b782-817b9654aa15","status":"InProgress","startTime":"2023-08-16T09:29:03.0549661Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '862'
+      - '188'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:48 GMT
+      - Wed, 16 Aug 2023 09:29:14 GMT
       expires:
       - '-1'
       pragma:
@@ -2779,7 +2882,155 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '149'
+      - '293'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e9aa1d70-8318-43aa-b782-817b9654aa15?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"e9aa1d70-8318-43aa-b782-817b9654aa15","name":"e9aa1d70-8318-43aa-b782-817b9654aa15","status":"InProgress","startTime":"2023-08-16T09:29:03.0549661Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:29:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '291'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e9aa1d70-8318-43aa-b782-817b9654aa15?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"e9aa1d70-8318-43aa-b782-817b9654aa15","name":"e9aa1d70-8318-43aa-b782-817b9654aa15","status":"Succeeded","startTime":"2023-08-16T09:29:03.0549661Z","endTime":"2023-08-16T09:29:03.0549661Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"67b09f1c-7d8b-4344-9f73-f51eb1d10f33"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:29:25 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '289'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/67b09f1c-7d8b-4344-9f73-f51eb1d10f33?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/67b09f1c-7d8b-4344-9f73-f51eb1d10f33","name":"67b09f1c-7d8b-4344-9f73-f51eb1d10f33","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT20.8556724S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
+        Share Name":"clitest-item000004","Storage Account Name":"clitest000003"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"DeleteBackupData","status":"Completed","startTime":"2023-08-16T09:29:03.0549661Z","endTime":"2023-08-16T09:29:23.9106385Z","activityId":"54b3d1a5-3c17-11ee-a673-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '863'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:29:26 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '148'
     status:
       code: 200
       message: OK
@@ -2797,8 +3048,8 @@ interactions:
       ParameterSetName:
       - -g -v -c --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
@@ -2812,56 +3063,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:49 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container unregister
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c --yes --backup-management-type
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+friendlyName+eq+%27clitest000003%27+and+status+eq+%27Registered%27
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","protectedItemCount":0,"acquireStorageAccountLock":"Acquire","friendlyName":"clitest000003","backupManagementType":"AzureStorage","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"StorageContainer","protectableObjectType":"StorageContainer"}}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '853'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:10:50 GMT
+      - Wed, 16 Aug 2023 09:29:28 GMT
       expires:
       - '-1'
       pragma:
@@ -2892,13 +3094,62 @@ interactions:
       - backup container unregister
       Connection:
       - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+friendlyName+eq+%27clitest000003%27+and+status+eq+%27Registered%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","protectedItemCount":0,"acquireStorageAccountLock":"Acquire","friendlyName":"clitest000003","backupManagementType":"AzureStorage","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"StorageContainer","protectableObjectType":"StorageContainer"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '853'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:29:29 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '297'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
       Content-Length:
       - '0'
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003?api-version=2023-02-01
   response:
@@ -2906,17 +3157,17 @@ interactions:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/46b464a7-9554-4cad-bafe-043dc387022f?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/1cb16464-1df2-445f-8424-757213812766?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:10:51 GMT
+      - Wed, 16 Aug 2023 09:29:30 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/46b464a7-9554-4cad-bafe-043dc387022f?fabricName=Azure?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/1cb16464-1df2-445f-8424-757213812766?fabricName=Azure?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -2944,16 +3195,16 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/46b464a7-9554-4cad-bafe-043dc387022f?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/1cb16464-1df2-445f-8424-757213812766?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/46b464a7-9554-4cad-bafe-043dc387022f?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/1cb16464-1df2-445f-8424-757213812766?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -2961,11 +3212,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:52 GMT
+      - Wed, 16 Aug 2023 09:29:31 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/46b464a7-9554-4cad-bafe-043dc387022f?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/1cb16464-1df2-445f-8424-757213812766?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -2993,16 +3244,16 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/46b464a7-9554-4cad-bafe-043dc387022f?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/1cb16464-1df2-445f-8424-757213812766?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/46b464a7-9554-4cad-bafe-043dc387022f?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/1cb16464-1df2-445f-8424-757213812766?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -3010,11 +3261,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:57 GMT
+      - Wed, 16 Aug 2023 09:29:36 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/46b464a7-9554-4cad-bafe-043dc387022f?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/1cb16464-1df2-445f-8424-757213812766?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -3042,16 +3293,16 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/46b464a7-9554-4cad-bafe-043dc387022f?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/1cb16464-1df2-445f-8424-757213812766?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/46b464a7-9554-4cad-bafe-043dc387022f?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/1cb16464-1df2-445f-8424-757213812766?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -3059,11 +3310,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:11:03 GMT
+      - Wed, 16 Aug 2023 09:29:42 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/46b464a7-9554-4cad-bafe-043dc387022f?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/1cb16464-1df2-445f-8424-757213812766?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -3091,16 +3342,16 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/46b464a7-9554-4cad-bafe-043dc387022f?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/1cb16464-1df2-445f-8424-757213812766?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/46b464a7-9554-4cad-bafe-043dc387022f?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/1cb16464-1df2-445f-8424-757213812766?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -3108,11 +3359,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:11:08 GMT
+      - Wed, 16 Aug 2023 09:29:47 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/46b464a7-9554-4cad-bafe-043dc387022f?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/1cb16464-1df2-445f-8424-757213812766?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -3140,10 +3391,500 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/46b464a7-9554-4cad-bafe-043dc387022f?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/1cb16464-1df2-445f-8424-757213812766?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/1cb16464-1df2-445f-8424-757213812766?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:29:52 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/1cb16464-1df2-445f-8424-757213812766?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '295'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/1cb16464-1df2-445f-8424-757213812766?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/1cb16464-1df2-445f-8424-757213812766?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:29:58 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/1cb16464-1df2-445f-8424-757213812766?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '294'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/1cb16464-1df2-445f-8424-757213812766?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/1cb16464-1df2-445f-8424-757213812766?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:30:04 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/1cb16464-1df2-445f-8424-757213812766?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '293'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/1cb16464-1df2-445f-8424-757213812766?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/1cb16464-1df2-445f-8424-757213812766?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:30:09 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/1cb16464-1df2-445f-8424-757213812766?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '292'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/1cb16464-1df2-445f-8424-757213812766?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/1cb16464-1df2-445f-8424-757213812766?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:30:15 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/1cb16464-1df2-445f-8424-757213812766?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '291'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/1cb16464-1df2-445f-8424-757213812766?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/1cb16464-1df2-445f-8424-757213812766?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:30:20 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/1cb16464-1df2-445f-8424-757213812766?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '290'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/1cb16464-1df2-445f-8424-757213812766?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/1cb16464-1df2-445f-8424-757213812766?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:30:25 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/1cb16464-1df2-445f-8424-757213812766?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '289'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/1cb16464-1df2-445f-8424-757213812766?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/1cb16464-1df2-445f-8424-757213812766?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:30:31 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/1cb16464-1df2-445f-8424-757213812766?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '288'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/1cb16464-1df2-445f-8424-757213812766?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/1cb16464-1df2-445f-8424-757213812766?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:30:36 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/1cb16464-1df2-445f-8424-757213812766?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '287'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/1cb16464-1df2-445f-8424-757213812766?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/1cb16464-1df2-445f-8424-757213812766?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:30:41 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/1cb16464-1df2-445f-8424-757213812766?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '286'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/1cb16464-1df2-445f-8424-757213812766?api-version=2023-02-01
   response:
     body:
       string: ''
@@ -3151,7 +3892,7 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Wed, 17 May 2023 12:11:13 GMT
+      - Wed, 16 Aug 2023 09:30:47 GMT
       expires:
       - '-1'
       pragma:
@@ -3163,7 +3904,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '295'
+      - '285'
     status:
       code: 204
       message: No Content
@@ -3181,8 +3922,8 @@ interactions:
       ParameterSetName:
       - --backup-management-type -v -g --query
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureIaasVM%27+and+status+eq+%27Registered%27
   response:
@@ -3196,7 +3937,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:12:55 GMT
+      - Wed, 16 Aug 2023 09:32:28 GMT
       expires:
       - '-1'
       pragma:
@@ -3212,7 +3953,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '297'
     status:
       code: 200
       message: OK
@@ -3232,7 +3973,8 @@ interactions:
       ParameterSetName:
       - -n -g --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2023-02-01
   response:
@@ -3244,7 +3986,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:13:05 GMT
+      - Wed, 16 Aug 2023 09:32:34 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/backup/tests/latest/recordings/test_afs_backup_restore.yaml
+++ b/src/azure-cli/azure/cli/command_modules/backup/tests/latest/recordings/test_afs_backup_restore.yaml
@@ -13,12 +13,13 @@ interactions:
       ParameterSetName:
       - -n -g --location
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003?api-version=2023-02-01
   response:
     body:
-      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.RecoveryServices/vaults/clitest-vault000002''
+      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.RecoveryServices/vaults/clitest-vault000003''
         under resource group ''clitest.rg000001'' was not found. For more details
         please go to https://aka.ms/ARMResourceNotFoundFix"}}'
     headers:
@@ -29,7 +30,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:06:48 GMT
+      - Wed, 16 Aug 2023 03:44:28 GMT
       expires:
       - '-1'
       pragma:
@@ -44,7 +45,7 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"location": "eastus2euap", "properties": {"publicNetworkAccess": "Enabled",
+    body: '{"location": "centraluseuap", "properties": {"publicNetworkAccess": "Enabled",
       "monitoringSettings": {"azureMonitorAlertSettings": {"alertsForAllJobFailures":
       "Enabled"}, "classicAlertSettings": {"alertsForCriticalOperations": "Enabled"}}},
       "sku": {"name": "Standard"}}'
@@ -58,39 +59,42 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '267'
+      - '269'
       Content-Type:
       - application/json
       ParameterSetName:
       - -n -g --location
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003?api-version=2023-02-01
   response:
     body:
-      string: '{"location":"eastus2euap","name":"clitest-vault000002","etag":"W/\"datetime''2023-05-17T12%3A06%3A54.3940196Z''\"","properties":{"provisioningState":"Provisioning","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}},"publicNetworkAccess":"Enabled","restoreSettings":{"crossSubscriptionRestoreSettings":{"crossSubscriptionRestoreState":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+      string: '{"location":"centraluseuap","name":"clitest-vault000003","etag":"W/\"datetime''2023-08-16T03%3A44%3A30.1658092Z''\"","properties":{"provisioningState":"Provisioning","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}},"publicNetworkAccess":"Enabled","restoreSettings":{"crossSubscriptionRestoreSettings":{"crossSubscriptionRestoreState":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0Nzs2MDU2MDkyNC05ZjhjLTRmZWYtOGFjNi04NmE1NWJlZmY4Njg=?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/operationStatus/MjA0NzsyNDJiMTFhYy0zMmE3LTQ4MjUtODA2MS03MDhjYjhmMDkyNDI=?api-version=2023-02-01
       cache-control:
       - no-cache
       content-length:
-      - '756'
+      - '758'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:06:55 GMT
+      - Wed, 16 Aug 2023 03:44:30 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-content-type-options:
       - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=12f8ea5c-1212-449e-b31c-0a574f43076e/centraluseuap/0e83b59c-9236-45da-99c9-319f512c6d26
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '299'
     status:
@@ -110,33 +114,34 @@ interactions:
       ParameterSetName:
       - -n -g --location
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0Nzs2MDU2MDkyNC05ZjhjLTRmZWYtOGFjNi04NmE1NWJlZmY4Njg=?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/operationStatus/MjA0NzsyNDJiMTFhYy0zMmE3LTQ4MjUtODA2MS03MDhjYjhmMDkyNDI=?api-version=2023-02-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0Nzs2MDU2MDkyNC05ZjhjLTRmZWYtOGFjNi04NmE1NWJlZmY4Njg=\",\r\n
-        \ \"name\": \"MjA0Nzs2MDU2MDkyNC05ZjhjLTRmZWYtOGFjNi04NmE1NWJlZmY4Njg=\",\r\n
-        \ \"status\": \"InProgress\"\r\n}"
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/operationStatus/MjA0NzsyNDJiMTFhYy0zMmE3LTQ4MjUtODA2MS03MDhjYjhmMDkyNDI=\"\
+        ,\r\n  \"name\": \"MjA0NzsyNDJiMTFhYy0zMmE3LTQ4MjUtODA2MS03MDhjYjhmMDkyNDI=\"\
+        ,\r\n  \"status\": \"InProgress\"\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0Nzs2MDU2MDkyNC05ZjhjLTRmZWYtOGFjNi04NmE1NWJlZmY4Njg=?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/operationStatus/MjA0NzsyNDJiMTFhYy0zMmE3LTQ4MjUtODA2MS03MDhjYjhmMDkyNDI=?api-version=2023-02-01
       cache-control:
       - no-cache
       content-length:
       - '334'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:06:56 GMT
+      - Wed, 16 Aug 2023 03:44:30 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationResults/MjA0Nzs2MDU2MDkyNC05ZjhjLTRmZWYtOGFjNi04NmE1NWJlZmY4Njg=?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/operationResults/MjA0NzsyNDJiMTFhYy0zMmE3LTQ4MjUtODA2MS03MDhjYjhmMDkyNDI=?api-version=2023-02-01
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -162,29 +167,30 @@ interactions:
       ParameterSetName:
       - -n -g --location
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0Nzs2MDU2MDkyNC05ZjhjLTRmZWYtOGFjNi04NmE1NWJlZmY4Njg=?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/operationStatus/MjA0NzsyNDJiMTFhYy0zMmE3LTQ4MjUtODA2MS03MDhjYjhmMDkyNDI=?api-version=2023-02-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0Nzs2MDU2MDkyNC05ZjhjLTRmZWYtOGFjNi04NmE1NWJlZmY4Njg=\",\r\n
-        \ \"name\": \"MjA0Nzs2MDU2MDkyNC05ZjhjLTRmZWYtOGFjNi04NmE1NWJlZmY4Njg=\",\r\n
-        \ \"status\": \"Succeeded\"\r\n}"
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/operationStatus/MjA0NzsyNDJiMTFhYy0zMmE3LTQ4MjUtODA2MS03MDhjYjhmMDkyNDI=\"\
+        ,\r\n  \"name\": \"MjA0NzsyNDJiMTFhYy0zMmE3LTQ4MjUtODA2MS03MDhjYjhmMDkyNDI=\"\
+        ,\r\n  \"status\": \"Succeeded\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
       - '333'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:07:56 GMT
+      - Wed, 16 Aug 2023 03:45:30 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -210,27 +216,28 @@ interactions:
       ParameterSetName:
       - -n -g --location
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003?api-version=2023-02-01
   response:
     body:
-      string: '{"location":"eastus2euap","name":"clitest-vault000002","etag":"W/\"datetime''2023-05-17T12%3A07%3A56.8273659Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","backupStorageVersion":"Unassigned","monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}},"securitySettings":{"immutabilitySettings":null,"softDeleteSettings":{"softDeleteRetentionPeriodInDays":14,"softDeleteState":"Enabled"},"multiUserAuthorization":"Disabled"},"publicNetworkAccess":"Enabled","restoreSettings":{"crossSubscriptionRestoreSettings":{"crossSubscriptionRestoreState":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+      string: '{"location":"centraluseuap","name":"clitest-vault000003","etag":"W/\"datetime''2023-08-16T03%3A44%3A30.8346446Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","backupStorageVersion":"Unassigned","monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}},"securitySettings":{"immutabilitySettings":null,"softDeleteSettings":{"softDeleteRetentionPeriodInDays":14,"softDeleteState":"Enabled"},"multiUserAuthorization":"Disabled"},"publicNetworkAccess":"Enabled","restoreSettings":{"crossSubscriptionRestoreSettings":{"crossSubscriptionRestoreState":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '962'
+      - '964'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:07:57 GMT
+      - Wed, 16 Aug 2023 03:45:30 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -239,6 +246,162 @@ interactions:
       - Accept-Encoding
       x-content-type-options:
       - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault backup-properties set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --soft-delete-feature-state
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupconfig/vaultconfig?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupconfig/vaultconfig","name":"vaultconfig","type":"Microsoft.RecoveryServices/vaults/backupconfig","properties":{"enhancedSecurityState":"Enabled","softDeleteFeatureState":"Enabled","softDeleteRetentionPeriodInDays":14,"isSoftDeleteFeatureStateEditable":true}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '419'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:45:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '299'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault backup-properties set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --soft-delete-feature-state
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupResourceGuardProxies?api-version=2023-02-01
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:45:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"enhancedSecurityState": "Enabled", "softDeleteFeatureState":
+      "Disabled"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault backup-properties set
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '90'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -n -g --soft-delete-feature-state
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: PATCH
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupconfig/vaultconfig?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupconfig/vaultconfig","name":"vaultconfig","type":"Microsoft.RecoveryServices/vaults/backupconfig","properties":{"enhancedSecurityState":"Enabled","softDeleteFeatureState":"Disabled","softDeleteRetentionPeriodInDays":14,"isSoftDeleteFeatureStateEditable":true}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '420'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:45:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1198'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -258,12 +421,13 @@ interactions:
       ParameterSetName:
       - --resource-group --account-name --query
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-storage/21.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003/listKeys?api-version=2022-09-01&$expand=kerb
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004/listKeys?api-version=2022-09-01&$expand=kerb
   response:
     body:
-      string: '{"keys":[{"creationTime":"2023-05-17T12:08:01.2956159Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2023-05-17T12:08:01.2956159Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
+      string: '{"keys":[{"creationTime":"2023-08-16T03:45:38.6198925Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2023-08-16T03:45:38.6198925Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
     headers:
       cache-control:
       - no-cache
@@ -272,7 +436,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 17 May 2023 12:08:24 GMT
+      - Wed, 16 Aug 2023 03:46:24 GMT
       expires:
       - '-1'
       pragma:
@@ -288,7 +452,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11997'
     status:
       code: 200
       message: OK
@@ -308,12 +472,13 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-storage/21.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003/listKeys?api-version=2022-09-01&$expand=kerb
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004/listKeys?api-version=2022-09-01&$expand=kerb
   response:
     body:
-      string: '{"keys":[{"creationTime":"2023-05-17T12:08:01.2956159Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2023-05-17T12:08:01.2956159Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
+      string: '{"keys":[{"creationTime":"2023-08-16T03:45:38.6198925Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2023-08-16T03:45:38.6198925Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
     headers:
       cache-control:
       - no-cache
@@ -322,7 +487,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 17 May 2023 12:08:25 GMT
+      - Wed, 16 Aug 2023 03:46:25 GMT
       expires:
       - '-1'
       pragma:
@@ -356,21 +521,22 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-storage/21.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","name":"clitest000003","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"keyCreationTime":{"key1":"2023-05-17T12:08:01.2956159Z","key2":"2023-05-17T12:08:01.2956159Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-05-17T12:08:01.7487432Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-05-17T12:08:01.7487432Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-05-17T12:08:01.2018473Z","primaryEndpoints":{"blob":"https://clitest000003.blob.core.windows.net/","queue":"https://clitest000003.queue.core.windows.net/","table":"https://clitest000003.table.core.windows.net/","file":"https://clitest000003.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004","name":"clitest000004","type":"Microsoft.Storage/storageAccounts","location":"centraluseuap","tags":{},"properties":{"keyCreationTime":{"key1":"2023-08-16T03:45:38.6198925Z","key2":"2023-08-16T03:45:38.6198925Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-08-16T03:45:38.8855125Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-08-16T03:45:38.8855125Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-08-16T03:45:38.5261630Z","primaryEndpoints":{"blob":"https://clitest000004.blob.core.windows.net/","queue":"https://clitest000004.queue.core.windows.net/","table":"https://clitest000004.table.core.windows.net/","file":"https://clitest000004.file.core.windows.net/"},"primaryLocation":"centraluseuap","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1280'
+      - '1284'
       content-type:
       - application/json
       date:
-      - Wed, 17 May 2023 12:08:25 GMT
+      - Wed, 16 Aug 2023 03:46:25 GMT
       expires:
       - '-1'
       pragma:
@@ -404,15 +570,16 @@ interactions:
       ParameterSetName:
       - --name --quota --connection-string
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-storage-file-share/12.12.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-storage-file-share/12.12.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Wed, 17 May 2023 12:08:24 GMT
+      - Wed, 16 Aug 2023 03:46:26 GMT
       x-ms-share-quota:
       - '1'
       x-ms-version:
       - '2022-11-02'
     method: PUT
-    uri: https://clitest000003.file.core.windows.net/clitest-item000007?restype=share
+    uri: https://clitest000004.file.core.windows.net/clitest-item000008?restype=share
   response:
     body:
       string: ''
@@ -420,11 +587,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:08:26 GMT
+      - Wed, 16 Aug 2023 03:46:27 GMT
       etag:
-      - '"0x8DB56CF6BF5DDE7"'
+      - '"0x8DB9E0B5EF02696"'
       last-modified:
-      - Wed, 17 May 2023 12:08:27 GMT
+      - Wed, 16 Aug 2023 03:46:27 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
@@ -448,11 +615,12 @@ interactions:
       ParameterSetName:
       - --account-name --account-key --share-name --source
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-storage-file-share/12.12.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-storage-file-share/12.12.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
       x-ms-content-length:
       - '0'
       x-ms-date:
-      - Wed, 17 May 2023 12:08:26 GMT
+      - Wed, 16 Aug 2023 03:46:28 GMT
       x-ms-file-attributes:
       - none
       x-ms-file-creation-time:
@@ -466,7 +634,7 @@ interactions:
       x-ms-version:
       - '2022-11-02'
     method: PUT
-    uri: https://clitest000003.file.core.windows.net/clitest-item000007/clitest-file000005
+    uri: https://clitest000004.file.core.windows.net/clitest-item000008/clitest-file000006
   response:
     body:
       string: ''
@@ -474,27 +642,27 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:08:27 GMT
+      - Wed, 16 Aug 2023 03:46:28 GMT
       etag:
-      - '"0x8DB56CF6C901832"'
+      - '"0x8DB9E0B5FB2E3ED"'
       last-modified:
-      - Wed, 17 May 2023 12:08:28 GMT
+      - Wed, 16 Aug 2023 03:46:29 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-file-attributes:
       - Archive
       x-ms-file-change-time:
-      - '2023-05-17T12:08:28.2658866Z'
+      - '2023-08-16T03:46:29.0445293Z'
       x-ms-file-creation-time:
-      - '2023-05-17T12:08:28.2658866Z'
+      - '2023-08-16T03:46:29.0445293Z'
       x-ms-file-id:
       - '13835128424026341376'
       x-ms-file-last-write-time:
-      - '2023-05-17T12:08:28.2658866Z'
+      - '2023-08-16T03:46:29.0445293Z'
       x-ms-file-parent-id:
       - '0'
       x-ms-file-permission-key:
-      - 101102253892263405*12233966502995342691
+      - 14243236058913975938*7857316777787115020
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -518,11 +686,12 @@ interactions:
       ParameterSetName:
       - --account-name --account-key --share-name --source
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-storage-file-share/12.12.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-storage-file-share/12.12.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
       x-ms-content-length:
       - '0'
       x-ms-date:
-      - Wed, 17 May 2023 12:08:27 GMT
+      - Wed, 16 Aug 2023 03:46:29 GMT
       x-ms-file-attributes:
       - none
       x-ms-file-creation-time:
@@ -536,7 +705,7 @@ interactions:
       x-ms-version:
       - '2022-11-02'
     method: PUT
-    uri: https://clitest000003.file.core.windows.net/clitest-item000007/clitest-file000006
+    uri: https://clitest000004.file.core.windows.net/clitest-item000008/clitest-file000007
   response:
     body:
       string: ''
@@ -544,27 +713,27 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:08:28 GMT
+      - Wed, 16 Aug 2023 03:46:29 GMT
       etag:
-      - '"0x8DB56CF6D321715"'
+      - '"0x8DB9E0B605C20EC"'
       last-modified:
-      - Wed, 17 May 2023 12:08:29 GMT
+      - Wed, 16 Aug 2023 03:46:30 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-file-attributes:
       - Archive
       x-ms-file-change-time:
-      - '2023-05-17T12:08:29.3275413Z'
+      - '2023-08-16T03:46:30.1536492Z'
       x-ms-file-creation-time:
-      - '2023-05-17T12:08:29.3275413Z'
+      - '2023-08-16T03:46:30.1536492Z'
       x-ms-file-id:
       - '13835093239654252544'
       x-ms-file-last-write-time:
-      - '2023-05-17T12:08:29.3275413Z'
+      - '2023-08-16T03:46:30.1536492Z'
       x-ms-file-parent-id:
       - '0'
       x-ms-file-permission-key:
-      - 101102253892263405*12233966502995342691
+      - 14243236058913975938*7857316777787115020
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -586,28 +755,28 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupPolicies/DefaultPolicy?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T13:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T13:30:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '764'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:08:29 GMT
+      - Wed, 16 Aug 2023 03:46:30 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -618,15 +787,17 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '299'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
 - request:
     body: '{"properties": {"protectedItemsCount": 0, "backupManagementType": "AzureStorage",
       "workLoadType": "AzureFileShare", "schedulePolicy": {"schedulePolicyType": "SimpleSchedulePolicy",
-      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2023-05-17T22:00:00.000Z"],
+      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2023-08-16T13:30:00.000Z"],
       "scheduleWeeklyFrequency": 0}, "retentionPolicy": {"retentionPolicyType": "LongTermRetentionPolicy",
-      "dailySchedule": {"retentionTimes": ["2023-05-17T22:00:00.000Z"], "retentionDuration":
+      "dailySchedule": {"retentionTimes": ["2023-08-16T13:30:00.000Z"], "retentionDuration":
       {"count": 30, "durationType": "Days"}}}, "timeZone": "UTC"}}'
     headers:
       Accept:
@@ -644,28 +815,28 @@ interactions:
       ParameterSetName:
       - -g -v --policy -n --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000008?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupPolicies/clitest-item000009?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000008","name":"clitest-item000008","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupPolicies/clitest-item000009","name":"clitest-item000009","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","workLoadType":"AzureFileShare","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T13:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T13:30:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '719'
+      - '751'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:08:31 GMT
+      - Wed, 16 Aug 2023 03:46:33 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -676,6 +847,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -693,10 +866,10 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+status+eq+%27Registered%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+status+eq+%27Registered%27
   response:
     body:
       string: '{"value":[]}'
@@ -706,15 +879,15 @@ interactions:
       content-length:
       - '12'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:08:32 GMT
+      - Wed, 16 Aug 2023 03:46:35 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -725,6 +898,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '299'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -742,28 +917,28 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","name":"StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"adiguptecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/adigupt-ecy-rg/providers/Microsoft.Storage/storageAccounts/adiguptecy"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg2yfprhyqds;clitesttz6sdom2jatwnfac4","name":"StorageContainer;Storage;clitest.rg2yfprhyqds;clitesttz6sdom2jatwnfac4","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesttz6sdom2jatwnfac4","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg2yfprhyqds/providers/Microsoft.Storage/storageAccounts/clitesttz6sdom2jatwnfac4"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest000003","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx;clitest5g7td7ozjqq2b6ccr","name":"StorageContainer;Storage;clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx;clitest5g7td7ozjqq2b6ccr","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest5g7td7ozjqq2b6ccr","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx/providers/Microsoft.Storage/storageAccounts/clitest5g7td7ozjqq2b6ccr"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgnochh2c3ax;clitestu2fyy2h47rugcmeo6","name":"StorageContainer;Storage;clitest.rgnochh2c3ax;clitestu2fyy2h47rugcmeo6","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestu2fyy2h47rugcmeo6","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgnochh2c3ax/providers/Microsoft.Storage/storageAccounts/clitestu2fyy2h47rugcmeo6"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgnvoelwrvnb;clitestw62rrt6h5fidon2vw","name":"StorageContainer;Storage;clitest.rgnvoelwrvnb;clitestw62rrt6h5fidon2vw","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestw62rrt6h5fidon2vw","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgnvoelwrvnb/providers/Microsoft.Storage/storageAccounts/clitestw62rrt6h5fidon2vw"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgr2bhgo2ujn;clitestuj7krn3kbijvk2vhl","name":"StorageContainer;Storage;clitest.rgr2bhgo2ujn;clitestuj7krn3kbijvk2vhl","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestuj7krn3kbijvk2vhl","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgr2bhgo2ujn/providers/Microsoft.Storage/storageAccounts/clitestuj7krn3kbijvk2vhl"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgt7y3m2jxoj;clitest4ok6wrvjr5q6texyd","name":"StorageContainer;Storage;clitest.rgt7y3m2jxoj;clitest4ok6wrvjr5q6texyd","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest4ok6wrvjr5q6texyd","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgt7y3m2jxoj/providers/Microsoft.Storage/storageAccounts/clitest4ok6wrvjr5q6texyd"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","name":"StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontusebvtaksecycansa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DonotUse-Blobs-BVT-EACAN-RG/providers/Microsoft.Storage/storageAccounts/dontusebvtaksecycansa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","name":"StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"iaasextstoreecy1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.czr/providers/Microsoft.Storage/storageAccounts/iaasextstoreecy1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","name":"StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesaksdonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-clitest-rg/providers/Microsoft.Storage/storageAccounts/clitesaksdonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"bloboprestorecontainers","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/bloboprestorecontainers"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopall","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopall"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopcontainer","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopcontainer"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopprefix","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopprefix"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG;zubairsaecy","name":"StorageContainer;Storage;zubairRG;zubairsaecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Storage/storageAccounts/zubairsaecy"}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;afs-pstest-rg;afsrestorediffregion","name":"StorageContainer;Storage;afs-pstest-rg;afsrestorediffregion","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"afsrestorediffregion","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/afs-pstest-rg/providers/Microsoft.Storage/storageAccounts/afsrestorediffregion"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;akkanaseCcyGrs;storeimqyzvpnwrv5a","name":"StorageContainer;Storage;akkanaseCcyGrs;storeimqyzvpnwrv5a","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"storeimqyzvpnwrv5a","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akkanaseCcyGrs/providers/Microsoft.Storage/storageAccounts/storeimqyzvpnwrv5a"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;akkanaseMAB;dnhccypod01otds1","name":"StorageContainer;Storage;akkanaseMAB;dnhccypod01otds1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dnhccypod01otds1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akkanaseMAB/providers/Microsoft.Storage/storageAccounts/dnhccypod01otds1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;akneema-we-rg;m3dccypod01otds01","name":"StorageContainer;Storage;akneema-we-rg;m3dccypod01otds01","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"m3dccypod01otds01","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akneema-we-rg/providers/Microsoft.Storage/storageAccounts/m3dccypod01otds01"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;akneema;uvqccypod01otds1","name":"StorageContainer;Storage;akneema;uvqccypod01otds1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"uvqccypod01otds1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akneema/providers/Microsoft.Storage/storageAccounts/uvqccypod01otds1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;Blob-Backup;testblobbackup","name":"StorageContainer;Storage;Blob-Backup;testblobbackup","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"testblobbackup","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Blob-Backup/providers/Microsoft.Storage/storageAccounts/testblobbackup"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;blob-pstest-rg;blobportalsa","name":"StorageContainer;Storage;blob-pstest-rg;blobportalsa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobportalsa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/blob-pstest-rg/providers/Microsoft.Storage/storageAccounts/blobportalsa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;blob-pstest-rg;blobpstestsa","name":"StorageContainer;Storage;blob-pstest-rg;blobpstestsa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobpstestsa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/blob-pstest-rg/providers/Microsoft.Storage/storageAccounts/blobpstestsa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;cli-dpp-bugbash-blob-rg;clidppbugbashstorage1","name":"StorageContainer;Storage;cli-dpp-bugbash-blob-rg;clidppbugbashstorage1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clidppbugbashstorage1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-dpp-bugbash-blob-rg/providers/Microsoft.Storage/storageAccounts/clidppbugbashstorage1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;cli-dpp-bugbash-blob-rg;clidppbugbashstorage2","name":"StorageContainer;Storage;cli-dpp-bugbash-blob-rg;clidppbugbashstorage2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clidppbugbashstorage2","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-dpp-bugbash-blob-rg/providers/Microsoft.Storage/storageAccounts/clidppbugbashstorage2"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest-dpp-rg;clitestsabidonotdelete","name":"StorageContainer;Storage;clitest-dpp-rg;clitestsabidonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestsabidonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-dpp-rg/providers/Microsoft.Storage/storageAccounts/clitestsabidonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest-dpp-rg;clitestsadonotdelete","name":"StorageContainer;Storage;clitest-dpp-rg;clitestsadonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestsadonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-dpp-rg/providers/Microsoft.Storage/storageAccounts/clitestsadonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest-dpp-rg;clitestvsdonotdelete","name":"StorageContainer;Storage;clitest-dpp-rg;clitestvsdonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestvsdonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-dpp-rg/providers/Microsoft.Storage/storageAccounts/clitestvsdonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgi33vpqpddyxu2gnmqdva;clitestop4wnja6zgojupdbv","name":"StorageContainer;Storage;clitest.rgi33vpqpddyxu2gnmqdva;clitestop4wnja6zgojupdbv","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestop4wnja6zgojupdbv","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgi33vpqpddyxu2gnmqdva/providers/Microsoft.Storage/storageAccounts/clitestop4wnja6zgojupdbv"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgv2fzjj7awo;clitestmtsb43oonrvkwgzxs","name":"StorageContainer;Storage;clitest.rgv2fzjj7awo;clitestmtsb43oonrvkwgzxs","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestmtsb43oonrvkwgzxs","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgv2fzjj7awo/providers/Microsoft.Storage/storageAccounts/clitestmtsb43oonrvkwgzxs"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DontUse-BlobRestore-BVT-CCY-RG;dontuseblobbvtccycontnr","name":"StorageContainer;Storage;DontUse-BlobRestore-BVT-CCY-RG;dontuseblobbvtccycontnr","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontuseblobbvtccycontnr","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DontUse-BlobRestore-BVT-CCY-RG/providers/Microsoft.Storage/storageAccounts/dontuseblobbvtccycontnr"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DontUse-BlobRestore-BVT-CCY-RG;dontuseblobbvtccyprefix","name":"StorageContainer;Storage;DontUse-BlobRestore-BVT-CCY-RG;dontuseblobbvtccyprefix","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontuseblobbvtccyprefix","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DontUse-BlobRestore-BVT-CCY-RG/providers/Microsoft.Storage/storageAccounts/dontuseblobbvtccyprefix"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DontUse-BlobRestore-BVT-CCY-RG;dontuseblobbvtccyrstrall","name":"StorageContainer;Storage;DontUse-BlobRestore-BVT-CCY-RG;dontuseblobbvtccyrstrall","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontuseblobbvtccyrstrall","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DontUse-BlobRestore-BVT-CCY-RG/providers/Microsoft.Storage/storageAccounts/dontuseblobbvtccyrstrall"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DontUse-BlobRestore-BVT-EA-RG;dontuseblobbvteacontnr","name":"StorageContainer;Storage;DontUse-BlobRestore-BVT-EA-RG;dontuseblobbvteacontnr","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontuseblobbvteacontnr","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DontUse-BlobRestore-BVT-EA-RG/providers/Microsoft.Storage/storageAccounts/dontuseblobbvteacontnr"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DontUse-BlobRestore-BVT-EA-RG;dontuseblobbvteaprefix","name":"StorageContainer;Storage;DontUse-BlobRestore-BVT-EA-RG;dontuseblobbvteaprefix","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontuseblobbvteaprefix","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DontUse-BlobRestore-BVT-EA-RG/providers/Microsoft.Storage/storageAccounts/dontuseblobbvteaprefix"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DontUse-BlobRestore-BVT-EA-RG;dontuseblobbvtearstrall","name":"StorageContainer;Storage;DontUse-BlobRestore-BVT-EA-RG;dontuseblobbvtearstrall","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontuseblobbvtearstrall","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DontUse-BlobRestore-BVT-EA-RG/providers/Microsoft.Storage/storageAccounts/dontuseblobbvtearstrall"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;iaasvm-clitest-rg;iaasvmclitestsa","name":"StorageContainer;Storage;iaasvm-clitest-rg;iaasvmclitestsa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"iaasvmclitestsa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm-clitest-rg/providers/Microsoft.Storage/storageAccounts/iaasvmclitestsa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;iaasvm-pstest-rg;pstestsa2","name":"StorageContainer;Storage;iaasvm-pstest-rg;pstestsa2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"pstestsa2","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm-pstest-rg/providers/Microsoft.Storage/storageAccounts/pstestsa2"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-clicloudtest-rg;ossclicloudtestsa","name":"StorageContainer;Storage;oss-clicloudtest-rg;ossclicloudtestsa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"ossclicloudtestsa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-clicloudtest-rg/providers/Microsoft.Storage/storageAccounts/ossclicloudtestsa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-clitest-rg;ossclitestsa","name":"StorageContainer;Storage;oss-clitest-rg;ossclitestsa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"ossclitestsa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-clitest-rg/providers/Microsoft.Storage/storageAccounts/ossclitestsa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-pstest-rg;osspstestsa","name":"StorageContainer;Storage;oss-pstest-rg;osspstestsa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"osspstestsa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-pstest-rg/providers/Microsoft.Storage/storageAccounts/osspstestsa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;sarath-rg;axiccypod01otds1","name":"StorageContainer;Storage;sarath-rg;axiccypod01otds1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"axiccypod01otds1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sarath-rg/providers/Microsoft.Storage/storageAccounts/axiccypod01otds1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;sarath-rg;clitestingsa","name":"StorageContainer;Storage;sarath-rg;clitestingsa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestingsa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sarath-rg/providers/Microsoft.Storage/storageAccounts/clitestingsa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;sarath-rg;cliteststoreaccount","name":"StorageContainer;Storage;sarath-rg;cliteststoreaccount","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"cliteststoreaccount","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sarath-rg/providers/Microsoft.Storage/storageAccounts/cliteststoreaccount"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;vepothir-rg-blobs;vepothirstorageblobtest1","name":"StorageContainer;Storage;vepothir-rg-blobs;vepothirstorageblobtest1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"vepothirstorageblobtest1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vepothir-rg-blobs/providers/Microsoft.Storage/storageAccounts/vepothirstorageblobtest1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;vpatel-rg;vpaksstorage","name":"StorageContainer;Storage;vpatel-rg;vpaksstorage","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"vpaksstorage","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vpatel-rg/providers/Microsoft.Storage/storageAccounts/vpaksstorage"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;vpatel-rg;vpbackupstorageacc","name":"StorageContainer;Storage;vpatel-rg;vpbackupstorageacc","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"vpbackupstorageacc","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vpatel-rg/providers/Microsoft.Storage/storageAccounts/vpbackupstorageacc"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG;zubairtestsa","name":"StorageContainer;Storage;zubairRG;zubairtestsa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairtestsa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Storage/storageAccounts/zubairtestsa"}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '12314'
+      - '24254'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:08:33 GMT
+      - Wed, 16 Aug 2023 03:46:37 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -774,12 +949,13 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '299'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
 - request:
-    body: '{"properties": {"backupManagementType": "AzureStorage", "containerType":
-      "StorageContainer", "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003"}}'
+    body: null
     headers:
       Accept:
       - application/json
@@ -790,44 +966,40 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '258'
-      Content-Type:
-      - application/json
+      - '0'
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003?api-version=2023-02-01
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/refreshContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
     body:
-      string: '{}'
+      string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/609d2391-0c19-411b-bb0c-ce12677cf574?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/operationsStatus/d4caf3d5-7a1f-4e94-9bd5-bfea5a1bab3a?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
-      - '2'
-      content-type:
-      - application/json; charset=utf-8
+      - '0'
       date:
-      - Wed, 17 May 2023 12:08:33 GMT
+      - Wed, 16 Aug 2023 03:46:38 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/609d2391-0c19-411b-bb0c-ce12677cf574?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/operationResults/d4caf3d5-7a1f-4e94-9bd5-bfea5a1bab3a?api-version=2023-02-01
       pragma:
       - no-cache
-      server:
-      - Kestrel
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 202
       message: Accepted
@@ -845,38 +1017,34 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/609d2391-0c19-411b-bb0c-ce12677cf574?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/operationResults/d4caf3d5-7a1f-4e94-9bd5-bfea5a1bab3a?api-version=2023-02-01
   response:
     body:
-      string: '{}'
+      string: ''
     headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/609d2391-0c19-411b-bb0c-ce12677cf574?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
-      - '2'
-      content-type:
-      - application/json; charset=utf-8
+      - '0'
       date:
-      - Wed, 17 May 2023 12:08:35 GMT
+      - Wed, 16 Aug 2023 03:46:40 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/609d2391-0c19-411b-bb0c-ce12677cf574?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/operationResults/d4caf3d5-7a1f-4e94-9bd5-bfea5a1bab3a?api-version=2023-02-01
       pragma:
       - no-cache
-      server:
-      - Kestrel
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '299'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 202
       message: Accepted
@@ -894,38 +1062,34 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/609d2391-0c19-411b-bb0c-ce12677cf574?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/operationResults/d4caf3d5-7a1f-4e94-9bd5-bfea5a1bab3a?api-version=2023-02-01
   response:
     body:
-      string: '{}'
+      string: ''
     headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/609d2391-0c19-411b-bb0c-ce12677cf574?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
-      - '2'
-      content-type:
-      - application/json; charset=utf-8
+      - '0'
       date:
-      - Wed, 17 May 2023 12:08:40 GMT
+      - Wed, 16 Aug 2023 03:46:45 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/609d2391-0c19-411b-bb0c-ce12677cf574?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/operationResults/d4caf3d5-7a1f-4e94-9bd5-bfea5a1bab3a?api-version=2023-02-01
       pragma:
       - no-cache
-      server:
-      - Kestrel
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '298'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 202
       message: Accepted
@@ -943,255 +1107,10 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/609d2391-0c19-411b-bb0c-ce12677cf574?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/609d2391-0c19-411b-bb0c-ce12677cf574?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:08:46 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/609d2391-0c19-411b-bb0c-ce12677cf574?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/609d2391-0c19-411b-bb0c-ce12677cf574?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","protectedItemCount":0,"acquireStorageAccountLock":"Acquire","friendlyName":"clitest000003","backupManagementType":"AzureStorage","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"StorageContainer","protectableObjectType":"StorageContainer"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '763'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:08:51 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '296'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectableItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+workloadType+eq+%27AzureFileShare%27
-  response:
-    body:
-      string: '{"value":[]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '12'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:08:52 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/inquire?api-version=2023-02-01&%24filter=workloadType+eq+%27AzureFileShare%27
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/4b2644d9-ccc4-4191-a396-ed93e5abc56b?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Wed, 17 May 2023 12:08:53 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/4b2644d9-ccc4-4191-a396-ed93e5abc56b?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/4b2644d9-ccc4-4191-a396-ed93e5abc56b?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/4b2644d9-ccc4-4191-a396-ed93e5abc56b?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:08:53 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/4b2644d9-ccc4-4191-a396-ed93e5abc56b?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/4b2644d9-ccc4-4191-a396-ed93e5abc56b?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/operationResults/d4caf3d5-7a1f-4e94-9bd5-bfea5a1bab3a?api-version=2023-02-01
   response:
     body:
       string: ''
@@ -1199,19 +1118,17 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Wed, 17 May 2023 12:08:59 GMT
-      expires:
-      - '-1'
+      - Wed, 16 Aug 2023 03:46:51 GMT
       pragma:
       - no-cache
-      server:
-      - Kestrel
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '295'
+      - '297'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 204
       message: No Content
@@ -1229,28 +1146,28 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectableItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+workloadType+eq+%27AzureFileShare%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectableItems/azurefileshare;cdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c","name":"azurefileshare;cdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"parentContainerFabricId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","parentContainerFriendlyName":"clitest000003","azureFileShareType":"XSMB","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","protectableItemType":"AzureFileShare","friendlyName":"clitest-item000007","protectionState":"NotProtected"}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;afs-pstest-rg;afsrestorediffregion","name":"StorageContainer;Storage;afs-pstest-rg;afsrestorediffregion","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"afsrestorediffregion","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/afs-pstest-rg/providers/Microsoft.Storage/storageAccounts/afsrestorediffregion"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;akkanaseCcyGrs;storeimqyzvpnwrv5a","name":"StorageContainer;Storage;akkanaseCcyGrs;storeimqyzvpnwrv5a","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"storeimqyzvpnwrv5a","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akkanaseCcyGrs/providers/Microsoft.Storage/storageAccounts/storeimqyzvpnwrv5a"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;akkanaseMAB;dnhccypod01otds1","name":"StorageContainer;Storage;akkanaseMAB;dnhccypod01otds1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dnhccypod01otds1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akkanaseMAB/providers/Microsoft.Storage/storageAccounts/dnhccypod01otds1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;akneema-we-rg;m3dccypod01otds01","name":"StorageContainer;Storage;akneema-we-rg;m3dccypod01otds01","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"m3dccypod01otds01","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akneema-we-rg/providers/Microsoft.Storage/storageAccounts/m3dccypod01otds01"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;akneema;uvqccypod01otds1","name":"StorageContainer;Storage;akneema;uvqccypod01otds1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"uvqccypod01otds1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akneema/providers/Microsoft.Storage/storageAccounts/uvqccypod01otds1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;Blob-Backup;testblobbackup","name":"StorageContainer;Storage;Blob-Backup;testblobbackup","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"testblobbackup","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Blob-Backup/providers/Microsoft.Storage/storageAccounts/testblobbackup"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;blob-pstest-rg;blobportalsa","name":"StorageContainer;Storage;blob-pstest-rg;blobportalsa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobportalsa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/blob-pstest-rg/providers/Microsoft.Storage/storageAccounts/blobportalsa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;blob-pstest-rg;blobpstestsa","name":"StorageContainer;Storage;blob-pstest-rg;blobpstestsa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobpstestsa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/blob-pstest-rg/providers/Microsoft.Storage/storageAccounts/blobpstestsa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;cli-dpp-bugbash-blob-rg;clidppbugbashstorage1","name":"StorageContainer;Storage;cli-dpp-bugbash-blob-rg;clidppbugbashstorage1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clidppbugbashstorage1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-dpp-bugbash-blob-rg/providers/Microsoft.Storage/storageAccounts/clidppbugbashstorage1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;cli-dpp-bugbash-blob-rg;clidppbugbashstorage2","name":"StorageContainer;Storage;cli-dpp-bugbash-blob-rg;clidppbugbashstorage2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clidppbugbashstorage2","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-dpp-bugbash-blob-rg/providers/Microsoft.Storage/storageAccounts/clidppbugbashstorage2"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest-dpp-rg;clitestsabidonotdelete","name":"StorageContainer;Storage;clitest-dpp-rg;clitestsabidonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestsabidonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-dpp-rg/providers/Microsoft.Storage/storageAccounts/clitestsabidonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest-dpp-rg;clitestsadonotdelete","name":"StorageContainer;Storage;clitest-dpp-rg;clitestsadonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestsadonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-dpp-rg/providers/Microsoft.Storage/storageAccounts/clitestsadonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest-dpp-rg;clitestvsdonotdelete","name":"StorageContainer;Storage;clitest-dpp-rg;clitestvsdonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestvsdonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-dpp-rg/providers/Microsoft.Storage/storageAccounts/clitestvsdonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg000002;clitest000005","name":"StorageContainer;Storage;clitest.rg000002;clitest000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest000005","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Storage/storageAccounts/clitest000005"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg000001;clitest000004","name":"StorageContainer;Storage;clitest.rg000001;clitest000004","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest000004","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DontUse-BlobRestore-BVT-CCY-RG;dontuseblobbvtccycontnr","name":"StorageContainer;Storage;DontUse-BlobRestore-BVT-CCY-RG;dontuseblobbvtccycontnr","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontuseblobbvtccycontnr","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DontUse-BlobRestore-BVT-CCY-RG/providers/Microsoft.Storage/storageAccounts/dontuseblobbvtccycontnr"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DontUse-BlobRestore-BVT-CCY-RG;dontuseblobbvtccyprefix","name":"StorageContainer;Storage;DontUse-BlobRestore-BVT-CCY-RG;dontuseblobbvtccyprefix","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontuseblobbvtccyprefix","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DontUse-BlobRestore-BVT-CCY-RG/providers/Microsoft.Storage/storageAccounts/dontuseblobbvtccyprefix"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DontUse-BlobRestore-BVT-CCY-RG;dontuseblobbvtccyrstrall","name":"StorageContainer;Storage;DontUse-BlobRestore-BVT-CCY-RG;dontuseblobbvtccyrstrall","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontuseblobbvtccyrstrall","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DontUse-BlobRestore-BVT-CCY-RG/providers/Microsoft.Storage/storageAccounts/dontuseblobbvtccyrstrall"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DontUse-BlobRestore-BVT-EA-RG;dontuseblobbvteacontnr","name":"StorageContainer;Storage;DontUse-BlobRestore-BVT-EA-RG;dontuseblobbvteacontnr","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontuseblobbvteacontnr","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DontUse-BlobRestore-BVT-EA-RG/providers/Microsoft.Storage/storageAccounts/dontuseblobbvteacontnr"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DontUse-BlobRestore-BVT-EA-RG;dontuseblobbvteaprefix","name":"StorageContainer;Storage;DontUse-BlobRestore-BVT-EA-RG;dontuseblobbvteaprefix","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontuseblobbvteaprefix","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DontUse-BlobRestore-BVT-EA-RG/providers/Microsoft.Storage/storageAccounts/dontuseblobbvteaprefix"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DontUse-BlobRestore-BVT-EA-RG;dontuseblobbvtearstrall","name":"StorageContainer;Storage;DontUse-BlobRestore-BVT-EA-RG;dontuseblobbvtearstrall","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontuseblobbvtearstrall","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DontUse-BlobRestore-BVT-EA-RG/providers/Microsoft.Storage/storageAccounts/dontuseblobbvtearstrall"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;iaasvm-clitest-rg;iaasvmclitestsa","name":"StorageContainer;Storage;iaasvm-clitest-rg;iaasvmclitestsa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"iaasvmclitestsa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm-clitest-rg/providers/Microsoft.Storage/storageAccounts/iaasvmclitestsa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;iaasvm-pstest-rg;pstestsa2","name":"StorageContainer;Storage;iaasvm-pstest-rg;pstestsa2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"pstestsa2","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm-pstest-rg/providers/Microsoft.Storage/storageAccounts/pstestsa2"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-clicloudtest-rg;ossclicloudtestsa","name":"StorageContainer;Storage;oss-clicloudtest-rg;ossclicloudtestsa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"ossclicloudtestsa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-clicloudtest-rg/providers/Microsoft.Storage/storageAccounts/ossclicloudtestsa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-clitest-rg;ossclitestsa","name":"StorageContainer;Storage;oss-clitest-rg;ossclitestsa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"ossclitestsa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-clitest-rg/providers/Microsoft.Storage/storageAccounts/ossclitestsa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-pstest-rg;osspstestsa","name":"StorageContainer;Storage;oss-pstest-rg;osspstestsa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"osspstestsa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-pstest-rg/providers/Microsoft.Storage/storageAccounts/osspstestsa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;sarath-rg;axiccypod01otds1","name":"StorageContainer;Storage;sarath-rg;axiccypod01otds1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"axiccypod01otds1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sarath-rg/providers/Microsoft.Storage/storageAccounts/axiccypod01otds1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;sarath-rg;clitestingsa","name":"StorageContainer;Storage;sarath-rg;clitestingsa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestingsa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sarath-rg/providers/Microsoft.Storage/storageAccounts/clitestingsa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;sarath-rg;cliteststoreaccount","name":"StorageContainer;Storage;sarath-rg;cliteststoreaccount","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"cliteststoreaccount","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sarath-rg/providers/Microsoft.Storage/storageAccounts/cliteststoreaccount"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;vepothir-rg-blobs;vepothirstorageblobtest1","name":"StorageContainer;Storage;vepothir-rg-blobs;vepothirstorageblobtest1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"vepothirstorageblobtest1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vepothir-rg-blobs/providers/Microsoft.Storage/storageAccounts/vepothirstorageblobtest1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;vpatel-rg;vpaksstorage","name":"StorageContainer;Storage;vpatel-rg;vpaksstorage","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"vpaksstorage","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vpatel-rg/providers/Microsoft.Storage/storageAccounts/vpaksstorage"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;vpatel-rg;vpbackupstorageacc","name":"StorageContainer;Storage;vpatel-rg;vpbackupstorageacc","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"vpbackupstorageacc","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vpatel-rg/providers/Microsoft.Storage/storageAccounts/vpbackupstorageacc"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG;zubairtestsa","name":"StorageContainer;Storage;zubairRG;zubairtestsa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairtestsa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Storage/storageAccounts/zubairtestsa"}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '983'
+      - '24112'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:09:01 GMT
+      - Wed, 16 Aug 2023 03:46:52 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -1260,7 +1177,422 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '298'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"backupManagementType": "AzureStorage", "containerType":
+      "StorageContainer", "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '258'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000004?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationsStatus/bc6c1127-ece6-4112-af8d-df886070afc3?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:46:54 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationResults/bc6c1127-ece6-4112-af8d-df886070afc3?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1198'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000004/operationResults/bc6c1127-ece6-4112-af8d-df886070afc3?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationsStatus/bc6c1127-ece6-4112-af8d-df886070afc3?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:46:55 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationResults/bc6c1127-ece6-4112-af8d-df886070afc3?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
       - '299'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000004/operationResults/bc6c1127-ece6-4112-af8d-df886070afc3?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationsStatus/bc6c1127-ece6-4112-af8d-df886070afc3?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:47:00 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationResults/bc6c1127-ece6-4112-af8d-df886070afc3?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '298'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000004/operationResults/bc6c1127-ece6-4112-af8d-df886070afc3?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationsStatus/bc6c1127-ece6-4112-af8d-df886070afc3?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:47:06 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationResults/bc6c1127-ece6-4112-af8d-df886070afc3?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '297'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000004/operationResults/bc6c1127-ece6-4112-af8d-df886070afc3?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationsStatus/bc6c1127-ece6-4112-af8d-df886070afc3?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:47:11 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationResults/bc6c1127-ece6-4112-af8d-df886070afc3?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '296'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000004/operationResults/bc6c1127-ece6-4112-af8d-df886070afc3?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationsStatus/bc6c1127-ece6-4112-af8d-df886070afc3?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:47:16 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationResults/bc6c1127-ece6-4112-af8d-df886070afc3?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '295'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000004/operationResults/bc6c1127-ece6-4112-af8d-df886070afc3?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationsStatus/bc6c1127-ece6-4112-af8d-df886070afc3?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:47:22 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationResults/bc6c1127-ece6-4112-af8d-df886070afc3?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '294'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000004/operationResults/bc6c1127-ece6-4112-af8d-df886070afc3?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004","name":"StorageContainer;Storage;clitest.rg000001;clitest000004","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004","protectedItemCount":0,"acquireStorageAccountLock":"Acquire","friendlyName":"clitest000004","backupManagementType":"AzureStorage","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"StorageContainer","protectableObjectType":"StorageContainer"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '763'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:47:27 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '293'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -1278,28 +1610,28 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000008?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupProtectableItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+workloadType+eq+%27AzureFileShare%27
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000008","name":"clitest-item000008","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000004/protectableItems/azurefileshare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e","name":"azurefileshare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"parentContainerFabricId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004","parentContainerFriendlyName":"clitest000004","azureFileShareType":"XSMB","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","protectableItemType":"AzureFileShare","friendlyName":"clitest-item000008","protectionState":"NotProtected"}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '719'
+      - '983'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:09:01 GMT
+      - Wed, 16 Aug 2023 03:47:29 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -1310,13 +1642,66 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '299'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupPolicies/clitest-item000009?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupPolicies/clitest-item000009","name":"clitest-item000009","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","workLoadType":"AzureFileShare","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T13:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T13:30:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '751'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:47:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '299'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
 - request:
     body: '{"properties": {"protectedItemType": "AzureFileShareProtectedItem", "sourceResourceId":
-      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003",
-      "policyId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000008"}}'
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004",
+      "policyId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupPolicies/clitest-item000009"}}'
     headers:
       Accept:
       - application/json
@@ -1333,36 +1718,36 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/azurefileshare%3Bcdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/storagecontainer%3Bstorage%3Bclitest.rg000001%3Bclitest000004/protectedItems/azurefileshare%3Ba999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e?api-version=2023-02-01
   response:
     body:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectedItems/azurefileshare;cdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c/operationsStatus/171492e9-af2c-4511-b663-6f2dfe58cd34?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000004/protectedItems/azurefileshare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e/operationsStatus/7f689de6-7385-487c-82c8-f7e495ad9122?api-version=2023-02-01
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:09:01 GMT
+      - Wed, 16 Aug 2023 03:47:32 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectedItems/azurefileshare;cdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c/operationResults/171492e9-af2c-4511-b663-6f2dfe58cd34?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000004/protectedItems/azurefileshare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e/operationResults/7f689de6-7385-487c-82c8-f7e495ad9122?api-version=2023-02-01
       pragma:
       - no-cache
-      server:
-      - Kestrel
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 202
       message: Accepted
@@ -1380,28 +1765,28 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/171492e9-af2c-4511-b663-6f2dfe58cd34?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupOperations/7f689de6-7385-487c-82c8-f7e495ad9122?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"171492e9-af2c-4511-b663-6f2dfe58cd34","name":"171492e9-af2c-4511-b663-6f2dfe58cd34","status":"InProgress","startTime":"2023-05-17T12:09:02.6953857Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"7f689de6-7385-487c-82c8-f7e495ad9122","name":"7f689de6-7385-487c-82c8-f7e495ad9122","status":"InProgress","startTime":"2023-08-16T03:47:32.5965225Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '188'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:09:02 GMT
+      - Wed, 16 Aug 2023 03:47:34 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -1412,6 +1797,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '299'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -1429,28 +1816,28 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/171492e9-af2c-4511-b663-6f2dfe58cd34?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupOperations/7f689de6-7385-487c-82c8-f7e495ad9122?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"171492e9-af2c-4511-b663-6f2dfe58cd34","name":"171492e9-af2c-4511-b663-6f2dfe58cd34","status":"InProgress","startTime":"2023-05-17T12:09:02.6953857Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"7f689de6-7385-487c-82c8-f7e495ad9122","name":"7f689de6-7385-487c-82c8-f7e495ad9122","status":"InProgress","startTime":"2023-08-16T03:47:32.5965225Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '188'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:09:08 GMT
+      - Wed, 16 Aug 2023 03:47:39 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -1461,6 +1848,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '298'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -1478,28 +1867,79 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/171492e9-af2c-4511-b663-6f2dfe58cd34?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupOperations/7f689de6-7385-487c-82c8-f7e495ad9122?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"171492e9-af2c-4511-b663-6f2dfe58cd34","name":"171492e9-af2c-4511-b663-6f2dfe58cd34","status":"InProgress","startTime":"2023-05-17T12:09:02.6953857Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"7f689de6-7385-487c-82c8-f7e495ad9122","name":"7f689de6-7385-487c-82c8-f7e495ad9122","status":"InProgress","startTime":"2023-08-16T03:47:32.5965225Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '188'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:09:14 GMT
+      - Wed, 16 Aug 2023 03:47:45 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '297'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupOperations/7f689de6-7385-487c-82c8-f7e495ad9122?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"7f689de6-7385-487c-82c8-f7e495ad9122","name":"7f689de6-7385-487c-82c8-f7e495ad9122","status":"InProgress","startTime":"2023-08-16T03:47:32.5965225Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:47:50 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -1510,6 +1950,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '296'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -1527,28 +1969,79 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/171492e9-af2c-4511-b663-6f2dfe58cd34?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupOperations/7f689de6-7385-487c-82c8-f7e495ad9122?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"171492e9-af2c-4511-b663-6f2dfe58cd34","name":"171492e9-af2c-4511-b663-6f2dfe58cd34","status":"InProgress","startTime":"2023-05-17T12:09:02.6953857Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"7f689de6-7385-487c-82c8-f7e495ad9122","name":"7f689de6-7385-487c-82c8-f7e495ad9122","status":"InProgress","startTime":"2023-08-16T03:47:32.5965225Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '188'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:09:20 GMT
+      - Wed, 16 Aug 2023 03:47:55 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '295'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupOperations/7f689de6-7385-487c-82c8-f7e495ad9122?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"7f689de6-7385-487c-82c8-f7e495ad9122","name":"7f689de6-7385-487c-82c8-f7e495ad9122","status":"InProgress","startTime":"2023-08-16T03:47:32.5965225Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:48:01 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -1559,6 +2052,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '294'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -1576,28 +2071,79 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/171492e9-af2c-4511-b663-6f2dfe58cd34?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupOperations/7f689de6-7385-487c-82c8-f7e495ad9122?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"171492e9-af2c-4511-b663-6f2dfe58cd34","name":"171492e9-af2c-4511-b663-6f2dfe58cd34","status":"InProgress","startTime":"2023-05-17T12:09:02.6953857Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"7f689de6-7385-487c-82c8-f7e495ad9122","name":"7f689de6-7385-487c-82c8-f7e495ad9122","status":"InProgress","startTime":"2023-08-16T03:47:32.5965225Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '188'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:09:25 GMT
+      - Wed, 16 Aug 2023 03:48:06 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '293'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupOperations/7f689de6-7385-487c-82c8-f7e495ad9122?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"7f689de6-7385-487c-82c8-f7e495ad9122","name":"7f689de6-7385-487c-82c8-f7e495ad9122","status":"InProgress","startTime":"2023-08-16T03:47:32.5965225Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:48:12 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -1608,6 +2154,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '292'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -1625,175 +2173,28 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/171492e9-af2c-4511-b663-6f2dfe58cd34?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupOperations/7f689de6-7385-487c-82c8-f7e495ad9122?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"171492e9-af2c-4511-b663-6f2dfe58cd34","name":"171492e9-af2c-4511-b663-6f2dfe58cd34","status":"InProgress","startTime":"2023-05-17T12:09:02.6953857Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:30 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '290'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/171492e9-af2c-4511-b663-6f2dfe58cd34?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"171492e9-af2c-4511-b663-6f2dfe58cd34","name":"171492e9-af2c-4511-b663-6f2dfe58cd34","status":"InProgress","startTime":"2023-05-17T12:09:02.6953857Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:36 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '288'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/171492e9-af2c-4511-b663-6f2dfe58cd34?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"171492e9-af2c-4511-b663-6f2dfe58cd34","name":"171492e9-af2c-4511-b663-6f2dfe58cd34","status":"InProgress","startTime":"2023-05-17T12:09:02.6953857Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:41 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '287'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/171492e9-af2c-4511-b663-6f2dfe58cd34?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"171492e9-af2c-4511-b663-6f2dfe58cd34","name":"171492e9-af2c-4511-b663-6f2dfe58cd34","status":"Succeeded","startTime":"2023-05-17T12:09:02.6953857Z","endTime":"2023-05-17T12:09:02.6953857Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"fbec5302-560c-46ec-b8d1-fa25ea62e262"}}'
+      string: '{"id":"7f689de6-7385-487c-82c8-f7e495ad9122","name":"7f689de6-7385-487c-82c8-f7e495ad9122","status":"Succeeded","startTime":"2023-08-16T03:47:32.5965225Z","endTime":"2023-08-16T03:47:32.5965225Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"c15a3b3d-3879-4419-8ce2-73eb84439742"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '304'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:09:47 GMT
+      - Wed, 16 Aug 2023 03:48:17 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -1803,7 +2204,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '286'
+      - '291'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -1821,30 +2224,31 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/fbec5302-560c-46ec-b8d1-fa25ea62e262?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/c15a3b3d-3879-4419-8ce2-73eb84439742?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/fbec5302-560c-46ec-b8d1-fa25ea62e262","name":"fbec5302-560c-46ec-b8d1-fa25ea62e262","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT41.6414483S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
-        Share Name":"clitest-item000007","Storage Account Name":"clitest000003","Policy
-        Name":"clitest-item000008"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"ConfigureBackup","status":"Completed","startTime":"2023-05-17T12:09:02.6953857Z","endTime":"2023-05-17T12:09:44.336834Z","activityId":"898beb25-f4ab-11ed-8227-c8f750f92764"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/c15a3b3d-3879-4419-8ce2-73eb84439742","name":"c15a3b3d-3879-4419-8ce2-73eb84439742","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT41.7596776S","storageAccountName":"clitest000004","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
+        Share Name":"clitest-item000008","Storage Account Name":"clitest000004","Policy
+        Name":"clitest-item000009"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"ConfigureBackup","status":"Completed","startTime":"2023-08-16T03:47:32.5965225Z","endTime":"2023-08-16T03:48:14.3562001Z","activityId":"7ec1ad06-3be7-11ee-b54d-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '896'
+      - '897'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:09:47 GMT
+      - Wed, 16 Aug 2023 03:48:19 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -1855,6 +2259,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '149'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -1872,28 +2278,28 @@ interactions:
       ParameterSetName:
       - -g -v -i -c --backup-management-type --retain-until --query
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;cdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c","name":"AzureFileShare;cdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000007","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000008","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000004/protectedItems/AzureFileShare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e","name":"AzureFileShare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000008","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000004","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000004","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupPolicies/clitest-item000009","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '1478'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:09:49 GMT
+      - Wed, 16 Aug 2023 03:48:20 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -1904,12 +2310,14 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '299'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
 - request:
     body: '{"properties": {"objectType": "AzureFileShareBackupRequest", "recoveryPointExpiryTimeInUTC":
-      "2023-06-16T00:00:00.000Z"}}'
+      "2023-09-15T00:00:00.000Z"}}'
     headers:
       Accept:
       - application/json
@@ -1926,36 +2334,36 @@ interactions:
       ParameterSetName:
       - -g -v -i -c --backup-management-type --retain-until --query
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3Bcdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c/backup?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000004/protectedItems/AzureFileShare%3Ba999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e/backup?api-version=2023-02-01
   response:
     body:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;cdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c/operationsStatus/2021110a-9638-4884-9cf9-5e6e214dd794?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000004/protectedItems/AzureFileShare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e/operationsStatus/9a457a60-6ac5-4564-8200-29785f90fbda?api-version=2023-02-01
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:09:50 GMT
+      - Wed, 16 Aug 2023 03:48:22 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;cdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c/operationResults/2021110a-9638-4884-9cf9-5e6e214dd794?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000004/protectedItems/AzureFileShare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e/operationResults/9a457a60-6ac5-4564-8200-29785f90fbda?api-version=2023-02-01
       pragma:
       - no-cache
-      server:
-      - Kestrel
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 202
       message: Accepted
@@ -1973,28 +2381,28 @@ interactions:
       ParameterSetName:
       - -g -v -i -c --backup-management-type --retain-until --query
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/2021110a-9638-4884-9cf9-5e6e214dd794?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupOperations/9a457a60-6ac5-4564-8200-29785f90fbda?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"2021110a-9638-4884-9cf9-5e6e214dd794","name":"2021110a-9638-4884-9cf9-5e6e214dd794","status":"Succeeded","startTime":"2023-05-17T12:09:50.1007757Z","endTime":"2023-05-17T12:09:50.1007757Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"111049ce-a8ed-464c-94bb-7276bb73aba2"}}'
+      string: '{"id":"9a457a60-6ac5-4564-8200-29785f90fbda","name":"9a457a60-6ac5-4564-8200-29785f90fbda","status":"Succeeded","startTime":"2023-08-16T03:48:22.6102845Z","endTime":"2023-08-16T03:48:22.6102845Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"e7e1738e-83e5-40a6-a459-c4b24c9e1c79"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '304'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:09:50 GMT
+      - Wed, 16 Aug 2023 03:48:24 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -2004,7 +2412,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '290'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -2022,30 +2432,31 @@ interactions:
       ParameterSetName:
       - -g -v -i -c --backup-management-type --retain-until --query
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/111049ce-a8ed-464c-94bb-7276bb73aba2?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/e7e1738e-83e5-40a6-a459-c4b24c9e1c79?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/111049ce-a8ed-464c-94bb-7276bb73aba2","name":"111049ce-a8ed-464c-94bb-7276bb73aba2","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT1.4930315S","storageAccountName":"clitest000003","storageAccountVersion":"MicrosoftStorage","extendedInfo":{"tasksList":[{"taskId":"Take
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/e7e1738e-83e5-40a6-a459-c4b24c9e1c79","name":"e7e1738e-83e5-40a6-a459-c4b24c9e1c79","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT2.8238399S","storageAccountName":"clitest000004","storageAccountVersion":"MicrosoftStorage","extendedInfo":{"tasksList":[{"taskId":"Take
         Snapshot","status":"InProgress"}],"propertyBag":{"Data Transferred (in MB)":"0","File
-        Share Name":"clitest-item000007","Whether job is adhoc or scheduled.":"True"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Backup","status":"InProgress","startTime":"2023-05-17T12:09:50.1007757Z","activityId":"b777205d-f4ab-11ed-83c2-c8f750f92764"}}'
+        Share Name":"clitest-item000008","Whether job is adhoc or scheduled.":"True"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Backup","status":"InProgress","startTime":"2023-08-16T03:48:22.6102845Z","activityId":"bd9afc59-3be7-11ee-87eb-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '905'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:09:51 GMT
+      - Wed, 16 Aug 2023 03:48:25 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -2056,6 +2467,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '149'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -2073,132 +2486,31 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/111049ce-a8ed-464c-94bb-7276bb73aba2?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/e7e1738e-83e5-40a6-a459-c4b24c9e1c79?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/111049ce-a8ed-464c-94bb-7276bb73aba2","name":"111049ce-a8ed-464c-94bb-7276bb73aba2","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT2.1961673S","storageAccountName":"clitest000003","storageAccountVersion":"MicrosoftStorage","extendedInfo":{"tasksList":[{"taskId":"Take
-        Snapshot","status":"InProgress"}],"propertyBag":{"Data Transferred (in MB)":"0","File
-        Share Name":"clitest-item000007","Whether job is adhoc or scheduled.":"True"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Backup","status":"InProgress","startTime":"2023-05-17T12:09:50.1007757Z","activityId":"b777205d-f4ab-11ed-83c2-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '905'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:52 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '148'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/111049ce-a8ed-464c-94bb-7276bb73aba2?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/111049ce-a8ed-464c-94bb-7276bb73aba2","name":"111049ce-a8ed-464c-94bb-7276bb73aba2","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT2.7341398S","storageAccountName":"clitest000003","storageAccountVersion":"MicrosoftStorage","extendedInfo":{"tasksList":[{"taskId":"Take
-        Snapshot","status":"InProgress"}],"propertyBag":{"Data Transferred (in MB)":"0","File
-        Share Name":"clitest-item000007","Whether job is adhoc or scheduled.":"True"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Backup","status":"InProgress","startTime":"2023-05-17T12:09:50.1007757Z","activityId":"b777205d-f4ab-11ed-83c2-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '905'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:52 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '147'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/111049ce-a8ed-464c-94bb-7276bb73aba2?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/111049ce-a8ed-464c-94bb-7276bb73aba2","name":"111049ce-a8ed-464c-94bb-7276bb73aba2","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT4.1229226S","storageAccountName":"clitest000003","storageAccountVersion":"MicrosoftStorage","extendedInfo":{"tasksList":[{"taskId":"Take
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/e7e1738e-83e5-40a6-a459-c4b24c9e1c79","name":"e7e1738e-83e5-40a6-a459-c4b24c9e1c79","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT3.1282726S","storageAccountName":"clitest000004","storageAccountVersion":"MicrosoftStorage","extendedInfo":{"tasksList":[{"taskId":"Take
         Snapshot","status":"Completed"}],"propertyBag":{"Data Transferred (in MB)":"0","File
-        Share Name":"clitest-item000007","Whether job is adhoc or scheduled.":"True"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Backup","status":"Completed","startTime":"2023-05-17T12:09:50.1007757Z","endTime":"2023-05-17T12:09:54.2236983Z","activityId":"b777205d-f4ab-11ed-83c2-c8f750f92764"}}'
+        Share Name":"clitest-item000008","Whether job is adhoc or scheduled.":"True"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Backup","status":"Completed","startTime":"2023-08-16T03:48:22.6102845Z","endTime":"2023-08-16T03:48:25.7385571Z","activityId":"bd9afc59-3be7-11ee-87eb-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '944'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:10:23 GMT
+      - Wed, 16 Aug 2023 03:48:26 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -2208,7 +2520,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '143'
+      - '149'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -2228,12 +2542,13 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-storage/21.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003/listKeys?api-version=2022-09-01&$expand=kerb
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004/listKeys?api-version=2022-09-01&$expand=kerb
   response:
     body:
-      string: '{"keys":[{"creationTime":"2023-05-17T12:08:01.2956159Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2023-05-17T12:08:01.2956159Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
+      string: '{"keys":[{"creationTime":"2023-08-16T03:45:38.6198925Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2023-08-16T03:45:38.6198925Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
     headers:
       cache-control:
       - no-cache
@@ -2242,7 +2557,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 17 May 2023 12:10:55 GMT
+      - Wed, 16 Aug 2023 03:48:27 GMT
       expires:
       - '-1'
       pragma:
@@ -2258,7 +2573,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11996'
     status:
       code: 200
       message: OK
@@ -2276,21 +2591,22 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-storage/21.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","name":"clitest000003","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"keyCreationTime":{"key1":"2023-05-17T12:08:01.2956159Z","key2":"2023-05-17T12:08:01.2956159Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-05-17T12:08:01.7487432Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-05-17T12:08:01.7487432Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-05-17T12:08:01.2018473Z","primaryEndpoints":{"blob":"https://clitest000003.blob.core.windows.net/","queue":"https://clitest000003.queue.core.windows.net/","table":"https://clitest000003.table.core.windows.net/","file":"https://clitest000003.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004","name":"clitest000004","type":"Microsoft.Storage/storageAccounts","location":"centraluseuap","tags":{},"properties":{"keyCreationTime":{"key1":"2023-08-16T03:45:38.6198925Z","key2":"2023-08-16T03:45:38.6198925Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-08-16T03:45:38.8855125Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-08-16T03:45:38.8855125Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-08-16T03:45:38.5261630Z","primaryEndpoints":{"blob":"https://clitest000004.blob.core.windows.net/","queue":"https://clitest000004.queue.core.windows.net/","table":"https://clitest000004.table.core.windows.net/","file":"https://clitest000004.file.core.windows.net/"},"primaryLocation":"centraluseuap","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1280'
+      - '1284'
       content-type:
       - application/json
       date:
-      - Wed, 17 May 2023 12:10:55 GMT
+      - Wed, 16 Aug 2023 03:48:28 GMT
       expires:
       - '-1'
       pragma:
@@ -2324,15 +2640,16 @@ interactions:
       ParameterSetName:
       - --name --quota --connection-string
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-storage-file-share/12.12.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-storage-file-share/12.12.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Wed, 17 May 2023 12:10:54 GMT
+      - Wed, 16 Aug 2023 03:48:28 GMT
       x-ms-share-quota:
       - '1'
       x-ms-version:
       - '2022-11-02'
     method: PUT
-    uri: https://clitest000003.file.core.windows.net/clitest-item000011?restype=share
+    uri: https://clitest000004.file.core.windows.net/clitest-item000012?restype=share
   response:
     body:
       string: ''
@@ -2340,11 +2657,154 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:10:57 GMT
+      - Wed, 16 Aug 2023 03:48:29 GMT
       etag:
-      - '"0x8DB56CFC5453568"'
+      - '"0x8DB9E0BA7B6D3C2"'
       last-modified:
-      - Wed, 17 May 2023 12:10:57 GMT
+      - Wed, 16 Aug 2023 03:48:29 GMT
+      server:
+      - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version:
+      - '2022-11-02'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage account show-connection-string
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-storage/21.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Storage/storageAccounts/clitest000005/listKeys?api-version=2022-09-01&$expand=kerb
+  response:
+    body:
+      string: '{"keys":[{"creationTime":"2023-08-16T03:46:01.9013252Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2023-08-16T03:46:01.9013252Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '260'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:48:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage account show-connection-string
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-storage/21.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Storage/storageAccounts/clitest000005?api-version=2022-09-01
+  response:
+    body:
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Storage/storageAccounts/clitest000005","name":"clitest000005","type":"Microsoft.Storage/storageAccounts","location":"centraluseuap","tags":{},"properties":{"keyCreationTime":{"key1":"2023-08-16T03:46:01.9013252Z","key2":"2023-08-16T03:46:01.9013252Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-08-16T03:46:02.0575519Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-08-16T03:46:02.0575519Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-08-16T03:46:01.8075259Z","primaryEndpoints":{"blob":"https://clitest000005.blob.core.windows.net/","queue":"https://clitest000005.queue.core.windows.net/","table":"https://clitest000005.table.core.windows.net/","file":"https://clitest000005.file.core.windows.net/"},"primaryLocation":"centraluseuap","statusOfPrimary":"available"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1284'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:48:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage share create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --name --quota --connection-string
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-storage-file-share/12.12.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+      x-ms-date:
+      - Wed, 16 Aug 2023 03:48:32 GMT
+      x-ms-share-quota:
+      - '1'
+      x-ms-version:
+      - '2022-11-02'
+    method: PUT
+    uri: https://clitest000005.file.core.windows.net/clitest-item000013?restype=share
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Wed, 16 Aug 2023 03:48:33 GMT
+      etag:
+      - '"0x8DB9E0BA9C14259"'
+      last-modified:
+      - Wed, 16 Aug 2023 03:48:33 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
@@ -2366,28 +2826,28 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --backup-management-type --query
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;cdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c","name":"AzureFileShare;cdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000007","protectionStatus":"Healthy","protectionState":"Protected","lastBackupStatus":"Completed","lastBackupTime":"2023-05-17T12:09:50.1007757Z","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000008","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000004/protectedItems/AzureFileShare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e","name":"AzureFileShare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000008","protectionStatus":"Healthy","protectionState":"Protected","lastBackupStatus":"Completed","lastBackupTime":"2023-08-16T03:48:22.6102845Z","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000004","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000004","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupPolicies/clitest-item000009","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '1526'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:10:57 GMT
+      - Wed, 16 Aug 2023 03:48:34 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -2398,6 +2858,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '299'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -2415,28 +2877,28 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --backup-management-type --query
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3Bcdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c/recoveryPoints?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000004/protectedItems/AzureFileShare%3Ba999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e/recoveryPoints?api-version=2023-02-01
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;cdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c/recoveryPoints/74080090672816","name":"74080090672816","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints","properties":{"objectType":"AzureFileShareRecoveryPoint","recoveryPointType":"FileSystemConsistent","recoveryPointTime":"2023-05-17T12:09:52Z","fileShareSnapshotUri":"https://clitest000003.file.core.windows.net/clitest-item000007?sharesnapshot=2023-05-17T12:09:52.0000000Z","recoveryPointSizeInGB":0,"recoveryPointTierDetails":[{"type":"InstantRP","status":"Valid"}]}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000004/protectedItems/AzureFileShare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e/recoveryPoints/386630283514636","name":"386630283514636","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints","properties":{"objectType":"AzureFileShareRecoveryPoint","recoveryPointType":"FileSystemConsistent","recoveryPointTime":"2023-08-16T03:48:23Z","fileShareSnapshotUri":"https://clitest000004.file.core.windows.net/clitest-item000008?sharesnapshot=2023-08-16T03:48:23.0000000Z","recoveryPointSizeInGB":0,"recoveryPointTierDetails":[{"type":"InstantRP","status":"Valid"}]}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '890'
+      - '892'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:10:58 GMT
+      - Wed, 16 Aug 2023 03:48:35 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -2447,6 +2909,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '299'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -2464,28 +2928,28 @@ interactions:
       ParameterSetName:
       - -g -v -c -i -r --resolve-conflict --restore-mode
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+itemType+eq+%27AzureFileShare%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+itemType+eq+%27AzureFileShare%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;cdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c","name":"AzureFileShare;cdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000007","protectionStatus":"Healthy","protectionState":"Protected","lastBackupStatus":"Completed","lastBackupTime":"2023-05-17T12:09:50.1007757Z","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000008","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000004/protectedItems/AzureFileShare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e","name":"AzureFileShare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000008","protectionStatus":"Healthy","protectionState":"Protected","lastBackupStatus":"Completed","lastBackupTime":"2023-08-16T03:48:22.6102845Z","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000004","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000004","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupPolicies/clitest-item000009","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '1526'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:10:59 GMT
+      - Wed, 16 Aug 2023 03:48:36 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -2495,7 +2959,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '298'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -2513,12 +2979,13 @@ interactions:
       ParameterSetName:
       - -g -v -c -i -r --resolve-conflict --restore-mode
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ClassicStorage/storageAccounts/clitest000003?api-version=2015-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ClassicStorage/storageAccounts/clitest000004?api-version=2015-12-01
   response:
     body:
-      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.ClassicStorage/storageAccounts/clitest000003''
+      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.ClassicStorage/storageAccounts/clitest000004''
         under resource group ''clitest.rg000001'' was not found. For more details
         please go to https://aka.ms/ARMResourceNotFoundFix"}}'
     headers:
@@ -2529,7 +2996,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:59 GMT
+      - Wed, 16 Aug 2023 03:48:37 GMT
       expires:
       - '-1'
       pragma:
@@ -2557,21 +3024,22 @@ interactions:
       ParameterSetName:
       - -g -v -c -i -r --resolve-conflict --restore-mode
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004?api-version=2016-01-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","name":"clitest000003","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2023-05-17T12:08:01.7487432Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-05-17T12:08:01.2018473Z","primaryEndpoints":{"blob":"https://clitest000003.blob.core.windows.net/","queue":"https://clitest000003.queue.core.windows.net/","table":"https://clitest000003.table.core.windows.net/","file":"https://clitest000003.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004","name":"clitest000004","type":"Microsoft.Storage/storageAccounts","location":"centraluseuap","tags":{},"properties":{"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2023-08-16T03:45:38.8855125Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-08-16T03:45:38.5261630Z","primaryEndpoints":{"blob":"https://clitest000004.blob.core.windows.net/","queue":"https://clitest000004.queue.core.windows.net/","table":"https://clitest000004.table.core.windows.net/","file":"https://clitest000004.file.core.windows.net/"},"primaryLocation":"centraluseuap","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '845'
+      - '849'
       content-type:
       - application/json
       date:
-      - Wed, 17 May 2023 12:11:00 GMT
+      - Wed, 16 Aug 2023 03:48:38 GMT
       expires:
       - '-1'
       pragma:
@@ -2591,7 +3059,7 @@ interactions:
       message: OK
 - request:
     body: '{"properties": {"objectType": "AzureFileShareRestoreRequest", "recoveryType":
-      "OriginalLocation", "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003",
+      "OriginalLocation", "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004",
       "copyOptions": "Overwrite", "restoreRequestType": "FullShareRestore"}}'
     headers:
       Accept:
@@ -2609,36 +3077,36 @@ interactions:
       ParameterSetName:
       - -g -v -c -i -r --resolve-conflict --restore-mode
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3Bcdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c/recoveryPoints/74080090672816/restore?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000004/protectedItems/AzureFileShare%3Ba999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e/recoveryPoints/386630283514636/restore?api-version=2023-02-01
   response:
     body:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;cdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c/operationsStatus/928c347b-536d-43e8-bd59-a0272f397e4a?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000004/protectedItems/AzureFileShare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e/operationsStatus/9d3d26e7-c448-47ec-93c7-2d845ef34aeb?api-version=2023-02-01
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:11:02 GMT
+      - Wed, 16 Aug 2023 03:48:40 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;cdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c/operationResults/928c347b-536d-43e8-bd59-a0272f397e4a?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000004/protectedItems/AzureFileShare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e/operationResults/9d3d26e7-c448-47ec-93c7-2d845ef34aeb?api-version=2023-02-01
       pragma:
       - no-cache
-      server:
-      - Kestrel
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
       - '1198'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 202
       message: Accepted
@@ -2656,28 +3124,28 @@ interactions:
       ParameterSetName:
       - -g -v -c -i -r --resolve-conflict --restore-mode
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/928c347b-536d-43e8-bd59-a0272f397e4a?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupOperations/9d3d26e7-c448-47ec-93c7-2d845ef34aeb?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"928c347b-536d-43e8-bd59-a0272f397e4a","name":"928c347b-536d-43e8-bd59-a0272f397e4a","status":"Succeeded","startTime":"2023-05-17T12:11:02.6903517Z","endTime":"2023-05-17T12:11:02.6903517Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"928c347b-536d-43e8-bd59-a0272f397e4a"}}'
+      string: '{"id":"9d3d26e7-c448-47ec-93c7-2d845ef34aeb","name":"9d3d26e7-c448-47ec-93c7-2d845ef34aeb","status":"Succeeded","startTime":"2023-08-16T03:48:40.1987622Z","endTime":"2023-08-16T03:48:40.1987622Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"9d3d26e7-c448-47ec-93c7-2d845ef34aeb"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '304'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:11:02 GMT
+      - Wed, 16 Aug 2023 03:48:41 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -2687,7 +3155,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '285'
+      - '299'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -2705,32 +3175,33 @@ interactions:
       ParameterSetName:
       - -g -v -c -i -r --resolve-conflict --restore-mode
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/928c347b-536d-43e8-bd59-a0272f397e4a?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/9d3d26e7-c448-47ec-93c7-2d845ef34aeb?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/928c347b-536d-43e8-bd59-a0272f397e4a","name":"928c347b-536d-43e8-bd59-a0272f397e4a","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT1.5187434S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Job
-        Type":"Recovering to the original file share","RestoreDestination":"clitest000003/clitest-item000007/","Data
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/9d3d26e7-c448-47ec-93c7-2d845ef34aeb","name":"9d3d26e7-c448-47ec-93c7-2d845ef34aeb","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT2.818717S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Job
+        Type":"Recovering to the original file share","RestoreDestination":"clitest000004/clitest-item000008/","Data
         Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:11:02.6903517Z","activityId":"e15d4412-f4ab-11ed-8dd4-c8f750f92764"}}'
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T03:48:40.1987622Z","activityId":"c74a2f47-3be7-11ee-a4e3-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1093'
+      - '1092'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:11:03 GMT
+      - Wed, 16 Aug 2023 03:48:43 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -2741,6 +3212,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '148'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -2758,138 +3231,33 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/928c347b-536d-43e8-bd59-a0272f397e4a?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/9d3d26e7-c448-47ec-93c7-2d845ef34aeb?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/928c347b-536d-43e8-bd59-a0272f397e4a","name":"928c347b-536d-43e8-bd59-a0272f397e4a","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT2.6249749S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Job
-        Type":"Recovering to the original file share","RestoreDestination":"clitest000003/clitest-item000007/","Data
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/9d3d26e7-c448-47ec-93c7-2d845ef34aeb","name":"9d3d26e7-c448-47ec-93c7-2d845ef34aeb","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT4.1805266S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Job
+        Type":"Recovering to the original file share","RestoreDestination":"clitest000004/clitest-item000008/","Data
         Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:11:02.6903517Z","activityId":"e15d4412-f4ab-11ed-8dd4-c8f750f92764"}}'
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T03:48:40.1987622Z","activityId":"c74a2f47-3be7-11ee-a4e3-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '1093'
       content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:11:05 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '149'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/928c347b-536d-43e8-bd59-a0272f397e4a?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/928c347b-536d-43e8-bd59-a0272f397e4a","name":"928c347b-536d-43e8-bd59-a0272f397e4a","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT3.1875459S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Job
-        Type":"Recovering to the original file share","RestoreDestination":"clitest000003/clitest-item000007/","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:11:02.6903517Z","activityId":"e15d4412-f4ab-11ed-8dd4-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1093'
-      content-type:
-      - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:11:05 GMT
+      - Wed, 16 Aug 2023 03:48:44 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '148'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/928c347b-536d-43e8-bd59-a0272f397e4a?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/928c347b-536d-43e8-bd59-a0272f397e4a","name":"928c347b-536d-43e8-bd59-a0272f397e4a","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT33.7509056S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Job
-        Type":"Recovering to the original file share","RestoreDestination":"clitest000003/clitest-item000007/","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:11:02.6903517Z","activityId":"e15d4412-f4ab-11ed-8dd4-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1094'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:11:35 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -2900,6 +3268,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '147'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -2917,32 +3287,33 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/928c347b-536d-43e8-bd59-a0272f397e4a?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/9d3d26e7-c448-47ec-93c7-2d845ef34aeb?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/928c347b-536d-43e8-bd59-a0272f397e4a","name":"928c347b-536d-43e8-bd59-a0272f397e4a","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT34.1644767S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","RestoreRecoveryPointTime":"5/17/2023
-        12:09:53 PM","Job Type":"Recovering to the original file share","RestoreDestination":"clitest000003/clitest-item000007/","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"2","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"Completed","startTime":"2023-05-17T12:11:02.6903517Z","endTime":"2023-05-17T12:11:36.8548284Z","activityId":"e15d4412-f4ab-11ed-8dd4-c8f750f92764"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/9d3d26e7-c448-47ec-93c7-2d845ef34aeb","name":"9d3d26e7-c448-47ec-93c7-2d845ef34aeb","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT4.6336453S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Job
+        Type":"Recovering to the original file share","RestoreDestination":"clitest000004/clitest-item000008/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T03:48:40.1987622Z","activityId":"c74a2f47-3be7-11ee-a4e3-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1185'
+      - '1093'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:12:06 GMT
+      - Wed, 16 Aug 2023 03:48:44 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -2953,6 +3324,571 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '146'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/9d3d26e7-c448-47ec-93c7-2d845ef34aeb?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/9d3d26e7-c448-47ec-93c7-2d845ef34aeb","name":"9d3d26e7-c448-47ec-93c7-2d845ef34aeb","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT35.1208028S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Job
+        Type":"Recovering to the original file share","RestoreDestination":"clitest000004/clitest-item000008/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T03:48:40.1987622Z","activityId":"c74a2f47-3be7-11ee-a4e3-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1094'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:49:14 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '145'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/9d3d26e7-c448-47ec-93c7-2d845ef34aeb?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/9d3d26e7-c448-47ec-93c7-2d845ef34aeb","name":"9d3d26e7-c448-47ec-93c7-2d845ef34aeb","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT1M5.6287801S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Job
+        Type":"Recovering to the original file share","RestoreDestination":"clitest000004/clitest-item000008/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T03:48:40.1987622Z","activityId":"c74a2f47-3be7-11ee-a4e3-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1095'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:49:45 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '144'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/9d3d26e7-c448-47ec-93c7-2d845ef34aeb?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/9d3d26e7-c448-47ec-93c7-2d845ef34aeb","name":"9d3d26e7-c448-47ec-93c7-2d845ef34aeb","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT1M36.1586998S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Job
+        Type":"Recovering to the original file share","RestoreDestination":"clitest000004/clitest-item000008/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T03:48:40.1987622Z","activityId":"c74a2f47-3be7-11ee-a4e3-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1096'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:50:16 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '143'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/9d3d26e7-c448-47ec-93c7-2d845ef34aeb?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/9d3d26e7-c448-47ec-93c7-2d845ef34aeb","name":"9d3d26e7-c448-47ec-93c7-2d845ef34aeb","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT2M6.7052406S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Job
+        Type":"Recovering to the original file share","RestoreDestination":"clitest000004/clitest-item000008/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T03:48:40.1987622Z","activityId":"c74a2f47-3be7-11ee-a4e3-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1095'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:50:46 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '142'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/9d3d26e7-c448-47ec-93c7-2d845ef34aeb?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/9d3d26e7-c448-47ec-93c7-2d845ef34aeb","name":"9d3d26e7-c448-47ec-93c7-2d845ef34aeb","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT2M37.2186186S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Job
+        Type":"Recovering to the original file share","RestoreDestination":"clitest000004/clitest-item000008/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T03:48:40.1987622Z","activityId":"c74a2f47-3be7-11ee-a4e3-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1096'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:51:17 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '141'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/9d3d26e7-c448-47ec-93c7-2d845ef34aeb?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/9d3d26e7-c448-47ec-93c7-2d845ef34aeb","name":"9d3d26e7-c448-47ec-93c7-2d845ef34aeb","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT3M7.7218577S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Job
+        Type":"Recovering to the original file share","RestoreDestination":"clitest000004/clitest-item000008/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T03:48:40.1987622Z","activityId":"c74a2f47-3be7-11ee-a4e3-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1095'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:51:47 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '140'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/9d3d26e7-c448-47ec-93c7-2d845ef34aeb?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/9d3d26e7-c448-47ec-93c7-2d845ef34aeb","name":"9d3d26e7-c448-47ec-93c7-2d845ef34aeb","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT3M38.2128311S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Job
+        Type":"Recovering to the original file share","RestoreDestination":"clitest000004/clitest-item000008/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T03:48:40.1987622Z","activityId":"c74a2f47-3be7-11ee-a4e3-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1096'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:52:17 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '139'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/9d3d26e7-c448-47ec-93c7-2d845ef34aeb?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/9d3d26e7-c448-47ec-93c7-2d845ef34aeb","name":"9d3d26e7-c448-47ec-93c7-2d845ef34aeb","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT4M8.6972007S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Job
+        Type":"Recovering to the original file share","RestoreDestination":"clitest000004/clitest-item000008/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T03:48:40.1987622Z","activityId":"c74a2f47-3be7-11ee-a4e3-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1095'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:52:48 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '138'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/9d3d26e7-c448-47ec-93c7-2d845ef34aeb?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/9d3d26e7-c448-47ec-93c7-2d845ef34aeb","name":"9d3d26e7-c448-47ec-93c7-2d845ef34aeb","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT4M39.2156149S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Job
+        Type":"Recovering to the original file share","RestoreDestination":"clitest000004/clitest-item000008/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T03:48:40.1987622Z","activityId":"c74a2f47-3be7-11ee-a4e3-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1096'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:53:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '137'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/9d3d26e7-c448-47ec-93c7-2d845ef34aeb?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/9d3d26e7-c448-47ec-93c7-2d845ef34aeb","name":"9d3d26e7-c448-47ec-93c7-2d845ef34aeb","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT5M4.4550432S","errorDetails":[{"errorCode":1073871825,"errorString":"Microsoft
+        Azure Backup encountered an internal error.","recommendations":["Wait for
+        a few minutes and then try the operation again. If the issue persists, please
+        contact Microsoft support."]}],"storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","RestoreRecoveryPointTime":"8/16/2023
+        3:48:24 AM","Job Type":"Recovering to the original file share","RestoreDestination":"clitest000004/clitest-item000008/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"Failed","startTime":"2023-08-16T03:48:40.1987622Z","endTime":"2023-08-16T03:53:44.6538054Z","activityId":"c74a2f47-3be7-11ee-a4e3-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1430'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:53:49 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '136'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -2970,32 +3906,36 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/928c347b-536d-43e8-bd59-a0272f397e4a?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/9d3d26e7-c448-47ec-93c7-2d845ef34aeb?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/928c347b-536d-43e8-bd59-a0272f397e4a","name":"928c347b-536d-43e8-bd59-a0272f397e4a","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT34.1644767S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","RestoreRecoveryPointTime":"5/17/2023
-        12:09:53 PM","Job Type":"Recovering to the original file share","RestoreDestination":"clitest000003/clitest-item000007/","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"2","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"Completed","startTime":"2023-05-17T12:11:02.6903517Z","endTime":"2023-05-17T12:11:36.8548284Z","activityId":"e15d4412-f4ab-11ed-8dd4-c8f750f92764"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/9d3d26e7-c448-47ec-93c7-2d845ef34aeb","name":"9d3d26e7-c448-47ec-93c7-2d845ef34aeb","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT5M4.4550432S","errorDetails":[{"errorCode":1073871825,"errorString":"Microsoft
+        Azure Backup encountered an internal error.","recommendations":["Wait for
+        a few minutes and then try the operation again. If the issue persists, please
+        contact Microsoft support."]}],"storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","RestoreRecoveryPointTime":"8/16/2023
+        3:48:24 AM","Job Type":"Recovering to the original file share","RestoreDestination":"clitest000004/clitest-item000008/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"Failed","startTime":"2023-08-16T03:48:40.1987622Z","endTime":"2023-08-16T03:53:44.6538054Z","activityId":"c74a2f47-3be7-11ee-a4e3-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1185'
+      - '1430'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:12:37 GMT
+      - Wed, 16 Aug 2023 03:54:21 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -3005,7 +3945,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '149'
+      - '135'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -3022,30 +3964,30 @@ interactions:
       - keep-alive
       ParameterSetName:
       - -g -v -c -i -r --resolve-conflict --restore-mode --target-storage-account
-        --target-file-share --target-folder
+        --target-file-share
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+itemType+eq+%27AzureFileShare%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+itemType+eq+%27AzureFileShare%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;cdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c","name":"AzureFileShare;cdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000007","protectionStatus":"Healthy","protectionState":"Protected","lastBackupStatus":"Completed","lastBackupTime":"2023-05-17T12:09:50.1007757Z","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000008","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000004/protectedItems/AzureFileShare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e","name":"AzureFileShare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000008","protectionStatus":"Healthy","protectionState":"Protected","lastBackupStatus":"Completed","lastBackupTime":"2023-08-16T03:48:22.6102845Z","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000004","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000004","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupPolicies/clitest-item000009","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '1526'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:12:38 GMT
+      - Wed, 16 Aug 2023 03:54:22 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -3056,6 +3998,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '299'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -3072,14 +4016,15 @@ interactions:
       - keep-alive
       ParameterSetName:
       - -g -v -c -i -r --resolve-conflict --restore-mode --target-storage-account
-        --target-file-share --target-folder
+        --target-file-share
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ClassicStorage/storageAccounts/clitest000003?api-version=2015-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ClassicStorage/storageAccounts/clitest000004?api-version=2015-12-01
   response:
     body:
-      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.ClassicStorage/storageAccounts/clitest000003''
+      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.ClassicStorage/storageAccounts/clitest000004''
         under resource group ''clitest.rg000001'' was not found. For more details
         please go to https://aka.ms/ARMResourceNotFoundFix"}}'
     headers:
@@ -3090,7 +4035,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:12:38 GMT
+      - Wed, 16 Aug 2023 03:54:23 GMT
       expires:
       - '-1'
       pragma:
@@ -3117,23 +4062,24 @@ interactions:
       - keep-alive
       ParameterSetName:
       - -g -v -c -i -r --resolve-conflict --restore-mode --target-storage-account
-        --target-file-share --target-folder
+        --target-file-share
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004?api-version=2016-01-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","name":"clitest000003","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2023-05-17T12:08:01.7487432Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-05-17T12:08:01.2018473Z","primaryEndpoints":{"blob":"https://clitest000003.blob.core.windows.net/","queue":"https://clitest000003.queue.core.windows.net/","table":"https://clitest000003.table.core.windows.net/","file":"https://clitest000003.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004","name":"clitest000004","type":"Microsoft.Storage/storageAccounts","location":"centraluseuap","tags":{},"properties":{"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2023-08-16T03:45:38.8855125Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-08-16T03:45:38.5261630Z","primaryEndpoints":{"blob":"https://clitest000004.blob.core.windows.net/","queue":"https://clitest000004.queue.core.windows.net/","table":"https://clitest000004.table.core.windows.net/","file":"https://clitest000004.file.core.windows.net/"},"primaryLocation":"centraluseuap","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '845'
+      - '849'
       content-type:
       - application/json
       date:
-      - Wed, 17 May 2023 12:12:40 GMT
+      - Wed, 16 Aug 2023 03:54:23 GMT
       expires:
       - '-1'
       pragma:
@@ -3164,14 +4110,15 @@ interactions:
       - keep-alive
       ParameterSetName:
       - -g -v -c -i -r --resolve-conflict --restore-mode --target-storage-account
-        --target-file-share --target-folder
+        --target-file-share
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ClassicStorage/storageAccounts/clitest000003?api-version=2015-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ClassicStorage/storageAccounts/clitest000005?api-version=2015-12-01
   response:
     body:
-      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.ClassicStorage/storageAccounts/clitest000003''
+      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.ClassicStorage/storageAccounts/clitest000005''
         under resource group ''clitest.rg000001'' was not found. For more details
         please go to https://aka.ms/ARMResourceNotFoundFix"}}'
     headers:
@@ -3182,7 +4129,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:12:40 GMT
+      - Wed, 16 Aug 2023 03:54:24 GMT
       expires:
       - '-1'
       pragma:
@@ -3209,23 +4156,262 @@ interactions:
       - keep-alive
       ParameterSetName:
       - -g -v -c -i -r --resolve-conflict --restore-mode --target-storage-account
-        --target-file-share --target-folder
+        --target-file-share
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000005?api-version=2016-01-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","name":"clitest000003","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2023-05-17T12:08:01.7487432Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-05-17T12:08:01.2018473Z","primaryEndpoints":{"blob":"https://clitest000003.blob.core.windows.net/","queue":"https://clitest000003.queue.core.windows.net/","table":"https://clitest000003.table.core.windows.net/","file":"https://clitest000003.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}}'
+      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Storage/storageAccounts/clitest000005''
+        under resource group ''clitest.rg000001'' was not found. For more details
+        please go to https://aka.ms/ARMResourceNotFoundFix"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '845'
+      - '235'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 03:54:24 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-failure-cause:
+      - gateway
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup restore restore-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i -r --resolve-conflict --restore-mode --target-storage-account
+        --target-file-share --target-rg-name
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+itemType+eq+%27AzureFileShare%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000004/protectedItems/AzureFileShare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e","name":"AzureFileShare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000008","protectionStatus":"Healthy","protectionState":"Protected","lastBackupStatus":"Completed","lastBackupTime":"2023-08-16T03:48:22.6102845Z","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000004","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000004","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupPolicies/clitest-item000009","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1526'
       content-type:
       - application/json
       date:
-      - Wed, 17 May 2023 12:12:41 GMT
+      - Wed, 16 Aug 2023 03:54:27 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '299'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup restore restore-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i -r --resolve-conflict --restore-mode --target-storage-account
+        --target-file-share --target-rg-name
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ClassicStorage/storageAccounts/clitest000004?api-version=2015-12-01
+  response:
+    body:
+      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.ClassicStorage/storageAccounts/clitest000004''
+        under resource group ''clitest.rg000001'' was not found. For more details
+        please go to https://aka.ms/ARMResourceNotFoundFix"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '242'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 03:54:28 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-failure-cause:
+      - gateway
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup restore restore-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i -r --resolve-conflict --restore-mode --target-storage-account
+        --target-file-share --target-rg-name
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004?api-version=2016-01-01
+  response:
+    body:
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004","name":"clitest000004","type":"Microsoft.Storage/storageAccounts","location":"centraluseuap","tags":{},"properties":{"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2023-08-16T03:45:38.8855125Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-08-16T03:45:38.5261630Z","primaryEndpoints":{"blob":"https://clitest000004.blob.core.windows.net/","queue":"https://clitest000004.queue.core.windows.net/","table":"https://clitest000004.table.core.windows.net/","file":"https://clitest000004.file.core.windows.net/"},"primaryLocation":"centraluseuap","statusOfPrimary":"available"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '849'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:54:28 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup restore restore-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i -r --resolve-conflict --restore-mode --target-storage-account
+        --target-file-share --target-rg-name
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002/providers/Microsoft.ClassicStorage/storageAccounts/clitest000005?api-version=2015-12-01
+  response:
+    body:
+      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.ClassicStorage/storageAccounts/clitest000005''
+        under resource group ''clitest.rg000002'' was not found. For more details
+        please go to https://aka.ms/ARMResourceNotFoundFix"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '242'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 03:54:29 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-failure-cause:
+      - gateway
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup restore restore-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i -r --resolve-conflict --restore-mode --target-storage-account
+        --target-file-share --target-rg-name
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002/providers/Microsoft.Storage/storageAccounts/clitest000005?api-version=2016-01-01
+  response:
+    body:
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Storage/storageAccounts/clitest000005","name":"clitest000005","type":"Microsoft.Storage/storageAccounts","location":"centraluseuap","tags":{},"properties":{"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2023-08-16T03:46:02.0575519Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-08-16T03:46:01.8075259Z","primaryEndpoints":{"blob":"https://clitest000005.blob.core.windows.net/","queue":"https://clitest000005.queue.core.windows.net/","table":"https://clitest000005.table.core.windows.net/","file":"https://clitest000005.file.core.windows.net/"},"primaryLocation":"centraluseuap","statusOfPrimary":"available"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '849'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:54:30 GMT
       expires:
       - '-1'
       pragma:
@@ -3245,9 +4431,1161 @@ interactions:
       message: OK
 - request:
     body: '{"properties": {"objectType": "AzureFileShareRestoreRequest", "recoveryType":
-      "AlternateLocation", "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003",
+      "AlternateLocation", "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004",
       "copyOptions": "Overwrite", "restoreRequestType": "FullShareRestore", "targetDetails":
-      {"name": "clitest-item000011", "targetResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003"}}}'
+      {"name": "clitest-item000013", "targetResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Storage/storageAccounts/clitest000005"}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup restore restore-azurefileshare
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '548'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -v -c -i -r --resolve-conflict --restore-mode --target-storage-account
+        --target-file-share --target-rg-name
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000004/protectedItems/AzureFileShare%3Ba999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e/recoveryPoints/386630283514636/restore?api-version=2023-02-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000004/protectedItems/AzureFileShare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e/operationsStatus/3a23dc4e-90d7-4ba1-9358-71d76d25a1d8?api-version=2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Wed, 16 Aug 2023 03:54:31 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000004/protectedItems/AzureFileShare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e/operationResults/3a23dc4e-90d7-4ba1-9358-71d76d25a1d8?api-version=2023-02-01
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup restore restore-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i -r --resolve-conflict --restore-mode --target-storage-account
+        --target-file-share --target-rg-name
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupOperations/3a23dc4e-90d7-4ba1-9358-71d76d25a1d8?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"3a23dc4e-90d7-4ba1-9358-71d76d25a1d8","name":"3a23dc4e-90d7-4ba1-9358-71d76d25a1d8","status":"Succeeded","startTime":"2023-08-16T03:54:31.4109057Z","endTime":"2023-08-16T03:54:31.4109057Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"3a23dc4e-90d7-4ba1-9358-71d76d25a1d8"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:54:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '289'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup restore restore-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i -r --resolve-conflict --restore-mode --target-storage-account
+        --target-file-share --target-rg-name
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/3a23dc4e-90d7-4ba1-9358-71d76d25a1d8?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/3a23dc4e-90d7-4ba1-9358-71d76d25a1d8","name":"3a23dc4e-90d7-4ba1-9358-71d76d25a1d8","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT3.0255428S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000013","Target Storage Account Name":"clitest000005","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000005/clitest-item000013/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T03:54:31.4109057Z","activityId":"97aeea9d-3be8-11ee-a589-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1182'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:54:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '148'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/3a23dc4e-90d7-4ba1-9358-71d76d25a1d8?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/3a23dc4e-90d7-4ba1-9358-71d76d25a1d8","name":"3a23dc4e-90d7-4ba1-9358-71d76d25a1d8","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT4.3628301S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000013","Target Storage Account Name":"clitest000005","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000005/clitest-item000013/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T03:54:31.4109057Z","activityId":"97aeea9d-3be8-11ee-a589-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1182'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:54:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '134'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/3a23dc4e-90d7-4ba1-9358-71d76d25a1d8?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/3a23dc4e-90d7-4ba1-9358-71d76d25a1d8","name":"3a23dc4e-90d7-4ba1-9358-71d76d25a1d8","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT4.8628209S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000013","Target Storage Account Name":"clitest000005","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000005/clitest-item000013/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T03:54:31.4109057Z","activityId":"97aeea9d-3be8-11ee-a589-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1182'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:54:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '133'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/3a23dc4e-90d7-4ba1-9358-71d76d25a1d8?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/3a23dc4e-90d7-4ba1-9358-71d76d25a1d8","name":"3a23dc4e-90d7-4ba1-9358-71d76d25a1d8","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT35.3471934S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000013","Target Storage Account Name":"clitest000005","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000005/clitest-item000013/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T03:54:31.4109057Z","activityId":"97aeea9d-3be8-11ee-a589-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1183'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:55:06 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '132'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/3a23dc4e-90d7-4ba1-9358-71d76d25a1d8?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/3a23dc4e-90d7-4ba1-9358-71d76d25a1d8","name":"3a23dc4e-90d7-4ba1-9358-71d76d25a1d8","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT1M5.8683104S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000013","Target Storage Account Name":"clitest000005","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000005/clitest-item000013/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T03:54:31.4109057Z","activityId":"97aeea9d-3be8-11ee-a589-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1184'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:55:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '131'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/3a23dc4e-90d7-4ba1-9358-71d76d25a1d8?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/3a23dc4e-90d7-4ba1-9358-71d76d25a1d8","name":"3a23dc4e-90d7-4ba1-9358-71d76d25a1d8","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT1M36.3581281S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000013","Target Storage Account Name":"clitest000005","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000005/clitest-item000013/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T03:54:31.4109057Z","activityId":"97aeea9d-3be8-11ee-a589-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1185'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:56:07 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '130'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/3a23dc4e-90d7-4ba1-9358-71d76d25a1d8?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/3a23dc4e-90d7-4ba1-9358-71d76d25a1d8","name":"3a23dc4e-90d7-4ba1-9358-71d76d25a1d8","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT2M6.8362398S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000013","Target Storage Account Name":"clitest000005","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000005/clitest-item000013/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T03:54:31.4109057Z","activityId":"97aeea9d-3be8-11ee-a589-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1184'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:56:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '129'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/3a23dc4e-90d7-4ba1-9358-71d76d25a1d8?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/3a23dc4e-90d7-4ba1-9358-71d76d25a1d8","name":"3a23dc4e-90d7-4ba1-9358-71d76d25a1d8","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT2M37.3473319S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000013","Target Storage Account Name":"clitest000005","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000005/clitest-item000013/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T03:54:31.4109057Z","activityId":"97aeea9d-3be8-11ee-a589-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1185'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:57:08 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '128'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/3a23dc4e-90d7-4ba1-9358-71d76d25a1d8?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/3a23dc4e-90d7-4ba1-9358-71d76d25a1d8","name":"3a23dc4e-90d7-4ba1-9358-71d76d25a1d8","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT3M7.8737646S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000013","Target Storage Account Name":"clitest000005","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000005/clitest-item000013/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T03:54:31.4109057Z","activityId":"97aeea9d-3be8-11ee-a589-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1184'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:57:39 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '127'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/3a23dc4e-90d7-4ba1-9358-71d76d25a1d8?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/3a23dc4e-90d7-4ba1-9358-71d76d25a1d8","name":"3a23dc4e-90d7-4ba1-9358-71d76d25a1d8","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT3M38.426506S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000013","Target Storage Account Name":"clitest000005","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000005/clitest-item000013/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T03:54:31.4109057Z","activityId":"97aeea9d-3be8-11ee-a589-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1184'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:58:09 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '126'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/3a23dc4e-90d7-4ba1-9358-71d76d25a1d8?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/3a23dc4e-90d7-4ba1-9358-71d76d25a1d8","name":"3a23dc4e-90d7-4ba1-9358-71d76d25a1d8","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT4M8.8991495S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000013","Target Storage Account Name":"clitest000005","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000005/clitest-item000013/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T03:54:31.4109057Z","activityId":"97aeea9d-3be8-11ee-a589-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1184'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:58:39 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '125'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/3a23dc4e-90d7-4ba1-9358-71d76d25a1d8?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/3a23dc4e-90d7-4ba1-9358-71d76d25a1d8","name":"3a23dc4e-90d7-4ba1-9358-71d76d25a1d8","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT4M39.4299883S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000013","Target Storage Account Name":"clitest000005","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000005/clitest-item000013/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T03:54:31.4109057Z","activityId":"97aeea9d-3be8-11ee-a589-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1185'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:59:09 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '124'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/3a23dc4e-90d7-4ba1-9358-71d76d25a1d8?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/3a23dc4e-90d7-4ba1-9358-71d76d25a1d8","name":"3a23dc4e-90d7-4ba1-9358-71d76d25a1d8","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT5M3.5727494S","errorDetails":[{"errorCode":1073871825,"errorString":"Microsoft
+        Azure Backup encountered an internal error.","recommendations":["Wait for
+        a few minutes and then try the operation again. If the issue persists, please
+        contact Microsoft support."]}],"storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","RestoreRecoveryPointTime":"8/16/2023
+        3:48:24 AM","Target File Share Name":"clitest-item000013","Target Storage
+        Account Name":"clitest000005","Job Type":"Recover to an alternate file share","RestoreDestination":"clitest000005/clitest-item000013/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"Failed","startTime":"2023-08-16T03:54:31.4109057Z","endTime":"2023-08-16T03:59:34.9836551Z","activityId":"97aeea9d-3be8-11ee-a589-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1519'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 03:59:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '123'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/3a23dc4e-90d7-4ba1-9358-71d76d25a1d8?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/3a23dc4e-90d7-4ba1-9358-71d76d25a1d8","name":"3a23dc4e-90d7-4ba1-9358-71d76d25a1d8","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT5M3.5727494S","errorDetails":[{"errorCode":1073871825,"errorString":"Microsoft
+        Azure Backup encountered an internal error.","recommendations":["Wait for
+        a few minutes and then try the operation again. If the issue persists, please
+        contact Microsoft support."]}],"storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","RestoreRecoveryPointTime":"8/16/2023
+        3:48:24 AM","Target File Share Name":"clitest-item000013","Target Storage
+        Account Name":"clitest000005","Job Type":"Recover to an alternate file share","RestoreDestination":"clitest000005/clitest-item000013/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"Failed","startTime":"2023-08-16T03:54:31.4109057Z","endTime":"2023-08-16T03:59:34.9836551Z","activityId":"97aeea9d-3be8-11ee-a589-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1519'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:00:12 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '149'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup restore restore-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i -r --resolve-conflict --restore-mode --target-storage-account
+        --target-file-share --target-folder
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+itemType+eq+%27AzureFileShare%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000004/protectedItems/AzureFileShare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e","name":"AzureFileShare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000008","protectionStatus":"Healthy","protectionState":"Protected","lastBackupStatus":"Completed","lastBackupTime":"2023-08-16T03:48:22.6102845Z","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000004","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000004","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupPolicies/clitest-item000009","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1526'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:00:14 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '298'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup restore restore-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i -r --resolve-conflict --restore-mode --target-storage-account
+        --target-file-share --target-folder
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ClassicStorage/storageAccounts/clitest000004?api-version=2015-12-01
+  response:
+    body:
+      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.ClassicStorage/storageAccounts/clitest000004''
+        under resource group ''clitest.rg000001'' was not found. For more details
+        please go to https://aka.ms/ARMResourceNotFoundFix"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '242'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 04:00:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-failure-cause:
+      - gateway
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup restore restore-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i -r --resolve-conflict --restore-mode --target-storage-account
+        --target-file-share --target-folder
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004?api-version=2016-01-01
+  response:
+    body:
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004","name":"clitest000004","type":"Microsoft.Storage/storageAccounts","location":"centraluseuap","tags":{},"properties":{"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2023-08-16T03:45:38.8855125Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-08-16T03:45:38.5261630Z","primaryEndpoints":{"blob":"https://clitest000004.blob.core.windows.net/","queue":"https://clitest000004.queue.core.windows.net/","table":"https://clitest000004.table.core.windows.net/","file":"https://clitest000004.file.core.windows.net/"},"primaryLocation":"centraluseuap","statusOfPrimary":"available"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '849'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:00:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup restore restore-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i -r --resolve-conflict --restore-mode --target-storage-account
+        --target-file-share --target-folder
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ClassicStorage/storageAccounts/clitest000004?api-version=2015-12-01
+  response:
+    body:
+      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.ClassicStorage/storageAccounts/clitest000004''
+        under resource group ''clitest.rg000001'' was not found. For more details
+        please go to https://aka.ms/ARMResourceNotFoundFix"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '242'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 04:00:16 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-failure-cause:
+      - gateway
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup restore restore-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i -r --resolve-conflict --restore-mode --target-storage-account
+        --target-file-share --target-folder
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004?api-version=2016-01-01
+  response:
+    body:
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004","name":"clitest000004","type":"Microsoft.Storage/storageAccounts","location":"centraluseuap","tags":{},"properties":{"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2023-08-16T03:45:38.8855125Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-08-16T03:45:38.5261630Z","primaryEndpoints":{"blob":"https://clitest000004.blob.core.windows.net/","queue":"https://clitest000004.queue.core.windows.net/","table":"https://clitest000004.table.core.windows.net/","file":"https://clitest000004.file.core.windows.net/"},"primaryLocation":"centraluseuap","statusOfPrimary":"available"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '849'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:00:16 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"objectType": "AzureFileShareRestoreRequest", "recoveryType":
+      "AlternateLocation", "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004",
+      "copyOptions": "Overwrite", "restoreRequestType": "FullShareRestore", "targetDetails":
+      {"name": "clitest-item000012", "targetResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004"}}}'
     headers:
       Accept:
       - application/json
@@ -3265,36 +5603,36 @@ interactions:
       - -g -v -c -i -r --resolve-conflict --restore-mode --target-storage-account
         --target-file-share --target-folder
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3Bcdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c/recoveryPoints/74080090672816/restore?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000004/protectedItems/AzureFileShare%3Ba999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e/recoveryPoints/386630283514636/restore?api-version=2023-02-01
   response:
     body:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;cdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c/operationsStatus/a32ed2ba-21da-44fc-ac3e-c67503131367?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000004/protectedItems/AzureFileShare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e/operationsStatus/b81347cf-a99b-4298-864d-3e78c15e5ebe?api-version=2023-02-01
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:12:42 GMT
+      - Wed, 16 Aug 2023 04:00:18 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;cdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c/operationResults/a32ed2ba-21da-44fc-ac3e-c67503131367?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000004/protectedItems/AzureFileShare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e/operationResults/b81347cf-a99b-4298-864d-3e78c15e5ebe?api-version=2023-02-01
       pragma:
       - no-cache
-      server:
-      - Kestrel
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 202
       message: Accepted
@@ -3313,28 +5651,28 @@ interactions:
       - -g -v -c -i -r --resolve-conflict --restore-mode --target-storage-account
         --target-file-share --target-folder
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/a32ed2ba-21da-44fc-ac3e-c67503131367?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupOperations/b81347cf-a99b-4298-864d-3e78c15e5ebe?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"a32ed2ba-21da-44fc-ac3e-c67503131367","name":"a32ed2ba-21da-44fc-ac3e-c67503131367","status":"Succeeded","startTime":"2023-05-17T12:12:43.3204034Z","endTime":"2023-05-17T12:12:43.3204034Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"a32ed2ba-21da-44fc-ac3e-c67503131367"}}'
+      string: '{"id":"b81347cf-a99b-4298-864d-3e78c15e5ebe","name":"b81347cf-a99b-4298-864d-3e78c15e5ebe","status":"Succeeded","startTime":"2023-08-16T04:00:18.5404494Z","endTime":"2023-08-16T04:00:18.5404494Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"b81347cf-a99b-4298-864d-3e78c15e5ebe"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '304'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:12:43 GMT
+      - Wed, 16 Aug 2023 04:00:19 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -3345,6 +5683,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '299'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -3363,141 +5703,34 @@ interactions:
       - -g -v -c -i -r --resolve-conflict --restore-mode --target-storage-account
         --target-file-share --target-folder
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/b81347cf-a99b-4298-864d-3e78c15e5ebe?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367","name":"a32ed2ba-21da-44fc-ac3e-c67503131367","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT1.7088348S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/","Data
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/b81347cf-a99b-4298-864d-3e78c15e5ebe","name":"b81347cf-a99b-4298-864d-3e78c15e5ebe","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT2.9526908S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000012","Target Storage Account Name":"clitest000004","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/","Data
         Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:12:43.3204034Z","activityId":"1c586abe-f4ac-11ed-b502-c8f750f92764"}}'
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:00:18.5404494Z","activityId":"66aca5bf-3be9-11ee-8419-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '1182'
       content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:12:44 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '149'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367","name":"a32ed2ba-21da-44fc-ac3e-c67503131367","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT2.5069227S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:12:43.3204034Z","activityId":"1c586abe-f4ac-11ed-b502-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1182'
-      content-type:
-      - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:12:45 GMT
+      - Wed, 16 Aug 2023 04:00:21 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '149'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367","name":"a32ed2ba-21da-44fc-ac3e-c67503131367","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT3.3194307S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:12:43.3204034Z","activityId":"1c586abe-f4ac-11ed-b502-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1182'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:12:46 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -3508,6 +5741,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '148'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -3525,33 +5760,148 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/b81347cf-a99b-4298-864d-3e78c15e5ebe?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367","name":"a32ed2ba-21da-44fc-ac3e-c67503131367","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT33.9165027S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/","Data
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/b81347cf-a99b-4298-864d-3e78c15e5ebe","name":"b81347cf-a99b-4298-864d-3e78c15e5ebe","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT4.3901713S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000012","Target Storage Account Name":"clitest000004","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/","Data
         Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:12:43.3204034Z","activityId":"1c586abe-f4ac-11ed-b502-c8f750f92764"}}'
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:00:18.5404494Z","activityId":"66aca5bf-3be9-11ee-8419-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1182'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:00:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '149'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/b81347cf-a99b-4298-864d-3e78c15e5ebe?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/b81347cf-a99b-4298-864d-3e78c15e5ebe","name":"b81347cf-a99b-4298-864d-3e78c15e5ebe","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT4.9214011S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000012","Target Storage Account Name":"clitest000004","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:00:18.5404494Z","activityId":"66aca5bf-3be9-11ee-8419-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1182'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:00:23 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '148'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/b81347cf-a99b-4298-864d-3e78c15e5ebe?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/b81347cf-a99b-4298-864d-3e78c15e5ebe","name":"b81347cf-a99b-4298-864d-3e78c15e5ebe","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT35.4030546S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000012","Target Storage Account Name":"clitest000004","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:00:18.5404494Z","activityId":"66aca5bf-3be9-11ee-8419-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '1183'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:13:17 GMT
+      - Wed, 16 Aug 2023 04:00:53 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -3562,6 +5912,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '147'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -3579,33 +5931,34 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/b81347cf-a99b-4298-864d-3e78c15e5ebe?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367","name":"a32ed2ba-21da-44fc-ac3e-c67503131367","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT1M4.5193143S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/","Data
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/b81347cf-a99b-4298-864d-3e78c15e5ebe","name":"b81347cf-a99b-4298-864d-3e78c15e5ebe","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT1M5.8794661S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000012","Target Storage Account Name":"clitest000004","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/","Data
         Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:12:43.3204034Z","activityId":"1c586abe-f4ac-11ed-b502-c8f750f92764"}}'
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:00:18.5404494Z","activityId":"66aca5bf-3be9-11ee-8419-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '1184'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:13:47 GMT
+      - Wed, 16 Aug 2023 04:01:23 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -3616,6 +5969,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '146'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -3633,33 +5988,34 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/b81347cf-a99b-4298-864d-3e78c15e5ebe?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367","name":"a32ed2ba-21da-44fc-ac3e-c67503131367","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT1M35.1123308S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/","Data
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/b81347cf-a99b-4298-864d-3e78c15e5ebe","name":"b81347cf-a99b-4298-864d-3e78c15e5ebe","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT1M36.4625389S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000012","Target Storage Account Name":"clitest000004","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/","Data
         Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:12:43.3204034Z","activityId":"1c586abe-f4ac-11ed-b502-c8f750f92764"}}'
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:00:18.5404494Z","activityId":"66aca5bf-3be9-11ee-8419-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '1185'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:14:17 GMT
+      - Wed, 16 Aug 2023 04:01:54 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -3670,6 +6026,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '145'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -3687,33 +6045,34 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/b81347cf-a99b-4298-864d-3e78c15e5ebe?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367","name":"a32ed2ba-21da-44fc-ac3e-c67503131367","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT2M5.737741S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/","Data
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/b81347cf-a99b-4298-864d-3e78c15e5ebe","name":"b81347cf-a99b-4298-864d-3e78c15e5ebe","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT2M6.9816009S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000012","Target Storage Account Name":"clitest000004","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/","Data
         Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:12:43.3204034Z","activityId":"1c586abe-f4ac-11ed-b502-c8f750f92764"}}'
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:00:18.5404494Z","activityId":"66aca5bf-3be9-11ee-8419-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1183'
+      - '1184'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:14:48 GMT
+      - Wed, 16 Aug 2023 04:02:25 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -3724,6 +6083,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '144'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -3741,33 +6102,34 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/b81347cf-a99b-4298-864d-3e78c15e5ebe?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367","name":"a32ed2ba-21da-44fc-ac3e-c67503131367","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT2M36.3499302S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/","Data
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/b81347cf-a99b-4298-864d-3e78c15e5ebe","name":"b81347cf-a99b-4298-864d-3e78c15e5ebe","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT2M37.5359711S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000012","Target Storage Account Name":"clitest000004","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/","Data
         Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:12:43.3204034Z","activityId":"1c586abe-f4ac-11ed-b502-c8f750f92764"}}'
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:00:18.5404494Z","activityId":"66aca5bf-3be9-11ee-8419-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '1185'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:15:19 GMT
+      - Wed, 16 Aug 2023 04:02:56 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -3778,6 +6140,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '143'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -3795,33 +6159,34 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/b81347cf-a99b-4298-864d-3e78c15e5ebe?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367","name":"a32ed2ba-21da-44fc-ac3e-c67503131367","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT3M7.1758266S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/","Data
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/b81347cf-a99b-4298-864d-3e78c15e5ebe","name":"b81347cf-a99b-4298-864d-3e78c15e5ebe","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT3M8.0666084S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000012","Target Storage Account Name":"clitest000004","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/","Data
         Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:12:43.3204034Z","activityId":"1c586abe-f4ac-11ed-b502-c8f750f92764"}}'
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:00:18.5404494Z","activityId":"66aca5bf-3be9-11ee-8419-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '1184'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:15:50 GMT
+      - Wed, 16 Aug 2023 04:03:26 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -3832,6 +6197,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '142'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -3849,33 +6216,34 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/b81347cf-a99b-4298-864d-3e78c15e5ebe?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367","name":"a32ed2ba-21da-44fc-ac3e-c67503131367","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT3M37.9957981S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/","Data
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/b81347cf-a99b-4298-864d-3e78c15e5ebe","name":"b81347cf-a99b-4298-864d-3e78c15e5ebe","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT3M38.5710032S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000012","Target Storage Account Name":"clitest000004","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/","Data
         Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:12:43.3204034Z","activityId":"1c586abe-f4ac-11ed-b502-c8f750f92764"}}'
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:00:18.5404494Z","activityId":"66aca5bf-3be9-11ee-8419-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '1185'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:16:21 GMT
+      - Wed, 16 Aug 2023 04:03:56 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -3886,6 +6254,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '141'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -3903,33 +6273,34 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/b81347cf-a99b-4298-864d-3e78c15e5ebe?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367","name":"a32ed2ba-21da-44fc-ac3e-c67503131367","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT4M8.8044397S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/","Data
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/b81347cf-a99b-4298-864d-3e78c15e5ebe","name":"b81347cf-a99b-4298-864d-3e78c15e5ebe","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT4M9.0878568S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000012","Target Storage Account Name":"clitest000004","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/","Data
         Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:12:43.3204034Z","activityId":"1c586abe-f4ac-11ed-b502-c8f750f92764"}}'
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:00:18.5404494Z","activityId":"66aca5bf-3be9-11ee-8419-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '1184'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:16:51 GMT
+      - Wed, 16 Aug 2023 04:04:27 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -3940,6 +6311,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '140'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -3957,33 +6330,34 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/b81347cf-a99b-4298-864d-3e78c15e5ebe?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367","name":"a32ed2ba-21da-44fc-ac3e-c67503131367","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT4M39.4018378S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/","Data
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/b81347cf-a99b-4298-864d-3e78c15e5ebe","name":"b81347cf-a99b-4298-864d-3e78c15e5ebe","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT4M39.5872575S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000012","Target Storage Account Name":"clitest000004","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/","Data
         Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:12:43.3204034Z","activityId":"1c586abe-f4ac-11ed-b502-c8f750f92764"}}'
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:00:18.5404494Z","activityId":"66aca5bf-3be9-11ee-8419-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '1185'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:17:22 GMT
+      - Wed, 16 Aug 2023 04:04:57 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -3994,6 +6368,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '139'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -4011,33 +6387,37 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/b81347cf-a99b-4298-864d-3e78c15e5ebe?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367","name":"a32ed2ba-21da-44fc-ac3e-c67503131367","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT5M9.9836708S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/","Data
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/b81347cf-a99b-4298-864d-3e78c15e5ebe","name":"b81347cf-a99b-4298-864d-3e78c15e5ebe","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT5M3.9300399S","errorDetails":[{"errorCode":1073871825,"errorString":"Microsoft
+        Azure Backup encountered an internal error.","recommendations":["Wait for
+        a few minutes and then try the operation again. If the issue persists, please
+        contact Microsoft support."]}],"storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","RestoreRecoveryPointTime":"8/16/2023
+        3:48:24 AM","Target File Share Name":"clitest-item000012","Target Storage
+        Account Name":"clitest000004","Job Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/","Data
         Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:12:43.3204034Z","activityId":"1c586abe-f4ac-11ed-b502-c8f750f92764"}}'
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"Failed","startTime":"2023-08-16T04:00:18.5404494Z","endTime":"2023-08-16T04:05:22.4704893Z","activityId":"66aca5bf-3be9-11ee-8419-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1184'
+      - '1519'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:17:52 GMT
+      - Wed, 16 Aug 2023 04:05:28 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -4048,333 +6428,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '138'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367","name":"a32ed2ba-21da-44fc-ac3e-c67503131367","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT5M40.5895383S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:12:43.3204034Z","activityId":"1c586abe-f4ac-11ed-b502-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1185'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:18:23 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '137'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367","name":"a32ed2ba-21da-44fc-ac3e-c67503131367","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT6M11.1799404S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:12:43.3204034Z","activityId":"1c586abe-f4ac-11ed-b502-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1185'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:18:53 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '136'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367","name":"a32ed2ba-21da-44fc-ac3e-c67503131367","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT6M41.8131528S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:12:43.3204034Z","activityId":"1c586abe-f4ac-11ed-b502-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1185'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:19:24 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '135'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367","name":"a32ed2ba-21da-44fc-ac3e-c67503131367","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT7M12.4079329S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:12:43.3204034Z","activityId":"1c586abe-f4ac-11ed-b502-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1185'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:19:55 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '134'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367","name":"a32ed2ba-21da-44fc-ac3e-c67503131367","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT7M43.0245593S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:12:43.3204034Z","activityId":"1c586abe-f4ac-11ed-b502-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1185'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:20:26 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '133'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367","name":"a32ed2ba-21da-44fc-ac3e-c67503131367","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT8M4.2618537S","errorDetails":[{"errorCode":1073871825,"errorString":"Microsoft
-        Azure Backup encountered an internal error.","recommendations":["Wait for
-        a few minutes and then try the operation again. If the issue persists, please
-        contact Microsoft support."]}],"storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","RestoreRecoveryPointTime":"5/17/2023
-        12:09:53 PM","Target File Share Name":"clitest-item000011","Target Storage
-        Account Name":"clitest000003","Job Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"Failed","startTime":"2023-05-17T12:12:43.3204034Z","endTime":"2023-05-17T12:20:47.5822571Z","activityId":"1c586abe-f4ac-11ed-b502-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1520'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:20:57 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '132'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -4392,36 +6447,37 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/b81347cf-a99b-4298-864d-3e78c15e5ebe?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a32ed2ba-21da-44fc-ac3e-c67503131367","name":"a32ed2ba-21da-44fc-ac3e-c67503131367","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT8M4.2618537S","errorDetails":[{"errorCode":1073871825,"errorString":"Microsoft
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/b81347cf-a99b-4298-864d-3e78c15e5ebe","name":"b81347cf-a99b-4298-864d-3e78c15e5ebe","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT5M3.9300399S","errorDetails":[{"errorCode":1073871825,"errorString":"Microsoft
         Azure Backup encountered an internal error.","recommendations":["Wait for
         a few minutes and then try the operation again. If the issue persists, please
-        contact Microsoft support."]}],"storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","RestoreRecoveryPointTime":"5/17/2023
-        12:09:53 PM","Target File Share Name":"clitest-item000011","Target Storage
-        Account Name":"clitest000003","Job Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/","Data
+        contact Microsoft support."]}],"storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","RestoreRecoveryPointTime":"8/16/2023
+        3:48:24 AM","Target File Share Name":"clitest-item000012","Target Storage
+        Account Name":"clitest000004","Job Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/","Data
         Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"Failed","startTime":"2023-05-17T12:12:43.3204034Z","endTime":"2023-05-17T12:20:47.5822571Z","activityId":"1c586abe-f4ac-11ed-b502-c8f750f92764"}}'
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"Failed","startTime":"2023-08-16T04:00:18.5404494Z","endTime":"2023-08-16T04:05:22.4704893Z","activityId":"66aca5bf-3be9-11ee-8419-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1520'
+      - '1519'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:21:28 GMT
+      - Wed, 16 Aug 2023 04:05:59 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -4431,7 +6487,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '148'
+      - '137'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -4450,28 +6508,28 @@ interactions:
       - -g -v -c -i -r --resolve-conflict --restore-mode --source-file-type --source-file-path
         --target-storage-account --target-file-share --target-folder
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+itemType+eq+%27AzureFileShare%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+itemType+eq+%27AzureFileShare%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;cdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c","name":"AzureFileShare;cdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000007","protectionStatus":"Healthy","protectionState":"Protected","lastBackupStatus":"Completed","lastBackupTime":"2023-05-17T12:09:50.1007757Z","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000008","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000004/protectedItems/AzureFileShare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e","name":"AzureFileShare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000008","protectionStatus":"Healthy","protectionState":"Protected","lastBackupStatus":"Completed","lastBackupTime":"2023-08-16T03:48:22.6102845Z","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000004","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000004","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupPolicies/clitest-item000009","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '1526'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:21:31 GMT
+      - Wed, 16 Aug 2023 04:06:01 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -4481,7 +6539,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '298'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -4500,12 +6560,13 @@ interactions:
       - -g -v -c -i -r --resolve-conflict --restore-mode --source-file-type --source-file-path
         --target-storage-account --target-file-share --target-folder
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ClassicStorage/storageAccounts/clitest000003?api-version=2015-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ClassicStorage/storageAccounts/clitest000004?api-version=2015-12-01
   response:
     body:
-      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.ClassicStorage/storageAccounts/clitest000003''
+      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.ClassicStorage/storageAccounts/clitest000004''
         under resource group ''clitest.rg000001'' was not found. For more details
         please go to https://aka.ms/ARMResourceNotFoundFix"}}'
     headers:
@@ -4516,7 +6577,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:21:35 GMT
+      - Wed, 16 Aug 2023 04:06:01 GMT
       expires:
       - '-1'
       pragma:
@@ -4545,21 +6606,22 @@ interactions:
       - -g -v -c -i -r --resolve-conflict --restore-mode --source-file-type --source-file-path
         --target-storage-account --target-file-share --target-folder
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004?api-version=2016-01-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","name":"clitest000003","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2023-05-17T12:08:01.7487432Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-05-17T12:08:01.2018473Z","primaryEndpoints":{"blob":"https://clitest000003.blob.core.windows.net/","queue":"https://clitest000003.queue.core.windows.net/","table":"https://clitest000003.table.core.windows.net/","file":"https://clitest000003.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004","name":"clitest000004","type":"Microsoft.Storage/storageAccounts","location":"centraluseuap","tags":{},"properties":{"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2023-08-16T03:45:38.8855125Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-08-16T03:45:38.5261630Z","primaryEndpoints":{"blob":"https://clitest000004.blob.core.windows.net/","queue":"https://clitest000004.queue.core.windows.net/","table":"https://clitest000004.table.core.windows.net/","file":"https://clitest000004.file.core.windows.net/"},"primaryLocation":"centraluseuap","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '845'
+      - '849'
       content-type:
       - application/json
       date:
-      - Wed, 17 May 2023 12:21:36 GMT
+      - Wed, 16 Aug 2023 04:06:02 GMT
       expires:
       - '-1'
       pragma:
@@ -4592,12 +6654,13 @@ interactions:
       - -g -v -c -i -r --resolve-conflict --restore-mode --source-file-type --source-file-path
         --target-storage-account --target-file-share --target-folder
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ClassicStorage/storageAccounts/clitest000003?api-version=2015-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ClassicStorage/storageAccounts/clitest000004?api-version=2015-12-01
   response:
     body:
-      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.ClassicStorage/storageAccounts/clitest000003''
+      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.ClassicStorage/storageAccounts/clitest000004''
         under resource group ''clitest.rg000001'' was not found. For more details
         please go to https://aka.ms/ARMResourceNotFoundFix"}}'
     headers:
@@ -4608,7 +6671,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:21:39 GMT
+      - Wed, 16 Aug 2023 04:06:03 GMT
       expires:
       - '-1'
       pragma:
@@ -4637,21 +6700,22 @@ interactions:
       - -g -v -c -i -r --resolve-conflict --restore-mode --source-file-type --source-file-path
         --target-storage-account --target-file-share --target-folder
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004?api-version=2016-01-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","name":"clitest000003","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2023-05-17T12:08:01.7487432Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-05-17T12:08:01.2018473Z","primaryEndpoints":{"blob":"https://clitest000003.blob.core.windows.net/","queue":"https://clitest000003.queue.core.windows.net/","table":"https://clitest000003.table.core.windows.net/","file":"https://clitest000003.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004","name":"clitest000004","type":"Microsoft.Storage/storageAccounts","location":"centraluseuap","tags":{},"properties":{"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2023-08-16T03:45:38.8855125Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-08-16T03:45:38.5261630Z","primaryEndpoints":{"blob":"https://clitest000004.blob.core.windows.net/","queue":"https://clitest000004.queue.core.windows.net/","table":"https://clitest000004.table.core.windows.net/","file":"https://clitest000004.file.core.windows.net/"},"primaryLocation":"centraluseuap","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '845'
+      - '849'
       content-type:
       - application/json
       date:
-      - Wed, 17 May 2023 12:21:40 GMT
+      - Wed, 16 Aug 2023 04:06:03 GMT
       expires:
       - '-1'
       pragma:
@@ -4671,11 +6735,11 @@ interactions:
       message: OK
 - request:
     body: '{"properties": {"objectType": "AzureFileShareRestoreRequest", "recoveryType":
-      "AlternateLocation", "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003",
+      "AlternateLocation", "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004",
       "copyOptions": "Overwrite", "restoreRequestType": "ItemLevelRestore", "restoreFileSpecs":
-      [{"path": "clitest-file000005", "fileSpecType": "File", "targetFolderPath":
-      "folder1"}], "targetDetails": {"name": "clitest-item000011", "targetResourceId":
-      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003"}}}'
+      [{"path": "clitest-file000006", "fileSpecType": "File", "targetFolderPath":
+      "folder1"}], "targetDetails": {"name": "clitest-item000012", "targetResourceId":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004"}}}'
     headers:
       Accept:
       - application/json
@@ -4693,36 +6757,36 @@ interactions:
       - -g -v -c -i -r --resolve-conflict --restore-mode --source-file-type --source-file-path
         --target-storage-account --target-file-share --target-folder
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3Bcdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c/recoveryPoints/74080090672816/restore?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000004/protectedItems/AzureFileShare%3Ba999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e/recoveryPoints/386630283514636/restore?api-version=2023-02-01
   response:
     body:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;cdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c/operationsStatus/98e3ad29-62f3-4503-99c2-fbed4c580d23?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000004/protectedItems/AzureFileShare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e/operationsStatus/cbc48678-2cc5-49c7-9751-6aa9b6cc7f05?api-version=2023-02-01
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:21:42 GMT
+      - Wed, 16 Aug 2023 04:06:05 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;cdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c/operationResults/98e3ad29-62f3-4503-99c2-fbed4c580d23?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000004/protectedItems/AzureFileShare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e/operationResults/cbc48678-2cc5-49c7-9751-6aa9b6cc7f05?api-version=2023-02-01
       pragma:
       - no-cache
-      server:
-      - Kestrel
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 202
       message: Accepted
@@ -4741,28 +6805,28 @@ interactions:
       - -g -v -c -i -r --resolve-conflict --restore-mode --source-file-type --source-file-path
         --target-storage-account --target-file-share --target-folder
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/98e3ad29-62f3-4503-99c2-fbed4c580d23?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupOperations/cbc48678-2cc5-49c7-9751-6aa9b6cc7f05?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"98e3ad29-62f3-4503-99c2-fbed4c580d23","name":"98e3ad29-62f3-4503-99c2-fbed4c580d23","status":"Succeeded","startTime":"2023-05-17T12:21:42.1619993Z","endTime":"2023-05-17T12:21:42.1619993Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"98e3ad29-62f3-4503-99c2-fbed4c580d23"}}'
+      string: '{"id":"cbc48678-2cc5-49c7-9751-6aa9b6cc7f05","name":"cbc48678-2cc5-49c7-9751-6aa9b6cc7f05","status":"Succeeded","startTime":"2023-08-16T04:06:05.6210541Z","endTime":"2023-08-16T04:06:05.6210541Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"cbc48678-2cc5-49c7-9751-6aa9b6cc7f05"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '304'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:21:42 GMT
+      - Wed, 16 Aug 2023 04:06:06 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -4773,6 +6837,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '299'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -4791,87 +6857,34 @@ interactions:
       - -g -v -c -i -r --resolve-conflict --restore-mode --source-file-type --source-file-path
         --target-storage-account --target-file-share --target-folder
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/cbc48678-2cc5-49c7-9751-6aa9b6cc7f05?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23","name":"98e3ad29-62f3-4503-99c2-fbed4c580d23","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT2.2378838S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/cbc48678-2cc5-49c7-9751-6aa9b6cc7f05","name":"cbc48678-2cc5-49c7-9751-6aa9b6cc7f05","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT2.956751S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000012","Target Storage Account Name":"clitest000004","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/folder1","Data
         Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:21:42.1619993Z","activityId":"5888fb54-f4ad-11ed-b9f0-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1189'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:21:44 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '149'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23","name":"98e3ad29-62f3-4503-99c2-fbed4c580d23","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT3.626382S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:21:42.1619993Z","activityId":"5888fb54-f4ad-11ed-b9f0-c8f750f92764"}}'
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:06:05.6210541Z","activityId":"358cedaf-3bea-11ee-ac76-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '1188'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:21:45 GMT
+      - Wed, 16 Aug 2023 04:06:08 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -4881,7 +6894,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '147'
+      - '122'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -4899,573 +6914,34 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/cbc48678-2cc5-49c7-9751-6aa9b6cc7f05?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23","name":"98e3ad29-62f3-4503-99c2-fbed4c580d23","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT4.2201262S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/cbc48678-2cc5-49c7-9751-6aa9b6cc7f05","name":"cbc48678-2cc5-49c7-9751-6aa9b6cc7f05","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT4.2902447S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000012","Target Storage Account Name":"clitest000004","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/folder1","Data
         Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:21:42.1619993Z","activityId":"5888fb54-f4ad-11ed-b9f0-c8f750f92764"}}'
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:06:05.6210541Z","activityId":"358cedaf-3bea-11ee-ac76-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '1189'
       content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:21:46 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '146'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23","name":"98e3ad29-62f3-4503-99c2-fbed4c580d23","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT34.7837296S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:21:42.1619993Z","activityId":"5888fb54-f4ad-11ed-b9f0-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1190'
-      content-type:
-      - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:22:16 GMT
+      - Wed, 16 Aug 2023 04:06:09 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '145'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23","name":"98e3ad29-62f3-4503-99c2-fbed4c580d23","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT1M5.3473859S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:21:42.1619993Z","activityId":"5888fb54-f4ad-11ed-b9f0-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:22:47 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '144'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23","name":"98e3ad29-62f3-4503-99c2-fbed4c580d23","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT1M35.9276565S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:21:42.1619993Z","activityId":"5888fb54-f4ad-11ed-b9f0-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:23:17 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '143'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23","name":"98e3ad29-62f3-4503-99c2-fbed4c580d23","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT2M6.5077374S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:21:42.1619993Z","activityId":"5888fb54-f4ad-11ed-b9f0-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:23:48 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '142'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23","name":"98e3ad29-62f3-4503-99c2-fbed4c580d23","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT2M37.0564993S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:21:42.1619993Z","activityId":"5888fb54-f4ad-11ed-b9f0-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:24:19 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '141'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23","name":"98e3ad29-62f3-4503-99c2-fbed4c580d23","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT3M7.6263833S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:21:42.1619993Z","activityId":"5888fb54-f4ad-11ed-b9f0-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:24:49 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '140'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23","name":"98e3ad29-62f3-4503-99c2-fbed4c580d23","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT3M38.2197477S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:21:42.1619993Z","activityId":"5888fb54-f4ad-11ed-b9f0-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:25:20 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '139'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23","name":"98e3ad29-62f3-4503-99c2-fbed4c580d23","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT4M8.8103971S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:21:42.1619993Z","activityId":"5888fb54-f4ad-11ed-b9f0-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:25:50 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '138'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23","name":"98e3ad29-62f3-4503-99c2-fbed4c580d23","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT4M39.3752451S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:21:42.1619993Z","activityId":"5888fb54-f4ad-11ed-b9f0-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:26:21 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '137'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23","name":"98e3ad29-62f3-4503-99c2-fbed4c580d23","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT5M9.9352744S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:21:42.1619993Z","activityId":"5888fb54-f4ad-11ed-b9f0-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:26:51 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -5476,6 +6952,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '136'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -5493,33 +6971,34 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/cbc48678-2cc5-49c7-9751-6aa9b6cc7f05?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23","name":"98e3ad29-62f3-4503-99c2-fbed4c580d23","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT5M40.5136541S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/cbc48678-2cc5-49c7-9751-6aa9b6cc7f05","name":"cbc48678-2cc5-49c7-9751-6aa9b6cc7f05","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT4.8317352S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000012","Target Storage Account Name":"clitest000004","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/folder1","Data
         Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:21:42.1619993Z","activityId":"5888fb54-f4ad-11ed-b9f0-c8f750f92764"}}'
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:06:05.6210541Z","activityId":"358cedaf-3bea-11ee-ac76-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1192'
+      - '1189'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:27:22 GMT
+      - Wed, 16 Aug 2023 04:06:09 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -5530,6 +7009,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '135'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -5547,33 +7028,34 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/cbc48678-2cc5-49c7-9751-6aa9b6cc7f05?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23","name":"98e3ad29-62f3-4503-99c2-fbed4c580d23","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT6M11.6925373S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/cbc48678-2cc5-49c7-9751-6aa9b6cc7f05","name":"cbc48678-2cc5-49c7-9751-6aa9b6cc7f05","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT35.3481969S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000012","Target Storage Account Name":"clitest000004","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/folder1","Data
         Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:21:42.1619993Z","activityId":"5888fb54-f4ad-11ed-b9f0-c8f750f92764"}}'
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:06:05.6210541Z","activityId":"358cedaf-3bea-11ee-ac76-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1192'
+      - '1190'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:27:53 GMT
+      - Wed, 16 Aug 2023 04:06:40 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -5584,6 +7066,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '134'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -5601,33 +7085,34 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/cbc48678-2cc5-49c7-9751-6aa9b6cc7f05?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23","name":"98e3ad29-62f3-4503-99c2-fbed4c580d23","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT6M42.3036023S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/cbc48678-2cc5-49c7-9751-6aa9b6cc7f05","name":"cbc48678-2cc5-49c7-9751-6aa9b6cc7f05","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT1M5.8815148S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000012","Target Storage Account Name":"clitest000004","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/folder1","Data
         Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:21:42.1619993Z","activityId":"5888fb54-f4ad-11ed-b9f0-c8f750f92764"}}'
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:06:05.6210541Z","activityId":"358cedaf-3bea-11ee-ac76-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1192'
+      - '1191'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:28:24 GMT
+      - Wed, 16 Aug 2023 04:07:10 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -5638,6 +7123,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '133'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -5655,33 +7142,34 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/cbc48678-2cc5-49c7-9751-6aa9b6cc7f05?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23","name":"98e3ad29-62f3-4503-99c2-fbed4c580d23","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT7M12.8650399S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/cbc48678-2cc5-49c7-9751-6aa9b6cc7f05","name":"cbc48678-2cc5-49c7-9751-6aa9b6cc7f05","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT1M36.3983658S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000012","Target Storage Account Name":"clitest000004","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/folder1","Data
         Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:21:42.1619993Z","activityId":"5888fb54-f4ad-11ed-b9f0-c8f750f92764"}}'
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:06:05.6210541Z","activityId":"358cedaf-3bea-11ee-ac76-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '1192'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:28:54 GMT
+      - Wed, 16 Aug 2023 04:07:41 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -5692,6 +7180,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '132'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -5709,33 +7199,34 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/cbc48678-2cc5-49c7-9751-6aa9b6cc7f05?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23","name":"98e3ad29-62f3-4503-99c2-fbed4c580d23","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT7M43.4320444S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/cbc48678-2cc5-49c7-9751-6aa9b6cc7f05","name":"cbc48678-2cc5-49c7-9751-6aa9b6cc7f05","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT2M6.8895365S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000012","Target Storage Account Name":"clitest000004","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/folder1","Data
         Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:21:42.1619993Z","activityId":"5888fb54-f4ad-11ed-b9f0-c8f750f92764"}}'
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:06:05.6210541Z","activityId":"358cedaf-3bea-11ee-ac76-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1192'
+      - '1191'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:29:25 GMT
+      - Wed, 16 Aug 2023 04:08:11 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -5746,6 +7237,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '131'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -5763,36 +7256,34 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/cbc48678-2cc5-49c7-9751-6aa9b6cc7f05?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23","name":"98e3ad29-62f3-4503-99c2-fbed4c580d23","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT8M5.3850666S","errorDetails":[{"errorCode":1073871825,"errorString":"Microsoft
-        Azure Backup encountered an internal error.","recommendations":["Wait for
-        a few minutes and then try the operation again. If the issue persists, please
-        contact Microsoft support."]}],"storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","RestoreRecoveryPointTime":"5/17/2023
-        12:09:53 PM","Target File Share Name":"clitest-item000011","Target Storage
-        Account Name":"clitest000003","Job Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/cbc48678-2cc5-49c7-9751-6aa9b6cc7f05","name":"cbc48678-2cc5-49c7-9751-6aa9b6cc7f05","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT2M37.4142023S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000012","Target Storage Account Name":"clitest000004","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/folder1","Data
         Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"Failed","startTime":"2023-05-17T12:21:42.1619993Z","endTime":"2023-05-17T12:29:47.5470659Z","activityId":"5888fb54-f4ad-11ed-b9f0-c8f750f92764"}}'
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:06:05.6210541Z","activityId":"358cedaf-3bea-11ee-ac76-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1527'
+      - '1192'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:29:56 GMT
+      - Wed, 16 Aug 2023 04:08:42 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -5803,6 +7294,296 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '130'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/cbc48678-2cc5-49c7-9751-6aa9b6cc7f05?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/cbc48678-2cc5-49c7-9751-6aa9b6cc7f05","name":"cbc48678-2cc5-49c7-9751-6aa9b6cc7f05","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT3M8.004081S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000012","Target Storage Account Name":"clitest000004","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/folder1","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:06:05.6210541Z","activityId":"358cedaf-3bea-11ee-ac76-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1190'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:09:13 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '129'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/cbc48678-2cc5-49c7-9751-6aa9b6cc7f05?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/cbc48678-2cc5-49c7-9751-6aa9b6cc7f05","name":"cbc48678-2cc5-49c7-9751-6aa9b6cc7f05","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT3M38.5330313S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000012","Target Storage Account Name":"clitest000004","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/folder1","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:06:05.6210541Z","activityId":"358cedaf-3bea-11ee-ac76-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1192'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:09:43 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '128'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/cbc48678-2cc5-49c7-9751-6aa9b6cc7f05?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/cbc48678-2cc5-49c7-9751-6aa9b6cc7f05","name":"cbc48678-2cc5-49c7-9751-6aa9b6cc7f05","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT4M9.0284801S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000012","Target Storage Account Name":"clitest000004","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/folder1","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:06:05.6210541Z","activityId":"358cedaf-3bea-11ee-ac76-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1191'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:10:14 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '127'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/cbc48678-2cc5-49c7-9751-6aa9b6cc7f05?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/cbc48678-2cc5-49c7-9751-6aa9b6cc7f05","name":"cbc48678-2cc5-49c7-9751-6aa9b6cc7f05","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT4M39.5874687S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000012","Target Storage Account Name":"clitest000004","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/folder1","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:06:05.6210541Z","activityId":"358cedaf-3bea-11ee-ac76-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1192'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:10:45 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '126'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/cbc48678-2cc5-49c7-9751-6aa9b6cc7f05?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/cbc48678-2cc5-49c7-9751-6aa9b6cc7f05","name":"cbc48678-2cc5-49c7-9751-6aa9b6cc7f05","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT5M3.722032S","errorDetails":[{"errorCode":1073871825,"errorString":"Microsoft
+        Azure Backup encountered an internal error.","recommendations":["Wait for
+        a few minutes and then try the operation again. If the issue persists, please
+        contact Microsoft support."]}],"storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","RestoreRecoveryPointTime":"8/16/2023
+        3:48:24 AM","Target File Share Name":"clitest-item000012","Target Storage
+        Account Name":"clitest000004","Job Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/folder1","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"Failed","startTime":"2023-08-16T04:06:05.6210541Z","endTime":"2023-08-16T04:11:09.3430861Z","activityId":"358cedaf-3bea-11ee-ac76-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1525'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:11:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '125'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -5820,36 +7601,37 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/cbc48678-2cc5-49c7-9751-6aa9b6cc7f05?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/98e3ad29-62f3-4503-99c2-fbed4c580d23","name":"98e3ad29-62f3-4503-99c2-fbed4c580d23","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT8M5.3850666S","errorDetails":[{"errorCode":1073871825,"errorString":"Microsoft
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/cbc48678-2cc5-49c7-9751-6aa9b6cc7f05","name":"cbc48678-2cc5-49c7-9751-6aa9b6cc7f05","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT5M3.722032S","errorDetails":[{"errorCode":1073871825,"errorString":"Microsoft
         Azure Backup encountered an internal error.","recommendations":["Wait for
         a few minutes and then try the operation again. If the issue persists, please
-        contact Microsoft support."]}],"storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","RestoreRecoveryPointTime":"5/17/2023
-        12:09:53 PM","Target File Share Name":"clitest-item000011","Target Storage
-        Account Name":"clitest000003","Job Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
+        contact Microsoft support."]}],"storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","RestoreRecoveryPointTime":"8/16/2023
+        3:48:24 AM","Target File Share Name":"clitest-item000012","Target Storage
+        Account Name":"clitest000004","Job Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/folder1","Data
         Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"Failed","startTime":"2023-05-17T12:21:42.1619993Z","endTime":"2023-05-17T12:29:47.5470659Z","activityId":"5888fb54-f4ad-11ed-b9f0-c8f750f92764"}}'
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"Failed","startTime":"2023-08-16T04:06:05.6210541Z","endTime":"2023-08-16T04:11:09.3430861Z","activityId":"358cedaf-3bea-11ee-ac76-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1527'
+      - '1525'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:30:27 GMT
+      - Wed, 16 Aug 2023 04:11:47 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -5859,7 +7641,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '147'
+      - '121'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -5877,28 +7661,28 @@ interactions:
       ParameterSetName:
       - -g -v -c -i -r --resolve-conflict --restore-mode --source-file-type --source-file-path
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+itemType+eq+%27AzureFileShare%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+itemType+eq+%27AzureFileShare%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;cdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c","name":"AzureFileShare;cdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000007","protectionStatus":"Healthy","protectionState":"Protected","lastBackupStatus":"Completed","lastBackupTime":"2023-05-17T12:09:50.1007757Z","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000008","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000004/protectedItems/AzureFileShare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e","name":"AzureFileShare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000008","protectionStatus":"Healthy","protectionState":"Protected","lastBackupStatus":"Completed","lastBackupTime":"2023-08-16T03:48:22.6102845Z","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000004","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000004","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupPolicies/clitest-item000009","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '1526'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:30:28 GMT
+      - Wed, 16 Aug 2023 04:11:48 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -5908,7 +7692,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '299'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -5926,12 +7712,13 @@ interactions:
       ParameterSetName:
       - -g -v -c -i -r --resolve-conflict --restore-mode --source-file-type --source-file-path
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ClassicStorage/storageAccounts/clitest000003?api-version=2015-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ClassicStorage/storageAccounts/clitest000004?api-version=2015-12-01
   response:
     body:
-      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.ClassicStorage/storageAccounts/clitest000003''
+      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.ClassicStorage/storageAccounts/clitest000004''
         under resource group ''clitest.rg000001'' was not found. For more details
         please go to https://aka.ms/ARMResourceNotFoundFix"}}'
     headers:
@@ -5942,7 +7729,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:30:28 GMT
+      - Wed, 16 Aug 2023 04:11:48 GMT
       expires:
       - '-1'
       pragma:
@@ -5970,21 +7757,22 @@ interactions:
       ParameterSetName:
       - -g -v -c -i -r --resolve-conflict --restore-mode --source-file-type --source-file-path
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004?api-version=2016-01-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","name":"clitest000003","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2023-05-17T12:08:01.7487432Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-05-17T12:08:01.2018473Z","primaryEndpoints":{"blob":"https://clitest000003.blob.core.windows.net/","queue":"https://clitest000003.queue.core.windows.net/","table":"https://clitest000003.table.core.windows.net/","file":"https://clitest000003.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004","name":"clitest000004","type":"Microsoft.Storage/storageAccounts","location":"centraluseuap","tags":{},"properties":{"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2023-08-16T03:45:38.8855125Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-08-16T03:45:38.5261630Z","primaryEndpoints":{"blob":"https://clitest000004.blob.core.windows.net/","queue":"https://clitest000004.queue.core.windows.net/","table":"https://clitest000004.table.core.windows.net/","file":"https://clitest000004.file.core.windows.net/"},"primaryLocation":"centraluseuap","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '845'
+      - '849'
       content-type:
       - application/json
       date:
-      - Wed, 17 May 2023 12:30:29 GMT
+      - Wed, 16 Aug 2023 04:11:49 GMT
       expires:
       - '-1'
       pragma:
@@ -6004,9 +7792,9 @@ interactions:
       message: OK
 - request:
     body: '{"properties": {"objectType": "AzureFileShareRestoreRequest", "recoveryType":
-      "OriginalLocation", "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003",
+      "OriginalLocation", "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004",
       "copyOptions": "Overwrite", "restoreRequestType": "ItemLevelRestore", "restoreFileSpecs":
-      [{"path": "clitest-file000005", "fileSpecType": "File"}]}}'
+      [{"path": "clitest-file000006", "fileSpecType": "File"}]}}'
     headers:
       Accept:
       - application/json
@@ -6023,36 +7811,36 @@ interactions:
       ParameterSetName:
       - -g -v -c -i -r --resolve-conflict --restore-mode --source-file-type --source-file-path
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3Bcdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c/recoveryPoints/74080090672816/restore?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000004/protectedItems/AzureFileShare%3Ba999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e/recoveryPoints/386630283514636/restore?api-version=2023-02-01
   response:
     body:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;cdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c/operationsStatus/9a7f522f-0ba6-4b6d-9dc1-c5d818357d1e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000004/protectedItems/AzureFileShare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e/operationsStatus/d93ef18b-60ce-4ed0-90be-71ff280408c2?api-version=2023-02-01
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:30:31 GMT
+      - Wed, 16 Aug 2023 04:11:51 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;cdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c/operationResults/9a7f522f-0ba6-4b6d-9dc1-c5d818357d1e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000004/protectedItems/AzureFileShare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e/operationResults/d93ef18b-60ce-4ed0-90be-71ff280408c2?api-version=2023-02-01
       pragma:
       - no-cache
-      server:
-      - Kestrel
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
       - '1198'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 202
       message: Accepted
@@ -6070,28 +7858,28 @@ interactions:
       ParameterSetName:
       - -g -v -c -i -r --resolve-conflict --restore-mode --source-file-type --source-file-path
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/9a7f522f-0ba6-4b6d-9dc1-c5d818357d1e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupOperations/d93ef18b-60ce-4ed0-90be-71ff280408c2?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"9a7f522f-0ba6-4b6d-9dc1-c5d818357d1e","name":"9a7f522f-0ba6-4b6d-9dc1-c5d818357d1e","status":"Succeeded","startTime":"2023-05-17T12:30:32.0096421Z","endTime":"2023-05-17T12:30:32.0096421Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"9a7f522f-0ba6-4b6d-9dc1-c5d818357d1e"}}'
+      string: '{"id":"d93ef18b-60ce-4ed0-90be-71ff280408c2","name":"d93ef18b-60ce-4ed0-90be-71ff280408c2","status":"Succeeded","startTime":"2023-08-16T04:11:51.4002748Z","endTime":"2023-08-16T04:11:51.4002748Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"d93ef18b-60ce-4ed0-90be-71ff280408c2"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '304'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:30:33 GMT
+      - Wed, 16 Aug 2023 04:11:52 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -6101,7 +7889,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '294'
+      - '288'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -6119,32 +7909,33 @@ interactions:
       ParameterSetName:
       - -g -v -c -i -r --resolve-conflict --restore-mode --source-file-type --source-file-path
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/9a7f522f-0ba6-4b6d-9dc1-c5d818357d1e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/d93ef18b-60ce-4ed0-90be-71ff280408c2?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/9a7f522f-0ba6-4b6d-9dc1-c5d818357d1e","name":"9a7f522f-0ba6-4b6d-9dc1-c5d818357d1e","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT2.2656732S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Job
-        Type":"Recovering to the original file share","RestoreDestination":"clitest000003/clitest-item000007/","Data
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/d93ef18b-60ce-4ed0-90be-71ff280408c2","name":"d93ef18b-60ce-4ed0-90be-71ff280408c2","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT2.8216499S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Job
+        Type":"Recovering to the original file share","RestoreDestination":"clitest000004/clitest-item000008/","Data
         Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:30:32.0096421Z","activityId":"99ed5d78-f4ae-11ed-b708-c8f750f92764"}}'
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:11:51.4002748Z","activityId":"047818ac-3beb-11ee-a5d8-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '1093'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:30:33 GMT
+      - Wed, 16 Aug 2023 04:11:54 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -6155,6 +7946,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '147'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -6172,32 +7965,145 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/9a7f522f-0ba6-4b6d-9dc1-c5d818357d1e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/d93ef18b-60ce-4ed0-90be-71ff280408c2?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/9a7f522f-0ba6-4b6d-9dc1-c5d818357d1e","name":"9a7f522f-0ba6-4b6d-9dc1-c5d818357d1e","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT3.0386349S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Job
-        Type":"Recovering to the original file share","RestoreDestination":"clitest000003/clitest-item000007/","Data
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/d93ef18b-60ce-4ed0-90be-71ff280408c2","name":"d93ef18b-60ce-4ed0-90be-71ff280408c2","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT4.1782957S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Job
+        Type":"Recovering to the original file share","RestoreDestination":"clitest000004/clitest-item000008/","Data
         Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:30:32.0096421Z","activityId":"99ed5d78-f4ae-11ed-b708-c8f750f92764"}}'
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:11:51.4002748Z","activityId":"047818ac-3beb-11ee-a5d8-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '1093'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:30:34 GMT
+      - Wed, 16 Aug 2023 04:11:55 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '147'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/d93ef18b-60ce-4ed0-90be-71ff280408c2?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/d93ef18b-60ce-4ed0-90be-71ff280408c2","name":"d93ef18b-60ce-4ed0-90be-71ff280408c2","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT4.6629992S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Job
+        Type":"Recovering to the original file share","RestoreDestination":"clitest000004/clitest-item000008/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:11:51.4002748Z","activityId":"047818ac-3beb-11ee-a5d8-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1093'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:11:55 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '146'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/d93ef18b-60ce-4ed0-90be-71ff280408c2?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/d93ef18b-60ce-4ed0-90be-71ff280408c2","name":"d93ef18b-60ce-4ed0-90be-71ff280408c2","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT35.1830908S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Job
+        Type":"Recovering to the original file share","RestoreDestination":"clitest000004/clitest-item000008/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:11:51.4002748Z","activityId":"047818ac-3beb-11ee-a5d8-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1094'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:12:26 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -6208,6 +8114,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '145'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -6225,32 +8133,33 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/9a7f522f-0ba6-4b6d-9dc1-c5d818357d1e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/d93ef18b-60ce-4ed0-90be-71ff280408c2?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/9a7f522f-0ba6-4b6d-9dc1-c5d818357d1e","name":"9a7f522f-0ba6-4b6d-9dc1-c5d818357d1e","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT3.610107S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Job
-        Type":"Recovering to the original file share","RestoreDestination":"clitest000003/clitest-item000007/","Data
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/d93ef18b-60ce-4ed0-90be-71ff280408c2","name":"d93ef18b-60ce-4ed0-90be-71ff280408c2","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT1M5.7040103S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Job
+        Type":"Recovering to the original file share","RestoreDestination":"clitest000004/clitest-item000008/","Data
         Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:30:32.0096421Z","activityId":"99ed5d78-f4ae-11ed-b708-c8f750f92764"}}'
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:11:51.4002748Z","activityId":"047818ac-3beb-11ee-a5d8-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1092'
+      - '1095'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:30:35 GMT
+      - Wed, 16 Aug 2023 04:12:56 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -6261,6 +8170,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '144'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -6278,32 +8189,33 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/9a7f522f-0ba6-4b6d-9dc1-c5d818357d1e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/d93ef18b-60ce-4ed0-90be-71ff280408c2?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/9a7f522f-0ba6-4b6d-9dc1-c5d818357d1e","name":"9a7f522f-0ba6-4b6d-9dc1-c5d818357d1e","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT32.3917577S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","RestoreRecoveryPointTime":"5/17/2023
-        12:09:53 PM","Job Type":"Recovering to the original file share","RestoreDestination":"clitest000003/clitest-item000007/","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"1","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"Completed","startTime":"2023-05-17T12:30:32.0096421Z","endTime":"2023-05-17T12:31:04.4013998Z","activityId":"99ed5d78-f4ae-11ed-b708-c8f750f92764"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/d93ef18b-60ce-4ed0-90be-71ff280408c2","name":"d93ef18b-60ce-4ed0-90be-71ff280408c2","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT1M36.216883S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Job
+        Type":"Recovering to the original file share","RestoreDestination":"clitest000004/clitest-item000008/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:11:51.4002748Z","activityId":"047818ac-3beb-11ee-a5d8-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1185'
+      - '1095'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:31:05 GMT
+      - Wed, 16 Aug 2023 04:13:26 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -6314,6 +8226,403 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '143'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/d93ef18b-60ce-4ed0-90be-71ff280408c2?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/d93ef18b-60ce-4ed0-90be-71ff280408c2","name":"d93ef18b-60ce-4ed0-90be-71ff280408c2","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT2M6.7942838S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Job
+        Type":"Recovering to the original file share","RestoreDestination":"clitest000004/clitest-item000008/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:11:51.4002748Z","activityId":"047818ac-3beb-11ee-a5d8-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1095'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:13:57 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '142'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/d93ef18b-60ce-4ed0-90be-71ff280408c2?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/d93ef18b-60ce-4ed0-90be-71ff280408c2","name":"d93ef18b-60ce-4ed0-90be-71ff280408c2","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT2M37.3178202S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Job
+        Type":"Recovering to the original file share","RestoreDestination":"clitest000004/clitest-item000008/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:11:51.4002748Z","activityId":"047818ac-3beb-11ee-a5d8-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1096'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:14:28 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '141'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/d93ef18b-60ce-4ed0-90be-71ff280408c2?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/d93ef18b-60ce-4ed0-90be-71ff280408c2","name":"d93ef18b-60ce-4ed0-90be-71ff280408c2","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT3M7.871758S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Job
+        Type":"Recovering to the original file share","RestoreDestination":"clitest000004/clitest-item000008/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:11:51.4002748Z","activityId":"047818ac-3beb-11ee-a5d8-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1094'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:14:59 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '140'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/d93ef18b-60ce-4ed0-90be-71ff280408c2?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/d93ef18b-60ce-4ed0-90be-71ff280408c2","name":"d93ef18b-60ce-4ed0-90be-71ff280408c2","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT3M38.4311674S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Job
+        Type":"Recovering to the original file share","RestoreDestination":"clitest000004/clitest-item000008/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:11:51.4002748Z","activityId":"047818ac-3beb-11ee-a5d8-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1096'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:15:29 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '139'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/d93ef18b-60ce-4ed0-90be-71ff280408c2?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/d93ef18b-60ce-4ed0-90be-71ff280408c2","name":"d93ef18b-60ce-4ed0-90be-71ff280408c2","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT4M9.0784171S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Job
+        Type":"Recovering to the original file share","RestoreDestination":"clitest000004/clitest-item000008/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:11:51.4002748Z","activityId":"047818ac-3beb-11ee-a5d8-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1095'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:16:00 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '138'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/d93ef18b-60ce-4ed0-90be-71ff280408c2?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/d93ef18b-60ce-4ed0-90be-71ff280408c2","name":"d93ef18b-60ce-4ed0-90be-71ff280408c2","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT4M39.5879741S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Job
+        Type":"Recovering to the original file share","RestoreDestination":"clitest000004/clitest-item000008/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:11:51.4002748Z","activityId":"047818ac-3beb-11ee-a5d8-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1096'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:16:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '137'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/d93ef18b-60ce-4ed0-90be-71ff280408c2?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/d93ef18b-60ce-4ed0-90be-71ff280408c2","name":"d93ef18b-60ce-4ed0-90be-71ff280408c2","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT5M3.4433919S","errorDetails":[{"errorCode":1073871825,"errorString":"Microsoft
+        Azure Backup encountered an internal error.","recommendations":["Wait for
+        a few minutes and then try the operation again. If the issue persists, please
+        contact Microsoft support."]}],"storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","RestoreRecoveryPointTime":"8/16/2023
+        3:48:24 AM","Job Type":"Recovering to the original file share","RestoreDestination":"clitest000004/clitest-item000008/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"Failed","startTime":"2023-08-16T04:11:51.4002748Z","endTime":"2023-08-16T04:16:54.8436667Z","activityId":"047818ac-3beb-11ee-a5d8-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1430'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:17:00 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '136'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -6331,32 +8640,36 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/9a7f522f-0ba6-4b6d-9dc1-c5d818357d1e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/d93ef18b-60ce-4ed0-90be-71ff280408c2?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/9a7f522f-0ba6-4b6d-9dc1-c5d818357d1e","name":"9a7f522f-0ba6-4b6d-9dc1-c5d818357d1e","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT32.3917577S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","RestoreRecoveryPointTime":"5/17/2023
-        12:09:53 PM","Job Type":"Recovering to the original file share","RestoreDestination":"clitest000003/clitest-item000007/","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"1","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"Completed","startTime":"2023-05-17T12:30:32.0096421Z","endTime":"2023-05-17T12:31:04.4013998Z","activityId":"99ed5d78-f4ae-11ed-b708-c8f750f92764"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/d93ef18b-60ce-4ed0-90be-71ff280408c2","name":"d93ef18b-60ce-4ed0-90be-71ff280408c2","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT5M3.4433919S","errorDetails":[{"errorCode":1073871825,"errorString":"Microsoft
+        Azure Backup encountered an internal error.","recommendations":["Wait for
+        a few minutes and then try the operation again. If the issue persists, please
+        contact Microsoft support."]}],"storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","RestoreRecoveryPointTime":"8/16/2023
+        3:48:24 AM","Job Type":"Recovering to the original file share","RestoreDestination":"clitest000004/clitest-item000008/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"Failed","startTime":"2023-08-16T04:11:51.4002748Z","endTime":"2023-08-16T04:16:54.8436667Z","activityId":"047818ac-3beb-11ee-a5d8-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1185'
+      - '1430'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:31:36 GMT
+      - Wed, 16 Aug 2023 04:17:32 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -6366,7 +8679,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '117'
+      - '135'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -6385,28 +8700,28 @@ interactions:
       - -g -v -c -i -r --resolve-conflict --restore-mode --source-file-type --source-file-path
         --target-storage-account --target-file-share --target-folder
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+itemType+eq+%27AzureFileShare%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+itemType+eq+%27AzureFileShare%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;cdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c","name":"AzureFileShare;cdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000007","protectionStatus":"Healthy","protectionState":"Protected","lastBackupStatus":"Completed","lastBackupTime":"2023-05-17T12:09:50.1007757Z","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000008","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000004/protectedItems/AzureFileShare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e","name":"AzureFileShare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000008","protectionStatus":"Healthy","protectionState":"Protected","lastBackupStatus":"Completed","lastBackupTime":"2023-08-16T03:48:22.6102845Z","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000004","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000004","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupPolicies/clitest-item000009","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '1526'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:31:37 GMT
+      - Wed, 16 Aug 2023 04:17:34 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -6416,7 +8731,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '297'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -6435,12 +8752,13 @@ interactions:
       - -g -v -c -i -r --resolve-conflict --restore-mode --source-file-type --source-file-path
         --target-storage-account --target-file-share --target-folder
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ClassicStorage/storageAccounts/clitest000003?api-version=2015-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ClassicStorage/storageAccounts/clitest000004?api-version=2015-12-01
   response:
     body:
-      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.ClassicStorage/storageAccounts/clitest000003''
+      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.ClassicStorage/storageAccounts/clitest000004''
         under resource group ''clitest.rg000001'' was not found. For more details
         please go to https://aka.ms/ARMResourceNotFoundFix"}}'
     headers:
@@ -6451,7 +8769,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:31:38 GMT
+      - Wed, 16 Aug 2023 04:17:35 GMT
       expires:
       - '-1'
       pragma:
@@ -6480,21 +8798,22 @@ interactions:
       - -g -v -c -i -r --resolve-conflict --restore-mode --source-file-type --source-file-path
         --target-storage-account --target-file-share --target-folder
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004?api-version=2016-01-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","name":"clitest000003","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2023-05-17T12:08:01.7487432Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-05-17T12:08:01.2018473Z","primaryEndpoints":{"blob":"https://clitest000003.blob.core.windows.net/","queue":"https://clitest000003.queue.core.windows.net/","table":"https://clitest000003.table.core.windows.net/","file":"https://clitest000003.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004","name":"clitest000004","type":"Microsoft.Storage/storageAccounts","location":"centraluseuap","tags":{},"properties":{"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2023-08-16T03:45:38.8855125Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-08-16T03:45:38.5261630Z","primaryEndpoints":{"blob":"https://clitest000004.blob.core.windows.net/","queue":"https://clitest000004.queue.core.windows.net/","table":"https://clitest000004.table.core.windows.net/","file":"https://clitest000004.file.core.windows.net/"},"primaryLocation":"centraluseuap","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '845'
+      - '849'
       content-type:
       - application/json
       date:
-      - Wed, 17 May 2023 12:31:39 GMT
+      - Wed, 16 Aug 2023 04:17:35 GMT
       expires:
       - '-1'
       pragma:
@@ -6527,12 +8846,13 @@ interactions:
       - -g -v -c -i -r --resolve-conflict --restore-mode --source-file-type --source-file-path
         --target-storage-account --target-file-share --target-folder
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ClassicStorage/storageAccounts/clitest000003?api-version=2015-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ClassicStorage/storageAccounts/clitest000004?api-version=2015-12-01
   response:
     body:
-      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.ClassicStorage/storageAccounts/clitest000003''
+      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.ClassicStorage/storageAccounts/clitest000004''
         under resource group ''clitest.rg000001'' was not found. For more details
         please go to https://aka.ms/ARMResourceNotFoundFix"}}'
     headers:
@@ -6543,7 +8863,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:31:40 GMT
+      - Wed, 16 Aug 2023 04:17:36 GMT
       expires:
       - '-1'
       pragma:
@@ -6572,21 +8892,22 @@ interactions:
       - -g -v -c -i -r --resolve-conflict --restore-mode --source-file-type --source-file-path
         --target-storage-account --target-file-share --target-folder
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004?api-version=2016-01-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","name":"clitest000003","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2023-05-17T12:08:01.7487432Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-05-17T12:08:01.2018473Z","primaryEndpoints":{"blob":"https://clitest000003.blob.core.windows.net/","queue":"https://clitest000003.queue.core.windows.net/","table":"https://clitest000003.table.core.windows.net/","file":"https://clitest000003.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004","name":"clitest000004","type":"Microsoft.Storage/storageAccounts","location":"centraluseuap","tags":{},"properties":{"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2023-08-16T03:45:38.8855125Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-08-16T03:45:38.5261630Z","primaryEndpoints":{"blob":"https://clitest000004.blob.core.windows.net/","queue":"https://clitest000004.queue.core.windows.net/","table":"https://clitest000004.table.core.windows.net/","file":"https://clitest000004.file.core.windows.net/"},"primaryLocation":"centraluseuap","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '845'
+      - '849'
       content-type:
       - application/json
       date:
-      - Wed, 17 May 2023 12:31:41 GMT
+      - Wed, 16 Aug 2023 04:17:36 GMT
       expires:
       - '-1'
       pragma:
@@ -6606,12 +8927,12 @@ interactions:
       message: OK
 - request:
     body: '{"properties": {"objectType": "AzureFileShareRestoreRequest", "recoveryType":
-      "AlternateLocation", "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003",
+      "AlternateLocation", "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004",
       "copyOptions": "Overwrite", "restoreRequestType": "ItemLevelRestore", "restoreFileSpecs":
-      [{"path": "clitest-file000005", "fileSpecType": "File", "targetFolderPath":
-      "folder1"}, {"path": "clitest-file000006", "fileSpecType": "File", "targetFolderPath":
-      "folder1"}], "targetDetails": {"name": "clitest-item000011", "targetResourceId":
-      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003"}}}'
+      [{"path": "clitest-file000006", "fileSpecType": "File", "targetFolderPath":
+      "folder1"}, {"path": "clitest-file000007", "fileSpecType": "File", "targetFolderPath":
+      "folder1"}], "targetDetails": {"name": "clitest-item000012", "targetResourceId":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004"}}}'
     headers:
       Accept:
       - application/json
@@ -6629,36 +8950,36 @@ interactions:
       - -g -v -c -i -r --resolve-conflict --restore-mode --source-file-type --source-file-path
         --target-storage-account --target-file-share --target-folder
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3Bcdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c/recoveryPoints/74080090672816/restore?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000004/protectedItems/AzureFileShare%3Ba999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e/recoveryPoints/386630283514636/restore?api-version=2023-02-01
   response:
     body:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;cdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c/operationsStatus/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000004/protectedItems/AzureFileShare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e/operationsStatus/aacfc3f8-58d7-42f8-8769-86fba8fd822c?api-version=2023-02-01
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:31:42 GMT
+      - Wed, 16 Aug 2023 04:17:38 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;cdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c/operationResults/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000004/protectedItems/AzureFileShare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e/operationResults/aacfc3f8-58d7-42f8-8769-86fba8fd822c?api-version=2023-02-01
       pragma:
       - no-cache
-      server:
-      - Kestrel
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
       - '1197'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 202
       message: Accepted
@@ -6677,28 +8998,28 @@ interactions:
       - -g -v -c -i -r --resolve-conflict --restore-mode --source-file-type --source-file-path
         --target-storage-account --target-file-share --target-folder
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupOperations/aacfc3f8-58d7-42f8-8769-86fba8fd822c?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","name":"7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","status":"Succeeded","startTime":"2023-05-17T12:31:42.4271924Z","endTime":"2023-05-17T12:31:42.4271924Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141"}}'
+      string: '{"id":"aacfc3f8-58d7-42f8-8769-86fba8fd822c","name":"aacfc3f8-58d7-42f8-8769-86fba8fd822c","status":"Succeeded","startTime":"2023-08-16T04:17:38.4409556Z","endTime":"2023-08-16T04:17:38.4409556Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"aacfc3f8-58d7-42f8-8769-86fba8fd822c"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '304'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:31:43 GMT
+      - Wed, 16 Aug 2023 04:17:39 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -6708,7 +9029,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '298'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -6727,33 +9050,34 @@ interactions:
       - -g -v -c -i -r --resolve-conflict --restore-mode --source-file-type --source-file-path
         --target-storage-account --target-file-share --target-folder
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/aacfc3f8-58d7-42f8-8769-86fba8fd822c?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","name":"7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT2.2773839S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/aacfc3f8-58d7-42f8-8769-86fba8fd822c","name":"aacfc3f8-58d7-42f8-8769-86fba8fd822c","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT2.8013133S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000012","Target Storage Account Name":"clitest000004","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/folder1","Data
         Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:31:42.4271924Z","activityId":"c33d68c2-f4ae-11ed-854a-c8f750f92764"}}'
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:17:38.4409556Z","activityId":"d28831ea-3beb-11ee-97e7-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '1189'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:31:44 GMT
+      - Wed, 16 Aug 2023 04:17:40 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -6763,7 +9087,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '116'
+      - '120'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -6781,789 +9107,34 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/aacfc3f8-58d7-42f8-8769-86fba8fd822c?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","name":"7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT2.9961426S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/aacfc3f8-58d7-42f8-8769-86fba8fd822c","name":"aacfc3f8-58d7-42f8-8769-86fba8fd822c","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT4.1406938S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000012","Target Storage Account Name":"clitest000004","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/folder1","Data
         Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:31:42.4271924Z","activityId":"c33d68c2-f4ae-11ed-854a-c8f750f92764"}}'
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:17:38.4409556Z","activityId":"d28831ea-3beb-11ee-97e7-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '1189'
       content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:31:45 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '148'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","name":"7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT3.5328535S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:31:42.4271924Z","activityId":"c33d68c2-f4ae-11ed-854a-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1189'
-      content-type:
-      - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:31:45 GMT
+      - Wed, 16 Aug 2023 04:17:42 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '147'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","name":"7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT34.0957572S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:31:42.4271924Z","activityId":"c33d68c2-f4ae-11ed-854a-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1190'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:32:15 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '146'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","name":"7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT1M4.6890934S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:31:42.4271924Z","activityId":"c33d68c2-f4ae-11ed-854a-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:32:46 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '145'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","name":"7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT1M35.2570381S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:31:42.4271924Z","activityId":"c33d68c2-f4ae-11ed-854a-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:33:17 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '144'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","name":"7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT2M5.8219426S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:31:42.4271924Z","activityId":"c33d68c2-f4ae-11ed-854a-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:33:48 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '143'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","name":"7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT2M36.3649156S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:31:42.4271924Z","activityId":"c33d68c2-f4ae-11ed-854a-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:34:18 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '142'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","name":"7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT3M6.9650703S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:31:42.4271924Z","activityId":"c33d68c2-f4ae-11ed-854a-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:34:49 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '141'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","name":"7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT3M37.5090209S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:31:42.4271924Z","activityId":"c33d68c2-f4ae-11ed-854a-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:35:19 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '140'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","name":"7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT4M8.0627402S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:31:42.4271924Z","activityId":"c33d68c2-f4ae-11ed-854a-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:35:50 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '139'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","name":"7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT4M38.6802669S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:31:42.4271924Z","activityId":"c33d68c2-f4ae-11ed-854a-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:36:20 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '138'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","name":"7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT5M9.317468S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:31:42.4271924Z","activityId":"c33d68c2-f4ae-11ed-854a-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1190'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:36:51 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '137'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","name":"7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT5M39.8574874S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:31:42.4271924Z","activityId":"c33d68c2-f4ae-11ed-854a-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:37:21 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '136'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","name":"7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT6M11.0640175S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:31:42.4271924Z","activityId":"c33d68c2-f4ae-11ed-854a-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:37:53 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '135'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","name":"7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT6M41.6074269S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:31:42.4271924Z","activityId":"c33d68c2-f4ae-11ed-854a-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1192'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:38:23 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -7574,6 +9145,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '134'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -7591,33 +9164,34 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/aacfc3f8-58d7-42f8-8769-86fba8fd822c?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","name":"7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT7M12.1909271S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/aacfc3f8-58d7-42f8-8769-86fba8fd822c","name":"aacfc3f8-58d7-42f8-8769-86fba8fd822c","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT4.7075204S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000012","Target Storage Account Name":"clitest000004","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/folder1","Data
         Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:31:42.4271924Z","activityId":"c33d68c2-f4ae-11ed-854a-c8f750f92764"}}'
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:17:38.4409556Z","activityId":"d28831ea-3beb-11ee-97e7-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1192'
+      - '1189'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:38:54 GMT
+      - Wed, 16 Aug 2023 04:17:42 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -7628,6 +9202,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '133'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -7645,33 +9221,34 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/aacfc3f8-58d7-42f8-8769-86fba8fd822c?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","name":"7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT7M42.7791163S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","Target
-        File Share Name":"clitest-item000011","Target Storage Account Name":"clitest000003","Job
-        Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/aacfc3f8-58d7-42f8-8769-86fba8fd822c","name":"aacfc3f8-58d7-42f8-8769-86fba8fd822c","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT35.1828127S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000012","Target Storage Account Name":"clitest000004","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/folder1","Data
         Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:31:42.4271924Z","activityId":"c33d68c2-f4ae-11ed-854a-c8f750f92764"}}'
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:17:38.4409556Z","activityId":"d28831ea-3beb-11ee-97e7-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1192'
+      - '1190'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:39:24 GMT
+      - Wed, 16 Aug 2023 04:18:13 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -7682,6 +9259,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '132'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -7699,36 +9278,34 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/aacfc3f8-58d7-42f8-8769-86fba8fd822c?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","name":"7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT8M4.3526869S","errorDetails":[{"errorCode":1073871825,"errorString":"Microsoft
-        Azure Backup encountered an internal error.","recommendations":["Wait for
-        a few minutes and then try the operation again. If the issue persists, please
-        contact Microsoft support."]}],"storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","RestoreRecoveryPointTime":"5/17/2023
-        12:09:53 PM","Target File Share Name":"clitest-item000011","Target Storage
-        Account Name":"clitest000003","Job Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/aacfc3f8-58d7-42f8-8769-86fba8fd822c","name":"aacfc3f8-58d7-42f8-8769-86fba8fd822c","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT1M5.7139184S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000012","Target Storage Account Name":"clitest000004","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/folder1","Data
         Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"Failed","startTime":"2023-05-17T12:31:42.4271924Z","endTime":"2023-05-17T12:39:46.7798793Z","activityId":"c33d68c2-f4ae-11ed-854a-c8f750f92764"}}'
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:17:38.4409556Z","activityId":"d28831ea-3beb-11ee-97e7-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1527'
+      - '1191'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:39:55 GMT
+      - Wed, 16 Aug 2023 04:18:44 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -7739,6 +9316,467 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '131'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/aacfc3f8-58d7-42f8-8769-86fba8fd822c?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/aacfc3f8-58d7-42f8-8769-86fba8fd822c","name":"aacfc3f8-58d7-42f8-8769-86fba8fd822c","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT1M36.2101222S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000012","Target Storage Account Name":"clitest000004","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/folder1","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:17:38.4409556Z","activityId":"d28831ea-3beb-11ee-97e7-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1192'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:19:14 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '130'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/aacfc3f8-58d7-42f8-8769-86fba8fd822c?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/aacfc3f8-58d7-42f8-8769-86fba8fd822c","name":"aacfc3f8-58d7-42f8-8769-86fba8fd822c","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT2M6.7423545S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000012","Target Storage Account Name":"clitest000004","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/folder1","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:17:38.4409556Z","activityId":"d28831ea-3beb-11ee-97e7-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1191'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:19:44 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '129'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/aacfc3f8-58d7-42f8-8769-86fba8fd822c?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/aacfc3f8-58d7-42f8-8769-86fba8fd822c","name":"aacfc3f8-58d7-42f8-8769-86fba8fd822c","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT2M37.3266239S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000012","Target Storage Account Name":"clitest000004","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/folder1","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:17:38.4409556Z","activityId":"d28831ea-3beb-11ee-97e7-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1192'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:20:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '128'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/aacfc3f8-58d7-42f8-8769-86fba8fd822c?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/aacfc3f8-58d7-42f8-8769-86fba8fd822c","name":"aacfc3f8-58d7-42f8-8769-86fba8fd822c","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT3M7.8654318S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000012","Target Storage Account Name":"clitest000004","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/folder1","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:17:38.4409556Z","activityId":"d28831ea-3beb-11ee-97e7-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1191'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:20:46 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '127'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/aacfc3f8-58d7-42f8-8769-86fba8fd822c?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/aacfc3f8-58d7-42f8-8769-86fba8fd822c","name":"aacfc3f8-58d7-42f8-8769-86fba8fd822c","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT3M38.3477977S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000012","Target Storage Account Name":"clitest000004","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/folder1","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:17:38.4409556Z","activityId":"d28831ea-3beb-11ee-97e7-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1192'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:21:16 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '126'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/aacfc3f8-58d7-42f8-8769-86fba8fd822c?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/aacfc3f8-58d7-42f8-8769-86fba8fd822c","name":"aacfc3f8-58d7-42f8-8769-86fba8fd822c","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT4M8.867605S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000012","Target Storage Account Name":"clitest000004","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/folder1","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:17:38.4409556Z","activityId":"d28831ea-3beb-11ee-97e7-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1190'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:21:46 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '125'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/aacfc3f8-58d7-42f8-8769-86fba8fd822c?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/aacfc3f8-58d7-42f8-8769-86fba8fd822c","name":"aacfc3f8-58d7-42f8-8769-86fba8fd822c","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT4M39.3563876S","storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","Target
+        File Share Name":"clitest-item000012","Target Storage Account Name":"clitest000004","Job
+        Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/folder1","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T04:17:38.4409556Z","activityId":"d28831ea-3beb-11ee-97e7-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1192'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:22:17 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '124'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/aacfc3f8-58d7-42f8-8769-86fba8fd822c?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/aacfc3f8-58d7-42f8-8769-86fba8fd822c","name":"aacfc3f8-58d7-42f8-8769-86fba8fd822c","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT5M3.2273901S","errorDetails":[{"errorCode":1073871825,"errorString":"Microsoft
+        Azure Backup encountered an internal error.","recommendations":["Wait for
+        a few minutes and then try the operation again. If the issue persists, please
+        contact Microsoft support."]}],"storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","RestoreRecoveryPointTime":"8/16/2023
+        3:48:24 AM","Target File Share Name":"clitest-item000012","Target Storage
+        Account Name":"clitest000004","Job Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/folder1","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"Failed","startTime":"2023-08-16T04:17:38.4409556Z","endTime":"2023-08-16T04:22:41.6683457Z","activityId":"d28831ea-3beb-11ee-97e7-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1526'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:22:47 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '123'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -7756,36 +9794,37 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/aacfc3f8-58d7-42f8-8769-86fba8fd822c?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","name":"7dcc8bc1-3c94-4d4b-bb46-4cc8e24cc141","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT8M4.3526869S","errorDetails":[{"errorCode":1073871825,"errorString":"Microsoft
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/aacfc3f8-58d7-42f8-8769-86fba8fd822c","name":"aacfc3f8-58d7-42f8-8769-86fba8fd822c","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT5M3.2273901S","errorDetails":[{"errorCode":1073871825,"errorString":"Microsoft
         Azure Backup encountered an internal error.","recommendations":["Wait for
         a few minutes and then try the operation again. If the issue persists, please
-        contact Microsoft support."]}],"storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000007","Source Storage Account Name":"clitest000003","RestoreRecoveryPointTime":"5/17/2023
-        12:09:53 PM","Target File Share Name":"clitest-item000011","Target Storage
-        Account Name":"clitest000003","Job Type":"Recover to an alternate file share","RestoreDestination":"clitest000003/clitest-item000011/folder1","Data
+        contact Microsoft support."]}],"storageAccountName":"clitest000004","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000008","Source Storage Account Name":"clitest000004","RestoreRecoveryPointTime":"8/16/2023
+        3:48:24 AM","Target File Share Name":"clitest-item000012","Target Storage
+        Account Name":"clitest000004","Job Type":"Recover to an alternate file share","RestoreDestination":"clitest000004/clitest-item000012/folder1","Data
         Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"Restore","status":"Failed","startTime":"2023-05-17T12:31:42.4271924Z","endTime":"2023-05-17T12:39:46.7798793Z","activityId":"c33d68c2-f4ae-11ed-854a-c8f750f92764"}}'
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"Restore","status":"Failed","startTime":"2023-08-16T04:17:38.4409556Z","endTime":"2023-08-16T04:22:41.6683457Z","activityId":"d28831ea-3beb-11ee-97e7-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1527'
+      - '1526'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:40:26 GMT
+      - Wed, 16 Aug 2023 04:23:19 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -7795,7 +9834,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '148'
+      - '122'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -7813,28 +9854,28 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --backup-management-type --delete-backup-data --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;cdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c","name":"AzureFileShare;cdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000007","protectionStatus":"Healthy","protectionState":"Protected","lastBackupStatus":"Completed","lastBackupTime":"2023-05-17T12:09:50.1007757Z","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000008","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000004/protectedItems/AzureFileShare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e","name":"AzureFileShare;a999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000008","protectionStatus":"Healthy","protectionState":"Protected","lastBackupStatus":"Completed","lastBackupTime":"2023-08-16T03:48:22.6102845Z","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000004","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000004","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupPolicies/clitest-item000009","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
       - '1526'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:40:28 GMT
+      - Wed, 16 Aug 2023 04:23:20 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -7845,6 +9886,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '297'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -7862,10 +9905,1320 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --backup-management-type --delete-backup-data --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupResourceGuardProxies?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupResourceGuardProxies?api-version=2023-02-01
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:23:21 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000004/protectedItems/AzureFileShare%3Ba999fc936adfa41f063f1d04501f90258e1d58d9dd4f997f228386fae6951f5e?api-version=2023-02-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupOperations/e333c838-3b36-44b7-9f13-2ecdff78601a?api-version=2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Wed, 16 Aug 2023 04:23:24 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupOperationResults/e333c838-3b36-44b7-9f13-2ecdff78601a?api-version=2023-02-01
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupOperations/e333c838-3b36-44b7-9f13-2ecdff78601a?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"e333c838-3b36-44b7-9f13-2ecdff78601a","name":"e333c838-3b36-44b7-9f13-2ecdff78601a","status":"InProgress","startTime":"2023-08-16T04:23:24.9245468Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:23:26 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '297'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupOperations/e333c838-3b36-44b7-9f13-2ecdff78601a?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"e333c838-3b36-44b7-9f13-2ecdff78601a","name":"e333c838-3b36-44b7-9f13-2ecdff78601a","status":"InProgress","startTime":"2023-08-16T04:23:24.9245468Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:23:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '296'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupOperations/e333c838-3b36-44b7-9f13-2ecdff78601a?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"e333c838-3b36-44b7-9f13-2ecdff78601a","name":"e333c838-3b36-44b7-9f13-2ecdff78601a","status":"InProgress","startTime":"2023-08-16T04:23:24.9245468Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:23:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '295'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupOperations/e333c838-3b36-44b7-9f13-2ecdff78601a?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"e333c838-3b36-44b7-9f13-2ecdff78601a","name":"e333c838-3b36-44b7-9f13-2ecdff78601a","status":"InProgress","startTime":"2023-08-16T04:23:24.9245468Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:23:42 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '294'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupOperations/e333c838-3b36-44b7-9f13-2ecdff78601a?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"e333c838-3b36-44b7-9f13-2ecdff78601a","name":"e333c838-3b36-44b7-9f13-2ecdff78601a","status":"Succeeded","startTime":"2023-08-16T04:23:24.9245468Z","endTime":"2023-08-16T04:23:24.9245468Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"6becd883-b712-4190-87fa-6f4045834312"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:23:48 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '293'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/6becd883-b712-4190-87fa-6f4045834312?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupJobs/6becd883-b712-4190-87fa-6f4045834312","name":"6becd883-b712-4190-87fa-6f4045834312","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT21.2452936S","storageAccountName":"clitest000004","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
+        Share Name":"clitest-item000008","Storage Account Name":"clitest000004"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000008","backupManagementType":"AzureStorage","operation":"DeleteBackupData","status":"Completed","startTime":"2023-08-16T04:23:24.9245468Z","endTime":"2023-08-16T04:23:46.1698404Z","activityId":"a13beec4-3bec-11ee-90ed-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '863'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:23:49 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '146'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+friendlyName+eq+%27clitest000004%27+and+status+eq+%27Registered%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004","name":"StorageContainer;Storage;clitest.rg000001;clitest000004","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000004","protectedItemCount":0,"acquireStorageAccountLock":"Acquire","friendlyName":"clitest000004","backupManagementType":"AzureStorage","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"StorageContainer","protectableObjectType":"StorageContainer"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '853'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:23:50 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '299'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000004?api-version=2023-02-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/operationsStatus/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Wed, 16 Aug 2023 04:23:52 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupOperationResults/f4032f3e-764b-4d02-be2e-f8e512d3d649?fabricName=Azure?api-version=2023-02-01
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000004/operationResults/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationsStatus/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:23:53 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationResults/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '292'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000004/operationResults/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationsStatus/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:23:58 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationResults/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '291'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000004/operationResults/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationsStatus/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:24:04 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationResults/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '290'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000004/operationResults/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationsStatus/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:24:10 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationResults/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '289'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000004/operationResults/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationsStatus/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:24:15 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationResults/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '288'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000004/operationResults/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationsStatus/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:24:21 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationResults/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '287'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000004/operationResults/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationsStatus/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:24:26 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationResults/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '286'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000004/operationResults/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationsStatus/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:24:31 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationResults/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '285'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000004/operationResults/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationsStatus/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:24:37 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationResults/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '284'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000004/operationResults/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationsStatus/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:24:42 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationResults/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '283'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000004/operationResults/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationsStatus/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:24:48 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationResults/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '282'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000004/operationResults/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationsStatus/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:24:54 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationResults/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '281'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000004/operationResults/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationsStatus/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:24:59 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationResults/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '280'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000004/operationResults/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationsStatus/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:25:05 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationResults/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '279'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000004/operationResults/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationsStatus/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:25:10 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000004/operationResults/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '278'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000004/operationResults/f4032f3e-764b-4d02-be2e-f8e512d3d649?api-version=2023-02-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      date:
+      - Wed, 16 Aug 2023 04:25:16 GMT
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '277'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - lock list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/locks?api-version=2016-09-01
   response:
     body:
       string: '{"value":[]}'
@@ -7877,19 +11230,17 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:40:29 GMT
+      - Wed, 16 Aug 2023 04:26:57 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
-      server:
-      - Kestrel
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
       - chunked
       vary:
-      - Accept-Encoding
+      - Accept-Encoding,Accept-Encoding
       x-content-type-options:
       - nosniff
     status:
@@ -7906,633 +11257,47 @@ interactions:
       - backup protection disable
       Connection:
       - keep-alive
-      Content-Length:
-      - '0'
       ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      - -g -v --container-name --item-name --backup-management-type --workload-type
+        --delete-backup-data --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3Bcdd84c8bb998c7743e013cbb191a31e1f38bfe7272d5d5293b758d983cc4b77c?api-version=2023-02-01
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/47760ce1-8ba5-4054-a16e-fe73f5ed3f26?api-version=2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Wed, 17 May 2023 12:40:30 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/47760ce1-8ba5-4054-a16e-fe73f5ed3f26?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-deletes:
-      - '14997'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/47760ce1-8ba5-4054-a16e-fe73f5ed3f26?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+itemType+eq+%27AzureFileShare%27
   response:
     body:
-      string: '{"id":"47760ce1-8ba5-4054-a16e-fe73f5ed3f26","name":"47760ce1-8ba5-4054-a16e-fe73f5ed3f26","status":"InProgress","startTime":"2023-05-17T12:40:30.8630465Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"value":[]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '12'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:40:31 GMT
+      - Wed, 16 Aug 2023 04:26:58 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
       - chunked
       vary:
       - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '293'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/47760ce1-8ba5-4054-a16e-fe73f5ed3f26?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"47760ce1-8ba5-4054-a16e-fe73f5ed3f26","name":"47760ce1-8ba5-4054-a16e-fe73f5ed3f26","status":"InProgress","startTime":"2023-05-17T12:40:30.8630465Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:40:37 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '292'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/47760ce1-8ba5-4054-a16e-fe73f5ed3f26?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"47760ce1-8ba5-4054-a16e-fe73f5ed3f26","name":"47760ce1-8ba5-4054-a16e-fe73f5ed3f26","status":"InProgress","startTime":"2023-05-17T12:40:30.8630465Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:40:43 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '291'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/47760ce1-8ba5-4054-a16e-fe73f5ed3f26?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"47760ce1-8ba5-4054-a16e-fe73f5ed3f26","name":"47760ce1-8ba5-4054-a16e-fe73f5ed3f26","status":"InProgress","startTime":"2023-05-17T12:40:30.8630465Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:40:48 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '290'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/47760ce1-8ba5-4054-a16e-fe73f5ed3f26?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"47760ce1-8ba5-4054-a16e-fe73f5ed3f26","name":"47760ce1-8ba5-4054-a16e-fe73f5ed3f26","status":"Succeeded","startTime":"2023-05-17T12:40:30.8630465Z","endTime":"2023-05-17T12:40:30.8630465Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"41cb6c78-f4be-4c42-8288-b09d9d257201"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:40:54 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '289'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/41cb6c78-f4be-4c42-8288-b09d9d257201?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/41cb6c78-f4be-4c42-8288-b09d9d257201","name":"41cb6c78-f4be-4c42-8288-b09d9d257201","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT21.0411068S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
-        Share Name":"clitest-item000007","Storage Account Name":"clitest000003"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000007","backupManagementType":"AzureStorage","operation":"DeleteBackupData","status":"Completed","startTime":"2023-05-17T12:40:30.8630465Z","endTime":"2023-05-17T12:40:51.9041533Z","activityId":"ff55020e-f4af-11ed-a25b-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '863'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:40:55 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '103'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container unregister
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c --yes --backup-management-type
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+friendlyName+eq+%27clitest000003%27+and+status+eq+%27Registered%27
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","protectedItemCount":0,"acquireStorageAccountLock":"Acquire","friendlyName":"clitest000003","backupManagementType":"AzureStorage","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"StorageContainer","protectableObjectType":"StorageContainer"}}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '853'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:40:57 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container unregister
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      ParameterSetName:
-      - -g -v -c --yes --backup-management-type
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003?api-version=2023-02-01
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/4e8d3b54-6710-440d-8107-c3875e5ae667?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Wed, 17 May 2023 12:40:57 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/4e8d3b54-6710-440d-8107-c3875e5ae667?fabricName=Azure?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-deletes:
-      - '14999'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container unregister
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c --yes --backup-management-type
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/4e8d3b54-6710-440d-8107-c3875e5ae667?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/4e8d3b54-6710-440d-8107-c3875e5ae667?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:41:00 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/4e8d3b54-6710-440d-8107-c3875e5ae667?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container unregister
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c --yes --backup-management-type
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/4e8d3b54-6710-440d-8107-c3875e5ae667?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/4e8d3b54-6710-440d-8107-c3875e5ae667?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:41:06 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/4e8d3b54-6710-440d-8107-c3875e5ae667?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container unregister
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c --yes --backup-management-type
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/4e8d3b54-6710-440d-8107-c3875e5ae667?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/4e8d3b54-6710-440d-8107-c3875e5ae667?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:41:11 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/4e8d3b54-6710-440d-8107-c3875e5ae667?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container unregister
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c --yes --backup-management-type
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/4e8d3b54-6710-440d-8107-c3875e5ae667?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/4e8d3b54-6710-440d-8107-c3875e5ae667?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:41:18 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/4e8d3b54-6710-440d-8107-c3875e5ae667?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '296'
+      x-powered-by:
+      - ASP.NET
     status:
-      code: 202
-      message: Accepted
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
@@ -8545,35 +11310,192 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -v -c --yes --backup-management-type
+      - --vault-name --resource-group --container-name --backup-management-type --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/4e8d3b54-6710-440d-8107-c3875e5ae667?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+friendlyName+eq+%27clitest000004%27+and+status+eq+%27Registered%27
   response:
     body:
-      string: ''
+      string: '{"value":[]}'
     headers:
       cache-control:
       - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json
       date:
-      - Wed, 17 May 2023 12:41:22 GMT
+      - Wed, 16 Aug 2023 04:26:59 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '295'
+      - '298'
+      x-powered-by:
+      - ASP.NET
     status:
-      code: 204
-      message: No Content
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup item list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupProtectedItems?api-version=2023-02-01
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:27:01 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '296'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - lock list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/locks?api-version=2016-09-01
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 04:27:02 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+status+eq+%27Registered%27
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Aug 2023 04:27:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '299'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
@@ -8588,10 +11510,10 @@ interactions:
       ParameterSetName:
       - --backup-management-type -v -g --query
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureIaasVM%27+and+status+eq+%27Registered%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureIaasVM%27+and+status+eq+%27Registered%27
   response:
     body:
       string: '{"value":[]}'
@@ -8601,15 +11523,15 @@ interactions:
       content-length:
       - '12'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Wed, 17 May 2023 12:43:04 GMT
+      - Wed, 16 Aug 2023 04:27:04 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       server:
-      - Kestrel
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -8620,6 +11542,8 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '297'
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -8639,9 +11563,10 @@ interactions:
       ParameterSetName:
       - -n -g --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000003?api-version=2023-02-01
   response:
     body:
       string: ''
@@ -8651,19 +11576,17 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:43:12 GMT
+      - Wed, 16 Aug 2023 04:27:10 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
-      server:
-      - Kestrel
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '48'
+      - '49'
     status:
       code: 200
       message: OK

--- a/src/azure-cli/azure/cli/command_modules/backup/tests/latest/recordings/test_afs_backup_rp.yaml
+++ b/src/azure-cli/azure/cli/command_modules/backup/tests/latest/recordings/test_afs_backup_rp.yaml
@@ -13,7 +13,8 @@ interactions:
       ParameterSetName:
       - -n -g --location
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2023-02-01
   response:
@@ -29,7 +30,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:06:47 GMT
+      - Wed, 16 Aug 2023 09:37:07 GMT
       expires:
       - '-1'
       pragma:
@@ -64,15 +65,16 @@ interactions:
       ParameterSetName:
       - -n -g --location
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2023-02-01
   response:
     body:
-      string: '{"location":"eastus2euap","name":"clitest-vault000002","etag":"W/\"datetime''2023-05-17T12%3A06%3A53.2855144Z''\"","properties":{"provisioningState":"Provisioning","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}},"publicNetworkAccess":"Enabled","restoreSettings":{"crossSubscriptionRestoreSettings":{"crossSubscriptionRestoreState":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+      string: '{"location":"eastus2euap","name":"clitest-vault000002","etag":"W/\"datetime''2023-08-16T09%3A37%3A08.4261964Z''\"","properties":{"provisioningState":"Provisioning","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}},"publicNetworkAccess":"Enabled","restoreSettings":{"crossSubscriptionRestoreSettings":{"crossSubscriptionRestoreState":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NztiOGI4YTc0Zi0xNDNjLTQ5OGItYWQ2YS03ZDZmZmNmZWFmZDM=?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0Nzs2N2UyOWE4ZC1lODZlLTRhODQtOTY2MC1jZTIyN2Y3NmEwMDE=?api-version=2023-02-01
       cache-control:
       - no-cache
       content-length:
@@ -80,7 +82,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:06:53 GMT
+      - Wed, 16 Aug 2023 09:37:08 GMT
       expires:
       - '-1'
       pragma:
@@ -91,6 +93,8 @@ interactions:
       - max-age=31536000; includeSubDomains
       x-content-type-options:
       - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=12f8ea5c-1212-449e-b31c-0a574f43076e/centraluseuap/6e512dbc-c22a-40db-be09-5dae7a303785
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '297'
     status:
@@ -110,17 +114,18 @@ interactions:
       ParameterSetName:
       - -n -g --location
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NztiOGI4YTc0Zi0xNDNjLTQ5OGItYWQ2YS03ZDZmZmNmZWFmZDM=?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0Nzs2N2UyOWE4ZC1lODZlLTRhODQtOTY2MC1jZTIyN2Y3NmEwMDE=?api-version=2023-02-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NztiOGI4YTc0Zi0xNDNjLTQ5OGItYWQ2YS03ZDZmZmNmZWFmZDM=\",\r\n
-        \ \"name\": \"MjA0NztiOGI4YTc0Zi0xNDNjLTQ5OGItYWQ2YS03ZDZmZmNmZWFmZDM=\",\r\n
-        \ \"status\": \"InProgress\"\r\n}"
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0Nzs2N2UyOWE4ZC1lODZlLTRhODQtOTY2MC1jZTIyN2Y3NmEwMDE=\"\
+        ,\r\n  \"name\": \"MjA0Nzs2N2UyOWE4ZC1lODZlLTRhODQtOTY2MC1jZTIyN2Y3NmEwMDE=\"\
+        ,\r\n  \"status\": \"InProgress\"\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NztiOGI4YTc0Zi0xNDNjLTQ5OGItYWQ2YS03ZDZmZmNmZWFmZDM=?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0Nzs2N2UyOWE4ZC1lODZlLTRhODQtOTY2MC1jZTIyN2Y3NmEwMDE=?api-version=2023-02-01
       cache-control:
       - no-cache
       content-length:
@@ -128,11 +133,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:06:54 GMT
+      - Wed, 16 Aug 2023 09:37:08 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationResults/MjA0NztiOGI4YTc0Zi0xNDNjLTQ5OGItYWQ2YS03ZDZmZmNmZWFmZDM=?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationResults/MjA0Nzs2N2UyOWE4ZC1lODZlLTRhODQtOTY2MC1jZTIyN2Y3NmEwMDE=?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -162,14 +167,68 @@ interactions:
       ParameterSetName:
       - -n -g --location
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NztiOGI4YTc0Zi0xNDNjLTQ5OGItYWQ2YS03ZDZmZmNmZWFmZDM=?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0Nzs2N2UyOWE4ZC1lODZlLTRhODQtOTY2MC1jZTIyN2Y3NmEwMDE=?api-version=2023-02-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NztiOGI4YTc0Zi0xNDNjLTQ5OGItYWQ2YS03ZDZmZmNmZWFmZDM=\",\r\n
-        \ \"name\": \"MjA0NztiOGI4YTc0Zi0xNDNjLTQ5OGItYWQ2YS03ZDZmZmNmZWFmZDM=\",\r\n
-        \ \"status\": \"Succeeded\"\r\n}"
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0Nzs2N2UyOWE4ZC1lODZlLTRhODQtOTY2MC1jZTIyN2Y3NmEwMDE=\"\
+        ,\r\n  \"name\": \"MjA0Nzs2N2UyOWE4ZC1lODZlLTRhODQtOTY2MC1jZTIyN2Y3NmEwMDE=\"\
+        ,\r\n  \"status\": \"InProgress\"\r\n}"
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0Nzs2N2UyOWE4ZC1lODZlLTRhODQtOTY2MC1jZTIyN2Y3NmEwMDE=?api-version=2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '334'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:38:09 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationResults/MjA0Nzs2N2UyOWE4ZC1lODZlLTRhODQtOTY2MC1jZTIyN2Y3NmEwMDE=?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --location
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0Nzs2N2UyOWE4ZC1lODZlLTRhODQtOTY2MC1jZTIyN2Y3NmEwMDE=?api-version=2023-02-01
+  response:
+    body:
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0Nzs2N2UyOWE4ZC1lODZlLTRhODQtOTY2MC1jZTIyN2Y3NmEwMDE=\"\
+        ,\r\n  \"name\": \"MjA0Nzs2N2UyOWE4ZC1lODZlLTRhODQtOTY2MC1jZTIyN2Y3NmEwMDE=\"\
+        ,\r\n  \"status\": \"Succeeded\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -178,7 +237,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:07:55 GMT
+      - Wed, 16 Aug 2023 09:39:09 GMT
       expires:
       - '-1'
       pragma:
@@ -210,21 +269,22 @@ interactions:
       ParameterSetName:
       - -n -g --location
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2023-02-01
   response:
     body:
-      string: '{"location":"eastus2euap","name":"clitest-vault000002","etag":"W/\"datetime''2023-05-17T12%3A06%3A56.7881382Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","backupStorageVersion":"Unassigned","monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}},"securitySettings":{"immutabilitySettings":null,"softDeleteSettings":{"softDeleteRetentionPeriodInDays":14,"softDeleteState":"Enabled"},"multiUserAuthorization":"Disabled"},"publicNetworkAccess":"Enabled","restoreSettings":{"crossSubscriptionRestoreSettings":{"crossSubscriptionRestoreState":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+      string: '{"location":"eastus2euap","name":"clitest-vault000002","etag":"W/\"datetime''2023-08-16T09%3A38%3A09.910351Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","backupStorageVersion":"Unassigned","monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}},"securitySettings":{"immutabilitySettings":null,"softDeleteSettings":{"softDeleteRetentionPeriodInDays":14,"softDeleteState":"Enabled"},"multiUserAuthorization":"Disabled"},"publicNetworkAccess":"Enabled","restoreSettings":{"crossSubscriptionRestoreSettings":{"crossSubscriptionRestoreState":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '962'
+      - '961'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:07:55 GMT
+      - Wed, 16 Aug 2023 09:39:09 GMT
       expires:
       - '-1'
       pragma:
@@ -239,6 +299,156 @@ interactions:
       - Accept-Encoding
       x-content-type-options:
       - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault backup-properties set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --soft-delete-feature-state
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupconfig/vaultconfig?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupconfig/vaultconfig","name":"vaultconfig","type":"Microsoft.RecoveryServices/vaults/backupconfig","properties":{"enhancedSecurityState":"Enabled","softDeleteFeatureState":"Enabled","softDeleteRetentionPeriodInDays":14,"isSoftDeleteFeatureStateEditable":true}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '419'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:39:11 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '298'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault backup-properties set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --soft-delete-feature-state
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupResourceGuardProxies?api-version=2023-02-01
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:39:12 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"enhancedSecurityState": "Enabled", "softDeleteFeatureState":
+      "Disabled"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault backup-properties set
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '90'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -n -g --soft-delete-feature-state
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: PATCH
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupconfig/vaultconfig?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupconfig/vaultconfig","name":"vaultconfig","type":"Microsoft.RecoveryServices/vaults/backupconfig","properties":{"enhancedSecurityState":"Enabled","softDeleteFeatureState":"Disabled","softDeleteRetentionPeriodInDays":14,"isSoftDeleteFeatureStateEditable":true}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '420'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:39:13 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1192'
     status:
       code: 200
       message: OK
@@ -258,12 +468,13 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-storage/21.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003/listKeys?api-version=2022-09-01&$expand=kerb
   response:
     body:
-      string: '{"keys":[{"creationTime":"2023-05-17T12:07:59.2955998Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2023-05-17T12:07:59.2955998Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
+      string: '{"keys":[{"creationTime":"2023-08-16T09:39:15.4564764Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2023-08-16T09:39:15.4564764Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
     headers:
       cache-control:
       - no-cache
@@ -272,7 +483,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 17 May 2023 12:08:22 GMT
+      - Wed, 16 Aug 2023 09:39:38 GMT
       expires:
       - '-1'
       pragma:
@@ -288,7 +499,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11994'
     status:
       code: 200
       message: OK
@@ -306,21 +517,22 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-storage/21.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","name":"clitest000003","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"keyCreationTime":{"key1":"2023-05-17T12:07:59.2955998Z","key2":"2023-05-17T12:07:59.2955998Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-05-17T12:07:59.7018446Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-05-17T12:07:59.7018446Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-05-17T12:07:59.2174656Z","primaryEndpoints":{"blob":"https://clitest000003.blob.core.windows.net/","queue":"https://clitest000003.queue.core.windows.net/","table":"https://clitest000003.table.core.windows.net/","file":"https://clitest000003.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","name":"clitest000003","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"keyCreationTime":{"key1":"2023-08-16T09:39:15.4564764Z","key2":"2023-08-16T09:39:15.4564764Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-08-16T09:39:15.8939714Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-08-16T09:39:15.8939714Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-08-16T09:39:15.3470958Z","primaryEndpoints":{"blob":"https://clitest000003.blob.core.windows.net/","queue":"https://clitest000003.queue.core.windows.net/","table":"https://clitest000003.table.core.windows.net/","file":"https://clitest000003.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1280'
+      - '1316'
       content-type:
       - application/json
       date:
-      - Wed, 17 May 2023 12:08:23 GMT
+      - Wed, 16 Aug 2023 09:39:39 GMT
       expires:
       - '-1'
       pragma:
@@ -354,9 +566,10 @@ interactions:
       ParameterSetName:
       - --name --quota --connection-string
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-storage-file-share/12.12.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-storage-file-share/12.12.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Wed, 17 May 2023 12:08:22 GMT
+      - Wed, 16 Aug 2023 09:39:40 GMT
       x-ms-share-quota:
       - '1'
       x-ms-version:
@@ -370,11 +583,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:08:24 GMT
+      - Wed, 16 Aug 2023 09:39:40 GMT
       etag:
-      - '"0x8DB56CF6A7F06AC"'
+      - '"0x8DB9E3CB70A48D4"'
       last-modified:
-      - Wed, 17 May 2023 12:08:24 GMT
+      - Wed, 16 Aug 2023 09:39:40 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
@@ -396,13 +609,13 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T19:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T19:30:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
@@ -411,7 +624,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:25 GMT
+      - Wed, 16 Aug 2023 09:39:44 GMT
       expires:
       - '-1'
       pragma:
@@ -427,16 +640,16 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '295'
     status:
       code: 200
       message: OK
 - request:
     body: '{"properties": {"protectedItemsCount": 0, "backupManagementType": "AzureStorage",
       "workLoadType": "AzureFileShare", "schedulePolicy": {"schedulePolicyType": "SimpleSchedulePolicy",
-      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2023-05-17T22:00:00.000Z"],
+      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2023-08-16T19:30:00.000Z"],
       "scheduleWeeklyFrequency": 0}, "retentionPolicy": {"retentionPolicyType": "LongTermRetentionPolicy",
-      "dailySchedule": {"retentionTimes": ["2023-05-17T22:00:00.000Z"], "retentionDuration":
+      "dailySchedule": {"retentionTimes": ["2023-08-16T19:30:00.000Z"], "retentionDuration":
       {"count": 30, "durationType": "Days"}}}, "timeZone": "UTC"}}'
     headers:
       Accept:
@@ -454,22 +667,22 @@ interactions:
       ParameterSetName:
       - -g -v --policy -n --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","name":"clitest-item000005","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","name":"clitest-item000005","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","workLoadType":"AzureFileShare","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T19:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T19:30:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '719'
+      - '751'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:26 GMT
+      - Wed, 16 Aug 2023 09:39:45 GMT
       expires:
       - '-1'
       pragma:
@@ -485,7 +698,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1191'
     status:
       code: 200
       message: OK
@@ -503,8 +716,8 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+status+eq+%27Registered%27
   response:
@@ -518,7 +731,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:28 GMT
+      - Wed, 16 Aug 2023 09:39:47 GMT
       expires:
       - '-1'
       pragma:
@@ -534,7 +747,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '296'
     status:
       code: 200
       message: OK
@@ -552,22 +765,22 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","name":"StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"adiguptecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/adigupt-ecy-rg/providers/Microsoft.Storage/storageAccounts/adiguptecy"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg2yfprhyqds;clitesttz6sdom2jatwnfac4","name":"StorageContainer;Storage;clitest.rg2yfprhyqds;clitesttz6sdom2jatwnfac4","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesttz6sdom2jatwnfac4","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg2yfprhyqds/providers/Microsoft.Storage/storageAccounts/clitesttz6sdom2jatwnfac4"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx;clitest5g7td7ozjqq2b6ccr","name":"StorageContainer;Storage;clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx;clitest5g7td7ozjqq2b6ccr","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest5g7td7ozjqq2b6ccr","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx/providers/Microsoft.Storage/storageAccounts/clitest5g7td7ozjqq2b6ccr"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","name":"StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontusebvtaksecycansa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DonotUse-Blobs-BVT-EACAN-RG/providers/Microsoft.Storage/storageAccounts/dontusebvtaksecycansa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","name":"StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"iaasextstoreecy1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.czr/providers/Microsoft.Storage/storageAccounts/iaasextstoreecy1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","name":"StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesaksdonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-clitest-rg/providers/Microsoft.Storage/storageAccounts/clitesaksdonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"bloboprestorecontainers","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/bloboprestorecontainers"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopall","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopall"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopcontainer","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopcontainer"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopprefix","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopprefix"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG;zubairsaecy","name":"StorageContainer;Storage;zubairRG;zubairsaecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Storage/storageAccounts/zubairsaecy"}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","name":"StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"adiguptecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/adigupt-ecy-rg/providers/Microsoft.Storage/storageAccounts/adiguptecy"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgxipdj2pzcf;clitesttgvhfd3jggjbyumfx","name":"StorageContainer;Storage;clitest.rgxipdj2pzcf;clitesttgvhfd3jggjbyumfx","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesttgvhfd3jggjbyumfx","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgxipdj2pzcf/providers/Microsoft.Storage/storageAccounts/clitesttgvhfd3jggjbyumfx"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","name":"StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontusebvtaksecycansa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DonotUse-Blobs-BVT-EACAN-RG/providers/Microsoft.Storage/storageAccounts/dontusebvtaksecycansa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","name":"StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"iaasextstoreecy1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.czr/providers/Microsoft.Storage/storageAccounts/iaasextstoreecy1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","name":"StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesaksdonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-clitest-rg/providers/Microsoft.Storage/storageAccounts/clitesaksdonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"bloboprestorecontainers","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/bloboprestorecontainers"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopall","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopall"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopcontainer","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopcontainer"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopprefix","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopprefix"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG2;zubairsaecy2","name":"StorageContainer;Storage;zubairRG2;zubairsaecy2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy2","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG2/providers/Microsoft.Storage/storageAccounts/zubairsaecy2"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG;zubairsaecy","name":"StorageContainer;Storage;zubairRG;zubairsaecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Storage/storageAccounts/zubairsaecy"}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '8530'
+      - '8284'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:28 GMT
+      - Wed, 16 Aug 2023 09:39:48 GMT
       expires:
       - '-1'
       pragma:
@@ -583,7 +796,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '297'
     status:
       code: 200
       message: OK
@@ -603,8 +816,8 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/refreshContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
@@ -612,17 +825,17 @@ interactions:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/f8555777-2850-4cc1-ae02-0eaf44c9091a?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/cc99558c-3a63-4902-bdab-53bc2e7068e8?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:08:30 GMT
+      - Wed, 16 Aug 2023 09:39:50 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/f8555777-2850-4cc1-ae02-0eaf44c9091a?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/cc99558c-3a63-4902-bdab-53bc2e7068e8?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -632,7 +845,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1196'
     status:
       code: 202
       message: Accepted
@@ -650,10 +863,10 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/f8555777-2850-4cc1-ae02-0eaf44c9091a?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/cc99558c-3a63-4902-bdab-53bc2e7068e8?api-version=2023-02-01
   response:
     body:
       string: ''
@@ -663,11 +876,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:08:30 GMT
+      - Wed, 16 Aug 2023 09:39:50 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/f8555777-2850-4cc1-ae02-0eaf44c9091a?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/cc99558c-3a63-4902-bdab-53bc2e7068e8?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -677,7 +890,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '290'
     status:
       code: 202
       message: Accepted
@@ -695,10 +908,10 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/f8555777-2850-4cc1-ae02-0eaf44c9091a?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/cc99558c-3a63-4902-bdab-53bc2e7068e8?api-version=2023-02-01
   response:
     body:
       string: ''
@@ -708,11 +921,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:08:35 GMT
+      - Wed, 16 Aug 2023 09:39:56 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/f8555777-2850-4cc1-ae02-0eaf44c9091a?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/cc99558c-3a63-4902-bdab-53bc2e7068e8?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -722,7 +935,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '289'
     status:
       code: 202
       message: Accepted
@@ -740,10 +953,10 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/f8555777-2850-4cc1-ae02-0eaf44c9091a?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/cc99558c-3a63-4902-bdab-53bc2e7068e8?api-version=2023-02-01
   response:
     body:
       string: ''
@@ -751,7 +964,7 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Wed, 17 May 2023 12:08:41 GMT
+      - Wed, 16 Aug 2023 09:40:01 GMT
       expires:
       - '-1'
       pragma:
@@ -763,7 +976,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
+      - '288'
     status:
       code: 204
       message: No Content
@@ -781,22 +994,22 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","name":"StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"adiguptecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/adigupt-ecy-rg/providers/Microsoft.Storage/storageAccounts/adiguptecy"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg2yfprhyqds;clitesttz6sdom2jatwnfac4","name":"StorageContainer;Storage;clitest.rg2yfprhyqds;clitesttz6sdom2jatwnfac4","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesttz6sdom2jatwnfac4","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg2yfprhyqds/providers/Microsoft.Storage/storageAccounts/clitesttz6sdom2jatwnfac4"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx;clitest5g7td7ozjqq2b6ccr","name":"StorageContainer;Storage;clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx;clitest5g7td7ozjqq2b6ccr","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest5g7td7ozjqq2b6ccr","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx/providers/Microsoft.Storage/storageAccounts/clitest5g7td7ozjqq2b6ccr"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest000003","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgnvoelwrvnb;clitestw62rrt6h5fidon2vw","name":"StorageContainer;Storage;clitest.rgnvoelwrvnb;clitestw62rrt6h5fidon2vw","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestw62rrt6h5fidon2vw","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgnvoelwrvnb/providers/Microsoft.Storage/storageAccounts/clitestw62rrt6h5fidon2vw"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgt7y3m2jxoj;clitest4ok6wrvjr5q6texyd","name":"StorageContainer;Storage;clitest.rgt7y3m2jxoj;clitest4ok6wrvjr5q6texyd","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest4ok6wrvjr5q6texyd","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgt7y3m2jxoj/providers/Microsoft.Storage/storageAccounts/clitest4ok6wrvjr5q6texyd"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","name":"StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontusebvtaksecycansa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DonotUse-Blobs-BVT-EACAN-RG/providers/Microsoft.Storage/storageAccounts/dontusebvtaksecycansa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","name":"StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"iaasextstoreecy1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.czr/providers/Microsoft.Storage/storageAccounts/iaasextstoreecy1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","name":"StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesaksdonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-clitest-rg/providers/Microsoft.Storage/storageAccounts/clitesaksdonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"bloboprestorecontainers","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/bloboprestorecontainers"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopall","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopall"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopcontainer","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopcontainer"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopprefix","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopprefix"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG;zubairsaecy","name":"StorageContainer;Storage;zubairRG;zubairsaecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Storage/storageAccounts/zubairsaecy"}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","name":"StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"adiguptecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/adigupt-ecy-rg/providers/Microsoft.Storage/storageAccounts/adiguptecy"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest000003","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgxipdj2pzcf;clitesttgvhfd3jggjbyumfx","name":"StorageContainer;Storage;clitest.rgxipdj2pzcf;clitesttgvhfd3jggjbyumfx","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesttgvhfd3jggjbyumfx","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgxipdj2pzcf/providers/Microsoft.Storage/storageAccounts/clitesttgvhfd3jggjbyumfx"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","name":"StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontusebvtaksecycansa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DonotUse-Blobs-BVT-EACAN-RG/providers/Microsoft.Storage/storageAccounts/dontusebvtaksecycansa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","name":"StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"iaasextstoreecy1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.czr/providers/Microsoft.Storage/storageAccounts/iaasextstoreecy1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","name":"StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesaksdonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-clitest-rg/providers/Microsoft.Storage/storageAccounts/clitesaksdonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"bloboprestorecontainers","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/bloboprestorecontainers"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopall","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopall"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopcontainer","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopcontainer"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopprefix","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopprefix"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG2;zubairsaecy2","name":"StorageContainer;Storage;zubairRG2;zubairsaecy2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy2","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG2/providers/Microsoft.Storage/storageAccounts/zubairsaecy2"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG;zubairsaecy","name":"StorageContainer;Storage;zubairRG;zubairsaecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Storage/storageAccounts/zubairsaecy"}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '10778'
+      - '8996'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:42 GMT
+      - Wed, 16 Aug 2023 09:40:03 GMT
       expires:
       - '-1'
       pragma:
@@ -812,7 +1025,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '296'
     status:
       code: 200
       message: OK
@@ -835,8 +1048,8 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003?api-version=2023-02-01
   response:
@@ -844,7 +1057,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/46f95b64-a7d2-44f2-bb95-5f1cc84c696c?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/c28aa247-b58a-4fc2-b6fb-4ff8b59440e0?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -852,11 +1065,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:43 GMT
+      - Wed, 16 Aug 2023 09:40:04 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/46f95b64-a7d2-44f2-bb95-5f1cc84c696c?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/c28aa247-b58a-4fc2-b6fb-4ff8b59440e0?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -866,7 +1079,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1193'
     status:
       code: 202
       message: Accepted
@@ -884,16 +1097,16 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/46f95b64-a7d2-44f2-bb95-5f1cc84c696c?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/c28aa247-b58a-4fc2-b6fb-4ff8b59440e0?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/46f95b64-a7d2-44f2-bb95-5f1cc84c696c?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/c28aa247-b58a-4fc2-b6fb-4ff8b59440e0?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -901,11 +1114,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:43 GMT
+      - Wed, 16 Aug 2023 09:40:05 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/46f95b64-a7d2-44f2-bb95-5f1cc84c696c?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/c28aa247-b58a-4fc2-b6fb-4ff8b59440e0?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -915,7 +1128,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '276'
     status:
       code: 202
       message: Accepted
@@ -933,16 +1146,16 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/46f95b64-a7d2-44f2-bb95-5f1cc84c696c?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/c28aa247-b58a-4fc2-b6fb-4ff8b59440e0?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/46f95b64-a7d2-44f2-bb95-5f1cc84c696c?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/c28aa247-b58a-4fc2-b6fb-4ff8b59440e0?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -950,11 +1163,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:49 GMT
+      - Wed, 16 Aug 2023 09:40:10 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/46f95b64-a7d2-44f2-bb95-5f1cc84c696c?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/c28aa247-b58a-4fc2-b6fb-4ff8b59440e0?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -964,7 +1177,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '275'
     status:
       code: 202
       message: Accepted
@@ -982,16 +1195,16 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/46f95b64-a7d2-44f2-bb95-5f1cc84c696c?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/c28aa247-b58a-4fc2-b6fb-4ff8b59440e0?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/46f95b64-a7d2-44f2-bb95-5f1cc84c696c?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/c28aa247-b58a-4fc2-b6fb-4ff8b59440e0?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -999,11 +1212,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:55 GMT
+      - Wed, 16 Aug 2023 09:40:15 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/46f95b64-a7d2-44f2-bb95-5f1cc84c696c?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/c28aa247-b58a-4fc2-b6fb-4ff8b59440e0?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -1013,7 +1226,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
+      - '274'
     status:
       code: 202
       message: Accepted
@@ -1031,16 +1244,16 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/46f95b64-a7d2-44f2-bb95-5f1cc84c696c?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/c28aa247-b58a-4fc2-b6fb-4ff8b59440e0?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/46f95b64-a7d2-44f2-bb95-5f1cc84c696c?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/c28aa247-b58a-4fc2-b6fb-4ff8b59440e0?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -1048,11 +1261,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:09:00 GMT
+      - Wed, 16 Aug 2023 09:40:21 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/46f95b64-a7d2-44f2-bb95-5f1cc84c696c?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/c28aa247-b58a-4fc2-b6fb-4ff8b59440e0?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -1062,7 +1275,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '296'
+      - '273'
     status:
       code: 202
       message: Accepted
@@ -1080,10 +1293,157 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/46f95b64-a7d2-44f2-bb95-5f1cc84c696c?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/c28aa247-b58a-4fc2-b6fb-4ff8b59440e0?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/c28aa247-b58a-4fc2-b6fb-4ff8b59440e0?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:40:27 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/c28aa247-b58a-4fc2-b6fb-4ff8b59440e0?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '272'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/c28aa247-b58a-4fc2-b6fb-4ff8b59440e0?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/c28aa247-b58a-4fc2-b6fb-4ff8b59440e0?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:40:32 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/c28aa247-b58a-4fc2-b6fb-4ff8b59440e0?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '271'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/c28aa247-b58a-4fc2-b6fb-4ff8b59440e0?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/c28aa247-b58a-4fc2-b6fb-4ff8b59440e0?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:40:37 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/c28aa247-b58a-4fc2-b6fb-4ff8b59440e0?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '270'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/c28aa247-b58a-4fc2-b6fb-4ff8b59440e0?api-version=2023-02-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","protectedItemCount":0,"acquireStorageAccountLock":"Acquire","friendlyName":"clitest000003","backupManagementType":"AzureStorage","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"StorageContainer","protectableObjectType":"StorageContainer"}}'
@@ -1095,7 +1455,244 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:09:06 GMT
+      - Wed, 16 Aug 2023 09:40:43 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '269'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectableItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+workloadType+eq+%27AzureFileShare%27
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:40:44 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '299'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/inquire?api-version=2023-02-01&%24filter=workloadType+eq+%27AzureFileShare%27
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/b945a974-cf1a-40cf-9960-e59a54c0de3d?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Wed, 16 Aug 2023 09:40:45 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/b945a974-cf1a-40cf-9960-e59a54c0de3d?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1195'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/b945a974-cf1a-40cf-9960-e59a54c0de3d?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/b945a974-cf1a-40cf-9960-e59a54c0de3d?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:40:46 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/b945a974-cf1a-40cf-9960-e59a54c0de3d?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '268'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/b945a974-cf1a-40cf-9960-e59a54c0de3d?api-version=2023-02-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      date:
+      - Wed, 16 Aug 2023 09:40:52 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '267'
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectableItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+workloadType+eq+%27AzureFileShare%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectableItems/azurefileshare;3b14ddb143df1d7e9bebab6ba55755d6637983c3b936aa9a521e6e2a02e70e53","name":"azurefileshare;3b14ddb143df1d7e9bebab6ba55755d6637983c3b936aa9a521e6e2a02e70e53","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"parentContainerFabricId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","parentContainerFriendlyName":"clitest000003","azureFileShareType":"XSMB","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","protectableItemType":"AzureFileShare","friendlyName":"clitest-item000004","protectionState":"NotProtected"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '983'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:40:53 GMT
       expires:
       - '-1'
       pragma:
@@ -1129,71 +1726,22 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectableItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+workloadType+eq+%27AzureFileShare%27
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectableItems/azurefileshare;1cfa4ad17c1d2105e185d0662029b51a3977be6d19084f87e396af8a7fd7db29","name":"azurefileshare;1cfa4ad17c1d2105e185d0662029b51a3977be6d19084f87e396af8a7fd7db29","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"parentContainerFabricId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","parentContainerFriendlyName":"clitest000003","azureFileShareType":"XSMB","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","protectableItemType":"AzureFileShare","friendlyName":"clitest-item000004","protectionState":"NotProtected"}}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '983'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:07 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","name":"clitest-item000005","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","name":"clitest-item000005","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","workLoadType":"AzureFileShare","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T19:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T19:30:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '719'
+      - '751'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:09:07 GMT
+      - Wed, 16 Aug 2023 09:40:54 GMT
       expires:
       - '-1'
       pragma:
@@ -1209,7 +1757,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '295'
     status:
       code: 200
       message: OK
@@ -1233,26 +1781,26 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/azurefileshare%3B1cfa4ad17c1d2105e185d0662029b51a3977be6d19084f87e396af8a7fd7db29?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/azurefileshare%3B3b14ddb143df1d7e9bebab6ba55755d6637983c3b936aa9a521e6e2a02e70e53?api-version=2023-02-01
   response:
     body:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectedItems/azurefileshare;1cfa4ad17c1d2105e185d0662029b51a3977be6d19084f87e396af8a7fd7db29/operationsStatus/2a6ddf30-0cee-40a1-96ba-1877c284a217?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectedItems/azurefileshare;3b14ddb143df1d7e9bebab6ba55755d6637983c3b936aa9a521e6e2a02e70e53/operationsStatus/d7977b78-e4f8-4625-8806-fb36d5ad1312?api-version=2023-02-01
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:09:08 GMT
+      - Wed, 16 Aug 2023 09:40:55 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectedItems/azurefileshare;1cfa4ad17c1d2105e185d0662029b51a3977be6d19084f87e396af8a7fd7db29/operationResults/2a6ddf30-0cee-40a1-96ba-1877c284a217?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectedItems/azurefileshare;3b14ddb143df1d7e9bebab6ba55755d6637983c3b936aa9a521e6e2a02e70e53/operationResults/d7977b78-e4f8-4625-8806-fb36d5ad1312?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -1262,7 +1810,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1192'
     status:
       code: 202
       message: Accepted
@@ -1280,22 +1828,22 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/2a6ddf30-0cee-40a1-96ba-1877c284a217?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/d7977b78-e4f8-4625-8806-fb36d5ad1312?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"2a6ddf30-0cee-40a1-96ba-1877c284a217","name":"2a6ddf30-0cee-40a1-96ba-1877c284a217","status":"InProgress","startTime":"2023-05-17T12:09:09.126105Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"d7977b78-e4f8-4625-8806-fb36d5ad1312","name":"d7977b78-e4f8-4625-8806-fb36d5ad1312","status":"InProgress","startTime":"2023-08-16T09:40:56.2625534Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '187'
+      - '188'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:09:09 GMT
+      - Wed, 16 Aug 2023 09:40:56 GMT
       expires:
       - '-1'
       pragma:
@@ -1311,7 +1859,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '257'
     status:
       code: 200
       message: OK
@@ -1329,22 +1877,22 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/2a6ddf30-0cee-40a1-96ba-1877c284a217?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/d7977b78-e4f8-4625-8806-fb36d5ad1312?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"2a6ddf30-0cee-40a1-96ba-1877c284a217","name":"2a6ddf30-0cee-40a1-96ba-1877c284a217","status":"InProgress","startTime":"2023-05-17T12:09:09.126105Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"d7977b78-e4f8-4625-8806-fb36d5ad1312","name":"d7977b78-e4f8-4625-8806-fb36d5ad1312","status":"InProgress","startTime":"2023-08-16T09:40:56.2625534Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '187'
+      - '188'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:09:15 GMT
+      - Wed, 16 Aug 2023 09:41:02 GMT
       expires:
       - '-1'
       pragma:
@@ -1360,7 +1908,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '256'
     status:
       code: 200
       message: OK
@@ -1378,22 +1926,22 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/2a6ddf30-0cee-40a1-96ba-1877c284a217?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/d7977b78-e4f8-4625-8806-fb36d5ad1312?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"2a6ddf30-0cee-40a1-96ba-1877c284a217","name":"2a6ddf30-0cee-40a1-96ba-1877c284a217","status":"InProgress","startTime":"2023-05-17T12:09:09.126105Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"d7977b78-e4f8-4625-8806-fb36d5ad1312","name":"d7977b78-e4f8-4625-8806-fb36d5ad1312","status":"InProgress","startTime":"2023-08-16T09:40:56.2625534Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '187'
+      - '188'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:09:20 GMT
+      - Wed, 16 Aug 2023 09:41:07 GMT
       expires:
       - '-1'
       pragma:
@@ -1409,7 +1957,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '296'
+      - '255'
     status:
       code: 200
       message: OK
@@ -1427,22 +1975,22 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/2a6ddf30-0cee-40a1-96ba-1877c284a217?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/d7977b78-e4f8-4625-8806-fb36d5ad1312?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"2a6ddf30-0cee-40a1-96ba-1877c284a217","name":"2a6ddf30-0cee-40a1-96ba-1877c284a217","status":"InProgress","startTime":"2023-05-17T12:09:09.126105Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"d7977b78-e4f8-4625-8806-fb36d5ad1312","name":"d7977b78-e4f8-4625-8806-fb36d5ad1312","status":"InProgress","startTime":"2023-08-16T09:40:56.2625534Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '187'
+      - '188'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:09:26 GMT
+      - Wed, 16 Aug 2023 09:41:13 GMT
       expires:
       - '-1'
       pragma:
@@ -1458,7 +2006,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '295'
+      - '254'
     status:
       code: 200
       message: OK
@@ -1476,22 +2024,22 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/2a6ddf30-0cee-40a1-96ba-1877c284a217?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/d7977b78-e4f8-4625-8806-fb36d5ad1312?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"2a6ddf30-0cee-40a1-96ba-1877c284a217","name":"2a6ddf30-0cee-40a1-96ba-1877c284a217","status":"InProgress","startTime":"2023-05-17T12:09:09.126105Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"d7977b78-e4f8-4625-8806-fb36d5ad1312","name":"d7977b78-e4f8-4625-8806-fb36d5ad1312","status":"InProgress","startTime":"2023-08-16T09:40:56.2625534Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '187'
+      - '188'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:09:31 GMT
+      - Wed, 16 Aug 2023 09:41:19 GMT
       expires:
       - '-1'
       pragma:
@@ -1507,7 +2055,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '293'
+      - '253'
     status:
       code: 200
       message: OK
@@ -1525,22 +2073,22 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/2a6ddf30-0cee-40a1-96ba-1877c284a217?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/d7977b78-e4f8-4625-8806-fb36d5ad1312?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"2a6ddf30-0cee-40a1-96ba-1877c284a217","name":"2a6ddf30-0cee-40a1-96ba-1877c284a217","status":"InProgress","startTime":"2023-05-17T12:09:09.126105Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"d7977b78-e4f8-4625-8806-fb36d5ad1312","name":"d7977b78-e4f8-4625-8806-fb36d5ad1312","status":"InProgress","startTime":"2023-08-16T09:40:56.2625534Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '187'
+      - '188'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:09:37 GMT
+      - Wed, 16 Aug 2023 09:41:24 GMT
       expires:
       - '-1'
       pragma:
@@ -1556,7 +2104,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '291'
+      - '252'
     status:
       code: 200
       message: OK
@@ -1574,22 +2122,22 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/2a6ddf30-0cee-40a1-96ba-1877c284a217?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/d7977b78-e4f8-4625-8806-fb36d5ad1312?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"2a6ddf30-0cee-40a1-96ba-1877c284a217","name":"2a6ddf30-0cee-40a1-96ba-1877c284a217","status":"InProgress","startTime":"2023-05-17T12:09:09.126105Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"d7977b78-e4f8-4625-8806-fb36d5ad1312","name":"d7977b78-e4f8-4625-8806-fb36d5ad1312","status":"InProgress","startTime":"2023-08-16T09:40:56.2625534Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '187'
+      - '188'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:09:43 GMT
+      - Wed, 16 Aug 2023 09:41:29 GMT
       expires:
       - '-1'
       pragma:
@@ -1605,7 +2153,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '289'
+      - '251'
     status:
       code: 200
       message: OK
@@ -1623,22 +2171,22 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/2a6ddf30-0cee-40a1-96ba-1877c284a217?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/d7977b78-e4f8-4625-8806-fb36d5ad1312?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"2a6ddf30-0cee-40a1-96ba-1877c284a217","name":"2a6ddf30-0cee-40a1-96ba-1877c284a217","status":"InProgress","startTime":"2023-05-17T12:09:09.126105Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"d7977b78-e4f8-4625-8806-fb36d5ad1312","name":"d7977b78-e4f8-4625-8806-fb36d5ad1312","status":"InProgress","startTime":"2023-08-16T09:40:56.2625534Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '187'
+      - '188'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:09:48 GMT
+      - Wed, 16 Aug 2023 09:41:35 GMT
       expires:
       - '-1'
       pragma:
@@ -1654,7 +2202,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '287'
+      - '250'
     status:
       code: 200
       message: OK
@@ -1672,214 +2220,13 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/2a6ddf30-0cee-40a1-96ba-1877c284a217?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/d7977b78-e4f8-4625-8806-fb36d5ad1312?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"2a6ddf30-0cee-40a1-96ba-1877c284a217","name":"2a6ddf30-0cee-40a1-96ba-1877c284a217","status":"Succeeded","startTime":"2023-05-17T12:09:09.126105Z","endTime":"2023-05-17T12:09:09.126105Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"ee7ee694-421e-451d-b26d-fca10331d41b"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '302'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:53 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '285'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/ee7ee694-421e-451d-b26d-fca10331d41b?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/ee7ee694-421e-451d-b26d-fca10331d41b","name":"ee7ee694-421e-451d-b26d-fca10331d41b","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT41.337438S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
-        Share Name":"clitest-item000004","Storage Account Name":"clitest000003","Policy
-        Name":"clitest-item000005"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"ConfigureBackup","status":"Completed","startTime":"2023-05-17T12:09:09.126105Z","endTime":"2023-05-17T12:09:50.463543Z","activityId":"8708241b-f4ab-11ed-bb9d-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '894'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:54 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '149'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection backup-now
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -i -c --backup-management-type --retain-until --query
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;1cfa4ad17c1d2105e185d0662029b51a3977be6d19084f87e396af8a7fd7db29","name":"AzureFileShare;1cfa4ad17c1d2105e185d0662029b51a3977be6d19084f87e396af8a7fd7db29","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1478'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:55 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"objectType": "AzureFileShareBackupRequest", "recoveryPointExpiryTimeInUTC":
-      "2023-06-16T00:00:00.000Z"}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection backup-now
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '121'
-      Content-Type:
-      - application/json
-      ParameterSetName:
-      - -g -v -i -c --backup-management-type --retain-until --query
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3B1cfa4ad17c1d2105e185d0662029b51a3977be6d19084f87e396af8a7fd7db29/backup?api-version=2023-02-01
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;1cfa4ad17c1d2105e185d0662029b51a3977be6d19084f87e396af8a7fd7db29/operationsStatus/1f2ef9a9-dcc1-4803-b183-bfb2e41a3be1?api-version=2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Wed, 17 May 2023 12:09:56 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;1cfa4ad17c1d2105e185d0662029b51a3977be6d19084f87e396af8a7fd7db29/operationResults/1f2ef9a9-dcc1-4803-b183-bfb2e41a3be1?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection backup-now
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -i -c --backup-management-type --retain-until --query
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/1f2ef9a9-dcc1-4803-b183-bfb2e41a3be1?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"1f2ef9a9-dcc1-4803-b183-bfb2e41a3be1","name":"1f2ef9a9-dcc1-4803-b183-bfb2e41a3be1","status":"Succeeded","startTime":"2023-05-17T12:09:56.5117403Z","endTime":"2023-05-17T12:09:56.5117403Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"1fb1564d-c381-47ee-967c-ffe9ee4e3504"}}'
+      string: '{"id":"d7977b78-e4f8-4625-8806-fb36d5ad1312","name":"d7977b78-e4f8-4625-8806-fb36d5ad1312","status":"Succeeded","startTime":"2023-08-16T09:40:56.2625534Z","endTime":"2023-08-16T09:40:56.2625534Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"5144d0a8-320f-4152-b13c-bb04d1bfd433"}}'
     headers:
       cache-control:
       - no-cache
@@ -1888,7 +2235,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:09:57 GMT
+      - Wed, 16 Aug 2023 09:41:41 GMT
       expires:
       - '-1'
       pragma:
@@ -1904,7 +2251,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '249'
     status:
       code: 200
       message: OK
@@ -1916,132 +2263,30 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - backup protection backup-now
+      - backup protection enable-for-azurefileshare
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -v -i -c --backup-management-type --retain-until --query
+      - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/1fb1564d-c381-47ee-967c-ffe9ee4e3504?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/5144d0a8-320f-4152-b13c-bb04d1bfd433?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/1fb1564d-c381-47ee-967c-ffe9ee4e3504","name":"1fb1564d-c381-47ee-967c-ffe9ee4e3504","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT1.3887576S","storageAccountName":"clitest000003","storageAccountVersion":"MicrosoftStorage","extendedInfo":{"tasksList":[{"taskId":"Take
-        Snapshot","status":"InProgress"}],"propertyBag":{"Data Transferred (in MB)":"0","File
-        Share Name":"clitest-item000004","Whether job is adhoc or scheduled.":"True"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"Backup","status":"InProgress","startTime":"2023-05-17T12:09:56.5117403Z","activityId":"bb4ed8c0-f4ab-11ed-bcbd-c8f750f92764"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/5144d0a8-320f-4152-b13c-bb04d1bfd433","name":"5144d0a8-320f-4152-b13c-bb04d1bfd433","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT42.1574589S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
+        Share Name":"clitest-item000004","Storage Account Name":"clitest000003","Policy
+        Name":"clitest-item000005"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"ConfigureBackup","status":"Completed","startTime":"2023-08-16T09:40:56.2625534Z","endTime":"2023-08-16T09:41:38.4200123Z","activityId":"d6653550-3c18-11ee-b640-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '905'
+      - '897'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:09:57 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '146'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/1fb1564d-c381-47ee-967c-ffe9ee4e3504?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/1fb1564d-c381-47ee-967c-ffe9ee4e3504","name":"1fb1564d-c381-47ee-967c-ffe9ee4e3504","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT2.0918753S","storageAccountName":"clitest000003","storageAccountVersion":"MicrosoftStorage","extendedInfo":{"tasksList":[{"taskId":"Take
-        Snapshot","status":"InProgress"}],"propertyBag":{"Data Transferred (in MB)":"0","File
-        Share Name":"clitest-item000004","Whether job is adhoc or scheduled.":"True"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"Backup","status":"InProgress","startTime":"2023-05-17T12:09:56.5117403Z","activityId":"bb4ed8c0-f4ab-11ed-bcbd-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '905'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:58 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '145'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/1fb1564d-c381-47ee-967c-ffe9ee4e3504?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/1fb1564d-c381-47ee-967c-ffe9ee4e3504","name":"1fb1564d-c381-47ee-967c-ffe9ee4e3504","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT2.6386922S","storageAccountName":"clitest000003","storageAccountVersion":"MicrosoftStorage","extendedInfo":{"tasksList":[{"taskId":"Take
-        Snapshot","status":"InProgress"}],"propertyBag":{"Data Transferred (in MB)":"0","File
-        Share Name":"clitest-item000004","Whether job is adhoc or scheduled.":"True"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"Backup","status":"InProgress","startTime":"2023-05-17T12:09:56.5117403Z","activityId":"bb4ed8c0-f4ab-11ed-bcbd-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '905'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:58 GMT
+      - Wed, 16 Aug 2023 09:41:42 GMT
       expires:
       - '-1'
       pragma:
@@ -2069,30 +2314,231 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
+      - backup protection backup-now
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -i -c --backup-management-type --retain-until --query
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;3b14ddb143df1d7e9bebab6ba55755d6637983c3b936aa9a521e6e2a02e70e53","name":"AzureFileShare;3b14ddb143df1d7e9bebab6ba55755d6637983c3b936aa9a521e6e2a02e70e53","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1478'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:41:43 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '292'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"objectType": "AzureFileShareBackupRequest", "recoveryPointExpiryTimeInUTC":
+      "2023-09-15T00:00:00.000Z"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection backup-now
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '121'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -v -i -c --backup-management-type --retain-until --query
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3B3b14ddb143df1d7e9bebab6ba55755d6637983c3b936aa9a521e6e2a02e70e53/backup?api-version=2023-02-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;3b14ddb143df1d7e9bebab6ba55755d6637983c3b936aa9a521e6e2a02e70e53/operationsStatus/ab97d518-7974-4ecc-8ccf-ea167572b634?api-version=2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Wed, 16 Aug 2023 09:41:45 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;3b14ddb143df1d7e9bebab6ba55755d6637983c3b936aa9a521e6e2a02e70e53/operationResults/ab97d518-7974-4ecc-8ccf-ea167572b634?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1196'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection backup-now
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -i -c --backup-management-type --retain-until --query
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ab97d518-7974-4ecc-8ccf-ea167572b634?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"ab97d518-7974-4ecc-8ccf-ea167572b634","name":"ab97d518-7974-4ecc-8ccf-ea167572b634","status":"Succeeded","startTime":"2023-08-16T09:41:45.0123387Z","endTime":"2023-08-16T09:41:45.0123387Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"2a41917b-1d51-4a62-a471-7824cec3a37f"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:41:45 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '248'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection backup-now
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -i -c --backup-management-type --retain-until --query
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/2a41917b-1d51-4a62-a471-7824cec3a37f?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/2a41917b-1d51-4a62-a471-7824cec3a37f","name":"2a41917b-1d51-4a62-a471-7824cec3a37f","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT2.3866111S","storageAccountName":"clitest000003","storageAccountVersion":"MicrosoftStorage","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","status":"InProgress"}],"propertyBag":{"Data Transferred (in MB)":"0","File
+        Share Name":"clitest-item000004","Whether job is adhoc or scheduled.":"True"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"Backup","status":"InProgress","startTime":"2023-08-16T09:41:45.0123387Z","activityId":"1b83b6b5-3c19-11ee-93a1-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '905'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:41:47 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '143'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
       - backup job wait
       Connection:
       - keep-alive
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/1fb1564d-c381-47ee-967c-ffe9ee4e3504?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/2a41917b-1d51-4a62-a471-7824cec3a37f?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/1fb1564d-c381-47ee-967c-ffe9ee4e3504","name":"1fb1564d-c381-47ee-967c-ffe9ee4e3504","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT3.1844186S","storageAccountName":"clitest000003","storageAccountVersion":"MicrosoftStorage","extendedInfo":{"tasksList":[{"taskId":"Take
-        Snapshot","status":"Completed"}],"propertyBag":{"Data Transferred (in MB)":"0","File
-        Share Name":"clitest-item000004","Whether job is adhoc or scheduled.":"True"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"Backup","status":"Completed","startTime":"2023-05-17T12:09:56.5117403Z","endTime":"2023-05-17T12:09:59.6961589Z","activityId":"bb4ed8c0-f4ab-11ed-bcbd-c8f750f92764"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/2a41917b-1d51-4a62-a471-7824cec3a37f","name":"2a41917b-1d51-4a62-a471-7824cec3a37f","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT3.5885363S","storageAccountName":"clitest000003","storageAccountVersion":"MicrosoftStorage","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","status":"InProgress"}],"propertyBag":{"Data Transferred (in MB)":"0","File
+        Share Name":"clitest-item000004","Whether job is adhoc or scheduled.":"True"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"Backup","status":"InProgress","startTime":"2023-08-16T09:41:45.0123387Z","activityId":"1b83b6b5-3c19-11ee-93a1-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '944'
+      - '905'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:10:29 GMT
+      - Wed, 16 Aug 2023 09:41:48 GMT
       expires:
       - '-1'
       pragma:
@@ -2120,465 +2566,21 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - backup recoverypoint list
+      - backup job wait
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -v -c -i --backup-management-type --query
+      - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/2a41917b-1d51-4a62-a471-7824cec3a37f?api-version=2023-02-01
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;1cfa4ad17c1d2105e185d0662029b51a3977be6d19084f87e396af8a7fd7db29","name":"AzureFileShare;1cfa4ad17c1d2105e185d0662029b51a3977be6d19084f87e396af8a7fd7db29","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"Protected","lastBackupStatus":"Completed","lastBackupTime":"2023-05-17T12:09:56.5117403Z","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1526'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:11:00 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup recoverypoint list
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --query
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3B1cfa4ad17c1d2105e185d0662029b51a3977be6d19084f87e396af8a7fd7db29/recoveryPoints?api-version=2023-02-01
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;1cfa4ad17c1d2105e185d0662029b51a3977be6d19084f87e396af8a7fd7db29/recoveryPoints/335866658183633","name":"335866658183633","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints","properties":{"objectType":"AzureFileShareRecoveryPoint","recoveryPointType":"FileSystemConsistent","recoveryPointTime":"2023-05-17T12:09:58Z","fileShareSnapshotUri":"https://clitest000003.file.core.windows.net/clitest-item000004?sharesnapshot=2023-05-17T12:09:58.0000000Z","recoveryPointSizeInGB":0,"recoveryPointTierDetails":[{"type":"InstantRP","status":"Valid"}]}}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '892'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:11:01 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup recoverypoint show
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i -n --backup-management-type
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;1cfa4ad17c1d2105e185d0662029b51a3977be6d19084f87e396af8a7fd7db29","name":"AzureFileShare;1cfa4ad17c1d2105e185d0662029b51a3977be6d19084f87e396af8a7fd7db29","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"Protected","lastBackupStatus":"Completed","lastBackupTime":"2023-05-17T12:09:56.5117403Z","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1526'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:11:01 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup recoverypoint show
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i -n --backup-management-type
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3B1cfa4ad17c1d2105e185d0662029b51a3977be6d19084f87e396af8a7fd7db29/recoveryPoints/335866658183633?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;1cfa4ad17c1d2105e185d0662029b51a3977be6d19084f87e396af8a7fd7db29/recoveryPoints/335866658183633","name":"335866658183633","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints","properties":{"objectType":"AzureFileShareRecoveryPoint","recoveryPointType":"FileSystemConsistent","recoveryPointTime":"2023-05-17T12:09:58Z","fileShareSnapshotUri":"https://clitest000003.file.core.windows.net/clitest-item000004?sharesnapshot=2023-05-17T12:09:58.0000000Z","recoveryPointSizeInGB":0,"recoveryPointTierDetails":[{"type":"InstantRP","status":"Valid"}]}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '880'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:11:03 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup recoverypoint list
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;1cfa4ad17c1d2105e185d0662029b51a3977be6d19084f87e396af8a7fd7db29","name":"AzureFileShare;1cfa4ad17c1d2105e185d0662029b51a3977be6d19084f87e396af8a7fd7db29","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"Protected","lastBackupStatus":"Completed","lastBackupTime":"2023-05-17T12:09:56.5117403Z","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1526'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:11:04 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup recoverypoint list
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3B1cfa4ad17c1d2105e185d0662029b51a3977be6d19084f87e396af8a7fd7db29/recoveryPoints?api-version=2023-02-01
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;1cfa4ad17c1d2105e185d0662029b51a3977be6d19084f87e396af8a7fd7db29/recoveryPoints/335866658183633","name":"335866658183633","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints","properties":{"objectType":"AzureFileShareRecoveryPoint","recoveryPointType":"FileSystemConsistent","recoveryPointTime":"2023-05-17T12:09:58Z","fileShareSnapshotUri":"https://clitest000003.file.core.windows.net/clitest-item000004?sharesnapshot=2023-05-17T12:09:58.0000000Z","recoveryPointSizeInGB":0,"recoveryPointTierDetails":[{"type":"InstantRP","status":"Valid"}]}}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '892'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:11:06 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection backup-now
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --retain-until --backup-management-type --query
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;1cfa4ad17c1d2105e185d0662029b51a3977be6d19084f87e396af8a7fd7db29","name":"AzureFileShare;1cfa4ad17c1d2105e185d0662029b51a3977be6d19084f87e396af8a7fd7db29","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"Protected","lastBackupStatus":"Completed","lastBackupTime":"2023-05-17T12:09:56.5117403Z","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1526'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:11:08 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"objectType": "AzureFileShareBackupRequest", "recoveryPointExpiryTimeInUTC":
-      "2023-06-16T00:00:00.000Z"}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection backup-now
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '121'
-      Content-Type:
-      - application/json
-      ParameterSetName:
-      - -g -v -c -i --retain-until --backup-management-type --query
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3B1cfa4ad17c1d2105e185d0662029b51a3977be6d19084f87e396af8a7fd7db29/backup?api-version=2023-02-01
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;1cfa4ad17c1d2105e185d0662029b51a3977be6d19084f87e396af8a7fd7db29/operationsStatus/6d6f8ca4-3262-4f2c-aa4e-c99e1820ea1f?api-version=2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Wed, 17 May 2023 12:11:09 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;1cfa4ad17c1d2105e185d0662029b51a3977be6d19084f87e396af8a7fd7db29/operationResults/6d6f8ca4-3262-4f2c-aa4e-c99e1820ea1f?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection backup-now
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --retain-until --backup-management-type --query
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/6d6f8ca4-3262-4f2c-aa4e-c99e1820ea1f?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"6d6f8ca4-3262-4f2c-aa4e-c99e1820ea1f","name":"6d6f8ca4-3262-4f2c-aa4e-c99e1820ea1f","status":"Succeeded","startTime":"2023-05-17T12:11:09.3508001Z","endTime":"2023-05-17T12:11:09.3508001Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"42b8f6d7-5d63-4733-aa97-facbb35def5d"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:11:09 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection backup-now
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --retain-until --backup-management-type --query
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/42b8f6d7-5d63-4733-aa97-facbb35def5d?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/42b8f6d7-5d63-4733-aa97-facbb35def5d","name":"42b8f6d7-5d63-4733-aa97-facbb35def5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT2.0486987S","storageAccountName":"clitest000003","storageAccountVersion":"MicrosoftStorage","extendedInfo":{"tasksList":[{"taskId":"Take
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/2a41917b-1d51-4a62-a471-7824cec3a37f","name":"2a41917b-1d51-4a62-a471-7824cec3a37f","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT3.9635353S","storageAccountName":"clitest000003","storageAccountVersion":"MicrosoftStorage","extendedInfo":{"tasksList":[{"taskId":"Take
         Snapshot","status":"InProgress"}],"propertyBag":{"Data Transferred (in MB)":"0","File
-        Share Name":"clitest-item000004","Whether job is adhoc or scheduled.":"True"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"Backup","status":"InProgress","startTime":"2023-05-17T12:11:09.3508001Z","activityId":"e5f410a3-f4ab-11ed-af65-c8f750f92764"}}'
+        Share Name":"clitest-item000004","Whether job is adhoc or scheduled.":"True"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"Backup","status":"InProgress","startTime":"2023-08-16T09:41:45.0123387Z","activityId":"1b83b6b5-3c19-11ee-93a1-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
@@ -2587,7 +2589,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:11:11 GMT
+      - Wed, 16 Aug 2023 09:41:48 GMT
       expires:
       - '-1'
       pragma:
@@ -2603,7 +2605,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '148'
+      - '141'
     status:
       code: 200
       message: OK
@@ -2621,117 +2623,15 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/42b8f6d7-5d63-4733-aa97-facbb35def5d?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/2a41917b-1d51-4a62-a471-7824cec3a37f?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/42b8f6d7-5d63-4733-aa97-facbb35def5d","name":"42b8f6d7-5d63-4733-aa97-facbb35def5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT2.7656091S","storageAccountName":"clitest000003","storageAccountVersion":"MicrosoftStorage","extendedInfo":{"tasksList":[{"taskId":"Take
-        Snapshot","status":"InProgress"}],"propertyBag":{"Data Transferred (in MB)":"0","File
-        Share Name":"clitest-item000004","Whether job is adhoc or scheduled.":"True"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"Backup","status":"InProgress","startTime":"2023-05-17T12:11:09.3508001Z","activityId":"e5f410a3-f4ab-11ed-af65-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '905'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:11:11 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '148'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/42b8f6d7-5d63-4733-aa97-facbb35def5d?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/42b8f6d7-5d63-4733-aa97-facbb35def5d","name":"42b8f6d7-5d63-4733-aa97-facbb35def5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT3.3280848S","storageAccountName":"clitest000003","storageAccountVersion":"MicrosoftStorage","extendedInfo":{"tasksList":[{"taskId":"Take
-        Snapshot","status":"InProgress"}],"propertyBag":{"Data Transferred (in MB)":"0","File
-        Share Name":"clitest-item000004","Whether job is adhoc or scheduled.":"True"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"Backup","status":"InProgress","startTime":"2023-05-17T12:11:09.3508001Z","activityId":"e5f410a3-f4ab-11ed-af65-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '905'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:11:12 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '147'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/42b8f6d7-5d63-4733-aa97-facbb35def5d?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/42b8f6d7-5d63-4733-aa97-facbb35def5d","name":"42b8f6d7-5d63-4733-aa97-facbb35def5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT4.4249969S","storageAccountName":"clitest000003","storageAccountVersion":"MicrosoftStorage","extendedInfo":{"tasksList":[{"taskId":"Take
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/2a41917b-1d51-4a62-a471-7824cec3a37f","name":"2a41917b-1d51-4a62-a471-7824cec3a37f","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT4.238627S","storageAccountName":"clitest000003","storageAccountVersion":"MicrosoftStorage","extendedInfo":{"tasksList":[{"taskId":"Take
         Snapshot","status":"Completed"}],"propertyBag":{"Data Transferred (in MB)":"0","File
-        Share Name":"clitest-item000004","Whether job is adhoc or scheduled.":"True"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"Backup","status":"Completed","startTime":"2023-05-17T12:11:09.3508001Z","endTime":"2023-05-17T12:11:13.775797Z","activityId":"e5f410a3-f4ab-11ed-af65-c8f750f92764"}}'
+        Share Name":"clitest-item000004","Whether job is adhoc or scheduled.":"True"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"Backup","status":"Completed","startTime":"2023-08-16T09:41:45.0123387Z","endTime":"2023-08-16T09:41:49.2509657Z","activityId":"1b83b6b5-3c19-11ee-93a1-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
@@ -2740,7 +2640,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:11:42 GMT
+      - Wed, 16 Aug 2023 09:42:18 GMT
       expires:
       - '-1'
       pragma:
@@ -2756,7 +2656,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '146'
+      - '140'
     status:
       code: 200
       message: OK
@@ -2772,15 +2672,15 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -v -c -i --backup-management-type
+      - -g -v -c -i --backup-management-type --query
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;1cfa4ad17c1d2105e185d0662029b51a3977be6d19084f87e396af8a7fd7db29","name":"AzureFileShare;1cfa4ad17c1d2105e185d0662029b51a3977be6d19084f87e396af8a7fd7db29","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"Protected","lastBackupStatus":"Completed","lastBackupTime":"2023-05-17T12:11:09.3508001Z","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;3b14ddb143df1d7e9bebab6ba55755d6637983c3b936aa9a521e6e2a02e70e53","name":"AzureFileShare;3b14ddb143df1d7e9bebab6ba55755d6637983c3b936aa9a521e6e2a02e70e53","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"Protected","lastBackupStatus":"Completed","lastBackupTime":"2023-08-16T09:41:45.0123387Z","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
     headers:
       cache-control:
       - no-cache
@@ -2789,7 +2689,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:12:13 GMT
+      - Wed, 16 Aug 2023 09:42:50 GMT
       expires:
       - '-1'
       pragma:
@@ -2805,7 +2705,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '291'
     status:
       code: 200
       message: OK
@@ -2821,267 +2721,24 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -v -c -i --backup-management-type
+      - -g -v -c -i --backup-management-type --query
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3B1cfa4ad17c1d2105e185d0662029b51a3977be6d19084f87e396af8a7fd7db29/recoveryPoints?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3B3b14ddb143df1d7e9bebab6ba55755d6637983c3b936aa9a521e6e2a02e70e53/recoveryPoints?api-version=2023-02-01
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;1cfa4ad17c1d2105e185d0662029b51a3977be6d19084f87e396af8a7fd7db29/recoveryPoints/338700810657166","name":"338700810657166","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints","properties":{"objectType":"AzureFileShareRecoveryPoint","recoveryPointType":"FileSystemConsistent","recoveryPointTime":"2023-05-17T12:11:11Z","fileShareSnapshotUri":"https://clitest000003.file.core.windows.net/clitest-item000004?sharesnapshot=2023-05-17T12:11:11.0000000Z","recoveryPointSizeInGB":0,"recoveryPointTierDetails":[{"type":"InstantRP","status":"Valid"}]}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;1cfa4ad17c1d2105e185d0662029b51a3977be6d19084f87e396af8a7fd7db29/recoveryPoints/335866658183633","name":"335866658183633","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints","properties":{"objectType":"AzureFileShareRecoveryPoint","recoveryPointType":"FileSystemConsistent","recoveryPointTime":"2023-05-17T12:09:58Z","fileShareSnapshotUri":"https://clitest000003.file.core.windows.net/clitest-item000004?sharesnapshot=2023-05-17T12:09:58.0000000Z","recoveryPointSizeInGB":0,"recoveryPointTierDetails":[{"type":"InstantRP","status":"Valid"}]}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;3b14ddb143df1d7e9bebab6ba55755d6637983c3b936aa9a521e6e2a02e70e53/recoveryPoints/509343315421769","name":"509343315421769","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints","properties":{"objectType":"AzureFileShareRecoveryPoint","recoveryPointType":"FileSystemConsistent","recoveryPointTime":"2023-08-16T09:41:47Z","fileShareSnapshotUri":"https://clitest000003.file.core.windows.net/clitest-item000004?sharesnapshot=2023-08-16T09:41:47.0000000Z","recoveryPointSizeInGB":0,"recoveryPointTierDetails":[{"type":"InstantRP","status":"Valid"}]}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1773'
+      - '892'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:12:14 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;1cfa4ad17c1d2105e185d0662029b51a3977be6d19084f87e396af8a7fd7db29","name":"AzureFileShare;1cfa4ad17c1d2105e185d0662029b51a3977be6d19084f87e396af8a7fd7db29","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"Protected","lastBackupStatus":"Completed","lastBackupTime":"2023-05-17T12:11:09.3508001Z","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1526'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:12:15 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupResourceGuardProxies?api-version=2023-02-01
-  response:
-    body:
-      string: '{"value":[]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '12'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:12:16 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3B1cfa4ad17c1d2105e185d0662029b51a3977be6d19084f87e396af8a7fd7db29?api-version=2023-02-01
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e7925d92-a93e-4f2d-9621-5835c5c9de8f?api-version=2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Wed, 17 May 2023 12:12:17 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/e7925d92-a93e-4f2d-9621-5835c5c9de8f?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-deletes:
-      - '14998'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e7925d92-a93e-4f2d-9621-5835c5c9de8f?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"e7925d92-a93e-4f2d-9621-5835c5c9de8f","name":"e7925d92-a93e-4f2d-9621-5835c5c9de8f","status":"InProgress","startTime":"2023-05-17T12:12:17.8771207Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:12:18 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e7925d92-a93e-4f2d-9621-5835c5c9de8f?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"e7925d92-a93e-4f2d-9621-5835c5c9de8f","name":"e7925d92-a93e-4f2d-9621-5835c5c9de8f","status":"InProgress","startTime":"2023-05-17T12:12:17.8771207Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:12:24 GMT
+      - Wed, 16 Aug 2023 09:42:51 GMT
       expires:
       - '-1'
       pragma:
@@ -3109,28 +2766,77 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - backup protection disable
+      - backup recoverypoint show
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      - -g -v -c -i -n --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e7925d92-a93e-4f2d-9621-5835c5c9de8f?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
     body:
-      string: '{"id":"e7925d92-a93e-4f2d-9621-5835c5c9de8f","name":"e7925d92-a93e-4f2d-9621-5835c5c9de8f","status":"InProgress","startTime":"2023-05-17T12:12:17.8771207Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;3b14ddb143df1d7e9bebab6ba55755d6637983c3b936aa9a521e6e2a02e70e53","name":"AzureFileShare;3b14ddb143df1d7e9bebab6ba55755d6637983c3b936aa9a521e6e2a02e70e53","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"Protected","lastBackupStatus":"Completed","lastBackupTime":"2023-08-16T09:41:45.0123387Z","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '1526'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:12:29 GMT
+      - Wed, 16 Aug 2023 09:42:52 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '288'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup recoverypoint show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i -n --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3B3b14ddb143df1d7e9bebab6ba55755d6637983c3b936aa9a521e6e2a02e70e53/recoveryPoints/509343315421769?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;3b14ddb143df1d7e9bebab6ba55755d6637983c3b936aa9a521e6e2a02e70e53/recoveryPoints/509343315421769","name":"509343315421769","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints","properties":{"objectType":"AzureFileShareRecoveryPoint","recoveryPointType":"FileSystemConsistent","recoveryPointTime":"2023-08-16T09:41:47Z","fileShareSnapshotUri":"https://clitest000003.file.core.windows.net/clitest-item000004?sharesnapshot=2023-08-16T09:41:47.0000000Z","recoveryPointSizeInGB":0,"recoveryPointTierDetails":[{"type":"InstantRP","status":"Valid"}]}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '880'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:42:54 GMT
       expires:
       - '-1'
       pragma:
@@ -3158,28 +2864,77 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - backup protection disable
+      - backup recoverypoint list
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      - -g -v -c -i --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e7925d92-a93e-4f2d-9621-5835c5c9de8f?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
     body:
-      string: '{"id":"e7925d92-a93e-4f2d-9621-5835c5c9de8f","name":"e7925d92-a93e-4f2d-9621-5835c5c9de8f","status":"InProgress","startTime":"2023-05-17T12:12:17.8771207Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;3b14ddb143df1d7e9bebab6ba55755d6637983c3b936aa9a521e6e2a02e70e53","name":"AzureFileShare;3b14ddb143df1d7e9bebab6ba55755d6637983c3b936aa9a521e6e2a02e70e53","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"Protected","lastBackupStatus":"Completed","lastBackupTime":"2023-08-16T09:41:45.0123387Z","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '1526'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:12:35 GMT
+      - Wed, 16 Aug 2023 09:42:55 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '291'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup recoverypoint list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3B3b14ddb143df1d7e9bebab6ba55755d6637983c3b936aa9a521e6e2a02e70e53/recoveryPoints?api-version=2023-02-01
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;3b14ddb143df1d7e9bebab6ba55755d6637983c3b936aa9a521e6e2a02e70e53/recoveryPoints/509343315421769","name":"509343315421769","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints","properties":{"objectType":"AzureFileShareRecoveryPoint","recoveryPointType":"FileSystemConsistent","recoveryPointTime":"2023-08-16T09:41:47Z","fileShareSnapshotUri":"https://clitest000003.file.core.windows.net/clitest-item000004?sharesnapshot=2023-08-16T09:41:47.0000000Z","recoveryPointSizeInGB":0,"recoveryPointTierDetails":[{"type":"InstantRP","status":"Valid"}]}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '892'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:42:57 GMT
       expires:
       - '-1'
       pragma:
@@ -3207,28 +2962,28 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - backup protection disable
+      - backup protection backup-now
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      - -g -v -c -i --retain-until --backup-management-type --query
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e7925d92-a93e-4f2d-9621-5835c5c9de8f?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
     body:
-      string: '{"id":"e7925d92-a93e-4f2d-9621-5835c5c9de8f","name":"e7925d92-a93e-4f2d-9621-5835c5c9de8f","status":"Succeeded","startTime":"2023-05-17T12:12:17.8771207Z","endTime":"2023-05-17T12:12:17.8771207Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"0ab842a4-76c0-43c9-81d7-b575239ea481"}}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;3b14ddb143df1d7e9bebab6ba55755d6637983c3b936aa9a521e6e2a02e70e53","name":"AzureFileShare;3b14ddb143df1d7e9bebab6ba55755d6637983c3b936aa9a521e6e2a02e70e53","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"Protected","lastBackupStatus":"Completed","lastBackupTime":"2023-08-16T09:41:45.0123387Z","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '1526'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:12:40 GMT
+      - Wed, 16 Aug 2023 09:42:57 GMT
       expires:
       - '-1'
       pragma:
@@ -3244,10 +2999,62 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '295'
+      - '290'
     status:
       code: 200
       message: OK
+- request:
+    body: '{"properties": {"objectType": "AzureFileShareBackupRequest", "recoveryPointExpiryTimeInUTC":
+      "2023-09-15T00:00:00.000Z"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection backup-now
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '121'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -v -c -i --retain-until --backup-management-type --query
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3B3b14ddb143df1d7e9bebab6ba55755d6637983c3b936aa9a521e6e2a02e70e53/backup?api-version=2023-02-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;3b14ddb143df1d7e9bebab6ba55755d6637983c3b936aa9a521e6e2a02e70e53/operationsStatus/c21e4830-fc7b-4b40-ba35-f2e41b30d4c9?api-version=2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Wed, 16 Aug 2023 09:42:59 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;3b14ddb143df1d7e9bebab6ba55755d6637983c3b936aa9a521e6e2a02e70e53/operationResults/c21e4830-fc7b-4b40-ba35-f2e41b30d4c9?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1193'
+    status:
+      code: 202
+      message: Accepted
 - request:
     body: null
     headers:
@@ -3256,29 +3063,28 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - backup protection disable
+      - backup protection backup-now
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      - -g -v -c -i --retain-until --backup-management-type --query
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/0ab842a4-76c0-43c9-81d7-b575239ea481?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c21e4830-fc7b-4b40-ba35-f2e41b30d4c9?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/0ab842a4-76c0-43c9-81d7-b575239ea481","name":"0ab842a4-76c0-43c9-81d7-b575239ea481","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT21.0268951S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
-        Share Name":"clitest-item000004","Storage Account Name":"clitest000003"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"DeleteBackupData","status":"Completed","startTime":"2023-05-17T12:12:17.8771207Z","endTime":"2023-05-17T12:12:38.9040158Z","activityId":"0ec4e6a9-f4ac-11ed-9f42-c8f750f92764"}}'
+      string: '{"id":"c21e4830-fc7b-4b40-ba35-f2e41b30d4c9","name":"c21e4830-fc7b-4b40-ba35-f2e41b30d4c9","status":"Succeeded","startTime":"2023-08-16T09:42:59.771411Z","endTime":"2023-08-16T09:42:59.771411Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"a6a4538c-0a51-4301-8e3f-6ad271022005"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '863'
+      - '302'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:12:41 GMT
+      - Wed, 16 Aug 2023 09:43:01 GMT
       expires:
       - '-1'
       pragma:
@@ -3294,7 +3100,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '149'
+      - '284'
     status:
       code: 200
       message: OK
@@ -3306,28 +3112,179 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - backup container unregister
+      - backup protection backup-now
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -v -c --yes --backup-management-type
+      - -g -v -c -i --retain-until --backup-management-type --query
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+friendlyName+eq+%27clitest000003%27+and+status+eq+%27Registered%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a6a4538c-0a51-4301-8e3f-6ad271022005?api-version=2023-02-01
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","protectedItemCount":0,"acquireStorageAccountLock":"Acquire","friendlyName":"clitest000003","backupManagementType":"AzureStorage","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"StorageContainer","protectableObjectType":"StorageContainer"}}]}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a6a4538c-0a51-4301-8e3f-6ad271022005","name":"a6a4538c-0a51-4301-8e3f-6ad271022005","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT2.4303526S","storageAccountName":"clitest000003","storageAccountVersion":"MicrosoftStorage","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","status":"InProgress"}],"propertyBag":{"Data Transferred (in MB)":"0","File
+        Share Name":"clitest-item000004","Whether job is adhoc or scheduled.":"True"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"Backup","status":"InProgress","startTime":"2023-08-16T09:42:59.771411Z","activityId":"48280e7e-3c19-11ee-8cd9-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '853'
+      - '904'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:12:42 GMT
+      - Wed, 16 Aug 2023 09:43:02 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '139'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a6a4538c-0a51-4301-8e3f-6ad271022005?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a6a4538c-0a51-4301-8e3f-6ad271022005","name":"a6a4538c-0a51-4301-8e3f-6ad271022005","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT2.1875149S","storageAccountName":"clitest000003","storageAccountVersion":"MicrosoftStorage","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","status":"Completed"}],"propertyBag":{"Data Transferred (in MB)":"0","File
+        Share Name":"clitest-item000004","Whether job is adhoc or scheduled.":"True"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"Backup","status":"Completed","startTime":"2023-08-16T09:42:59.771411Z","endTime":"2023-08-16T09:43:01.9589259Z","activityId":"48280e7e-3c19-11ee-8cd9-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '943'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:43:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '140'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup recoverypoint list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;3b14ddb143df1d7e9bebab6ba55755d6637983c3b936aa9a521e6e2a02e70e53","name":"AzureFileShare;3b14ddb143df1d7e9bebab6ba55755d6637983c3b936aa9a521e6e2a02e70e53","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"Protected","lastBackupStatus":"Completed","lastBackupTime":"2023-08-16T09:42:59.771411Z","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1525'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:43:04 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '298'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup recoverypoint list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3B3b14ddb143df1d7e9bebab6ba55755d6637983c3b936aa9a521e6e2a02e70e53/recoveryPoints?api-version=2023-02-01
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;3b14ddb143df1d7e9bebab6ba55755d6637983c3b936aa9a521e6e2a02e70e53/recoveryPoints/504451752071833","name":"504451752071833","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints","properties":{"objectType":"AzureFileShareRecoveryPoint","recoveryPointType":"FileSystemConsistent","recoveryPointTime":"2023-08-16T09:43:00Z","fileShareSnapshotUri":"https://clitest000003.file.core.windows.net/clitest-item000004?sharesnapshot=2023-08-16T09:43:00.0000000Z","recoveryPointSizeInGB":0,"recoveryPointTierDetails":[{"type":"InstantRP","status":"Valid"}]}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;3b14ddb143df1d7e9bebab6ba55755d6637983c3b936aa9a521e6e2a02e70e53/recoveryPoints/509343315421769","name":"509343315421769","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints","properties":{"objectType":"AzureFileShareRecoveryPoint","recoveryPointType":"FileSystemConsistent","recoveryPointTime":"2023-08-16T09:41:47Z","fileShareSnapshotUri":"https://clitest000003.file.core.windows.net/clitest-item000004?sharesnapshot=2023-08-16T09:41:47.0000000Z","recoveryPointSizeInGB":0,"recoveryPointTierDetails":[{"type":"InstantRP","status":"Valid"}]}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1773'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:43:05 GMT
       expires:
       - '-1'
       pragma:
@@ -3355,6 +3312,495 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;3b14ddb143df1d7e9bebab6ba55755d6637983c3b936aa9a521e6e2a02e70e53","name":"AzureFileShare;3b14ddb143df1d7e9bebab6ba55755d6637983c3b936aa9a521e6e2a02e70e53","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"Protected","lastBackupStatus":"Completed","lastBackupTime":"2023-08-16T09:42:59.771411Z","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1525'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:43:06 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '289'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupResourceGuardProxies?api-version=2023-02-01
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:43:08 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3B3b14ddb143df1d7e9bebab6ba55755d6637983c3b936aa9a521e6e2a02e70e53?api-version=2023-02-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b8eaa462-e544-4b37-bc6b-f600629bbab5?api-version=2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Wed, 16 Aug 2023 09:43:09 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/b8eaa462-e544-4b37-bc6b-f600629bbab5?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14992'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b8eaa462-e544-4b37-bc6b-f600629bbab5?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"b8eaa462-e544-4b37-bc6b-f600629bbab5","name":"b8eaa462-e544-4b37-bc6b-f600629bbab5","status":"InProgress","startTime":"2023-08-16T09:43:09.6991347Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:43:10 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '247'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b8eaa462-e544-4b37-bc6b-f600629bbab5?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"b8eaa462-e544-4b37-bc6b-f600629bbab5","name":"b8eaa462-e544-4b37-bc6b-f600629bbab5","status":"InProgress","startTime":"2023-08-16T09:43:09.6991347Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:43:16 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '246'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b8eaa462-e544-4b37-bc6b-f600629bbab5?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"b8eaa462-e544-4b37-bc6b-f600629bbab5","name":"b8eaa462-e544-4b37-bc6b-f600629bbab5","status":"InProgress","startTime":"2023-08-16T09:43:09.6991347Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:43:21 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '245'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b8eaa462-e544-4b37-bc6b-f600629bbab5?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"b8eaa462-e544-4b37-bc6b-f600629bbab5","name":"b8eaa462-e544-4b37-bc6b-f600629bbab5","status":"InProgress","startTime":"2023-08-16T09:43:09.6991347Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:43:26 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '244'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b8eaa462-e544-4b37-bc6b-f600629bbab5?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"b8eaa462-e544-4b37-bc6b-f600629bbab5","name":"b8eaa462-e544-4b37-bc6b-f600629bbab5","status":"Succeeded","startTime":"2023-08-16T09:43:09.6991347Z","endTime":"2023-08-16T09:43:09.6991347Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"d79f45e6-12e3-4e2c-aee5-0af75684aa1c"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:43:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '243'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/d79f45e6-12e3-4e2c-aee5-0af75684aa1c?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/d79f45e6-12e3-4e2c-aee5-0af75684aa1c","name":"d79f45e6-12e3-4e2c-aee5-0af75684aa1c","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT21.0520035S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
+        Share Name":"clitest-item000004","Storage Account Name":"clitest000003"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"DeleteBackupData","status":"Completed","startTime":"2023-08-16T09:43:09.6991347Z","endTime":"2023-08-16T09:43:30.7511382Z","activityId":"4d5fd2e7-3c19-11ee-a4fc-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '863'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:43:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '143'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+friendlyName+eq+%27clitest000003%27+and+status+eq+%27Registered%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","protectedItemCount":0,"acquireStorageAccountLock":"Acquire","friendlyName":"clitest000003","backupManagementType":"AzureStorage","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"StorageContainer","protectableObjectType":"StorageContainer"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '853'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:43:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '295'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
       - backup container unregister
       Connection:
       - keep-alive
@@ -3363,8 +3809,8 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003?api-version=2023-02-01
   response:
@@ -3372,17 +3818,17 @@ interactions:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/28bedae5-11e7-44b4-ad46-b8948086fc97?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:12:45 GMT
+      - Wed, 16 Aug 2023 09:43:37 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/28bedae5-11e7-44b4-ad46-b8948086fc97?fabricName=Azure?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?fabricName=Azure?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -3410,16 +3856,16 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/28bedae5-11e7-44b4-ad46-b8948086fc97?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/28bedae5-11e7-44b4-ad46-b8948086fc97?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -3427,11 +3873,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:12:45 GMT
+      - Wed, 16 Aug 2023 09:43:37 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/28bedae5-11e7-44b4-ad46-b8948086fc97?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -3441,7 +3887,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '253'
     status:
       code: 202
       message: Accepted
@@ -3459,16 +3905,16 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/28bedae5-11e7-44b4-ad46-b8948086fc97?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/28bedae5-11e7-44b4-ad46-b8948086fc97?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -3476,11 +3922,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:12:51 GMT
+      - Wed, 16 Aug 2023 09:43:44 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/28bedae5-11e7-44b4-ad46-b8948086fc97?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -3490,7 +3936,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
+      - '252'
     status:
       code: 202
       message: Accepted
@@ -3508,16 +3954,16 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/28bedae5-11e7-44b4-ad46-b8948086fc97?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/28bedae5-11e7-44b4-ad46-b8948086fc97?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -3525,11 +3971,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:12:56 GMT
+      - Wed, 16 Aug 2023 09:43:48 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/28bedae5-11e7-44b4-ad46-b8948086fc97?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -3539,7 +3985,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '295'
+      - '251'
     status:
       code: 202
       message: Accepted
@@ -3557,16 +4003,16 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/28bedae5-11e7-44b4-ad46-b8948086fc97?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/28bedae5-11e7-44b4-ad46-b8948086fc97?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -3574,11 +4020,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:13:02 GMT
+      - Wed, 16 Aug 2023 09:43:54 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/28bedae5-11e7-44b4-ad46-b8948086fc97?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -3588,7 +4034,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '293'
+      - '250'
     status:
       code: 202
       message: Accepted
@@ -3606,10 +4052,500 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/28bedae5-11e7-44b4-ad46-b8948086fc97?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:43:59 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '249'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:44:05 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '248'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:44:10 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '247'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:44:16 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '246'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:44:21 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '245'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:44:27 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '244'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:44:32 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '243'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:44:37 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '242'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:44:42 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '241'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:44:48 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '240'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/bba2c7e7-24ea-4ed5-bdb0-73eec0adebdb?api-version=2023-02-01
   response:
     body:
       string: ''
@@ -3617,7 +4553,7 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Wed, 17 May 2023 12:13:08 GMT
+      - Wed, 16 Aug 2023 09:44:53 GMT
       expires:
       - '-1'
       pragma:
@@ -3629,7 +4565,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '292'
+      - '239'
     status:
       code: 204
       message: No Content
@@ -3641,16 +4577,16 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - backup container list
+      - lock list
       Connection:
       - keep-alive
       ParameterSetName:
-      - --backup-management-type -v -g --query
+      - -g
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureIaasVM%27+and+status+eq+%27Registered%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/locks?api-version=2016-09-01
   response:
     body:
       string: '{"value":[]}'
@@ -3662,7 +4598,53 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:14:48 GMT
+      - Wed, 16 Aug 2023 09:46:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --container-name --item-name --backup-management-type --workload-type
+        --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+itemType+eq+%27AzureFileShare%27
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:46:37 GMT
       expires:
       - '-1'
       pragma:
@@ -3678,7 +4660,105 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '287'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --vault-name --resource-group --container-name --backup-management-type --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+friendlyName+eq+%27clitest000003%27+and+status+eq+%27Registered%27
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:46:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '290'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type -v -g --query
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureIaasVM%27+and+status+eq+%27Registered%27
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:46:39 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '294'
     status:
       code: 200
       message: OK
@@ -3698,7 +4778,8 @@ interactions:
       ParameterSetName:
       - -n -g --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2023-02-01
   response:
@@ -3710,7 +4791,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:14:56 GMT
+      - Wed, 16 Aug 2023 09:46:43 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/backup/tests/latest/recordings/test_afs_backup_scenario.yaml
+++ b/src/azure-cli/azure/cli/command_modules/backup/tests/latest/recordings/test_afs_backup_scenario.yaml
@@ -13,7 +13,8 @@ interactions:
       ParameterSetName:
       - -n -g --location
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2023-02-01
   response:
@@ -29,7 +30,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:11:52 GMT
+      - Wed, 16 Aug 2023 09:36:58 GMT
       expires:
       - '-1'
       pragma:
@@ -64,15 +65,16 @@ interactions:
       ParameterSetName:
       - -n -g --location
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2023-02-01
   response:
     body:
-      string: '{"location":"eastus2euap","name":"clitest-vault000002","etag":"W/\"datetime''2023-05-17T12%3A11%3A55.8751436Z''\"","properties":{"provisioningState":"Provisioning","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}},"publicNetworkAccess":"Enabled","restoreSettings":{"crossSubscriptionRestoreSettings":{"crossSubscriptionRestoreState":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+      string: '{"location":"eastus2euap","name":"clitest-vault000002","etag":"W/\"datetime''2023-08-16T09%3A37%3A00.2817656Z''\"","properties":{"provisioningState":"Provisioning","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}},"publicNetworkAccess":"Enabled","restoreSettings":{"crossSubscriptionRestoreSettings":{"crossSubscriptionRestoreState":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NztiN2FmZjBjMC05NzY2LTRkMjUtYmFkNi01MzAwNzg2NDhjM2I=?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0Nzs0ZGEyYmMyYy03ODFlLTQ1M2MtYjJlMS0wZWY5MzY3NDRmMzg=?api-version=2023-02-01
       cache-control:
       - no-cache
       content-length:
@@ -80,7 +82,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:11:56 GMT
+      - Wed, 16 Aug 2023 09:37:00 GMT
       expires:
       - '-1'
       pragma:
@@ -91,8 +93,10 @@ interactions:
       - max-age=31536000; includeSubDomains
       x-content-type-options:
       - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=12f8ea5c-1212-449e-b31c-0a574f43076e/centraluseuap/fc909b7c-45aa-4ddb-ab9e-80cfb35dc4f3
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '296'
+      - '298'
     status:
       code: 201
       message: Created
@@ -110,14 +114,68 @@ interactions:
       ParameterSetName:
       - -n -g --location
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NztiN2FmZjBjMC05NzY2LTRkMjUtYmFkNi01MzAwNzg2NDhjM2I=?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0Nzs0ZGEyYmMyYy03ODFlLTQ1M2MtYjJlMS0wZWY5MzY3NDRmMzg=?api-version=2023-02-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NztiN2FmZjBjMC05NzY2LTRkMjUtYmFkNi01MzAwNzg2NDhjM2I=\",\r\n
-        \ \"name\": \"MjA0NztiN2FmZjBjMC05NzY2LTRkMjUtYmFkNi01MzAwNzg2NDhjM2I=\",\r\n
-        \ \"status\": \"Succeeded\"\r\n}"
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0Nzs0ZGEyYmMyYy03ODFlLTQ1M2MtYjJlMS0wZWY5MzY3NDRmMzg=\"\
+        ,\r\n  \"name\": \"MjA0Nzs0ZGEyYmMyYy03ODFlLTQ1M2MtYjJlMS0wZWY5MzY3NDRmMzg=\"\
+        ,\r\n  \"status\": \"InProgress\"\r\n}"
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0Nzs0ZGEyYmMyYy03ODFlLTQ1M2MtYjJlMS0wZWY5MzY3NDRmMzg=?api-version=2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '334'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:37:00 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationResults/MjA0Nzs0ZGEyYmMyYy03ODFlLTQ1M2MtYjJlMS0wZWY5MzY3NDRmMzg=?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --location
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0Nzs0ZGEyYmMyYy03ODFlLTQ1M2MtYjJlMS0wZWY5MzY3NDRmMzg=?api-version=2023-02-01
+  response:
+    body:
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0Nzs0ZGEyYmMyYy03ODFlLTQ1M2MtYjJlMS0wZWY5MzY3NDRmMzg=\"\
+        ,\r\n  \"name\": \"MjA0Nzs0ZGEyYmMyYy03ODFlLTQ1M2MtYjJlMS0wZWY5MzY3NDRmMzg=\"\
+        ,\r\n  \"status\": \"Succeeded\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -126,7 +184,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:11:56 GMT
+      - Wed, 16 Aug 2023 09:38:00 GMT
       expires:
       - '-1'
       pragma:
@@ -158,12 +216,13 @@ interactions:
       ParameterSetName:
       - -n -g --location
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2023-02-01
   response:
     body:
-      string: '{"location":"eastus2euap","name":"clitest-vault000002","etag":"W/\"datetime''2023-05-17T12%3A11%3A56.4705057Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","backupStorageVersion":"Unassigned","monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}},"securitySettings":{"immutabilitySettings":null,"softDeleteSettings":{"softDeleteRetentionPeriodInDays":14,"softDeleteState":"Enabled"},"multiUserAuthorization":"Disabled"},"publicNetworkAccess":"Enabled","restoreSettings":{"crossSubscriptionRestoreSettings":{"crossSubscriptionRestoreState":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+      string: '{"location":"eastus2euap","name":"clitest-vault000002","etag":"W/\"datetime''2023-08-16T09%3A37%3A00.7923755Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","backupStorageVersion":"Unassigned","monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}},"securitySettings":{"immutabilitySettings":null,"softDeleteSettings":{"softDeleteRetentionPeriodInDays":14,"softDeleteState":"Enabled"},"multiUserAuthorization":"Disabled"},"publicNetworkAccess":"Enabled","restoreSettings":{"crossSubscriptionRestoreSettings":{"crossSubscriptionRestoreState":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
     headers:
       cache-control:
       - no-cache
@@ -172,7 +231,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:11:57 GMT
+      - Wed, 16 Aug 2023 09:38:00 GMT
       expires:
       - '-1'
       pragma:
@@ -187,6 +246,156 @@ interactions:
       - Accept-Encoding
       x-content-type-options:
       - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault backup-properties set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --soft-delete-feature-state
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupconfig/vaultconfig?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupconfig/vaultconfig","name":"vaultconfig","type":"Microsoft.RecoveryServices/vaults/backupconfig","properties":{"enhancedSecurityState":"Enabled","softDeleteFeatureState":"Enabled","softDeleteRetentionPeriodInDays":14,"isSoftDeleteFeatureStateEditable":true}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '419'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:38:02 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '299'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault backup-properties set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --soft-delete-feature-state
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupResourceGuardProxies?api-version=2023-02-01
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:38:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"enhancedSecurityState": "Enabled", "softDeleteFeatureState":
+      "Disabled"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault backup-properties set
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '90'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -n -g --soft-delete-feature-state
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: PATCH
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupconfig/vaultconfig?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupconfig/vaultconfig","name":"vaultconfig","type":"Microsoft.RecoveryServices/vaults/backupconfig","properties":{"enhancedSecurityState":"Enabled","softDeleteFeatureState":"Disabled","softDeleteRetentionPeriodInDays":14,"isSoftDeleteFeatureStateEditable":true}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '420'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:38:04 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1180'
     status:
       code: 200
       message: OK
@@ -206,12 +415,13 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-storage/21.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003/listKeys?api-version=2022-09-01&$expand=kerb
   response:
     body:
-      string: '{"keys":[{"creationTime":"2023-05-17T12:12:04.3755234Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2023-05-17T12:12:04.3755234Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
+      string: '{"keys":[{"creationTime":"2023-08-16T09:38:07.7191493Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2023-08-16T09:38:07.7191493Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
     headers:
       cache-control:
       - no-cache
@@ -220,7 +430,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 17 May 2023 12:12:27 GMT
+      - Wed, 16 Aug 2023 09:38:31 GMT
       expires:
       - '-1'
       pragma:
@@ -236,7 +446,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11998'
     status:
       code: 200
       message: OK
@@ -254,21 +464,22 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-storage/21.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","name":"clitest000003","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"keyCreationTime":{"key1":"2023-05-17T12:12:04.3755234Z","key2":"2023-05-17T12:12:04.3755234Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-05-17T12:12:04.8131169Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-05-17T12:12:04.8131169Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-05-17T12:12:04.2817728Z","primaryEndpoints":{"blob":"https://clitest000003.blob.core.windows.net/","queue":"https://clitest000003.queue.core.windows.net/","table":"https://clitest000003.table.core.windows.net/","file":"https://clitest000003.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","name":"clitest000003","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"keyCreationTime":{"key1":"2023-08-16T09:38:07.7191493Z","key2":"2023-08-16T09:38:07.7191493Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-08-16T09:38:08.1879179Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-08-16T09:38:08.1879179Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-08-16T09:38:07.6098003Z","primaryEndpoints":{"blob":"https://clitest000003.blob.core.windows.net/","queue":"https://clitest000003.queue.core.windows.net/","table":"https://clitest000003.table.core.windows.net/","file":"https://clitest000003.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1280'
+      - '1316'
       content-type:
       - application/json
       date:
-      - Wed, 17 May 2023 12:12:29 GMT
+      - Wed, 16 Aug 2023 09:38:31 GMT
       expires:
       - '-1'
       pragma:
@@ -302,9 +513,10 @@ interactions:
       ParameterSetName:
       - --name --quota --connection-string
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-storage-file-share/12.12.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-storage-file-share/12.12.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Wed, 17 May 2023 12:12:27 GMT
+      - Wed, 16 Aug 2023 09:38:32 GMT
       x-ms-share-quota:
       - '1'
       x-ms-version:
@@ -318,11 +530,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:12:29 GMT
+      - Wed, 16 Aug 2023 09:38:32 GMT
       etag:
-      - '"0x8DB56CFFCB4B6C6"'
+      - '"0x8DB9E3C8EB17C21"'
       last-modified:
-      - Wed, 17 May 2023 12:12:30 GMT
+      - Wed, 16 Aug 2023 09:38:33 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
@@ -344,13 +556,13 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T19:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T19:30:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
@@ -359,7 +571,163 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:12:30 GMT
+      - Wed, 16 Aug 2023 09:38:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '291'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"protectedItemsCount": 0, "backupManagementType": "AzureStorage",
+      "workLoadType": "AzureFileShare", "schedulePolicy": {"schedulePolicyType": "SimpleSchedulePolicy",
+      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2023-08-16T19:30:00.000Z"],
+      "scheduleWeeklyFrequency": 0}, "retentionPolicy": {"retentionPolicyType": "LongTermRetentionPolicy",
+      "dailySchedule": {"retentionTimes": ["2023-08-16T19:30:00.000Z"], "retentionDuration":
+      {"count": 30, "durationType": "Days"}}}, "timeZone": "UTC"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup policy create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '512'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -v --policy -n --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","name":"clitest-item000005","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","workLoadType":"AzureFileShare","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T19:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T19:30:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '751'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:38:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1179'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+status+eq+%27Registered%27
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:38:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '290'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","name":"StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"adiguptecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/adigupt-ecy-rg/providers/Microsoft.Storage/storageAccounts/adiguptecy"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg762eboi6az;clitestnw7hezxfnda4gree2","name":"StorageContainer;Storage;clitest.rg762eboi6az;clitestnw7hezxfnda4gree2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestnw7hezxfnda4gree2","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg762eboi6az/providers/Microsoft.Storage/storageAccounts/clitestnw7hezxfnda4gree2"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgzoyjagb5eb;clitestamxx27lkbfywib4s6","name":"StorageContainer;Storage;clitest.rgzoyjagb5eb;clitestamxx27lkbfywib4s6","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestamxx27lkbfywib4s6","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgzoyjagb5eb/providers/Microsoft.Storage/storageAccounts/clitestamxx27lkbfywib4s6"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgzoyjagb5eb;clitestym2nwetgkgpa5azz2","name":"StorageContainer;Storage;clitest.rgzoyjagb5eb;clitestym2nwetgkgpa5azz2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestym2nwetgkgpa5azz2","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgzoyjagb5eb/providers/Microsoft.Storage/storageAccounts/clitestym2nwetgkgpa5azz2"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","name":"StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontusebvtaksecycansa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DonotUse-Blobs-BVT-EACAN-RG/providers/Microsoft.Storage/storageAccounts/dontusebvtaksecycansa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","name":"StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"iaasextstoreecy1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.czr/providers/Microsoft.Storage/storageAccounts/iaasextstoreecy1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","name":"StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesaksdonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-clitest-rg/providers/Microsoft.Storage/storageAccounts/clitesaksdonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"bloboprestorecontainers","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/bloboprestorecontainers"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopall","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopall"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopcontainer","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopcontainer"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopprefix","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopprefix"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG2;zubairsaecy2","name":"StorageContainer;Storage;zubairRG2;zubairsaecy2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy2","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG2/providers/Microsoft.Storage/storageAccounts/zubairsaecy2"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG;zubairsaecy","name":"StorageContainer;Storage;zubairRG;zubairsaecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Storage/storageAccounts/zubairsaecy"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '9820'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:38:37 GMT
       expires:
       - '-1'
       pragma:
@@ -380,162 +748,6 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"properties": {"protectedItemsCount": 0, "backupManagementType": "AzureStorage",
-      "workLoadType": "AzureFileShare", "schedulePolicy": {"schedulePolicyType": "SimpleSchedulePolicy",
-      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2023-05-17T22:00:00.000Z"],
-      "scheduleWeeklyFrequency": 0}, "retentionPolicy": {"retentionPolicyType": "LongTermRetentionPolicy",
-      "dailySchedule": {"retentionTimes": ["2023-05-17T22:00:00.000Z"], "retentionDuration":
-      {"count": 30, "durationType": "Days"}}}, "timeZone": "UTC"}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup policy create
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '512'
-      Content-Type:
-      - application/json
-      ParameterSetName:
-      - -g -v --policy -n --backup-management-type
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","name":"clitest-item000005","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '719'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:12:31 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1195'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --storage-account --azure-file-share -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+status+eq+%27Registered%27
-  response:
-    body:
-      string: '{"value":[]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '12'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:12:32 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --storage-account --azure-file-share -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","name":"StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"adiguptecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/adigupt-ecy-rg/providers/Microsoft.Storage/storageAccounts/adiguptecy"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg2yfprhyqds;clitesttz6sdom2jatwnfac4","name":"StorageContainer;Storage;clitest.rg2yfprhyqds;clitesttz6sdom2jatwnfac4","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesttz6sdom2jatwnfac4","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg2yfprhyqds/providers/Microsoft.Storage/storageAccounts/clitesttz6sdom2jatwnfac4"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgaphtzd4b6w;clitest2e4uvoffeuotuhhkv","name":"StorageContainer;Storage;clitest.rgaphtzd4b6w;clitest2e4uvoffeuotuhhkv","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest2e4uvoffeuotuhhkv","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgaphtzd4b6w/providers/Microsoft.Storage/storageAccounts/clitest2e4uvoffeuotuhhkv"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx;clitest5g7td7ozjqq2b6ccr","name":"StorageContainer;Storage;clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx;clitest5g7td7ozjqq2b6ccr","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest5g7td7ozjqq2b6ccr","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx/providers/Microsoft.Storage/storageAccounts/clitest5g7td7ozjqq2b6ccr"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgt7y3m2jxoj;clitest4ok6wrvjr5q6texyd","name":"StorageContainer;Storage;clitest.rgt7y3m2jxoj;clitest4ok6wrvjr5q6texyd","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest4ok6wrvjr5q6texyd","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgt7y3m2jxoj/providers/Microsoft.Storage/storageAccounts/clitest4ok6wrvjr5q6texyd"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rguojke4c6gf;clitestid5t5zlxfktv7il2t","name":"StorageContainer;Storage;clitest.rguojke4c6gf;clitestid5t5zlxfktv7il2t","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestid5t5zlxfktv7il2t","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rguojke4c6gf/providers/Microsoft.Storage/storageAccounts/clitestid5t5zlxfktv7il2t"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","name":"StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontusebvtaksecycansa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DonotUse-Blobs-BVT-EACAN-RG/providers/Microsoft.Storage/storageAccounts/dontusebvtaksecycansa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","name":"StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"iaasextstoreecy1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.czr/providers/Microsoft.Storage/storageAccounts/iaasextstoreecy1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","name":"StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesaksdonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-clitest-rg/providers/Microsoft.Storage/storageAccounts/clitesaksdonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"bloboprestorecontainers","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/bloboprestorecontainers"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopall","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopall"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopcontainer","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopcontainer"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopprefix","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopprefix"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG;zubairsaecy","name":"StorageContainer;Storage;zubairRG;zubairsaecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Storage/storageAccounts/zubairsaecy"}}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '10834'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:12:34 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -551,8 +763,8 @@ interactions:
       ParameterSetName:
       - -g -v --storage-account --azure-file-share -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/refreshContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
@@ -560,17 +772,17 @@ interactions:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/6dbfcaf8-79d5-40e9-a393-1be3b92eb501?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/e62c5fa9-679c-45b2-a761-9c6e719d0fa4?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:12:34 GMT
+      - Wed, 16 Aug 2023 09:38:38 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6dbfcaf8-79d5-40e9-a393-1be3b92eb501?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/e62c5fa9-679c-45b2-a761-9c6e719d0fa4?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -580,7 +792,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1197'
     status:
       code: 202
       message: Accepted
@@ -598,10 +810,10 @@ interactions:
       ParameterSetName:
       - -g -v --storage-account --azure-file-share -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6dbfcaf8-79d5-40e9-a393-1be3b92eb501?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/e62c5fa9-679c-45b2-a761-9c6e719d0fa4?api-version=2023-02-01
   response:
     body:
       string: ''
@@ -611,11 +823,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:12:35 GMT
+      - Wed, 16 Aug 2023 09:38:40 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6dbfcaf8-79d5-40e9-a393-1be3b92eb501?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/e62c5fa9-679c-45b2-a761-9c6e719d0fa4?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -625,7 +837,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '296'
+      - '290'
     status:
       code: 202
       message: Accepted
@@ -643,10 +855,10 @@ interactions:
       ParameterSetName:
       - -g -v --storage-account --azure-file-share -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6dbfcaf8-79d5-40e9-a393-1be3b92eb501?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/e62c5fa9-679c-45b2-a761-9c6e719d0fa4?api-version=2023-02-01
   response:
     body:
       string: ''
@@ -656,11 +868,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:12:41 GMT
+      - Wed, 16 Aug 2023 09:38:46 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6dbfcaf8-79d5-40e9-a393-1be3b92eb501?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/e62c5fa9-679c-45b2-a761-9c6e719d0fa4?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -670,7 +882,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '295'
+      - '289'
     status:
       code: 202
       message: Accepted
@@ -688,10 +900,10 @@ interactions:
       ParameterSetName:
       - -g -v --storage-account --azure-file-share -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6dbfcaf8-79d5-40e9-a393-1be3b92eb501?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/e62c5fa9-679c-45b2-a761-9c6e719d0fa4?api-version=2023-02-01
   response:
     body:
       string: ''
@@ -699,7 +911,7 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Wed, 17 May 2023 12:12:47 GMT
+      - Wed, 16 Aug 2023 09:38:51 GMT
       expires:
       - '-1'
       pragma:
@@ -711,7 +923,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '294'
+      - '288'
     status:
       code: 204
       message: No Content
@@ -729,22 +941,22 @@ interactions:
       ParameterSetName:
       - -g -v --storage-account --azure-file-share -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","name":"StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"adiguptecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/adigupt-ecy-rg/providers/Microsoft.Storage/storageAccounts/adiguptecy"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg2yfprhyqds;clitesttz6sdom2jatwnfac4","name":"StorageContainer;Storage;clitest.rg2yfprhyqds;clitesttz6sdom2jatwnfac4","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesttz6sdom2jatwnfac4","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg2yfprhyqds/providers/Microsoft.Storage/storageAccounts/clitesttz6sdom2jatwnfac4"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgaphtzd4b6w;clitest2e4uvoffeuotuhhkv","name":"StorageContainer;Storage;clitest.rgaphtzd4b6w;clitest2e4uvoffeuotuhhkv","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest2e4uvoffeuotuhhkv","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgaphtzd4b6w/providers/Microsoft.Storage/storageAccounts/clitest2e4uvoffeuotuhhkv"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest000003","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx;clitest5g7td7ozjqq2b6ccr","name":"StorageContainer;Storage;clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx;clitest5g7td7ozjqq2b6ccr","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest5g7td7ozjqq2b6ccr","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx/providers/Microsoft.Storage/storageAccounts/clitest5g7td7ozjqq2b6ccr"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgt7y3m2jxoj;clitest4ok6wrvjr5q6texyd","name":"StorageContainer;Storage;clitest.rgt7y3m2jxoj;clitest4ok6wrvjr5q6texyd","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest4ok6wrvjr5q6texyd","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgt7y3m2jxoj/providers/Microsoft.Storage/storageAccounts/clitest4ok6wrvjr5q6texyd"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rguojke4c6gf;clitestid5t5zlxfktv7il2t","name":"StorageContainer;Storage;clitest.rguojke4c6gf;clitestid5t5zlxfktv7il2t","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestid5t5zlxfktv7il2t","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rguojke4c6gf/providers/Microsoft.Storage/storageAccounts/clitestid5t5zlxfktv7il2t"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","name":"StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontusebvtaksecycansa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DonotUse-Blobs-BVT-EACAN-RG/providers/Microsoft.Storage/storageAccounts/dontusebvtaksecycansa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","name":"StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"iaasextstoreecy1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.czr/providers/Microsoft.Storage/storageAccounts/iaasextstoreecy1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","name":"StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesaksdonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-clitest-rg/providers/Microsoft.Storage/storageAccounts/clitesaksdonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"bloboprestorecontainers","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/bloboprestorecontainers"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopall","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopall"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopcontainer","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopcontainer"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopprefix","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopprefix"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG;zubairsaecy","name":"StorageContainer;Storage;zubairRG;zubairsaecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Storage/storageAccounts/zubairsaecy"}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","name":"StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"adiguptecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/adigupt-ecy-rg/providers/Microsoft.Storage/storageAccounts/adiguptecy"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest000003","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgxipdj2pzcf;clitesttgvhfd3jggjbyumfx","name":"StorageContainer;Storage;clitest.rgxipdj2pzcf;clitesttgvhfd3jggjbyumfx","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesttgvhfd3jggjbyumfx","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgxipdj2pzcf/providers/Microsoft.Storage/storageAccounts/clitesttgvhfd3jggjbyumfx"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","name":"StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontusebvtaksecycansa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DonotUse-Blobs-BVT-EACAN-RG/providers/Microsoft.Storage/storageAccounts/dontusebvtaksecycansa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","name":"StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"iaasextstoreecy1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.czr/providers/Microsoft.Storage/storageAccounts/iaasextstoreecy1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","name":"StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesaksdonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-clitest-rg/providers/Microsoft.Storage/storageAccounts/clitesaksdonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"bloboprestorecontainers","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/bloboprestorecontainers"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopall","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopall"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopcontainer","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopcontainer"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopprefix","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopprefix"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG2;zubairsaecy2","name":"StorageContainer;Storage;zubairRG2;zubairsaecy2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy2","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG2/providers/Microsoft.Storage/storageAccounts/zubairsaecy2"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG;zubairsaecy","name":"StorageContainer;Storage;zubairRG;zubairsaecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Storage/storageAccounts/zubairsaecy"}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '11546'
+      - '8996'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:12:47 GMT
+      - Wed, 16 Aug 2023 09:38:52 GMT
       expires:
       - '-1'
       pragma:
@@ -760,7 +972,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '296'
     status:
       code: 200
       message: OK
@@ -783,8 +995,8 @@ interactions:
       ParameterSetName:
       - -g -v --storage-account --azure-file-share -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003?api-version=2023-02-01
   response:
@@ -792,7 +1004,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/64299eb9-45ef-49c9-ba43-8f4df0080a1d?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/eb2bf3a6-a213-4183-bd0c-bec33533af80?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -800,11 +1012,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:12:49 GMT
+      - Wed, 16 Aug 2023 09:38:53 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/64299eb9-45ef-49c9-ba43-8f4df0080a1d?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/eb2bf3a6-a213-4183-bd0c-bec33533af80?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -814,7 +1026,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1196'
+      - '1193'
     status:
       code: 202
       message: Accepted
@@ -832,16 +1044,16 @@ interactions:
       ParameterSetName:
       - -g -v --storage-account --azure-file-share -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/64299eb9-45ef-49c9-ba43-8f4df0080a1d?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/eb2bf3a6-a213-4183-bd0c-bec33533af80?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/64299eb9-45ef-49c9-ba43-8f4df0080a1d?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/eb2bf3a6-a213-4183-bd0c-bec33533af80?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -849,11 +1061,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:12:49 GMT
+      - Wed, 16 Aug 2023 09:38:54 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/64299eb9-45ef-49c9-ba43-8f4df0080a1d?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/eb2bf3a6-a213-4183-bd0c-bec33533af80?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -863,7 +1075,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '284'
     status:
       code: 202
       message: Accepted
@@ -881,16 +1093,16 @@ interactions:
       ParameterSetName:
       - -g -v --storage-account --azure-file-share -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/64299eb9-45ef-49c9-ba43-8f4df0080a1d?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/eb2bf3a6-a213-4183-bd0c-bec33533af80?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/64299eb9-45ef-49c9-ba43-8f4df0080a1d?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/eb2bf3a6-a213-4183-bd0c-bec33533af80?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -898,11 +1110,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:12:55 GMT
+      - Wed, 16 Aug 2023 09:39:00 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/64299eb9-45ef-49c9-ba43-8f4df0080a1d?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/eb2bf3a6-a213-4183-bd0c-bec33533af80?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -912,7 +1124,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '296'
+      - '283'
     status:
       code: 202
       message: Accepted
@@ -930,10 +1142,255 @@ interactions:
       ParameterSetName:
       - -g -v --storage-account --azure-file-share -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/64299eb9-45ef-49c9-ba43-8f4df0080a1d?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/eb2bf3a6-a213-4183-bd0c-bec33533af80?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/eb2bf3a6-a213-4183-bd0c-bec33533af80?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:39:05 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/eb2bf3a6-a213-4183-bd0c-bec33533af80?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '282'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/eb2bf3a6-a213-4183-bd0c-bec33533af80?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/eb2bf3a6-a213-4183-bd0c-bec33533af80?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:39:11 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/eb2bf3a6-a213-4183-bd0c-bec33533af80?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '281'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/eb2bf3a6-a213-4183-bd0c-bec33533af80?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/eb2bf3a6-a213-4183-bd0c-bec33533af80?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:39:17 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/eb2bf3a6-a213-4183-bd0c-bec33533af80?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '280'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/eb2bf3a6-a213-4183-bd0c-bec33533af80?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/eb2bf3a6-a213-4183-bd0c-bec33533af80?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:39:22 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/eb2bf3a6-a213-4183-bd0c-bec33533af80?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '279'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/eb2bf3a6-a213-4183-bd0c-bec33533af80?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/eb2bf3a6-a213-4183-bd0c-bec33533af80?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:39:27 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/eb2bf3a6-a213-4183-bd0c-bec33533af80?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '278'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/eb2bf3a6-a213-4183-bd0c-bec33533af80?api-version=2023-02-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","protectedItemCount":0,"acquireStorageAccountLock":"Acquire","friendlyName":"clitest000003","backupManagementType":"AzureStorage","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"StorageContainer","protectableObjectType":"StorageContainer"}}'
@@ -945,787 +1402,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:13:01 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '294'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --storage-account --azure-file-share -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectableItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+workloadType+eq+%27AzureFileShare%27
-  response:
-    body:
-      string: '{"value":[]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '12'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:13:02 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      ParameterSetName:
-      - -g -v --storage-account --azure-file-share -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/inquire?api-version=2023-02-01&%24filter=workloadType+eq+%27AzureFileShare%27
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/75aeb924-9e19-40b9-b41a-e1dadb8a932c?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Wed, 17 May 2023 12:13:02 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/75aeb924-9e19-40b9-b41a-e1dadb8a932c?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --storage-account --azure-file-share -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/75aeb924-9e19-40b9-b41a-e1dadb8a932c?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/75aeb924-9e19-40b9-b41a-e1dadb8a932c?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:13:03 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/75aeb924-9e19-40b9-b41a-e1dadb8a932c?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --storage-account --azure-file-share -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/75aeb924-9e19-40b9-b41a-e1dadb8a932c?api-version=2023-02-01
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      date:
-      - Wed, 17 May 2023 12:13:08 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --storage-account --azure-file-share -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectableItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+workloadType+eq+%27AzureFileShare%27
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectableItems/azurefileshare;9be41d011153ba6eecf0b01d71d68e3b98444c3bc7a800916b63f29f311553fa","name":"azurefileshare;9be41d011153ba6eecf0b01d71d68e3b98444c3bc7a800916b63f29f311553fa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"parentContainerFabricId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","parentContainerFriendlyName":"clitest000003","azureFileShareType":"XSMB","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","protectableItemType":"AzureFileShare","friendlyName":"clitest-item000004","protectionState":"NotProtected"}}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '983'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:13:09 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --storage-account --azure-file-share -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","name":"clitest-item000005","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '719'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:13:10 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"protectedItemType": "AzureFileShareProtectedItem", "sourceResourceId":
-      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003",
-      "policyId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005"}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '430'
-      Content-Type:
-      - application/json
-      ParameterSetName:
-      - -g -v --storage-account --azure-file-share -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/azurefileshare%3B9be41d011153ba6eecf0b01d71d68e3b98444c3bc7a800916b63f29f311553fa?api-version=2023-02-01
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectedItems/azurefileshare;9be41d011153ba6eecf0b01d71d68e3b98444c3bc7a800916b63f29f311553fa/operationsStatus/bc170eab-e7c7-4ffd-8d63-d8bbd9f4bb24?api-version=2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Wed, 17 May 2023 12:13:11 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectedItems/azurefileshare;9be41d011153ba6eecf0b01d71d68e3b98444c3bc7a800916b63f29f311553fa/operationResults/bc170eab-e7c7-4ffd-8d63-d8bbd9f4bb24?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1188'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --storage-account --azure-file-share -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/bc170eab-e7c7-4ffd-8d63-d8bbd9f4bb24?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"bc170eab-e7c7-4ffd-8d63-d8bbd9f4bb24","name":"bc170eab-e7c7-4ffd-8d63-d8bbd9f4bb24","status":"InProgress","startTime":"2023-05-17T12:13:11.8765515Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:13:12 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '285'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --storage-account --azure-file-share -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/bc170eab-e7c7-4ffd-8d63-d8bbd9f4bb24?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"bc170eab-e7c7-4ffd-8d63-d8bbd9f4bb24","name":"bc170eab-e7c7-4ffd-8d63-d8bbd9f4bb24","status":"InProgress","startTime":"2023-05-17T12:13:11.8765515Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:13:17 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '284'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --storage-account --azure-file-share -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/bc170eab-e7c7-4ffd-8d63-d8bbd9f4bb24?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"bc170eab-e7c7-4ffd-8d63-d8bbd9f4bb24","name":"bc170eab-e7c7-4ffd-8d63-d8bbd9f4bb24","status":"InProgress","startTime":"2023-05-17T12:13:11.8765515Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:13:24 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '283'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --storage-account --azure-file-share -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/bc170eab-e7c7-4ffd-8d63-d8bbd9f4bb24?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"bc170eab-e7c7-4ffd-8d63-d8bbd9f4bb24","name":"bc170eab-e7c7-4ffd-8d63-d8bbd9f4bb24","status":"InProgress","startTime":"2023-05-17T12:13:11.8765515Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:13:29 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '282'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --storage-account --azure-file-share -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/bc170eab-e7c7-4ffd-8d63-d8bbd9f4bb24?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"bc170eab-e7c7-4ffd-8d63-d8bbd9f4bb24","name":"bc170eab-e7c7-4ffd-8d63-d8bbd9f4bb24","status":"InProgress","startTime":"2023-05-17T12:13:11.8765515Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:13:34 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '281'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --storage-account --azure-file-share -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/bc170eab-e7c7-4ffd-8d63-d8bbd9f4bb24?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"bc170eab-e7c7-4ffd-8d63-d8bbd9f4bb24","name":"bc170eab-e7c7-4ffd-8d63-d8bbd9f4bb24","status":"InProgress","startTime":"2023-05-17T12:13:11.8765515Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:13:40 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '280'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --storage-account --azure-file-share -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/bc170eab-e7c7-4ffd-8d63-d8bbd9f4bb24?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"bc170eab-e7c7-4ffd-8d63-d8bbd9f4bb24","name":"bc170eab-e7c7-4ffd-8d63-d8bbd9f4bb24","status":"InProgress","startTime":"2023-05-17T12:13:11.8765515Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:13:46 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '279'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --storage-account --azure-file-share -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/bc170eab-e7c7-4ffd-8d63-d8bbd9f4bb24?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"bc170eab-e7c7-4ffd-8d63-d8bbd9f4bb24","name":"bc170eab-e7c7-4ffd-8d63-d8bbd9f4bb24","status":"InProgress","startTime":"2023-05-17T12:13:11.8765515Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:13:52 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '278'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --storage-account --azure-file-share -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/bc170eab-e7c7-4ffd-8d63-d8bbd9f4bb24?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"bc170eab-e7c7-4ffd-8d63-d8bbd9f4bb24","name":"bc170eab-e7c7-4ffd-8d63-d8bbd9f4bb24","status":"Succeeded","startTime":"2023-05-17T12:13:11.8765515Z","endTime":"2023-05-17T12:13:11.8765515Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"b9ce6a67-032f-4a8e-a540-3a4dd5c19e3a"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:13:57 GMT
+      - Wed, 16 Aug 2023 09:39:32 GMT
       expires:
       - '-1'
       pragma:
@@ -1759,24 +1436,22 @@ interactions:
       ParameterSetName:
       - -g -v --storage-account --azure-file-share -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/b9ce6a67-032f-4a8e-a540-3a4dd5c19e3a?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectableItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+workloadType+eq+%27AzureFileShare%27
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/b9ce6a67-032f-4a8e-a540-3a4dd5c19e3a","name":"b9ce6a67-032f-4a8e-a540-3a4dd5c19e3a","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT41.3762285S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
-        Share Name":"clitest-item000004","Storage Account Name":"clitest000003","Policy
-        Name":"clitest-item000005"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"ConfigureBackup","status":"Completed","startTime":"2023-05-17T12:13:11.8765515Z","endTime":"2023-05-17T12:13:53.25278Z","activityId":"18eba837-f4ac-11ed-8b3f-c8f750f92764"}}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectableItems/azurefileshare;8f4047bdaf7626495f2ed27982e9993809e79c8e05e8b30f66300a4b5bda4670","name":"azurefileshare;8f4047bdaf7626495f2ed27982e9993809e79c8e05e8b30f66300a4b5bda4670","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"parentContainerFabricId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","parentContainerFriendlyName":"clitest000003","azureFileShareType":"XSMB","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","protectableItemType":"AzureFileShare","friendlyName":"clitest-item000004","protectionState":"NotProtected"}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '895'
+      - '983'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:13:58 GMT
+      - Wed, 16 Aug 2023 09:39:34 GMT
       expires:
       - '-1'
       pragma:
@@ -1792,7 +1467,601 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '148'
+      - '296'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","name":"clitest-item000005","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","workLoadType":"AzureFileShare","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T19:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T19:30:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '751'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:39:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '296'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"protectedItemType": "AzureFileShareProtectedItem", "sourceResourceId":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003",
+      "policyId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '430'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/azurefileshare%3B8f4047bdaf7626495f2ed27982e9993809e79c8e05e8b30f66300a4b5bda4670?api-version=2023-02-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectedItems/azurefileshare;8f4047bdaf7626495f2ed27982e9993809e79c8e05e8b30f66300a4b5bda4670/operationsStatus/2c15f0c1-12e0-4ef0-bcf8-9a87a96c58aa?api-version=2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Wed, 16 Aug 2023 09:39:36 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectedItems/azurefileshare;8f4047bdaf7626495f2ed27982e9993809e79c8e05e8b30f66300a4b5bda4670/operationResults/2c15f0c1-12e0-4ef0-bcf8-9a87a96c58aa?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1194'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/2c15f0c1-12e0-4ef0-bcf8-9a87a96c58aa?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"2c15f0c1-12e0-4ef0-bcf8-9a87a96c58aa","name":"2c15f0c1-12e0-4ef0-bcf8-9a87a96c58aa","status":"InProgress","startTime":"2023-08-16T09:39:36.974842Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:39:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '257'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/2c15f0c1-12e0-4ef0-bcf8-9a87a96c58aa?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"2c15f0c1-12e0-4ef0-bcf8-9a87a96c58aa","name":"2c15f0c1-12e0-4ef0-bcf8-9a87a96c58aa","status":"InProgress","startTime":"2023-08-16T09:39:36.974842Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:39:42 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '256'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/2c15f0c1-12e0-4ef0-bcf8-9a87a96c58aa?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"2c15f0c1-12e0-4ef0-bcf8-9a87a96c58aa","name":"2c15f0c1-12e0-4ef0-bcf8-9a87a96c58aa","status":"InProgress","startTime":"2023-08-16T09:39:36.974842Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:39:49 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '255'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/2c15f0c1-12e0-4ef0-bcf8-9a87a96c58aa?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"2c15f0c1-12e0-4ef0-bcf8-9a87a96c58aa","name":"2c15f0c1-12e0-4ef0-bcf8-9a87a96c58aa","status":"InProgress","startTime":"2023-08-16T09:39:36.974842Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:39:54 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '254'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/2c15f0c1-12e0-4ef0-bcf8-9a87a96c58aa?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"2c15f0c1-12e0-4ef0-bcf8-9a87a96c58aa","name":"2c15f0c1-12e0-4ef0-bcf8-9a87a96c58aa","status":"InProgress","startTime":"2023-08-16T09:39:36.974842Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:39:59 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '253'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/2c15f0c1-12e0-4ef0-bcf8-9a87a96c58aa?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"2c15f0c1-12e0-4ef0-bcf8-9a87a96c58aa","name":"2c15f0c1-12e0-4ef0-bcf8-9a87a96c58aa","status":"InProgress","startTime":"2023-08-16T09:39:36.974842Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:40:04 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '252'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/2c15f0c1-12e0-4ef0-bcf8-9a87a96c58aa?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"2c15f0c1-12e0-4ef0-bcf8-9a87a96c58aa","name":"2c15f0c1-12e0-4ef0-bcf8-9a87a96c58aa","status":"InProgress","startTime":"2023-08-16T09:39:36.974842Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:40:10 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '251'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/2c15f0c1-12e0-4ef0-bcf8-9a87a96c58aa?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"2c15f0c1-12e0-4ef0-bcf8-9a87a96c58aa","name":"2c15f0c1-12e0-4ef0-bcf8-9a87a96c58aa","status":"InProgress","startTime":"2023-08-16T09:39:36.974842Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:40:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '250'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/2c15f0c1-12e0-4ef0-bcf8-9a87a96c58aa?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"2c15f0c1-12e0-4ef0-bcf8-9a87a96c58aa","name":"2c15f0c1-12e0-4ef0-bcf8-9a87a96c58aa","status":"Succeeded","startTime":"2023-08-16T09:39:36.974842Z","endTime":"2023-08-16T09:39:36.974842Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"896853db-7600-47be-8f7d-2072759be838"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '302'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:40:21 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '249'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --storage-account --azure-file-share -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/896853db-7600-47be-8f7d-2072759be838?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/896853db-7600-47be-8f7d-2072759be838","name":"896853db-7600-47be-8f7d-2072759be838","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT41.480338S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
+        Share Name":"clitest-item000004","Storage Account Name":"clitest000003","Policy
+        Name":"clitest-item000005"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"ConfigureBackup","status":"Completed","startTime":"2023-08-16T09:39:36.974842Z","endTime":"2023-08-16T09:40:18.45518Z","activityId":"ac6614cf-3c18-11ee-9882-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '893'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:40:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '145'
     status:
       code: 200
       message: OK
@@ -1810,13 +2079,13 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --retain-until --backup-management-type --query
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;9be41d011153ba6eecf0b01d71d68e3b98444c3bc7a800916b63f29f311553fa","name":"AzureFileShare;9be41d011153ba6eecf0b01d71d68e3b98444c3bc7a800916b63f29f311553fa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;8f4047bdaf7626495f2ed27982e9993809e79c8e05e8b30f66300a4b5bda4670","name":"AzureFileShare;8f4047bdaf7626495f2ed27982e9993809e79c8e05e8b30f66300a4b5bda4670","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
     headers:
       cache-control:
       - no-cache
@@ -1825,7 +2094,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:14:00 GMT
+      - Wed, 16 Aug 2023 09:40:23 GMT
       expires:
       - '-1'
       pragma:
@@ -1841,13 +2110,13 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '293'
     status:
       code: 200
       message: OK
 - request:
     body: '{"properties": {"objectType": "AzureFileShareBackupRequest", "recoveryPointExpiryTimeInUTC":
-      "2023-06-16T00:00:00.000Z"}}'
+      "2023-09-15T00:00:00.000Z"}}'
     headers:
       Accept:
       - application/json
@@ -1864,26 +2133,26 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --retain-until --backup-management-type --query
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3B9be41d011153ba6eecf0b01d71d68e3b98444c3bc7a800916b63f29f311553fa/backup?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3B8f4047bdaf7626495f2ed27982e9993809e79c8e05e8b30f66300a4b5bda4670/backup?api-version=2023-02-01
   response:
     body:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;9be41d011153ba6eecf0b01d71d68e3b98444c3bc7a800916b63f29f311553fa/operationsStatus/8dfc50a1-5e74-42dc-a12a-d2b47087dcb5?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;8f4047bdaf7626495f2ed27982e9993809e79c8e05e8b30f66300a4b5bda4670/operationsStatus/853d10a6-ceea-4eeb-ac95-5022a690a7f8?api-version=2023-02-01
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:14:01 GMT
+      - Wed, 16 Aug 2023 09:40:24 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;9be41d011153ba6eecf0b01d71d68e3b98444c3bc7a800916b63f29f311553fa/operationResults/8dfc50a1-5e74-42dc-a12a-d2b47087dcb5?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;8f4047bdaf7626495f2ed27982e9993809e79c8e05e8b30f66300a4b5bda4670/operationResults/853d10a6-ceea-4eeb-ac95-5022a690a7f8?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -1893,7 +2162,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1199'
     status:
       code: 202
       message: Accepted
@@ -1911,13 +2180,13 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --retain-until --backup-management-type --query
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8dfc50a1-5e74-42dc-a12a-d2b47087dcb5?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/853d10a6-ceea-4eeb-ac95-5022a690a7f8?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"8dfc50a1-5e74-42dc-a12a-d2b47087dcb5","name":"8dfc50a1-5e74-42dc-a12a-d2b47087dcb5","status":"Succeeded","startTime":"2023-05-17T12:14:01.7947692Z","endTime":"2023-05-17T12:14:01.7947692Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"5891803e-f2e6-4efb-940c-7465935dec3d"}}'
+      string: '{"id":"853d10a6-ceea-4eeb-ac95-5022a690a7f8","name":"853d10a6-ceea-4eeb-ac95-5022a690a7f8","status":"Succeeded","startTime":"2023-08-16T09:40:25.1590969Z","endTime":"2023-08-16T09:40:25.1590969Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"f9436a1f-05cc-4012-bfac-b20d457fef07"}}'
     headers:
       cache-control:
       - no-cache
@@ -1926,7 +2195,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:14:02 GMT
+      - Wed, 16 Aug 2023 09:40:26 GMT
       expires:
       - '-1'
       pragma:
@@ -1942,7 +2211,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '294'
+      - '286'
     status:
       code: 200
       message: OK
@@ -1960,15 +2229,15 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --retain-until --backup-management-type --query
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/5891803e-f2e6-4efb-940c-7465935dec3d?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f9436a1f-05cc-4012-bfac-b20d457fef07?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/5891803e-f2e6-4efb-940c-7465935dec3d","name":"5891803e-f2e6-4efb-940c-7465935dec3d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT1.5235468S","storageAccountName":"clitest000003","storageAccountVersion":"MicrosoftStorage","extendedInfo":{"tasksList":[{"taskId":"Take
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f9436a1f-05cc-4012-bfac-b20d457fef07","name":"f9436a1f-05cc-4012-bfac-b20d457fef07","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT2.4815324S","storageAccountName":"clitest000003","storageAccountVersion":"MicrosoftStorage","extendedInfo":{"tasksList":[{"taskId":"Take
         Snapshot","status":"InProgress"}],"propertyBag":{"Data Transferred (in MB)":"0","File
-        Share Name":"clitest-item000004","Whether job is adhoc or scheduled.":"True"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"Backup","status":"InProgress","startTime":"2023-05-17T12:14:01.7947692Z","activityId":"4cbf592a-f4ac-11ed-9e12-c8f750f92764"}}'
+        Share Name":"clitest-item000004","Whether job is adhoc or scheduled.":"True"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"Backup","status":"InProgress","startTime":"2023-08-16T09:40:25.1590969Z","activityId":"ebfdffb2-3c18-11ee-930d-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
@@ -1977,7 +2246,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:14:03 GMT
+      - Wed, 16 Aug 2023 09:40:27 GMT
       expires:
       - '-1'
       pragma:
@@ -1993,7 +2262,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '148'
+      - '144'
     status:
       code: 200
       message: OK
@@ -2011,15 +2280,15 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/5891803e-f2e6-4efb-940c-7465935dec3d?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f9436a1f-05cc-4012-bfac-b20d457fef07?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/5891803e-f2e6-4efb-940c-7465935dec3d","name":"5891803e-f2e6-4efb-940c-7465935dec3d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT2.8324417S","storageAccountName":"clitest000003","storageAccountVersion":"MicrosoftStorage","extendedInfo":{"tasksList":[{"taskId":"Take
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f9436a1f-05cc-4012-bfac-b20d457fef07","name":"f9436a1f-05cc-4012-bfac-b20d457fef07","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT3.7637091S","storageAccountName":"clitest000003","storageAccountVersion":"MicrosoftStorage","extendedInfo":{"tasksList":[{"taskId":"Take
         Snapshot","status":"InProgress"}],"propertyBag":{"Data Transferred (in MB)":"0","File
-        Share Name":"clitest-item000004","Whether job is adhoc or scheduled.":"True"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"Backup","status":"InProgress","startTime":"2023-05-17T12:14:01.7947692Z","activityId":"4cbf592a-f4ac-11ed-9e12-c8f750f92764"}}'
+        Share Name":"clitest-item000004","Whether job is adhoc or scheduled.":"True"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"Backup","status":"InProgress","startTime":"2023-08-16T09:40:25.1590969Z","activityId":"ebfdffb2-3c18-11ee-930d-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
@@ -2028,7 +2297,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:14:04 GMT
+      - Wed, 16 Aug 2023 09:40:28 GMT
       expires:
       - '-1'
       pragma:
@@ -2044,7 +2313,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '149'
+      - '144'
     status:
       code: 200
       message: OK
@@ -2062,15 +2331,15 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/5891803e-f2e6-4efb-940c-7465935dec3d?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f9436a1f-05cc-4012-bfac-b20d457fef07?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/5891803e-f2e6-4efb-940c-7465935dec3d","name":"5891803e-f2e6-4efb-940c-7465935dec3d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT3.3949444S","storageAccountName":"clitest000003","storageAccountVersion":"MicrosoftStorage","extendedInfo":{"tasksList":[{"taskId":"Take
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f9436a1f-05cc-4012-bfac-b20d457fef07","name":"f9436a1f-05cc-4012-bfac-b20d457fef07","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT4.1699788S","storageAccountName":"clitest000003","storageAccountVersion":"MicrosoftStorage","extendedInfo":{"tasksList":[{"taskId":"Take
         Snapshot","status":"InProgress"}],"propertyBag":{"Data Transferred (in MB)":"0","File
-        Share Name":"clitest-item000004","Whether job is adhoc or scheduled.":"True"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"Backup","status":"InProgress","startTime":"2023-05-17T12:14:01.7947692Z","activityId":"4cbf592a-f4ac-11ed-9e12-c8f750f92764"}}'
+        Share Name":"clitest-item000004","Whether job is adhoc or scheduled.":"True"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"Backup","status":"InProgress","startTime":"2023-08-16T09:40:25.1590969Z","activityId":"ebfdffb2-3c18-11ee-930d-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
@@ -2079,7 +2348,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:14:04 GMT
+      - Wed, 16 Aug 2023 09:40:28 GMT
       expires:
       - '-1'
       pragma:
@@ -2095,7 +2364,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '148'
+      - '143'
     status:
       code: 200
       message: OK
@@ -2113,15 +2382,15 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/5891803e-f2e6-4efb-940c-7465935dec3d?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f9436a1f-05cc-4012-bfac-b20d457fef07?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/5891803e-f2e6-4efb-940c-7465935dec3d","name":"5891803e-f2e6-4efb-940c-7465935dec3d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT3.6014615S","storageAccountName":"clitest000003","storageAccountVersion":"MicrosoftStorage","extendedInfo":{"tasksList":[{"taskId":"Take
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f9436a1f-05cc-4012-bfac-b20d457fef07","name":"f9436a1f-05cc-4012-bfac-b20d457fef07","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT4.4139933S","storageAccountName":"clitest000003","storageAccountVersion":"MicrosoftStorage","extendedInfo":{"tasksList":[{"taskId":"Take
         Snapshot","status":"Completed"}],"propertyBag":{"Data Transferred (in MB)":"0","File
-        Share Name":"clitest-item000004","Whether job is adhoc or scheduled.":"True"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"Backup","status":"Completed","startTime":"2023-05-17T12:14:01.7947692Z","endTime":"2023-05-17T12:14:05.3962307Z","activityId":"4cbf592a-f4ac-11ed-9e12-c8f750f92764"}}'
+        Share Name":"clitest-item000004","Whether job is adhoc or scheduled.":"True"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"Backup","status":"Completed","startTime":"2023-08-16T09:40:25.1590969Z","endTime":"2023-08-16T09:40:29.5730902Z","activityId":"ebfdffb2-3c18-11ee-930d-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
@@ -2130,7 +2399,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:14:35 GMT
+      - Wed, 16 Aug 2023 09:40:59 GMT
       expires:
       - '-1'
       pragma:
@@ -2146,7 +2415,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '147'
+      - '142'
     status:
       code: 200
       message: OK
@@ -2164,13 +2433,13 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --backup-management-type --query
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;9be41d011153ba6eecf0b01d71d68e3b98444c3bc7a800916b63f29f311553fa","name":"AzureFileShare;9be41d011153ba6eecf0b01d71d68e3b98444c3bc7a800916b63f29f311553fa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"Protected","lastBackupStatus":"Completed","lastBackupTime":"2023-05-17T12:14:01.7947692Z","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;8f4047bdaf7626495f2ed27982e9993809e79c8e05e8b30f66300a4b5bda4670","name":"AzureFileShare;8f4047bdaf7626495f2ed27982e9993809e79c8e05e8b30f66300a4b5bda4670","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"Protected","lastBackupStatus":"Completed","lastBackupTime":"2023-08-16T09:40:25.1590969Z","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
     headers:
       cache-control:
       - no-cache
@@ -2179,7 +2448,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:15:06 GMT
+      - Wed, 16 Aug 2023 09:41:30 GMT
       expires:
       - '-1'
       pragma:
@@ -2195,7 +2464,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '290'
     status:
       code: 200
       message: OK
@@ -2213,13 +2482,13 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --backup-management-type --query
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3B9be41d011153ba6eecf0b01d71d68e3b98444c3bc7a800916b63f29f311553fa/recoveryPoints?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3B8f4047bdaf7626495f2ed27982e9993809e79c8e05e8b30f66300a4b5bda4670/recoveryPoints?api-version=2023-02-01
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;9be41d011153ba6eecf0b01d71d68e3b98444c3bc7a800916b63f29f311553fa/recoveryPoints/257501605952379","name":"257501605952379","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints","properties":{"objectType":"AzureFileShareRecoveryPoint","recoveryPointType":"FileSystemConsistent","recoveryPointTime":"2023-05-17T12:14:03Z","fileShareSnapshotUri":"https://clitest000003.file.core.windows.net/clitest-item000004?sharesnapshot=2023-05-17T12:14:03.0000000Z","recoveryPointSizeInGB":0,"recoveryPointTierDetails":[{"type":"InstantRP","status":"Valid"}]}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;8f4047bdaf7626495f2ed27982e9993809e79c8e05e8b30f66300a4b5bda4670/recoveryPoints/373186767391571","name":"373186767391571","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints","properties":{"objectType":"AzureFileShareRecoveryPoint","recoveryPointType":"FileSystemConsistent","recoveryPointTime":"2023-08-16T09:40:27Z","fileShareSnapshotUri":"https://clitest000003.file.core.windows.net/clitest-item000004?sharesnapshot=2023-08-16T09:40:27.0000000Z","recoveryPointSizeInGB":0,"recoveryPointTierDetails":[{"type":"InstantRP","status":"Valid"}]}}]}'
     headers:
       cache-control:
       - no-cache
@@ -2228,7 +2497,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:15:07 GMT
+      - Wed, 16 Aug 2023 09:41:32 GMT
       expires:
       - '-1'
       pragma:
@@ -2262,13 +2531,13 @@ interactions:
       ParameterSetName:
       - -g -v -c -i -r --resolve-conflict --restore-mode --query
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+itemType+eq+%27AzureFileShare%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;9be41d011153ba6eecf0b01d71d68e3b98444c3bc7a800916b63f29f311553fa","name":"AzureFileShare;9be41d011153ba6eecf0b01d71d68e3b98444c3bc7a800916b63f29f311553fa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"Protected","lastBackupStatus":"Completed","lastBackupTime":"2023-05-17T12:14:01.7947692Z","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;8f4047bdaf7626495f2ed27982e9993809e79c8e05e8b30f66300a4b5bda4670","name":"AzureFileShare;8f4047bdaf7626495f2ed27982e9993809e79c8e05e8b30f66300a4b5bda4670","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"Protected","lastBackupStatus":"Completed","lastBackupTime":"2023-08-16T09:40:25.1590969Z","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
     headers:
       cache-control:
       - no-cache
@@ -2277,7 +2546,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:15:08 GMT
+      - Wed, 16 Aug 2023 09:41:33 GMT
       expires:
       - '-1'
       pragma:
@@ -2293,7 +2562,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '289'
     status:
       code: 200
       message: OK
@@ -2311,7 +2580,8 @@ interactions:
       ParameterSetName:
       - -g -v -c -i -r --resolve-conflict --restore-mode --query
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ClassicStorage/storageAccounts/clitest000003?api-version=2015-12-01
   response:
@@ -2327,7 +2597,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:15:09 GMT
+      - Wed, 16 Aug 2023 09:41:34 GMT
       expires:
       - '-1'
       pragma:
@@ -2355,12 +2625,13 @@ interactions:
       ParameterSetName:
       - -g -v -c -i -r --resolve-conflict --restore-mode --query
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003?api-version=2016-01-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","name":"clitest000003","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2023-05-17T12:12:04.8131169Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-05-17T12:12:04.2817728Z","primaryEndpoints":{"blob":"https://clitest000003.blob.core.windows.net/","queue":"https://clitest000003.queue.core.windows.net/","table":"https://clitest000003.table.core.windows.net/","file":"https://clitest000003.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","name":"clitest000003","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2023-08-16T09:38:08.1879179Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-08-16T09:38:07.6098003Z","primaryEndpoints":{"blob":"https://clitest000003.blob.core.windows.net/","queue":"https://clitest000003.queue.core.windows.net/","table":"https://clitest000003.table.core.windows.net/","file":"https://clitest000003.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -2369,7 +2640,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 17 May 2023 12:15:10 GMT
+      - Wed, 16 Aug 2023 09:41:34 GMT
       expires:
       - '-1'
       pragma:
@@ -2407,26 +2678,26 @@ interactions:
       ParameterSetName:
       - -g -v -c -i -r --resolve-conflict --restore-mode --query
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3B9be41d011153ba6eecf0b01d71d68e3b98444c3bc7a800916b63f29f311553fa/recoveryPoints/257501605952379/restore?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3B8f4047bdaf7626495f2ed27982e9993809e79c8e05e8b30f66300a4b5bda4670/recoveryPoints/373186767391571/restore?api-version=2023-02-01
   response:
     body:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;9be41d011153ba6eecf0b01d71d68e3b98444c3bc7a800916b63f29f311553fa/operationsStatus/9c3f8031-7d1b-4a00-ba8d-2ca624145795?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;8f4047bdaf7626495f2ed27982e9993809e79c8e05e8b30f66300a4b5bda4670/operationsStatus/c7af20fa-440e-4ca5-be48-38997a193f1c?api-version=2023-02-01
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:15:11 GMT
+      - Wed, 16 Aug 2023 09:41:36 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;9be41d011153ba6eecf0b01d71d68e3b98444c3bc7a800916b63f29f311553fa/operationResults/9c3f8031-7d1b-4a00-ba8d-2ca624145795?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;8f4047bdaf7626495f2ed27982e9993809e79c8e05e8b30f66300a4b5bda4670/operationResults/c7af20fa-440e-4ca5-be48-38997a193f1c?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -2436,7 +2707,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1194'
     status:
       code: 202
       message: Accepted
@@ -2454,13 +2725,13 @@ interactions:
       ParameterSetName:
       - -g -v -c -i -r --resolve-conflict --restore-mode --query
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/9c3f8031-7d1b-4a00-ba8d-2ca624145795?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c7af20fa-440e-4ca5-be48-38997a193f1c?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"9c3f8031-7d1b-4a00-ba8d-2ca624145795","name":"9c3f8031-7d1b-4a00-ba8d-2ca624145795","status":"Succeeded","startTime":"2023-05-17T12:15:11.0483999Z","endTime":"2023-05-17T12:15:11.0483999Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"9c3f8031-7d1b-4a00-ba8d-2ca624145795"}}'
+      string: '{"id":"c7af20fa-440e-4ca5-be48-38997a193f1c","name":"c7af20fa-440e-4ca5-be48-38997a193f1c","status":"Succeeded","startTime":"2023-08-16T09:41:36.5640733Z","endTime":"2023-08-16T09:41:36.5640733Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"c7af20fa-440e-4ca5-be48-38997a193f1c"}}'
     headers:
       cache-control:
       - no-cache
@@ -2469,7 +2740,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:15:11 GMT
+      - Wed, 16 Aug 2023 09:41:37 GMT
       expires:
       - '-1'
       pragma:
@@ -2485,7 +2756,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '284'
+      - '285'
     status:
       code: 200
       message: OK
@@ -2503,17 +2774,17 @@ interactions:
       ParameterSetName:
       - -g -v -c -i -r --resolve-conflict --restore-mode --query
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/9c3f8031-7d1b-4a00-ba8d-2ca624145795?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/c7af20fa-440e-4ca5-be48-38997a193f1c?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/9c3f8031-7d1b-4a00-ba8d-2ca624145795","name":"9c3f8031-7d1b-4a00-ba8d-2ca624145795","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT1.5874898S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/c7af20fa-440e-4ca5-be48-38997a193f1c","name":"c7af20fa-440e-4ca5-be48-38997a193f1c","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT2.5802523S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
         File Share Name":"clitest-item000004","Source Storage Account Name":"clitest000003","Job
         Type":"Recovering to the original file share","RestoreDestination":"clitest000003/clitest-item000004/","Data
         Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:15:11.0483999Z","activityId":"75d0ab68-f4ac-11ed-8639-c8f750f92764"}}'
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T09:41:36.5640733Z","activityId":"15953b85-3c19-11ee-8aa0-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
@@ -2522,7 +2793,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:15:12 GMT
+      - Wed, 16 Aug 2023 09:41:38 GMT
       expires:
       - '-1'
       pragma:
@@ -2538,7 +2809,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '146'
+      - '141'
     status:
       code: 200
       message: OK
@@ -2556,17 +2827,17 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/9c3f8031-7d1b-4a00-ba8d-2ca624145795?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/c7af20fa-440e-4ca5-be48-38997a193f1c?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/9c3f8031-7d1b-4a00-ba8d-2ca624145795","name":"9c3f8031-7d1b-4a00-ba8d-2ca624145795","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT2.8883125S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/c7af20fa-440e-4ca5-be48-38997a193f1c","name":"c7af20fa-440e-4ca5-be48-38997a193f1c","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT3.8466685S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
         File Share Name":"clitest-item000004","Source Storage Account Name":"clitest000003","Job
         Type":"Recovering to the original file share","RestoreDestination":"clitest000003/clitest-item000004/","Data
         Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:15:11.0483999Z","activityId":"75d0ab68-f4ac-11ed-8639-c8f750f92764"}}'
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T09:41:36.5640733Z","activityId":"15953b85-3c19-11ee-8aa0-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
@@ -2575,60 +2846,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:15:13 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '148'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup job wait
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -n
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/9c3f8031-7d1b-4a00-ba8d-2ca624145795?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/9c3f8031-7d1b-4a00-ba8d-2ca624145795","name":"9c3f8031-7d1b-4a00-ba8d-2ca624145795","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT3.4351381S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000004","Source Storage Account Name":"clitest000003","Job
-        Type":"Recovering to the original file share","RestoreDestination":"clitest000003/clitest-item000004/","Data
-        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:15:11.0483999Z","activityId":"75d0ab68-f4ac-11ed-8639-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1093'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:15:13 GMT
+      - Wed, 16 Aug 2023 09:41:40 GMT
       expires:
       - '-1'
       pragma:
@@ -2662,26 +2880,26 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/9c3f8031-7d1b-4a00-ba8d-2ca624145795?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/c7af20fa-440e-4ca5-be48-38997a193f1c?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/9c3f8031-7d1b-4a00-ba8d-2ca624145795","name":"9c3f8031-7d1b-4a00-ba8d-2ca624145795","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT33.9663252S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/c7af20fa-440e-4ca5-be48-38997a193f1c","name":"c7af20fa-440e-4ca5-be48-38997a193f1c","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT4.2529296S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
         File Share Name":"clitest-item000004","Source Storage Account Name":"clitest000003","Job
         Type":"Recovering to the original file share","RestoreDestination":"clitest000003/clitest-item000004/","Data
         Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-05-17T12:15:11.0483999Z","activityId":"75d0ab68-f4ac-11ed-8639-c8f750f92764"}}'
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T09:41:36.5640733Z","activityId":"15953b85-3c19-11ee-8aa0-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1094'
+      - '1093'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:15:44 GMT
+      - Wed, 16 Aug 2023 09:41:40 GMT
       expires:
       - '-1'
       pragma:
@@ -2715,26 +2933,26 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/9c3f8031-7d1b-4a00-ba8d-2ca624145795?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/c7af20fa-440e-4ca5-be48-38997a193f1c?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/9c3f8031-7d1b-4a00-ba8d-2ca624145795","name":"9c3f8031-7d1b-4a00-ba8d-2ca624145795","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT33.4276274S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
-        File Share Name":"clitest-item000004","Source Storage Account Name":"clitest000003","RestoreRecoveryPointTime":"5/17/2023
-        12:14:04 PM","Job Type":"Recovering to the original file share","RestoreDestination":"clitest000003/clitest-item000004/","Data
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/c7af20fa-440e-4ca5-be48-38997a193f1c","name":"c7af20fa-440e-4ca5-be48-38997a193f1c","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT34.6794766S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000004","Source Storage Account Name":"clitest000003","Job
+        Type":"Recovering to the original file share","RestoreDestination":"clitest000003/clitest-item000004/","Data
         Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
-        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"Restore","status":"Completed","startTime":"2023-05-17T12:15:11.0483999Z","endTime":"2023-05-17T12:15:44.4760273Z","activityId":"75d0ab68-f4ac-11ed-8639-c8f750f92764"}}'
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"Restore","status":"InProgress","startTime":"2023-08-16T09:41:36.5640733Z","activityId":"15953b85-3c19-11ee-8aa0-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1185'
+      - '1094'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:16:15 GMT
+      - Wed, 16 Aug 2023 09:42:10 GMT
       expires:
       - '-1'
       pragma:
@@ -2762,28 +2980,32 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - backup protection disable
+      - backup job wait
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/c7af20fa-440e-4ca5-be48-38997a193f1c?api-version=2023-02-01
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;9be41d011153ba6eecf0b01d71d68e3b98444c3bc7a800916b63f29f311553fa","name":"AzureFileShare;9be41d011153ba6eecf0b01d71d68e3b98444c3bc7a800916b63f29f311553fa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"Protected","lastBackupStatus":"Completed","lastBackupTime":"2023-05-17T12:14:01.7947692Z","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/c7af20fa-440e-4ca5-be48-38997a193f1c","name":"c7af20fa-440e-4ca5-be48-38997a193f1c","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","actionsInfo":["Cancellable"],"duration":"PT34.1409532S","storageAccountName":"clitest000003","storageAccountVersion":"ClassicCompute","extendedInfo":{"tasksList":[],"propertyBag":{"Source
+        File Share Name":"clitest-item000004","Source Storage Account Name":"clitest000003","RestoreRecoveryPointTime":"8/16/2023
+        9:40:28 AM","Job Type":"Recovering to the original file share","RestoreDestination":"clitest000003/clitest-item000004/","Data
+        Transferred (in MB)":"0","Number Of Restored Files":"0","Number Of Skipped
+        Files":"0","Number Of Failed Files":"0"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"Restore","status":"Completed","startTime":"2023-08-16T09:41:36.5640733Z","endTime":"2023-08-16T09:42:10.7050265Z","activityId":"15953b85-3c19-11ee-8aa0-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1526'
+      - '1184'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:16:46 GMT
+      - Wed, 16 Aug 2023 09:42:41 GMT
       expires:
       - '-1'
       pragma:
@@ -2799,7 +3021,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '144'
     status:
       code: 200
       message: OK
@@ -2817,8 +3039,57 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --backup-management-type --delete-backup-data --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;8f4047bdaf7626495f2ed27982e9993809e79c8e05e8b30f66300a4b5bda4670","name":"AzureFileShare;8f4047bdaf7626495f2ed27982e9993809e79c8e05e8b30f66300a4b5bda4670","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"Protected","lastBackupStatus":"Completed","lastBackupTime":"2023-08-16T09:40:25.1590969Z","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1526'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:43:12 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '297'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupResourceGuardProxies?api-version=2023-02-01
   response:
@@ -2832,7 +3103,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:16:46 GMT
+      - Wed, 16 Aug 2023 09:43:13 GMT
       expires:
       - '-1'
       pragma:
@@ -2866,26 +3137,26 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --backup-management-type --delete-backup-data --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3B9be41d011153ba6eecf0b01d71d68e3b98444c3bc7a800916b63f29f311553fa?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3B8f4047bdaf7626495f2ed27982e9993809e79c8e05e8b30f66300a4b5bda4670?api-version=2023-02-01
   response:
     body:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/daf83976-f524-4ed0-bf39-fe92ca694576?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/0e5db85e-4133-41a5-8f81-f5227c3176c5?api-version=2023-02-01
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:16:48 GMT
+      - Wed, 16 Aug 2023 09:43:14 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/daf83976-f524-4ed0-bf39-fe92ca694576?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/0e5db85e-4133-41a5-8f81-f5227c3176c5?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -2895,7 +3166,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-deletes:
-      - '14999'
+      - '14995'
     status:
       code: 202
       message: Accepted
@@ -2913,22 +3184,22 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --backup-management-type --delete-backup-data --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/daf83976-f524-4ed0-bf39-fe92ca694576?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/0e5db85e-4133-41a5-8f81-f5227c3176c5?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"daf83976-f524-4ed0-bf39-fe92ca694576","name":"daf83976-f524-4ed0-bf39-fe92ca694576","status":"InProgress","startTime":"2023-05-17T12:16:48.4973532Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"0e5db85e-4133-41a5-8f81-f5227c3176c5","name":"0e5db85e-4133-41a5-8f81-f5227c3176c5","status":"InProgress","startTime":"2023-08-16T09:43:15.433266Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:16:50 GMT
+      - Wed, 16 Aug 2023 09:43:15 GMT
       expires:
       - '-1'
       pragma:
@@ -2944,7 +3215,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '280'
     status:
       code: 200
       message: OK
@@ -2962,22 +3233,22 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --backup-management-type --delete-backup-data --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/daf83976-f524-4ed0-bf39-fe92ca694576?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/0e5db85e-4133-41a5-8f81-f5227c3176c5?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"daf83976-f524-4ed0-bf39-fe92ca694576","name":"daf83976-f524-4ed0-bf39-fe92ca694576","status":"InProgress","startTime":"2023-05-17T12:16:48.4973532Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"0e5db85e-4133-41a5-8f81-f5227c3176c5","name":"0e5db85e-4133-41a5-8f81-f5227c3176c5","status":"InProgress","startTime":"2023-08-16T09:43:15.433266Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:16:55 GMT
+      - Wed, 16 Aug 2023 09:43:21 GMT
       expires:
       - '-1'
       pragma:
@@ -2993,7 +3264,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '279'
     status:
       code: 200
       message: OK
@@ -3011,22 +3282,22 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --backup-management-type --delete-backup-data --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/daf83976-f524-4ed0-bf39-fe92ca694576?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/0e5db85e-4133-41a5-8f81-f5227c3176c5?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"daf83976-f524-4ed0-bf39-fe92ca694576","name":"daf83976-f524-4ed0-bf39-fe92ca694576","status":"InProgress","startTime":"2023-05-17T12:16:48.4973532Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"0e5db85e-4133-41a5-8f81-f5227c3176c5","name":"0e5db85e-4133-41a5-8f81-f5227c3176c5","status":"InProgress","startTime":"2023-08-16T09:43:15.433266Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:17:00 GMT
+      - Wed, 16 Aug 2023 09:43:27 GMT
       expires:
       - '-1'
       pragma:
@@ -3042,7 +3313,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
+      - '278'
     status:
       code: 200
       message: OK
@@ -3060,22 +3331,22 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --backup-management-type --delete-backup-data --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/daf83976-f524-4ed0-bf39-fe92ca694576?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/0e5db85e-4133-41a5-8f81-f5227c3176c5?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"daf83976-f524-4ed0-bf39-fe92ca694576","name":"daf83976-f524-4ed0-bf39-fe92ca694576","status":"InProgress","startTime":"2023-05-17T12:16:48.4973532Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"0e5db85e-4133-41a5-8f81-f5227c3176c5","name":"0e5db85e-4133-41a5-8f81-f5227c3176c5","status":"InProgress","startTime":"2023-08-16T09:43:15.433266Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:17:06 GMT
+      - Wed, 16 Aug 2023 09:43:32 GMT
       expires:
       - '-1'
       pragma:
@@ -3091,7 +3362,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '296'
+      - '277'
     status:
       code: 200
       message: OK
@@ -3109,22 +3380,22 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --backup-management-type --delete-backup-data --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/daf83976-f524-4ed0-bf39-fe92ca694576?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/0e5db85e-4133-41a5-8f81-f5227c3176c5?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"daf83976-f524-4ed0-bf39-fe92ca694576","name":"daf83976-f524-4ed0-bf39-fe92ca694576","status":"Succeeded","startTime":"2023-05-17T12:16:48.4973532Z","endTime":"2023-05-17T12:16:48.4973532Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"7beff408-15da-4b8c-9333-8db5ff032a15"}}'
+      string: '{"id":"0e5db85e-4133-41a5-8f81-f5227c3176c5","name":"0e5db85e-4133-41a5-8f81-f5227c3176c5","status":"Succeeded","startTime":"2023-08-16T09:43:15.433266Z","endTime":"2023-08-16T09:43:15.433266Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"497a2734-cb4a-4ae1-8a17-19e017f9748e"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '302'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:17:11 GMT
+      - Wed, 16 Aug 2023 09:43:38 GMT
       expires:
       - '-1'
       pragma:
@@ -3140,7 +3411,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '295'
+      - '276'
     status:
       code: 200
       message: OK
@@ -3158,23 +3429,23 @@ interactions:
       ParameterSetName:
       - -g -v -c -i --backup-management-type --delete-backup-data --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7beff408-15da-4b8c-9333-8db5ff032a15?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/497a2734-cb4a-4ae1-8a17-19e017f9748e?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7beff408-15da-4b8c-9333-8db5ff032a15","name":"7beff408-15da-4b8c-9333-8db5ff032a15","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT20.9990868S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
-        Share Name":"clitest-item000004","Storage Account Name":"clitest000003"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"DeleteBackupData","status":"Completed","startTime":"2023-05-17T12:16:48.4973532Z","endTime":"2023-05-17T12:17:09.49644Z","activityId":"affe1fcb-f4ac-11ed-9c2d-c8f750f92764"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/497a2734-cb4a-4ae1-8a17-19e017f9748e","name":"497a2734-cb4a-4ae1-8a17-19e017f9748e","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT21.0516339S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
+        Share Name":"clitest-item000004","Storage Account Name":"clitest000003"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"DeleteBackupData","status":"Completed","startTime":"2023-08-16T09:43:15.433266Z","endTime":"2023-08-16T09:43:36.4848999Z","activityId":"50b9d31c-3c19-11ee-93b4-60a5e243551b"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '861'
+      - '862'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:17:15 GMT
+      - Wed, 16 Aug 2023 09:43:38 GMT
       expires:
       - '-1'
       pragma:
@@ -3190,7 +3461,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '149'
+      - '142'
     status:
       code: 200
       message: OK
@@ -3208,8 +3479,8 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+friendlyName+eq+%27clitest000003%27+and+status+eq+%27Registered%27
   response:
@@ -3223,7 +3494,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:17:19 GMT
+      - Wed, 16 Aug 2023 09:43:40 GMT
       expires:
       - '-1'
       pragma:
@@ -3239,7 +3510,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '291'
     status:
       code: 200
       message: OK
@@ -3259,8 +3530,8 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003?api-version=2023-02-01
   response:
@@ -3268,17 +3539,17 @@ interactions:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/0d87f7ab-ef7a-41d6-835b-b5b260920490?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:17:20 GMT
+      - Wed, 16 Aug 2023 09:43:41 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/0d87f7ab-ef7a-41d6-835b-b5b260920490?fabricName=Azure?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?fabricName=Azure?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -3288,7 +3559,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-deletes:
-      - '14999'
+      - '14994'
     status:
       code: 202
       message: Accepted
@@ -3306,16 +3577,16 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/0d87f7ab-ef7a-41d6-835b-b5b260920490?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/0d87f7ab-ef7a-41d6-835b-b5b260920490?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -3323,11 +3594,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:17:21 GMT
+      - Wed, 16 Aug 2023 09:43:43 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/0d87f7ab-ef7a-41d6-835b-b5b260920490?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -3337,7 +3608,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '259'
     status:
       code: 202
       message: Accepted
@@ -3355,16 +3626,16 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/0d87f7ab-ef7a-41d6-835b-b5b260920490?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/0d87f7ab-ef7a-41d6-835b-b5b260920490?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -3372,11 +3643,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:17:26 GMT
+      - Wed, 16 Aug 2023 09:43:49 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/0d87f7ab-ef7a-41d6-835b-b5b260920490?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -3386,7 +3657,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '258'
     status:
       code: 202
       message: Accepted
@@ -3404,16 +3675,16 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/0d87f7ab-ef7a-41d6-835b-b5b260920490?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/0d87f7ab-ef7a-41d6-835b-b5b260920490?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -3421,11 +3692,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:17:33 GMT
+      - Wed, 16 Aug 2023 09:43:53 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/0d87f7ab-ef7a-41d6-835b-b5b260920490?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -3435,7 +3706,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
+      - '257'
     status:
       code: 202
       message: Accepted
@@ -3453,16 +3724,16 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/0d87f7ab-ef7a-41d6-835b-b5b260920490?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/0d87f7ab-ef7a-41d6-835b-b5b260920490?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -3470,11 +3741,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:17:38 GMT
+      - Wed, 16 Aug 2023 09:44:00 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/0d87f7ab-ef7a-41d6-835b-b5b260920490?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -3484,7 +3755,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '296'
+      - '256'
     status:
       code: 202
       message: Accepted
@@ -3502,10 +3773,549 @@ interactions:
       ParameterSetName:
       - -g -v -c --yes --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/0d87f7ab-ef7a-41d6-835b-b5b260920490?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:44:05 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '255'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:44:10 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '254'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:44:16 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '253'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:44:21 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '252'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:44:27 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '251'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:44:32 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '250'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:44:38 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '249'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:44:44 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '248'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:44:49 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '247'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:44:54 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '246'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:45:00 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '245'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/2b921e13-59ea-4cf1-ad7b-14496a51cb6a?api-version=2023-02-01
   response:
     body:
       string: ''
@@ -3513,7 +4323,7 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Wed, 17 May 2023 12:17:43 GMT
+      - Wed, 16 Aug 2023 09:45:04 GMT
       expires:
       - '-1'
       pragma:
@@ -3525,7 +4335,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '295'
+      - '244'
     status:
       code: 204
       message: No Content
@@ -3543,8 +4353,8 @@ interactions:
       ParameterSetName:
       - --backup-management-type -v -g --query
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureIaasVM%27+and+status+eq+%27Registered%27
   response:
@@ -3558,7 +4368,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:19:24 GMT
+      - Wed, 16 Aug 2023 09:46:46 GMT
       expires:
       - '-1'
       pragma:
@@ -3574,7 +4384,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '289'
     status:
       code: 200
       message: OK
@@ -3594,7 +4404,8 @@ interactions:
       ParameterSetName:
       - -n -g --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2023-02-01
   response:
@@ -3606,7 +4417,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:19:33 GMT
+      - Wed, 16 Aug 2023 09:46:51 GMT
       expires:
       - '-1'
       pragma:
@@ -3618,7 +4429,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '49'
+      - '46'
     status:
       code: 200
       message: OK

--- a/src/azure-cli/azure/cli/command_modules/backup/tests/latest/recordings/test_afs_unregister_container.yaml
+++ b/src/azure-cli/azure/cli/command_modules/backup/tests/latest/recordings/test_afs_unregister_container.yaml
@@ -13,7 +13,8 @@ interactions:
       ParameterSetName:
       - -n -g --location
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2023-02-01
   response:
@@ -29,7 +30,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:06:46 GMT
+      - Wed, 16 Aug 2023 09:33:32 GMT
       expires:
       - '-1'
       pragma:
@@ -64,15 +65,16 @@ interactions:
       ParameterSetName:
       - -n -g --location
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2023-02-01
   response:
     body:
-      string: '{"location":"eastus2euap","name":"clitest-vault000002","etag":"W/\"datetime''2023-05-17T12%3A06%3A51.7887812Z''\"","properties":{"provisioningState":"Provisioning","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}},"publicNetworkAccess":"Enabled","restoreSettings":{"crossSubscriptionRestoreSettings":{"crossSubscriptionRestoreState":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+      string: '{"location":"eastus2euap","name":"clitest-vault000002","etag":"W/\"datetime''2023-08-16T09%3A33%3A33.7272155Z''\"","properties":{"provisioningState":"Provisioning","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}},"publicNetworkAccess":"Enabled","restoreSettings":{"crossSubscriptionRestoreSettings":{"crossSubscriptionRestoreState":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NzsxMzlhODIzNS1jYzU3LTRmYzQtODg1ZC01Mzg2OTZmOWZjNzc=?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NzszOGFmMWZiMC0wYTQ3LTQ2NDItOGU2OC05YmZiYmZjZTYwZjI=?api-version=2023-02-01
       cache-control:
       - no-cache
       content-length:
@@ -80,7 +82,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:06:53 GMT
+      - Wed, 16 Aug 2023 09:33:33 GMT
       expires:
       - '-1'
       pragma:
@@ -91,8 +93,10 @@ interactions:
       - max-age=31536000; includeSubDomains
       x-content-type-options:
       - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=12f8ea5c-1212-449e-b31c-0a574f43076e/centraluseuap/42e73d42-f7fb-4b9a-905b-6fb0b608007a
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '299'
     status:
       code: 201
       message: Created
@@ -110,14 +114,68 @@ interactions:
       ParameterSetName:
       - -n -g --location
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NzsxMzlhODIzNS1jYzU3LTRmYzQtODg1ZC01Mzg2OTZmOWZjNzc=?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NzszOGFmMWZiMC0wYTQ3LTQ2NDItOGU2OC05YmZiYmZjZTYwZjI=?api-version=2023-02-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NzsxMzlhODIzNS1jYzU3LTRmYzQtODg1ZC01Mzg2OTZmOWZjNzc=\",\r\n
-        \ \"name\": \"MjA0NzsxMzlhODIzNS1jYzU3LTRmYzQtODg1ZC01Mzg2OTZmOWZjNzc=\",\r\n
-        \ \"status\": \"Succeeded\"\r\n}"
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NzszOGFmMWZiMC0wYTQ3LTQ2NDItOGU2OC05YmZiYmZjZTYwZjI=\"\
+        ,\r\n  \"name\": \"MjA0NzszOGFmMWZiMC0wYTQ3LTQ2NDItOGU2OC05YmZiYmZjZTYwZjI=\"\
+        ,\r\n  \"status\": \"InProgress\"\r\n}"
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NzszOGFmMWZiMC0wYTQ3LTQ2NDItOGU2OC05YmZiYmZjZTYwZjI=?api-version=2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '334'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:33:33 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationResults/MjA0NzszOGFmMWZiMC0wYTQ3LTQ2NDItOGU2OC05YmZiYmZjZTYwZjI=?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --location
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NzszOGFmMWZiMC0wYTQ3LTQ2NDItOGU2OC05YmZiYmZjZTYwZjI=?api-version=2023-02-01
+  response:
+    body:
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NzszOGFmMWZiMC0wYTQ3LTQ2NDItOGU2OC05YmZiYmZjZTYwZjI=\"\
+        ,\r\n  \"name\": \"MjA0NzszOGFmMWZiMC0wYTQ3LTQ2NDItOGU2OC05YmZiYmZjZTYwZjI=\"\
+        ,\r\n  \"status\": \"Succeeded\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -126,7 +184,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:06:54 GMT
+      - Wed, 16 Aug 2023 09:34:33 GMT
       expires:
       - '-1'
       pragma:
@@ -158,12 +216,13 @@ interactions:
       ParameterSetName:
       - -n -g --location
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2023-02-01
   response:
     body:
-      string: '{"location":"eastus2euap","name":"clitest-vault000002","etag":"W/\"datetime''2023-05-17T12%3A06%3A52.7199537Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","backupStorageVersion":"Unassigned","monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}},"securitySettings":{"immutabilitySettings":null,"softDeleteSettings":{"softDeleteRetentionPeriodInDays":14,"softDeleteState":"Enabled"},"multiUserAuthorization":"Disabled"},"publicNetworkAccess":"Enabled","restoreSettings":{"crossSubscriptionRestoreSettings":{"crossSubscriptionRestoreState":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+      string: '{"location":"eastus2euap","name":"clitest-vault000002","etag":"W/\"datetime''2023-08-16T09%3A33%3A34.2903321Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","backupStorageVersion":"Unassigned","monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}},"securitySettings":{"immutabilitySettings":null,"softDeleteSettings":{"softDeleteRetentionPeriodInDays":14,"softDeleteState":"Enabled"},"multiUserAuthorization":"Disabled"},"publicNetworkAccess":"Enabled","restoreSettings":{"crossSubscriptionRestoreSettings":{"crossSubscriptionRestoreState":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
     headers:
       cache-control:
       - no-cache
@@ -172,7 +231,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:06:54 GMT
+      - Wed, 16 Aug 2023 09:34:34 GMT
       expires:
       - '-1'
       pragma:
@@ -187,6 +246,156 @@ interactions:
       - Accept-Encoding
       x-content-type-options:
       - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault backup-properties set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --soft-delete-feature-state
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupconfig/vaultconfig?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupconfig/vaultconfig","name":"vaultconfig","type":"Microsoft.RecoveryServices/vaults/backupconfig","properties":{"enhancedSecurityState":"Enabled","softDeleteFeatureState":"Enabled","softDeleteRetentionPeriodInDays":14,"isSoftDeleteFeatureStateEditable":true}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '419'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:34:36 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '299'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault backup-properties set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --soft-delete-feature-state
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupResourceGuardProxies?api-version=2023-02-01
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:34:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"enhancedSecurityState": "Enabled", "softDeleteFeatureState":
+      "Disabled"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault backup-properties set
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '90'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -n -g --soft-delete-feature-state
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: PATCH
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupconfig/vaultconfig?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupconfig/vaultconfig","name":"vaultconfig","type":"Microsoft.RecoveryServices/vaults/backupconfig","properties":{"enhancedSecurityState":"Enabled","softDeleteFeatureState":"Disabled","softDeleteRetentionPeriodInDays":14,"isSoftDeleteFeatureStateEditable":true}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '420'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:34:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1196'
     status:
       code: 200
       message: OK
@@ -206,12 +415,13 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-storage/21.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003/listKeys?api-version=2022-09-01&$expand=kerb
   response:
     body:
-      string: '{"keys":[{"creationTime":"2023-05-17T12:06:59.0607805Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2023-05-17T12:06:59.0607805Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
+      string: '{"keys":[{"creationTime":"2023-08-16T09:34:40.1140590Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2023-08-16T09:34:40.1140590Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
     headers:
       cache-control:
       - no-cache
@@ -220,7 +430,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 17 May 2023 12:07:25 GMT
+      - Wed, 16 Aug 2023 09:35:07 GMT
       expires:
       - '-1'
       pragma:
@@ -236,7 +446,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11993'
     status:
       code: 200
       message: OK
@@ -254,21 +464,22 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-storage/21.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","name":"clitest000003","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"keyCreationTime":{"key1":"2023-05-17T12:06:59.0607805Z","key2":"2023-05-17T12:06:59.0607805Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-05-17T12:06:59.4670042Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-05-17T12:06:59.4670042Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-05-17T12:06:58.9669864Z","primaryEndpoints":{"blob":"https://clitest000003.blob.core.windows.net/","queue":"https://clitest000003.queue.core.windows.net/","table":"https://clitest000003.table.core.windows.net/","file":"https://clitest000003.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","name":"clitest000003","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"keyCreationTime":{"key1":"2023-08-16T09:34:40.1140590Z","key2":"2023-08-16T09:34:40.1140590Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-08-16T09:34:40.6609862Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-08-16T09:34:40.6609862Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-08-16T09:34:40.0046836Z","primaryEndpoints":{"blob":"https://clitest000003.blob.core.windows.net/","queue":"https://clitest000003.queue.core.windows.net/","table":"https://clitest000003.table.core.windows.net/","file":"https://clitest000003.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1280'
+      - '1316'
       content-type:
       - application/json
       date:
-      - Wed, 17 May 2023 12:07:25 GMT
+      - Wed, 16 Aug 2023 09:35:07 GMT
       expires:
       - '-1'
       pragma:
@@ -302,9 +513,10 @@ interactions:
       ParameterSetName:
       - --name --quota --connection-string
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-storage-file-share/12.12.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-storage-file-share/12.12.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
       x-ms-date:
-      - Wed, 17 May 2023 12:07:25 GMT
+      - Wed, 16 Aug 2023 09:35:08 GMT
       x-ms-share-quota:
       - '1'
       x-ms-version:
@@ -318,11 +530,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:07:27 GMT
+      - Wed, 16 Aug 2023 09:35:08 GMT
       etag:
-      - '"0x8DB56CF486980F0"'
+      - '"0x8DB9E3C15174EA9"'
       last-modified:
-      - Wed, 17 May 2023 12:07:27 GMT
+      - Wed, 16 Aug 2023 09:35:09 GMT
       server:
       - Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
@@ -344,13 +556,13 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T19:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T19:30:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
@@ -359,7 +571,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:07:27 GMT
+      - Wed, 16 Aug 2023 09:35:10 GMT
       expires:
       - '-1'
       pragma:
@@ -375,16 +587,16 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '297'
     status:
       code: 200
       message: OK
 - request:
     body: '{"properties": {"protectedItemsCount": 0, "backupManagementType": "AzureStorage",
       "workLoadType": "AzureFileShare", "schedulePolicy": {"schedulePolicyType": "SimpleSchedulePolicy",
-      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2023-05-17T22:00:00.000Z"],
+      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2023-08-16T19:30:00.000Z"],
       "scheduleWeeklyFrequency": 0}, "retentionPolicy": {"retentionPolicyType": "LongTermRetentionPolicy",
-      "dailySchedule": {"retentionTimes": ["2023-05-17T22:00:00.000Z"], "retentionDuration":
+      "dailySchedule": {"retentionTimes": ["2023-08-16T19:30:00.000Z"], "retentionDuration":
       {"count": 30, "durationType": "Days"}}}, "timeZone": "UTC"}}'
     headers:
       Accept:
@@ -402,22 +614,22 @@ interactions:
       ParameterSetName:
       - -g -v --policy -n --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","name":"clitest-item000005","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","name":"clitest-item000005","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","workLoadType":"AzureFileShare","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T19:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T19:30:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '719'
+      - '751'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:07:31 GMT
+      - Wed, 16 Aug 2023 09:35:11 GMT
       expires:
       - '-1'
       pragma:
@@ -433,7 +645,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1196'
+      - '1193'
     status:
       code: 200
       message: OK
@@ -451,8 +663,8 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+status+eq+%27Registered%27
   response:
@@ -466,7 +678,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:07:32 GMT
+      - Wed, 16 Aug 2023 09:35:12 GMT
       expires:
       - '-1'
       pragma:
@@ -482,7 +694,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '294'
     status:
       code: 200
       message: OK
@@ -500,22 +712,22 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","name":"StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"adiguptecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/adigupt-ecy-rg/providers/Microsoft.Storage/storageAccounts/adiguptecy"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg2yfprhyqds;clitesttz6sdom2jatwnfac4","name":"StorageContainer;Storage;clitest.rg2yfprhyqds;clitesttz6sdom2jatwnfac4","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesttz6sdom2jatwnfac4","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg2yfprhyqds/providers/Microsoft.Storage/storageAccounts/clitesttz6sdom2jatwnfac4"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgcg55fjw6oydcqxadogkryma2vngbhcbisbtwvzrlednvwxiqdh5vw4j7ltte2nacv;clitestle63ytisykbtb4afs","name":"StorageContainer;Storage;clitest.rgcg55fjw6oydcqxadogkryma2vngbhcbisbtwvzrlednvwxiqdh5vw4j7ltte2nacv;clitestle63ytisykbtb4afs","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestle63ytisykbtb4afs","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgcg55fjw6oydcqxadogkryma2vngbhcbisbtwvzrlednvwxiqdh5vw4j7ltte2nacv/providers/Microsoft.Storage/storageAccounts/clitestle63ytisykbtb4afs"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx;clitest5g7td7ozjqq2b6ccr","name":"StorageContainer;Storage;clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx;clitest5g7td7ozjqq2b6ccr","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest5g7td7ozjqq2b6ccr","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx/providers/Microsoft.Storage/storageAccounts/clitest5g7td7ozjqq2b6ccr"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rglhjd23gmd22yjo46bvchsudoznlqkhubppep3t6sillavnqqy7ioqnd5cmz66wupg;clitestyg5bffz6esoe2kj6r","name":"StorageContainer;Storage;clitest.rglhjd23gmd22yjo46bvchsudoznlqkhubppep3t6sillavnqqy7ioqnd5cmz66wupg;clitestyg5bffz6esoe2kj6r","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestyg5bffz6esoe2kj6r","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rglhjd23gmd22yjo46bvchsudoznlqkhubppep3t6sillavnqqy7ioqnd5cmz66wupg/providers/Microsoft.Storage/storageAccounts/clitestyg5bffz6esoe2kj6r"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rguab7asrflt;clitestfdfvj5rqbl2gzzi3b","name":"StorageContainer;Storage;clitest.rguab7asrflt;clitestfdfvj5rqbl2gzzi3b","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestfdfvj5rqbl2gzzi3b","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rguab7asrflt/providers/Microsoft.Storage/storageAccounts/clitestfdfvj5rqbl2gzzi3b"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","name":"StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontusebvtaksecycansa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DonotUse-Blobs-BVT-EACAN-RG/providers/Microsoft.Storage/storageAccounts/dontusebvtaksecycansa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","name":"StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"iaasextstoreecy1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.czr/providers/Microsoft.Storage/storageAccounts/iaasextstoreecy1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","name":"StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesaksdonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-clitest-rg/providers/Microsoft.Storage/storageAccounts/clitesaksdonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"bloboprestorecontainers","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/bloboprestorecontainers"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopall","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopall"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopcontainer","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopcontainer"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopprefix","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopprefix"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG;zubairsaecy","name":"StorageContainer;Storage;zubairRG;zubairsaecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Storage/storageAccounts/zubairsaecy"}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","name":"StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"adiguptecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/adigupt-ecy-rg/providers/Microsoft.Storage/storageAccounts/adiguptecy"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg762eboi6az;clitestnw7hezxfnda4gree2","name":"StorageContainer;Storage;clitest.rg762eboi6az;clitestnw7hezxfnda4gree2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestnw7hezxfnda4gree2","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg762eboi6az/providers/Microsoft.Storage/storageAccounts/clitestnw7hezxfnda4gree2"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgl7ufwgcue4;clitestropgruks4gtf2d2ty","name":"StorageContainer;Storage;clitest.rgl7ufwgcue4;clitestropgruks4gtf2d2ty","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestropgruks4gtf2d2ty","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgl7ufwgcue4/providers/Microsoft.Storage/storageAccounts/clitestropgruks4gtf2d2ty"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgzcoeu5bkqn;clitestvb64o3blwtaoncicw","name":"StorageContainer;Storage;clitest.rgzcoeu5bkqn;clitestvb64o3blwtaoncicw","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestvb64o3blwtaoncicw","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgzcoeu5bkqn/providers/Microsoft.Storage/storageAccounts/clitestvb64o3blwtaoncicw"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgzoyjagb5eb;clitestamxx27lkbfywib4s6","name":"StorageContainer;Storage;clitest.rgzoyjagb5eb;clitestamxx27lkbfywib4s6","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestamxx27lkbfywib4s6","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgzoyjagb5eb/providers/Microsoft.Storage/storageAccounts/clitestamxx27lkbfywib4s6"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgzoyjagb5eb;clitestym2nwetgkgpa5azz2","name":"StorageContainer;Storage;clitest.rgzoyjagb5eb;clitestym2nwetgkgpa5azz2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestym2nwetgkgpa5azz2","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgzoyjagb5eb/providers/Microsoft.Storage/storageAccounts/clitestym2nwetgkgpa5azz2"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","name":"StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontusebvtaksecycansa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DonotUse-Blobs-BVT-EACAN-RG/providers/Microsoft.Storage/storageAccounts/dontusebvtaksecycansa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","name":"StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"iaasextstoreecy1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.czr/providers/Microsoft.Storage/storageAccounts/iaasextstoreecy1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","name":"StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesaksdonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-clitest-rg/providers/Microsoft.Storage/storageAccounts/clitesaksdonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"bloboprestorecontainers","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/bloboprestorecontainers"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopall","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopall"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopcontainer","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopcontainer"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopprefix","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopprefix"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG2;zubairsaecy2","name":"StorageContainer;Storage;zubairRG2;zubairsaecy2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy2","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG2/providers/Microsoft.Storage/storageAccounts/zubairsaecy2"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG;zubairsaecy","name":"StorageContainer;Storage;zubairRG;zubairsaecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Storage/storageAccounts/zubairsaecy"}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '11164'
+      - '11356'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:07:33 GMT
+      - Wed, 16 Aug 2023 09:35:13 GMT
       expires:
       - '-1'
       pragma:
@@ -531,7 +743,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '297'
     status:
       code: 200
       message: OK
@@ -551,8 +763,8 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/refreshContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
@@ -560,251 +772,17 @@ interactions:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/6ba91de4-68fa-4cf5-abfd-c47e948f2b70?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/1c3661fd-a17c-4d6b-95d7-9c509b17ebae?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:07:36 GMT
+      - Wed, 16 Aug 2023 09:35:15 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6ba91de4-68fa-4cf5-abfd-c47e948f2b70?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6ba91de4-68fa-4cf5-abfd-c47e948f2b70?api-version=2023-02-01
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Wed, 17 May 2023 12:07:37 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6ba91de4-68fa-4cf5-abfd-c47e948f2b70?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6ba91de4-68fa-4cf5-abfd-c47e948f2b70?api-version=2023-02-01
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Wed, 17 May 2023 12:07:42 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6ba91de4-68fa-4cf5-abfd-c47e948f2b70?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6ba91de4-68fa-4cf5-abfd-c47e948f2b70?api-version=2023-02-01
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      date:
-      - Wed, 17 May 2023 12:07:48 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","name":"StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"adiguptecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/adigupt-ecy-rg/providers/Microsoft.Storage/storageAccounts/adiguptecy"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg2yfprhyqds;clitesttz6sdom2jatwnfac4","name":"StorageContainer;Storage;clitest.rg2yfprhyqds;clitesttz6sdom2jatwnfac4","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesttz6sdom2jatwnfac4","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg2yfprhyqds/providers/Microsoft.Storage/storageAccounts/clitesttz6sdom2jatwnfac4"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgaphtzd4b6w;clitest2e4uvoffeuotuhhkv","name":"StorageContainer;Storage;clitest.rgaphtzd4b6w;clitest2e4uvoffeuotuhhkv","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest2e4uvoffeuotuhhkv","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgaphtzd4b6w/providers/Microsoft.Storage/storageAccounts/clitest2e4uvoffeuotuhhkv"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx;clitest5g7td7ozjqq2b6ccr","name":"StorageContainer;Storage;clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx;clitest5g7td7ozjqq2b6ccr","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest5g7td7ozjqq2b6ccr","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgjdu34pdlmeo24ffsui37ouhvnkg24mvkyruudsrpsquguzyp4cvmrop3ancqg5udx/providers/Microsoft.Storage/storageAccounts/clitest5g7td7ozjqq2b6ccr"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest000003","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","name":"StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontusebvtaksecycansa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DonotUse-Blobs-BVT-EACAN-RG/providers/Microsoft.Storage/storageAccounts/dontusebvtaksecycansa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","name":"StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"iaasextstoreecy1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.czr/providers/Microsoft.Storage/storageAccounts/iaasextstoreecy1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","name":"StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesaksdonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-clitest-rg/providers/Microsoft.Storage/storageAccounts/clitesaksdonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"bloboprestorecontainers","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/bloboprestorecontainers"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopall","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopall"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopcontainer","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopcontainer"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopprefix","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopprefix"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG;zubairsaecy","name":"StorageContainer;Storage;zubairRG;zubairsaecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Storage/storageAccounts/zubairsaecy"}}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '10010'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:07:49 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"backupManagementType": "AzureStorage", "containerType":
-      "StorageContainer", "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003"}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '258'
-      Content-Type:
-      - application/json
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/955da72f-9d76-4558-bb58-c305eecf9999?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:07:50 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/955da72f-9d76-4558-bb58-c305eecf9999?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/1c3661fd-a17c-4d6b-95d7-9c509b17ebae?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -832,188 +810,37 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/955da72f-9d76-4558-bb58-c305eecf9999?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/1c3661fd-a17c-4d6b-95d7-9c509b17ebae?api-version=2023-02-01
   response:
     body:
-      string: '{}'
+      string: ''
     headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/955da72f-9d76-4558-bb58-c305eecf9999?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
-      - '2'
-      content-type:
-      - application/json; charset=utf-8
+      - '0'
       date:
-      - Wed, 17 May 2023 12:07:51 GMT
+      - Wed, 16 Aug 2023 09:35:16 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/955da72f-9d76-4558-bb58-c305eecf9999?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/1c3661fd-a17c-4d6b-95d7-9c509b17ebae?api-version=2023-02-01
       pragma:
       - no-cache
       server:
       - Kestrel
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/955da72f-9d76-4558-bb58-c305eecf9999?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/955da72f-9d76-4558-bb58-c305eecf9999?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:07:56 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/955da72f-9d76-4558-bb58-c305eecf9999?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/955da72f-9d76-4558-bb58-c305eecf9999?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/955da72f-9d76-4558-bb58-c305eecf9999?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:08:02 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/955da72f-9d76-4558-bb58-c305eecf9999?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '295'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/955da72f-9d76-4558-bb58-c305eecf9999?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","protectedItemCount":0,"acquireStorageAccountLock":"Acquire","friendlyName":"clitest000003","backupManagementType":"AzureStorage","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"StorageContainer","protectableObjectType":"StorageContainer"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '763'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:08:08 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '293'
     status:
-      code: 200
-      message: OK
+      code: 202
+      message: Accepted
 - request:
     body: null
     headers:
@@ -1028,77 +855,24 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectableItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+workloadType+eq+%27AzureFileShare%27
-  response:
-    body:
-      string: '{"value":[]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '12'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:08:08 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/inquire?api-version=2023-02-01&%24filter=workloadType+eq+%27AzureFileShare%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/1c3661fd-a17c-4d6b-95d7-9c509b17ebae?api-version=2023-02-01
   response:
     body:
       string: ''
     headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/e588cea7-e11e-4bb6-9910-0d39baa7f1b9?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:08:12 GMT
+      - Wed, 16 Aug 2023 09:35:21 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/e588cea7-e11e-4bb6-9910-0d39baa7f1b9?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/1c3661fd-a17c-4d6b-95d7-9c509b17ebae?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -1107,8 +881,8 @@ interactions:
       - max-age=31536000; includeSubDomains
       x-content-type-options:
       - nosniff
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '292'
     status:
       code: 202
       message: Accepted
@@ -1126,28 +900,20 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/e588cea7-e11e-4bb6-9910-0d39baa7f1b9?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/1c3661fd-a17c-4d6b-95d7-9c509b17ebae?api-version=2023-02-01
   response:
     body:
-      string: '{}'
+      string: ''
     headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/e588cea7-e11e-4bb6-9910-0d39baa7f1b9?api-version=2019-05-13-preview
       cache-control:
       - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:12 GMT
+      - Wed, 16 Aug 2023 09:35:27 GMT
       expires:
       - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/e588cea7-e11e-4bb6-9910-0d39baa7f1b9?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -1158,47 +924,6 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '291'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/e588cea7-e11e-4bb6-9910-0d39baa7f1b9?api-version=2023-02-01
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      date:
-      - Wed, 17 May 2023 12:08:18 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '289'
     status:
       code: 204
       message: No Content
@@ -1216,22 +941,22 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectableItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+workloadType+eq+%27AzureFileShare%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectableItems/azurefileshare;766e3beeab52973a81d8bf6c2bc1426c22920bceaf8f0b291c869e4f2986e092","name":"azurefileshare;766e3beeab52973a81d8bf6c2bc1426c22920bceaf8f0b291c869e4f2986e092","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"parentContainerFabricId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","parentContainerFriendlyName":"clitest000003","azureFileShareType":"XSMB","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","protectableItemType":"AzureFileShare","friendlyName":"clitest-item000004","protectionState":"NotProtected"}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","name":"StorageContainer;Storage;adigupt-ecy-rg;adiguptecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"adiguptecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/adigupt-ecy-rg/providers/Microsoft.Storage/storageAccounts/adiguptecy"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg762eboi6az;clitestnw7hezxfnda4gree2","name":"StorageContainer;Storage;clitest.rg762eboi6az;clitestnw7hezxfnda4gree2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestnw7hezxfnda4gree2","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg762eboi6az/providers/Microsoft.Storage/storageAccounts/clitestnw7hezxfnda4gree2"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitest000003","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgzoyjagb5eb;clitestamxx27lkbfywib4s6","name":"StorageContainer;Storage;clitest.rgzoyjagb5eb;clitestamxx27lkbfywib4s6","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestamxx27lkbfywib4s6","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgzoyjagb5eb/providers/Microsoft.Storage/storageAccounts/clitestamxx27lkbfywib4s6"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;clitest.rgzoyjagb5eb;clitestym2nwetgkgpa5azz2","name":"StorageContainer;Storage;clitest.rgzoyjagb5eb;clitestym2nwetgkgpa5azz2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitestym2nwetgkgpa5azz2","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgzoyjagb5eb/providers/Microsoft.Storage/storageAccounts/clitestym2nwetgkgpa5azz2"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","name":"StorageContainer;Storage;DonotUse-Blobs-BVT-EACAN-RG;dontusebvtaksecycansa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"dontusebvtaksecycansa","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/DonotUse-Blobs-BVT-EACAN-RG/providers/Microsoft.Storage/storageAccounts/dontusebvtaksecycansa"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","name":"StorageContainer;Storage;iaasvm.existing.czr;iaasextstoreecy1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"iaasextstoreecy1","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.czr/providers/Microsoft.Storage/storageAccounts/iaasextstoreecy1"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","name":"StorageContainer;Storage;oss-clitest-rg;clitesaksdonotdelete","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"clitesaksdonotdelete","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/oss-clitest-rg/providers/Microsoft.Storage/storageAccounts/clitesaksdonotdelete"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;bloboprestorecontainers","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"bloboprestorecontainers","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/bloboprestorecontainers"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopall","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopall","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopall"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopcontainer","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopcontainer","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopcontainer"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","name":"StorageContainer;Storage;PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING;blobrestoreopprefix","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"blobrestoreopprefix","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PORTAL.DPP.BVT.BLOB.RESTORE.EXISTING/providers/Microsoft.Storage/storageAccounts/blobrestoreopprefix"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG2;zubairsaecy2","name":"StorageContainer;Storage;zubairRG2;zubairsaecy2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy2","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG2/providers/Microsoft.Storage/storageAccounts/zubairsaecy2"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectableContainers/StorageContainer;Storage;zubairRG;zubairsaecy","name":"StorageContainer;Storage;zubairRG;zubairsaecy","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers","properties":{"friendlyName":"zubairsaecy","backupManagementType":"AzureStorage","protectableContainerType":"StorageContainer","healthStatus":"Healthy","containerId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Storage/storageAccounts/zubairsaecy"}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '983'
+      - '10532'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:19 GMT
+      - Wed, 16 Aug 2023 09:35:27 GMT
       expires:
       - '-1'
       pragma:
@@ -1247,7 +972,453 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '296'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"backupManagementType": "AzureStorage", "containerType":
+      "StorageContainer", "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '258'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/d1f79355-08e4-4b0b-9421-e730457f9382?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:35:30 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/d1f79355-08e4-4b0b-9421-e730457f9382?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1183'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/d1f79355-08e4-4b0b-9421-e730457f9382?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/d1f79355-08e4-4b0b-9421-e730457f9382?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:35:31 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/d1f79355-08e4-4b0b-9421-e730457f9382?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '267'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/d1f79355-08e4-4b0b-9421-e730457f9382?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/d1f79355-08e4-4b0b-9421-e730457f9382?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:35:36 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/d1f79355-08e4-4b0b-9421-e730457f9382?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '266'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/d1f79355-08e4-4b0b-9421-e730457f9382?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/d1f79355-08e4-4b0b-9421-e730457f9382?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:35:41 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/d1f79355-08e4-4b0b-9421-e730457f9382?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '265'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/d1f79355-08e4-4b0b-9421-e730457f9382?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/d1f79355-08e4-4b0b-9421-e730457f9382?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:35:47 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/d1f79355-08e4-4b0b-9421-e730457f9382?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '264'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/d1f79355-08e4-4b0b-9421-e730457f9382?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/d1f79355-08e4-4b0b-9421-e730457f9382?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:35:52 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/d1f79355-08e4-4b0b-9421-e730457f9382?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '263'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/d1f79355-08e4-4b0b-9421-e730457f9382?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/d1f79355-08e4-4b0b-9421-e730457f9382?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:35:58 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/d1f79355-08e4-4b0b-9421-e730457f9382?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '262'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/d1f79355-08e4-4b0b-9421-e730457f9382?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/d1f79355-08e4-4b0b-9421-e730457f9382?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:36:02 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/d1f79355-08e4-4b0b-9421-e730457f9382?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '261'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/d1f79355-08e4-4b0b-9421-e730457f9382?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","protectedItemCount":0,"acquireStorageAccountLock":"Acquire","friendlyName":"clitest000003","backupManagementType":"AzureStorage","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"StorageContainer","protectableObjectType":"StorageContainer"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '763'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:36:08 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '260'
     status:
       code: 200
       message: OK
@@ -1265,22 +1436,22 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectableItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+workloadType+eq+%27AzureFileShare%27
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","name":"clitest-item000005","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-05-17T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-05-17T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"value":[]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '719'
+      - '12'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:20 GMT
+      - Wed, 16 Aug 2023 09:36:10 GMT
       expires:
       - '-1'
       pragma:
@@ -1296,14 +1467,12 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '296'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"properties": {"protectedItemType": "AzureFileShareProtectedItem", "sourceResourceId":
-      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003",
-      "policyId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005"}}'
+    body: null
     headers:
       Accept:
       - application/json
@@ -1314,32 +1483,30 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '430'
-      Content-Type:
-      - application/json
+      - '0'
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/azurefileshare%3B766e3beeab52973a81d8bf6c2bc1426c22920bceaf8f0b291c869e4f2986e092?api-version=2023-02-01
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/inquire?api-version=2023-02-01&%24filter=workloadType+eq+%27AzureFileShare%27
   response:
     body:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectedItems/azurefileshare;766e3beeab52973a81d8bf6c2bc1426c22920bceaf8f0b291c869e4f2986e092/operationsStatus/7891c4c0-33b0-4169-92e8-ea451b2f87e6?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/e774d6cd-38f8-473c-8f50-31a881fca917?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:08:21 GMT
+      - Wed, 16 Aug 2023 09:36:11 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectedItems/azurefileshare;766e3beeab52973a81d8bf6c2bc1426c22920bceaf8f0b291c869e4f2986e092/operationResults/7891c4c0-33b0-4169-92e8-ea451b2f87e6?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/e774d6cd-38f8-473c-8f50-31a881fca917?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -1367,41 +1534,41 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/7891c4c0-33b0-4169-92e8-ea451b2f87e6?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/e774d6cd-38f8-473c-8f50-31a881fca917?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"7891c4c0-33b0-4169-92e8-ea451b2f87e6","name":"7891c4c0-33b0-4169-92e8-ea451b2f87e6","status":"InProgress","startTime":"2023-05-17T12:08:22.0666763Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{}'
     headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/e774d6cd-38f8-473c-8f50-31a881fca917?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '2'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:23 GMT
+      - Wed, 16 Aug 2023 09:36:12 GMT
       expires:
       - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/e774d6cd-38f8-473c-8f50-31a881fca917?api-version=2023-02-01
       pragma:
       - no-cache
       server:
       - Kestrel
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '261'
     status:
-      code: 200
-      message: OK
+      code: 202
+      message: Accepted
 - request:
     body: null
     headers:
@@ -1416,22 +1583,18 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/7891c4c0-33b0-4169-92e8-ea451b2f87e6?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/e774d6cd-38f8-473c-8f50-31a881fca917?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"7891c4c0-33b0-4169-92e8-ea451b2f87e6","name":"7891c4c0-33b0-4169-92e8-ea451b2f87e6","status":"InProgress","startTime":"2023-05-17T12:08:22.0666763Z","endTime":"0001-01-01T00:00:00"}'
+      string: ''
     headers:
       cache-control:
       - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:28 GMT
+      - Wed, 16 Aug 2023 09:36:18 GMT
       expires:
       - '-1'
       pragma:
@@ -1440,17 +1603,13 @@ interactions:
       - Kestrel
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '260'
     status:
-      code: 200
-      message: OK
+      code: 204
+      message: No Content
 - request:
     body: null
     headers:
@@ -1465,120 +1624,22 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/7891c4c0-33b0-4169-92e8-ea451b2f87e6?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectableItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+workloadType+eq+%27AzureFileShare%27
   response:
     body:
-      string: '{"id":"7891c4c0-33b0-4169-92e8-ea451b2f87e6","name":"7891c4c0-33b0-4169-92e8-ea451b2f87e6","status":"InProgress","startTime":"2023-05-17T12:08:22.0666763Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectableItems/azurefileshare;f19d451146cddebb1b99f2176dcb50ecd7542f62d25455697b965e2ed03ad08d","name":"azurefileshare;f19d451146cddebb1b99f2176dcb50ecd7542f62d25455697b965e2ed03ad08d","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"parentContainerFabricId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","parentContainerFriendlyName":"clitest000003","azureFileShareType":"XSMB","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","protectableItemType":"AzureFileShare","friendlyName":"clitest-item000004","protectionState":"NotProtected"}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '983'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:34 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/7891c4c0-33b0-4169-92e8-ea451b2f87e6?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"7891c4c0-33b0-4169-92e8-ea451b2f87e6","name":"7891c4c0-33b0-4169-92e8-ea451b2f87e6","status":"InProgress","startTime":"2023-05-17T12:08:22.0666763Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:08:39 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '296'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/7891c4c0-33b0-4169-92e8-ea451b2f87e6?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"7891c4c0-33b0-4169-92e8-ea451b2f87e6","name":"7891c4c0-33b0-4169-92e8-ea451b2f87e6","status":"InProgress","startTime":"2023-05-17T12:08:22.0666763Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:08:45 GMT
+      - Wed, 16 Aug 2023 09:36:19 GMT
       expires:
       - '-1'
       pragma:
@@ -1612,13 +1673,115 @@ interactions:
       ParameterSetName:
       - -g -v --azure-file-share --storage-account -p
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/7891c4c0-33b0-4169-92e8-ea451b2f87e6?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"7891c4c0-33b0-4169-92e8-ea451b2f87e6","name":"7891c4c0-33b0-4169-92e8-ea451b2f87e6","status":"InProgress","startTime":"2023-05-17T12:08:22.0666763Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","name":"clitest-item000005","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureStorage","workLoadType":"AzureFileShare","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-08-16T19:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-08-16T19:30:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"timeZone":"UTC","protectedItemsCount":0}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '751'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:36:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '292'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"protectedItemType": "AzureFileShareProtectedItem", "sourceResourceId":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003",
+      "policyId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '430'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/azurefileshare%3Bf19d451146cddebb1b99f2176dcb50ecd7542f62d25455697b965e2ed03ad08d?api-version=2023-02-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectedItems/azurefileshare;f19d451146cddebb1b99f2176dcb50ecd7542f62d25455697b965e2ed03ad08d/operationsStatus/2da73310-c340-4b65-ba7a-131d2fcc0c37?api-version=2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Wed, 16 Aug 2023 09:36:21 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/storagecontainer;storage;clitest.rg000001;clitest000003/protectedItems/azurefileshare;f19d451146cddebb1b99f2176dcb50ecd7542f62d25455697b965e2ed03ad08d/operationResults/2da73310-c340-4b65-ba7a-131d2fcc0c37?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1182'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/2da73310-c340-4b65-ba7a-131d2fcc0c37?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"2da73310-c340-4b65-ba7a-131d2fcc0c37","name":"2da73310-c340-4b65-ba7a-131d2fcc0c37","status":"InProgress","startTime":"2023-08-16T09:36:22.0519362Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -1627,7 +1790,548 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:50 GMT
+      - Wed, 16 Aug 2023 09:36:23 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '271'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/2da73310-c340-4b65-ba7a-131d2fcc0c37?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"2da73310-c340-4b65-ba7a-131d2fcc0c37","name":"2da73310-c340-4b65-ba7a-131d2fcc0c37","status":"InProgress","startTime":"2023-08-16T09:36:22.0519362Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:36:28 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '270'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/2da73310-c340-4b65-ba7a-131d2fcc0c37?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"2da73310-c340-4b65-ba7a-131d2fcc0c37","name":"2da73310-c340-4b65-ba7a-131d2fcc0c37","status":"InProgress","startTime":"2023-08-16T09:36:22.0519362Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:36:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '269'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/2da73310-c340-4b65-ba7a-131d2fcc0c37?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"2da73310-c340-4b65-ba7a-131d2fcc0c37","name":"2da73310-c340-4b65-ba7a-131d2fcc0c37","status":"InProgress","startTime":"2023-08-16T09:36:22.0519362Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:36:39 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '268'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/2da73310-c340-4b65-ba7a-131d2fcc0c37?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"2da73310-c340-4b65-ba7a-131d2fcc0c37","name":"2da73310-c340-4b65-ba7a-131d2fcc0c37","status":"InProgress","startTime":"2023-08-16T09:36:22.0519362Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:36:45 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '267'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/2da73310-c340-4b65-ba7a-131d2fcc0c37?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"2da73310-c340-4b65-ba7a-131d2fcc0c37","name":"2da73310-c340-4b65-ba7a-131d2fcc0c37","status":"InProgress","startTime":"2023-08-16T09:36:22.0519362Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:36:50 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '266'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/2da73310-c340-4b65-ba7a-131d2fcc0c37?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"2da73310-c340-4b65-ba7a-131d2fcc0c37","name":"2da73310-c340-4b65-ba7a-131d2fcc0c37","status":"InProgress","startTime":"2023-08-16T09:36:22.0519362Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:36:55 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '265'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/2da73310-c340-4b65-ba7a-131d2fcc0c37?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"2da73310-c340-4b65-ba7a-131d2fcc0c37","name":"2da73310-c340-4b65-ba7a-131d2fcc0c37","status":"InProgress","startTime":"2023-08-16T09:36:22.0519362Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:37:01 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '264'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/2da73310-c340-4b65-ba7a-131d2fcc0c37?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"2da73310-c340-4b65-ba7a-131d2fcc0c37","name":"2da73310-c340-4b65-ba7a-131d2fcc0c37","status":"Succeeded","startTime":"2023-08-16T09:36:22.0519362Z","endTime":"2023-08-16T09:36:22.0519362Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"60740883-e74b-4970-ab4c-2f32985215bb"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:37:05 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '263'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-azurefileshare
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --azure-file-share --storage-account -p
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/60740883-e74b-4970-ab4c-2f32985215bb?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/60740883-e74b-4970-ab4c-2f32985215bb","name":"60740883-e74b-4970-ab4c-2f32985215bb","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT41.5787381S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
+        Share Name":"clitest-item000004","Storage Account Name":"clitest000003","Policy
+        Name":"clitest-item000005"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"ConfigureBackup","status":"Completed","startTime":"2023-08-16T09:36:22.0519362Z","endTime":"2023-08-16T09:37:03.6306743Z","activityId":"32c64291-3c18-11ee-999d-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '897'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:37:07 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '146'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -v -g --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+friendlyName+eq+%27clitest000003%27+and+status+eq+%27Registered%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","protectedItemCount":1,"acquireStorageAccountLock":"Acquire","friendlyName":"clitest000003","backupManagementType":"AzureStorage","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"StorageContainer","protectableObjectType":"StorageContainer"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '853'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:37:09 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '297'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup item list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --query
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;f19d451146cddebb1b99f2176dcb50ecd7542f62d25455697b965e2ed03ad08d","name":"AzureFileShare;f19d451146cddebb1b99f2176dcb50ecd7542f62d25455697b965e2ed03ad08d","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1478'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:37:09 GMT
       expires:
       - '-1'
       pragma:
@@ -1655,19 +2359,164 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - backup protection enable-for-azurefileshare
+      - backup protection disable
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/7891c4c0-33b0-4169-92e8-ea451b2f87e6?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3Bf19d451146cddebb1b99f2176dcb50ecd7542f62d25455697b965e2ed03ad08d?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"7891c4c0-33b0-4169-92e8-ea451b2f87e6","name":"7891c4c0-33b0-4169-92e8-ea451b2f87e6","status":"InProgress","startTime":"2023-05-17T12:08:22.0666763Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;f19d451146cddebb1b99f2176dcb50ecd7542f62d25455697b965e2ed03ad08d","name":"AzureFileShare;f19d451146cddebb1b99f2176dcb50ecd7542f62d25455697b965e2ed03ad08d","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","extendedInfo":{"recoveryPointCount":0,"policyState":"Consistent","resourceState":"Active","resourceStateSyncTime":"2023-08-16T09:37:03.3649958Z"},"protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1613'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:37:11 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '299'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupResourceGuardProxies?api-version=2023-02-01
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:37:12 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3Bf19d451146cddebb1b99f2176dcb50ecd7542f62d25455697b965e2ed03ad08d?api-version=2023-02-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/cf18d0cf-2457-4d35-b1a5-f175b4fce4d8?api-version=2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Wed, 16 Aug 2023 09:37:14 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/cf18d0cf-2457-4d35-b1a5-f175b4fce4d8?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14997'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/cf18d0cf-2457-4d35-b1a5-f175b4fce4d8?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"cf18d0cf-2457-4d35-b1a5-f175b4fce4d8","name":"cf18d0cf-2457-4d35-b1a5-f175b4fce4d8","status":"InProgress","startTime":"2023-08-16T09:37:14.2730921Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -1676,7 +2525,1127 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:08:56 GMT
+      - Wed, 16 Aug 2023 09:37:14 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '262'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/cf18d0cf-2457-4d35-b1a5-f175b4fce4d8?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"cf18d0cf-2457-4d35-b1a5-f175b4fce4d8","name":"cf18d0cf-2457-4d35-b1a5-f175b4fce4d8","status":"InProgress","startTime":"2023-08-16T09:37:14.2730921Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:37:20 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '261'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/cf18d0cf-2457-4d35-b1a5-f175b4fce4d8?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"cf18d0cf-2457-4d35-b1a5-f175b4fce4d8","name":"cf18d0cf-2457-4d35-b1a5-f175b4fce4d8","status":"InProgress","startTime":"2023-08-16T09:37:14.2730921Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:37:25 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '260'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/cf18d0cf-2457-4d35-b1a5-f175b4fce4d8?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"cf18d0cf-2457-4d35-b1a5-f175b4fce4d8","name":"cf18d0cf-2457-4d35-b1a5-f175b4fce4d8","status":"InProgress","startTime":"2023-08-16T09:37:14.2730921Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:37:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '259'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/cf18d0cf-2457-4d35-b1a5-f175b4fce4d8?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"cf18d0cf-2457-4d35-b1a5-f175b4fce4d8","name":"cf18d0cf-2457-4d35-b1a5-f175b4fce4d8","status":"Succeeded","startTime":"2023-08-16T09:37:14.2730921Z","endTime":"2023-08-16T09:37:14.2730921Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"8617dcad-d23c-4f64-b4d2-e642c1db3114"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:37:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '258'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/8617dcad-d23c-4f64-b4d2-e642c1db3114?api-version=2023-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/8617dcad-d23c-4f64-b4d2-e642c1db3114","name":"8617dcad-d23c-4f64-b4d2-e642c1db3114","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT21.0552639S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
+        Share Name":"clitest-item000004","Storage Account Name":"clitest000003"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"DeleteBackupData","status":"Completed","startTime":"2023-08-16T09:37:14.2730921Z","endTime":"2023-08-16T09:37:35.328356Z","activityId":"796ffb01-3c18-11ee-95c9-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '862'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:37:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '145'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+status+eq+%27Registered%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","protectedItemCount":0,"acquireStorageAccountLock":"Acquire","friendlyName":"clitest000003","backupManagementType":"AzureStorage","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"StorageContainer","protectableObjectType":"StorageContainer"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '853'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:37:39 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '291'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -v -c --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003?api-version=2023-02-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Wed, 16 Aug 2023 09:37:40 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/37a4b4cc-23ee-417e-9293-f89584521b2f?fabricName=Azure?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14996'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:37:41 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '268'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:37:47 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '267'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:37:52 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '266'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:37:58 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '265'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:38:03 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '264'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:38:08 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '263'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:38:14 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '262'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:38:19 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '261'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:38:25 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '260'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:38:29 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '259'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:38:35 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '258'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:38:41 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '257'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:38:46 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '256'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:38:51 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '255'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container unregister
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/37a4b4cc-23ee-417e-9293-f89584521b2f?api-version=2023-02-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      date:
+      - Wed, 16 Aug 2023 09:38:57 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '254'
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -v -g --backup-management-type
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+status+eq+%27Registered%27
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:38:58 GMT
       expires:
       - '-1'
       pragma:
@@ -1704,28 +3673,74 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - backup protection enable-for-azurefileshare
+      - lock list
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
+      - -g
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/7891c4c0-33b0-4169-92e8-ea451b2f87e6?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/locks?api-version=2016-09-01
   response:
     body:
-      string: '{"id":"7891c4c0-33b0-4169-92e8-ea451b2f87e6","name":"7891c4c0-33b0-4169-92e8-ea451b2f87e6","status":"InProgress","startTime":"2023-05-17T12:08:22.0666763Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"value":[]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '12'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:09:02 GMT
+      - Wed, 16 Aug 2023 09:40:39 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --container-name --item-name --backup-management-type --workload-type
+        --delete-backup-data --yes
+      User-Agent:
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+itemType+eq+%27AzureFileShare%27
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Aug 2023 09:40:40 GMT
       expires:
       - '-1'
       pragma:
@@ -1753,263 +3768,16 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - backup protection enable-for-azurefileshare
+      - backup container unregister
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
+      - --vault-name --resource-group --container-name --backup-management-type --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/7891c4c0-33b0-4169-92e8-ea451b2f87e6?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"7891c4c0-33b0-4169-92e8-ea451b2f87e6","name":"7891c4c0-33b0-4169-92e8-ea451b2f87e6","status":"Succeeded","startTime":"2023-05-17T12:08:22.0666763Z","endTime":"2023-05-17T12:08:22.0666763Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"c6e848b9-b125-46f9-82d8-2566e37b4143"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:08 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '291'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-azurefileshare
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --azure-file-share --storage-account -p
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/c6e848b9-b125-46f9-82d8-2566e37b4143?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/c6e848b9-b125-46f9-82d8-2566e37b4143","name":"c6e848b9-b125-46f9-82d8-2566e37b4143","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT41.4291445S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
-        Share Name":"clitest-item000004","Storage Account Name":"clitest000003","Policy
-        Name":"clitest-item000005"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"ConfigureBackup","status":"Completed","startTime":"2023-05-17T12:08:22.0666763Z","endTime":"2023-05-17T12:09:03.4958208Z","activityId":"6594922a-f4ab-11ed-beaf-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '897'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:08 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '149'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container show
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -v -g --backup-management-type
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+friendlyName+eq+%27clitest000003%27+and+status+eq+%27Registered%27
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","protectedItemCount":1,"acquireStorageAccountLock":"Acquire","friendlyName":"clitest000003","backupManagementType":"AzureStorage","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"StorageContainer","protectableObjectType":"StorageContainer"}}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '853'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:09 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup item list
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c --query
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2023-02-01
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;766e3beeab52973a81d8bf6c2bc1426c22920bceaf8f0b291c869e4f2986e092","name":"AzureFileShare;766e3beeab52973a81d8bf6c2bc1426c22920bceaf8f0b291c869e4f2986e092","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1478'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:11 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3B766e3beeab52973a81d8bf6c2bc1426c22920bceaf8f0b291c869e4f2986e092?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;storage;clitest.rg000001;clitest000003/protectedItems/AzureFileShare;766e3beeab52973a81d8bf6c2bc1426c22920bceaf8f0b291c869e4f2986e092","name":"AzureFileShare;766e3beeab52973a81d8bf6c2bc1426c22920bceaf8f0b291c869e4f2986e092","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"friendlyName":"clitest-item000004","protectionStatus":"Healthy","protectionState":"IRPending","lastBackupStatus":"IRPending","extendedInfo":{"recoveryPointCount":0,"policyState":"Consistent","resourceState":"Active","resourceStateSyncTime":"2023-05-17T12:09:03.3082791Z"},"protectedItemType":"AzureFileShareProtectedItem","backupManagementType":"AzureStorage","workloadType":"AzureFileShare","containerName":"StorageContainer;storage;clitest.rg000001;clitest000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.storage/storageAccounts/clitest000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000005","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1613'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:11 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupResourceGuardProxies?api-version=2023-02-01
   response:
     body:
       string: '{"value":[]}'
@@ -2021,103 +3789,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:09:12 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3Bstorage%3Bclitest.rg000001%3Bclitest000003/protectedItems/AzureFileShare%3B766e3beeab52973a81d8bf6c2bc1426c22920bceaf8f0b291c869e4f2986e092?api-version=2023-02-01
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/36ed4f7a-9845-4e5c-b0e8-9bbc2180861a?api-version=2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Wed, 17 May 2023 12:09:13 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/36ed4f7a-9845-4e5c-b0e8-9bbc2180861a?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-deletes:
-      - '14999'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/36ed4f7a-9845-4e5c-b0e8-9bbc2180861a?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"36ed4f7a-9845-4e5c-b0e8-9bbc2180861a","name":"36ed4f7a-9845-4e5c-b0e8-9bbc2180861a","status":"InProgress","startTime":"2023-05-17T12:09:13.2732136Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:14 GMT
+      - Wed, 16 Aug 2023 09:40:42 GMT
       expires:
       - '-1'
       pragma:
@@ -2133,7 +3805,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
+      - '292'
     status:
       code: 200
       message: OK
@@ -2145,175 +3817,28 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - backup protection disable
+      - backup container list
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
+      - --backup-management-type -v -g --query
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/36ed4f7a-9845-4e5c-b0e8-9bbc2180861a?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureIaasVM%27+and+status+eq+%27Registered%27
   response:
     body:
-      string: '{"id":"36ed4f7a-9845-4e5c-b0e8-9bbc2180861a","name":"36ed4f7a-9845-4e5c-b0e8-9bbc2180861a","status":"InProgress","startTime":"2023-05-17T12:09:13.2732136Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"value":[]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '12'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 17 May 2023 12:09:19 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '295'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/36ed4f7a-9845-4e5c-b0e8-9bbc2180861a?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"36ed4f7a-9845-4e5c-b0e8-9bbc2180861a","name":"36ed4f7a-9845-4e5c-b0e8-9bbc2180861a","status":"InProgress","startTime":"2023-05-17T12:09:13.2732136Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:24 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '293'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/36ed4f7a-9845-4e5c-b0e8-9bbc2180861a?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"36ed4f7a-9845-4e5c-b0e8-9bbc2180861a","name":"36ed4f7a-9845-4e5c-b0e8-9bbc2180861a","status":"InProgress","startTime":"2023-05-17T12:09:13.2732136Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:30 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '291'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/36ed4f7a-9845-4e5c-b0e8-9bbc2180861a?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"36ed4f7a-9845-4e5c-b0e8-9bbc2180861a","name":"36ed4f7a-9845-4e5c-b0e8-9bbc2180861a","status":"Succeeded","startTime":"2023-05-17T12:09:13.2732136Z","endTime":"2023-05-17T12:09:13.2732136Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"95472bbf-f48d-4a5a-8f67-e12a401d1f6b"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:35 GMT
+      - Wed, 16 Aug 2023 09:40:43 GMT
       expires:
       - '-1'
       pragma:
@@ -2341,489 +3866,6 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c -i --backup-management-type --delete-backup-data --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/95472bbf-f48d-4a5a-8f67-e12a401d1f6b?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/95472bbf-f48d-4a5a-8f67-e12a401d1f6b","name":"95472bbf-f48d-4a5a-8f67-e12a401d1f6b","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureStorageJob","duration":"PT20.9662001S","storageAccountName":"clitest000003","storageAccountVersion":"Storage","extendedInfo":{"tasksList":[],"propertyBag":{"File
-        Share Name":"clitest-item000004","Storage Account Name":"clitest000003"}},"isUserTriggered":false,"entityFriendlyName":"clitest-item000004","backupManagementType":"AzureStorage","operation":"DeleteBackupData","status":"Completed","startTime":"2023-05-17T12:09:13.2732136Z","endTime":"2023-05-17T12:09:34.2394137Z","activityId":"a1117a21-f4ab-11ed-afd9-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '863'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:36 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '149'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container unregister
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+status+eq+%27Registered%27
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003","name":"StorageContainer;Storage;clitest.rg000001;clitest000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000003","protectedItemCount":0,"acquireStorageAccountLock":"Acquire","friendlyName":"clitest000003","backupManagementType":"AzureStorage","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"StorageContainer","protectableObjectType":"StorageContainer"}}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '853'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:37 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container unregister
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      ParameterSetName:
-      - -g -v -c --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003?api-version=2023-02-01
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/f3ebb2fc-e89b-452f-a7ed-1b9eb6dbb734?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Wed, 17 May 2023 12:09:38 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/f3ebb2fc-e89b-452f-a7ed-1b9eb6dbb734?fabricName=Azure?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-deletes:
-      - '14998'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container unregister
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/f3ebb2fc-e89b-452f-a7ed-1b9eb6dbb734?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/f3ebb2fc-e89b-452f-a7ed-1b9eb6dbb734?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:38 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/f3ebb2fc-e89b-452f-a7ed-1b9eb6dbb734?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container unregister
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/f3ebb2fc-e89b-452f-a7ed-1b9eb6dbb734?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/f3ebb2fc-e89b-452f-a7ed-1b9eb6dbb734?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:43 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/f3ebb2fc-e89b-452f-a7ed-1b9eb6dbb734?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container unregister
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/f3ebb2fc-e89b-452f-a7ed-1b9eb6dbb734?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/f3ebb2fc-e89b-452f-a7ed-1b9eb6dbb734?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:50 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/f3ebb2fc-e89b-452f-a7ed-1b9eb6dbb734?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '296'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container unregister
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/f3ebb2fc-e89b-452f-a7ed-1b9eb6dbb734?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationsStatus/f3ebb2fc-e89b-452f-a7ed-1b9eb6dbb734?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:09:56 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;clitest.rg000001;clitest000003/operationResults/f3ebb2fc-e89b-452f-a7ed-1b9eb6dbb734?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '295'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container unregister
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v -c --yes
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/StorageContainer%3BStorage%3Bclitest.rg000001%3Bclitest000003/operationResults/f3ebb2fc-e89b-452f-a7ed-1b9eb6dbb734?api-version=2023-02-01
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      date:
-      - Wed, 17 May 2023 12:10:01 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '294'
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container list
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureStorage%27+and+status+eq+%27Registered%27
-  response:
-    body:
-      string: '{"value":[]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '12'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:10:02 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container list
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type -v -g --query
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureIaasVM%27+and+status+eq+%27Registered%27
-  response:
-    body:
-      string: '{"value":[]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '12'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 17 May 2023 12:11:43 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Kestrel
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
       - backup vault delete
       Connection:
       - keep-alive
@@ -2832,7 +3874,8 @@ interactions:
       ParameterSetName:
       - -n -g --yes
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-recoveryservices/1.0.0b1 Python/3.8.5 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.51.0 (PIP) azsdk-python-mgmt-recoveryservices/2.4.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2023-02-01
   response:
@@ -2844,7 +3887,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 17 May 2023 12:11:53 GMT
+      - Wed, 16 Aug 2023 09:40:45 GMT
       expires:
       - '-1'
       pragma:
@@ -2856,7 +3899,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '49'
+      - '47'
     status:
       code: 200
       message: OK

--- a/src/azure-cli/azure/cli/command_modules/backup/tests/latest/test_afs_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/tests/latest/test_afs_commands.py
@@ -25,7 +25,7 @@ vault_name = "sarath-vault"
 class BackupTests(ScenarioTest, unittest.TestCase):
     #@record_only()
     @ResourceGroupPreparer(location="eastus2euap", random_name_length=20)
-    @VaultPreparer()
+    @VaultPreparer(soft_delete=False)
     @StorageAccountPreparer(location="eastus2euap")
     @FileSharePreparer()
     @AFSPolicyPreparer()
@@ -58,7 +58,7 @@ class BackupTests(ScenarioTest, unittest.TestCase):
 
     #@record_only()
     @ResourceGroupPreparer(location="eastus2euap", random_name_length=20)
-    @VaultPreparer()
+    @VaultPreparer(soft_delete=False)
     @StorageAccountPreparer(location="eastus2euap")
     @FileSharePreparer()
     @AFSPolicyPreparer()
@@ -106,7 +106,7 @@ class BackupTests(ScenarioTest, unittest.TestCase):
 
     #@record_only()
     @ResourceGroupPreparer(location="eastus2euap", random_name_length=20)
-    @VaultPreparer()
+    @VaultPreparer(soft_delete=False)
     @StorageAccountPreparer(location="eastus2euap")
     @FileSharePreparer()
     @FileSharePreparer(parameter_name="afs2")
@@ -174,7 +174,7 @@ class BackupTests(ScenarioTest, unittest.TestCase):
 
     #@record_only()
     @ResourceGroupPreparer(location="eastus2euap", random_name_length=20)
-    @VaultPreparer()
+    @VaultPreparer(soft_delete=False)
     @StorageAccountPreparer(location="eastus2euap")
     @FileSharePreparer()
     @AFSPolicyPreparer()
@@ -216,7 +216,7 @@ class BackupTests(ScenarioTest, unittest.TestCase):
     #@record_only()
     @ResourceGroupPreparer(location="eastus2euap", random_name_length=20)
     @ResourceGroupPreparer(location="centraluseuap", random_name_length=30, parameter_name="resource_group2")
-    @VaultPreparer()
+    @VaultPreparer(soft_delete=False)
     @StorageAccountPreparer(location="centraluseuap", parameter_name="storage_account", resource_group_parameter_name="resource_group")
     @StorageAccountPreparer(location="centraluseuap", parameter_name="storage_account_rg2", resource_group_parameter_name="resource_group2")
     @FilePreparer()
@@ -226,7 +226,7 @@ class BackupTests(ScenarioTest, unittest.TestCase):
     @AFSItemPreparer()
     @AFSRPPreparer()
     @FileSharePreparer(parameter_name="afs2")
-    # @FileSharePreparer(parameter_name="afs_rg2", storage_account_parameter_name="storage_account_rg2", resource_group_parameter_name="resource_group2")
+    @FileSharePreparer(parameter_name="afs_rg2", storage_account_parameter_name="storage_account_rg2", resource_group_parameter_name="resource_group2")
     def test_afs_backup_restore(self, resource_group, vault_name, storage_account, file_name, afs_name, afs2, file2, resource_group2, storage_account_rg2, afs_rg2):
         self.kwargs.update({
             'vault': vault_name,
@@ -241,25 +241,6 @@ class BackupTests(ScenarioTest, unittest.TestCase):
             'file': file_name,
             'file2': file2
         })
-        # full share restore alternate location with a different resource group
-
-        self.cmd('backup restore restore-azurefileshare -g {rg} -v {vault} -c {container} -i {item1} -r {rp1} --resolve-conflict Overwrite --restore-mode AlternateLocation --target-storage-account {container_rg2} --target-file-share {item_rg2}', expect_failure=True)
-
-        trigger_restore_job3_json = self.cmd('backup restore restore-azurefileshare -g {rg} -v {vault} -c {container} -i {item1} -r {rp1} --resolve-conflict Overwrite --restore-mode AlternateLocation --target-storage-account {container_rg2} --target-file-share {item_rg2} --target-rg-name {rg2}', checks=[
-            self.check("properties.entityFriendlyName", '{item1}'),
-            self.check("properties.operation", "Restore"),
-            self.check("properties.status", "InProgress"),
-            self.check("resourceGroup", '{rg}')
-        ]).get_output_in_json()
-        self.kwargs['job3'] = trigger_restore_job3_json['name']
-        self.cmd('backup job wait -g {rg} -v {vault} -n {job3}')
-
-        self.cmd('backup job show -g {rg} -v {vault} -n {job3}', checks=[
-            self.check("properties.entityFriendlyName", '{item1}'),
-            self.check("properties.operation", "Restore"),
-            self.check("resourceGroup", '{rg}')
-        ])
-
         # full share restore original location
 
         rp_names = self.cmd('backup recoverypoint list -g {rg} -v {vault} -c {container} -i {item1} --backup-management-type {type} --query [].name').get_output_in_json()
@@ -280,7 +261,26 @@ class BackupTests(ScenarioTest, unittest.TestCase):
             self.check("resourceGroup", '{rg}')
         ])
 
-        # full share alternate location
+        # full share restore alternate location with a different resource group
+
+        self.cmd('backup restore restore-azurefileshare -g {rg} -v {vault} -c {container} -i {item1} -r {rp1} --resolve-conflict Overwrite --restore-mode AlternateLocation --target-storage-account {container_rg2} --target-file-share {item_rg2}', expect_failure=True)
+
+        trigger_restore_job3_json = self.cmd('backup restore restore-azurefileshare -g {rg} -v {vault} -c {container} -i {item1} -r {rp1} --resolve-conflict Overwrite --restore-mode AlternateLocation --target-storage-account {container_rg2} --target-file-share {item_rg2} --target-rg-name {rg2}', checks=[
+            self.check("properties.entityFriendlyName", '{item1}'),
+            self.check("properties.operation", "Restore"),
+            self.check("properties.status", "InProgress"),
+            self.check("resourceGroup", '{rg}')
+        ]).get_output_in_json()
+        self.kwargs['job3'] = trigger_restore_job3_json['name']
+        self.cmd('backup job wait -g {rg} -v {vault} -n {job3}')
+
+        self.cmd('backup job show -g {rg} -v {vault} -n {job3}', checks=[
+            self.check("properties.entityFriendlyName", '{item1}'),
+            self.check("properties.operation", "Restore"),
+            self.check("resourceGroup", '{rg}')
+        ])
+
+       # full share alternate location
 
         trigger_restore_job2_json = self.cmd('backup restore restore-azurefileshare -g {rg} -v {vault} -c {container} -i {item1} -r {rp1} --resolve-conflict Overwrite --restore-mode AlternateLocation --target-storage-account {container} --target-file-share {item2} --target-folder folder1', checks=[
             self.check("properties.entityFriendlyName", '{item1}'),
@@ -407,7 +407,7 @@ class BackupTests(ScenarioTest, unittest.TestCase):
 
     #@record_only()
     @ResourceGroupPreparer(location="eastus2euap", random_name_length=20)
-    @VaultPreparer()
+    @VaultPreparer(soft_delete=False)
     @StorageAccountPreparer(location="eastus2euap")
     @FileSharePreparer()
     @AFSPolicyPreparer()
@@ -464,7 +464,7 @@ class BackupTests(ScenarioTest, unittest.TestCase):
 
     #@record_only()
     @ResourceGroupPreparer(location="eastus2euap", random_name_length=20)
-    @VaultPreparer()
+    @VaultPreparer(soft_delete=False)
     @StorageAccountPreparer(location="eastus2euap")
     @FileSharePreparer()
     @AFSPolicyPreparer()

--- a/src/azure-cli/azure/cli/command_modules/backup/tests/latest/test_afs_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/tests/latest/test_afs_commands.py
@@ -215,10 +215,10 @@ class BackupTests(ScenarioTest, unittest.TestCase):
 
     #@record_only()
     @ResourceGroupPreparer(location="eastus2euap", random_name_length=20)
-    @ResourceGroupPreparer(location="centraluseuap", random_name_length=20, parameter_name="resource_group2")
+    @ResourceGroupPreparer(location="centraluseuap", random_name_length=30, parameter_name="resource_group2")
     @VaultPreparer()
-    @StorageAccountPreparer(location="eastus2euap")
-    # @StorageAccountPreparer(location="centraluseuap", parameter_name="storage_account_rg2", resource_group_parameter_name="resource_group2")
+    @StorageAccountPreparer(location="centraluseuap", parameter_name="storage_account", resource_group_parameter_name="resource_group")
+    @StorageAccountPreparer(location="centraluseuap", parameter_name="storage_account_rg2", resource_group_parameter_name="resource_group2")
     @FilePreparer()
     @FilePreparer(parameter_name="file2")
     @FileSharePreparer(file_upload=True, file_parameter_name=['file_name', 'file2'])
@@ -227,21 +227,38 @@ class BackupTests(ScenarioTest, unittest.TestCase):
     @AFSRPPreparer()
     @FileSharePreparer(parameter_name="afs2")
     # @FileSharePreparer(parameter_name="afs_rg2", storage_account_parameter_name="storage_account_rg2", resource_group_parameter_name="resource_group2")
-    def test_afs_backup_restore(self, resource_group, vault_name, storage_account, file_name, afs_name, afs2, file2, resource_group2):
-        # , storage_account_rg2, afs_rg2):
+    def test_afs_backup_restore(self, resource_group, vault_name, storage_account, file_name, afs_name, afs2, file2, resource_group2, storage_account_rg2, afs_rg2):
         self.kwargs.update({
             'vault': vault_name,
             'item1': afs_name,
             'item2': afs2,
-            # 'item_rg2': afs_rg2,
+            'item_rg2': afs_rg2,
             'container': storage_account,
-            # 'container_rg2': storage_account_rg2, 
+            'container_rg2': storage_account_rg2, 
             'rg': resource_group,
             'rg2': resource_group2,
             'type': "AzureStorage",
             'file': file_name,
             'file2': file2
         })
+        # full share restore alternate location with a different resource group
+
+        self.cmd('backup restore restore-azurefileshare -g {rg} -v {vault} -c {container} -i {item1} -r {rp1} --resolve-conflict Overwrite --restore-mode AlternateLocation --target-storage-account {container_rg2} --target-file-share {item_rg2}', expect_failure=True)
+
+        trigger_restore_job3_json = self.cmd('backup restore restore-azurefileshare -g {rg} -v {vault} -c {container} -i {item1} -r {rp1} --resolve-conflict Overwrite --restore-mode AlternateLocation --target-storage-account {container_rg2} --target-file-share {item_rg2} --target-rg-name {rg2}', checks=[
+            self.check("properties.entityFriendlyName", '{item1}'),
+            self.check("properties.operation", "Restore"),
+            self.check("properties.status", "InProgress"),
+            self.check("resourceGroup", '{rg}')
+        ]).get_output_in_json()
+        self.kwargs['job3'] = trigger_restore_job3_json['name']
+        self.cmd('backup job wait -g {rg} -v {vault} -n {job3}')
+
+        self.cmd('backup job show -g {rg} -v {vault} -n {job3}', checks=[
+            self.check("properties.entityFriendlyName", '{item1}'),
+            self.check("properties.operation", "Restore"),
+            self.check("resourceGroup", '{rg}')
+        ])
 
         # full share restore original location
 
@@ -275,25 +292,6 @@ class BackupTests(ScenarioTest, unittest.TestCase):
         self.cmd('backup job wait -g {rg} -v {vault} -n {job2}')
 
         self.cmd('backup job show -g {rg} -v {vault} -n {job2}', checks=[
-            self.check("properties.entityFriendlyName", '{item1}'),
-            self.check("properties.operation", "Restore"),
-            self.check("resourceGroup", '{rg}')
-        ])
-
-        # full share restore alternate location with a different resource group
-
-        self.cmd('backup restore restore-azurefileshare -g {rg} -v {vault} -c {container} -i {item1} -r {rp1} --resolve-conflict Overwrite --restore-mode AlternateLocation --target-storage-account {container_rg2} --target-file-share {item_rg2}', expect_failure=True)
-
-        trigger_restore_job3_json = self.cmd('backup restore restore-azurefileshare -g {rg} -v {vault} -c {container} -i {item1} -r {rp1} --resolve-conflict Overwrite --restore-mode AlternateLocation --target-storage-account {container_rg2} --target-file-share {item_rg2} --target-rg-name {rg2}', checks=[
-            self.check("properties.entityFriendlyName", '{item1}'),
-            self.check("properties.operation", "Restore"),
-            self.check("properties.status", "InProgress"),
-            self.check("resourceGroup", '{rg}')
-        ]).get_output_in_json()
-        self.kwargs['job3'] = trigger_restore_job3_json['name']
-        self.cmd('backup job wait -g {rg} -v {vault} -n {job3}')
-
-        self.cmd('backup job show -g {rg} -v {vault} -n {job3}', checks=[
             self.check("properties.entityFriendlyName", '{item1}'),
             self.check("properties.operation", "Restore"),
             self.check("resourceGroup", '{rg}')


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az backup restore restore-azurefileshare`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Resolving work item <https://msazure.visualstudio.com/DefaultCollection/One/_workitems/edit/24475508/>. Allows users to AFS restore to a storage account that is in a different resource group from the vault, without having to provide the full ARM ID of the Storage Account.

**Testing Guide**
<!--Example commands with explanations.-->


**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
