### PR TITLE
{Core} Fix authentication TypeError

### DIFF
--- a/src/azure-cli-core/azure/cli/core/auth/credential_adaptor.py
+++ b/src/azure-cli-core/azure/cli/core/auth/credential_adaptor.py
@@ -60,6 +60,7 @@ class CredentialAdaptor:
         # SDK azure-keyvault-keys 4.5.0b5 passes tenant_id as kwargs, but we don't support tenant_id for now,
         # so discard it.
         kwargs.pop('tenant_id', None)
+        kwargs.pop('enable_cae', None)
 
         scopes = _normalize_scopes(scopes)
         token, _ = self._get_token(scopes, **kwargs)

--- a/src/azure-cli-core/azure/cli/core/auth/msal_authentication.py
+++ b/src/azure-cli-core/azure/cli/core/auth/msal_authentication.py
@@ -20,7 +20,7 @@ from knack.log import get_logger
 from knack.util import CLIError
 from msal import PublicClientApplication, ConfidentialClientApplication
 
-from .util import check_result, build_sdk_access_token
+from .util import check_result, build_sdk_access_token, clean_get_token_kwargs
 
 # OAuth 2.0 client credentials flow parameter
 # https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-client-creds-grant-flow
@@ -62,6 +62,7 @@ class UserCredential(PublicClientApplication):
     def get_token(self, *scopes, claims=None, **kwargs):
         # scopes = ['https://pas.windows.net/CheckMyAccess/Linux/.default']
         logger.debug("UserCredential.get_token: scopes=%r, claims=%r, kwargs=%r", scopes, claims, kwargs)
+        clean_get_token_kwargs(kwargs)
 
         if claims:
             logger.warning('Acquiring new access token silently for tenant %s with claims challenge: %s',
@@ -133,7 +134,7 @@ class ServicePrincipalCredential(ConfidentialClientApplication):
 
     def get_token(self, *scopes, **kwargs):
         logger.debug("ServicePrincipalCredential.get_token: scopes=%r, kwargs=%r", scopes, kwargs)
-
+        clean_get_token_kwargs(kwargs)
         scopes = list(scopes)
         result = self.acquire_token_silent(scopes, None, **kwargs)
         if not result:

--- a/src/azure-cli-core/azure/cli/core/auth/util.py
+++ b/src/azure-cli-core/azure/cli/core/auth/util.py
@@ -188,3 +188,12 @@ def read_response_templates():
         error_template = f.read()
 
     return success_template, error_template
+
+
+def clean_get_token_kwargs(kwargs):
+    """Remove kwargs that are not meant for further propagation."""
+    kwargs_to_remove = ["enable_cae"]
+    if not kwargs:
+        return
+    for key in kwargs_to_remove:
+        kwargs.pop(key, None)


### PR DESCRIPTION
With the latest version of azure-core, the `BearerTokenCredentialPolicy` now passes in a new keyword argument to `get_token` called `enable_cae`. 

This PR fixes TypeErrors in msal for unexpected keyword arguments due to this keyword being propagated.

Fixes: https://github.com/Azure/azure-cli/issues/27131