### PR TITLE
{AKS} `az aks create/update`: update logic for euap region mapping

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/amw/defaults.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/amw/defaults.py
@@ -7,7 +7,7 @@ from azure.cli.command_modules.acs.azuremonitormetrics.deaults import get_defaul
 from azure.cli.command_modules.acs.azuremonitormetrics.responseparsers.amwlocationresponseparser import (
     parseResourceProviderResponseForLocations
 )
-from azure.cli.command_modules.acs.azuremonitormetrics.constants import RP_LOCATION_API
+from azure.cli.command_modules.acs.azuremonitormetrics.constants import RP_LOCATION_API, MapToClosestMACRegion
 from knack.util import CLIError
 
 
@@ -25,6 +25,8 @@ def get_supported_rp_locations(cmd, rp_name):
 
 def get_default_mac_region(cmd, cluster_region):
     supported_locations = get_supported_rp_locations(cmd, 'Microsoft.Monitor')
+    if cluster_region == 'centraluseuap':
+        return MapToClosestMACRegion[cluster_region]
     if cluster_region in supported_locations:
         return cluster_region
     if len(supported_locations) > 0:

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/constants.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/constants.py
@@ -59,7 +59,7 @@ MapToClosestMACRegion = {
     "germanynorth": "westeurope",
     "uaecentral": "westeurope",
     "eastus2euap": "eastus2euap",
-    "centraluseuap": "westeurope",
+    "centraluseuap": "eastus2euap",
     "brazilsoutheast": "eastus",
     "jioindiacentral": "centralindia",
     "swedencentral": "westeurope",


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

```az aks update -n kaveeshcli -g kaveeshcli --enable-azure-monitor-metrics --enable-windows-recording-rules```

```az aks create -n kaveeshcli -g kaveeshcli --location centraluseuap --enable-azure-monitor-metrics --enable-windows-recording-rules --azure-monitor-workspace-resource-id "{full_id}" --grafana-resource-id "{full_id}"```

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

centraluseuap will not be a supported region for Azure Monitor Workspace anymore thus we're mapping the creation to the closest euap region i.e. eastus2euap.

**Testing Guide**
<!--Example commands with explanations.-->

This is a bug fix and can be tested by onboarding to the azure monitor for metrics addon using the above mentioned commands with an AKS cluster in centraluseuap.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
