### PR TITLE
Snap: refresh and move to core22

### DIFF
--- a/.snapcraft.yaml
+++ b/.snapcraft.yaml
@@ -3,40 +3,30 @@ summary: Microsoft Azure CLI
 description: |
  A great cloud needs great tools; we're excited to introduce Azure CLI, our
  next generation multi-platform command line experience for Azure.
-version: "release"
-version-script: |
- grep VERSION src/azure-cli/setup.py | head -n 1 | cut -d'"' -f2
-confinement: classic
+confinement: strict
 grade: stable
+base: core22
+adopt-info: azure-cli
+
 apps:
   az:
-    command: usr/bin/python -m azure.cli
-    completer: az.completion
+    command: bin/python3 $SNAP/bin/az
+    completer: az.snap.completion
+    plugs:
+      - network
+      - home
+
 parts:
   azure-cli:
     plugin: python
     source: .
-    python-version: python3
-    build-packages:
-      - build-essential
-      - python3-dev
-      - python3-wheel
-      - libffi-dev
-      - libssl-dev
-    stage-packages:
-      - libffi6
-      - libssl1.0.0
-    requirements: requirements.txt
-    install: |
-      python_packages="src/azure-cli-core src/command_modules/azure-cli*"
-      export PYTHONUSERBASE=$SNAPCRAFT_PART_INSTALL
-      export PYTHONHOME=$SNAPCRAFT_PART_INSTALL/usr
-      echo $SNAPCRAFT_PART_INSTALL/usr/bin/python3
-      $SNAPCRAFT_PART_INSTALL/usr/bin/python3 -c 'import site; print("PYTHONUSERBASE set to {!r}".format(site.getuserbase()))'
-      $SNAPCRAFT_PART_INSTALL/usr/bin/python3 -m pip install --user $python_packages
-      $SNAPCRAFT_PART_INSTALL/usr/bin/python3 -m pip install --no-index --user src/azure-cli --no-binary cryptography
-      install build_scripts/snap/az.snap.completion $SNAPCRAFT_PART_INSTALL/az.completion
-      # PEP 394 says you should use python3, but the client uses python.
-      ln -s python3 $SNAPCRAFT_PART_INSTALL/usr/bin/python
-    prime:
-      - -lib/python3.5/site-packages/tabulate-0.7.7.dist-info/.PKG-INFO.swp
+    python-packages:
+      - './src/azure-cli-core'
+      - './src/azure-cli'
+    python-requirements:
+      - './src/azure-cli/requirements.py3.Linux.txt'
+    override-build: |
+      craftctl default
+      cp $SNAPCRAFT_PART_BUILD/build_scripts/snap/az.snap.completion $SNAPCRAFT_PART_INSTALL/
+
+      craftctl set version="$(git describe --tags --abbrev=0 | cut -d'-' -f3)"

--- a/build_scripts/snap/az.snap.completion
+++ b/build_scripts/snap/az.snap.completion
@@ -11,7 +11,7 @@ _python_argcomplete() {
                   _ARGCOMPLETE_COMP_WORDBREAKS="$COMP_WORDBREAKS" \
                   _ARGCOMPLETE=1 \
                   _ARGCOMPLETE_SUPPRESS_SPACE=$SUPPRESS_SPACE \
-                  "$SNAP/usr/bin/python" -m azure.cli 8>&1 9>&2 1>/dev/null 2>/dev/null) )
+                  "$SNAP/bin/python3" -m azure.cli 8>&1 9>&2 1>/dev/null 2>/dev/null) )
     if [[ $? != 0 ]]; then
         unset COMPREPLY
     elif [[ $SUPPRESS_SPACE == 1 ]] && [[ "$COMPREPLY" =~ [=/:]$ ]]; then


### PR DESCRIPTION
**Related command**
All

**Description**<!--Mandatory-->

The current version of the `snapcraft.yaml` is very old and uses `classic` confinement. These changes bring the snap to the latest base: `core22` and switch the confinement to strict in order to ease the publication process.

Note that the Azure CLI is not published into the snapstore anymore. This PR creates the per-requisites for republishing the snap into the store.

**Testing Guide**

Build the snap by running `snapcraft`
Install it locally: `snap install --dangerous azure-cli_*.snap`
Verify that the CLI is working as expected: `azure-cli.az xxx`

(since the snap is not named `az` but `azure-cli` the alias is not setup by default)

**History Notes**

Historically, Microsoft was publishing the Azure CLI in the snapstore. It was decided to remove the snap from the store as it wasn't updated and was confusing users who would install the CLI via the snap and end up with an out-dated non-working software. For similarly reasons, Ubuntu decided to remove the upstream Debian package from its repository as the package doesn't contain an up-to-date version of the CLI. Moreover, the debian packages do not seem very well suited for this kind of CLI which are constantly updated and have to follow new API updates.
We've now ended up in a situation where users of Ubuntu cannot natively install the CLI and have to add extra package repositories to their source list in order to get it.