### PR TITLE
[cosmosdb] `az cosmosdb restore`: Support enabling/disabling public network access

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/_params.py
@@ -390,6 +390,7 @@ def load_arguments(self, _):
         c.argument('tables_to_restore', nargs='+', action=CreateTableRestoreResource)
         c.argument('assign_identity', nargs='*', help="Assign system or user assigned identities separated by spaces. Use '[system]' to refer system assigned identity.")
         c.argument('default_identity', help="The primary identity to access key vault in CMK related features. e.g. 'FirstPartyIdentity', 'SystemAssignedIdentity' and more.")
+        c.argument('public_network_access', options_list=['--public-network-access', '-p'], arg_type=get_enum_type(['ENABLED', 'DISABLED']), help="Sets public network access in server to either Enabled or Disabled.")
 
     # Mongo role definition
     with self.argument_context('cosmosdb mongodb role definition') as c:

--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/custom.py
@@ -1778,7 +1778,8 @@ def cli_cosmosdb_restore(cmd,
                          default_identity=None,
                          databases_to_restore=None,
                          gremlin_databases_to_restore=None,
-                         tables_to_restore=None):
+                         tables_to_restore=None,
+                         public_network_access=None):
     from azure.cli.command_modules.cosmosdb._client_factory import cf_restorable_database_accounts
     restorable_database_accounts_client = cf_restorable_database_accounts(cmd.cli_ctx, [])
     restorable_database_accounts = restorable_database_accounts_client.list()
@@ -1883,7 +1884,8 @@ def cli_cosmosdb_restore(cmd,
                                     databases_to_restore=databases_to_restore,
                                     gremlin_databases_to_restore=gremlin_databases_to_restore,
                                     tables_to_restore=tables_to_restore,
-                                    arm_location=target_restorable_account.location)
+                                    arm_location=target_restorable_account.location,
+                                    public_network_access=public_network_access)
 
 
 def _convert_to_utc_timestamp(timestamp_string):

--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/tests/latest/recordings/test_cosmosdb_public_network_access_restore.yaml
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/tests/latest/recordings/test_cosmosdb_public_network_access_restore.yaml
@@ -1,0 +1,2896 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --backup-policy-type --locations --kind
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cosmosdb_public_network_access_restore000001?api-version=2022-09-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_public_network_access_restore000001","name":"cli_test_cosmosdb_public_network_access_restore000001","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"product":"azurecli","cause":"automation","test":"test_cosmosdb_public_network_access_restore","date":"2023-08-21T13:32:32Z","module":"cosmosdb"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '458'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 21 Aug 2023 13:32:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "eastus2", "kind": "GlobalDocumentDB", "properties": {"locations":
+      [{"locationName": "eastus2", "failoverPriority": 0, "isZoneRedundant": false}],
+      "databaseAccountOfferType": "Standard", "apiProperties": {}, "createMode": "Default",
+      "backupPolicy": {"type": "Continuous", "continuousModeProperties": {"tier":
+      "Continuous30Days"}}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '344'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -n -g --backup-policy-type --locations --kind
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_public_network_access_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli-systemid-000002?api-version=2023-04-15
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_public_network_access_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli-systemid-000002","name":"cli-systemid-000002","location":"East
+        US 2","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2023-08-21T13:32:38.13733Z"},"properties":{"provisioningState":"Creating","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"0bdc1b28-85d2-44f8-ba04-9c4053b9c09e","createMode":"Default","databaseAccountOfferType":"Standard","defaultIdentity":"","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"minimalTlsVersion":"Tls12","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli-systemid-000002-eastus2","locationName":"East
+        US 2","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli-systemid-000002-eastus2","locationName":"East
+        US 2","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli-systemid-000002-eastus2","locationName":"East
+        US 2","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli-systemid-000002-eastus2","locationName":"East
+        US 2","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"networkAclBypassResourceIds":[],"keysMetadata":{"primaryMasterKey":{"generationTime":"2023-08-21T13:32:38.13733Z"},"secondaryMasterKey":{"generationTime":"2023-08-21T13:32:38.13733Z"},"primaryReadonlyMasterKey":{"generationTime":"2023-08-21T13:32:38.13733Z"},"secondaryReadonlyMasterKey":{"generationTime":"2023-08-21T13:32:38.13733Z"}}},"identity":{"type":"None"}}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/97b142f7-a2c8-4f30-a98a-cbc8aa71844a?api-version=2023-04-15&t=2023-08-21T13%3a32%3a39&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=G_ovxpeDf-Nds1-qHNtvEmEGzzzSduDTVEHiZ_EQhK9xBSkuImkL65YY2JTX4Cdxu_UEhq7oRdmvKU7NPf3BJBRLFHhscsnJPmTccMgfcUiFvDMbwqrjgyn2IJcTxBZxHfeE8GBECRokI-N4ndm-1gBKgOc8t-BxZa63V7sIRK622q_0XIPTebZOskmPZuMBWgyHPs9vI1c6yT4DF1Y0BTfWdUWnnebSyZlLYxeprWzg5UTtkYDyozqEK9HYQ3JdGPCl7ulKA1aoHr_5AzmIdLaK5yTb0HG6j21Wu5kXrRmEtLliQvbDUBzhEy8WelLNzvC7OP6dZjqk0lAUgmXRNg&h=h9ENZuq-u5uFOeUu3N7v8X1dav4_0lQZ8V1UW5Yw6JY
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '2269'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:32:38 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_public_network_access_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli-systemid-000002/operationResults/97b142f7-a2c8-4f30-a98a-cbc8aa71844a?api-version=2023-04-15
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --backup-policy-type --locations --kind
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/97b142f7-a2c8-4f30-a98a-cbc8aa71844a?api-version=2023-04-15&t=2023-08-21T13%3A32%3A39&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=G_ovxpeDf-Nds1-qHNtvEmEGzzzSduDTVEHiZ_EQhK9xBSkuImkL65YY2JTX4Cdxu_UEhq7oRdmvKU7NPf3BJBRLFHhscsnJPmTccMgfcUiFvDMbwqrjgyn2IJcTxBZxHfeE8GBECRokI-N4ndm-1gBKgOc8t-BxZa63V7sIRK622q_0XIPTebZOskmPZuMBWgyHPs9vI1c6yT4DF1Y0BTfWdUWnnebSyZlLYxeprWzg5UTtkYDyozqEK9HYQ3JdGPCl7ulKA1aoHr_5AzmIdLaK5yTb0HG6j21Wu5kXrRmEtLliQvbDUBzhEy8WelLNzvC7OP6dZjqk0lAUgmXRNg&h=h9ENZuq-u5uFOeUu3N7v8X1dav4_0lQZ8V1UW5Yw6JY
+  response:
+    body:
+      string: '{"status":"Enqueued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:32:38 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --backup-policy-type --locations --kind
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/97b142f7-a2c8-4f30-a98a-cbc8aa71844a?api-version=2023-04-15&t=2023-08-21T13%3A32%3A39&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=G_ovxpeDf-Nds1-qHNtvEmEGzzzSduDTVEHiZ_EQhK9xBSkuImkL65YY2JTX4Cdxu_UEhq7oRdmvKU7NPf3BJBRLFHhscsnJPmTccMgfcUiFvDMbwqrjgyn2IJcTxBZxHfeE8GBECRokI-N4ndm-1gBKgOc8t-BxZa63V7sIRK622q_0XIPTebZOskmPZuMBWgyHPs9vI1c6yT4DF1Y0BTfWdUWnnebSyZlLYxeprWzg5UTtkYDyozqEK9HYQ3JdGPCl7ulKA1aoHr_5AzmIdLaK5yTb0HG6j21Wu5kXrRmEtLliQvbDUBzhEy8WelLNzvC7OP6dZjqk0lAUgmXRNg&h=h9ENZuq-u5uFOeUu3N7v8X1dav4_0lQZ8V1UW5Yw6JY
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:33:09 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --backup-policy-type --locations --kind
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/97b142f7-a2c8-4f30-a98a-cbc8aa71844a?api-version=2023-04-15&t=2023-08-21T13%3A32%3A39&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=G_ovxpeDf-Nds1-qHNtvEmEGzzzSduDTVEHiZ_EQhK9xBSkuImkL65YY2JTX4Cdxu_UEhq7oRdmvKU7NPf3BJBRLFHhscsnJPmTccMgfcUiFvDMbwqrjgyn2IJcTxBZxHfeE8GBECRokI-N4ndm-1gBKgOc8t-BxZa63V7sIRK622q_0XIPTebZOskmPZuMBWgyHPs9vI1c6yT4DF1Y0BTfWdUWnnebSyZlLYxeprWzg5UTtkYDyozqEK9HYQ3JdGPCl7ulKA1aoHr_5AzmIdLaK5yTb0HG6j21Wu5kXrRmEtLliQvbDUBzhEy8WelLNzvC7OP6dZjqk0lAUgmXRNg&h=h9ENZuq-u5uFOeUu3N7v8X1dav4_0lQZ8V1UW5Yw6JY
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:33:39 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --backup-policy-type --locations --kind
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/97b142f7-a2c8-4f30-a98a-cbc8aa71844a?api-version=2023-04-15&t=2023-08-21T13%3A32%3A39&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=G_ovxpeDf-Nds1-qHNtvEmEGzzzSduDTVEHiZ_EQhK9xBSkuImkL65YY2JTX4Cdxu_UEhq7oRdmvKU7NPf3BJBRLFHhscsnJPmTccMgfcUiFvDMbwqrjgyn2IJcTxBZxHfeE8GBECRokI-N4ndm-1gBKgOc8t-BxZa63V7sIRK622q_0XIPTebZOskmPZuMBWgyHPs9vI1c6yT4DF1Y0BTfWdUWnnebSyZlLYxeprWzg5UTtkYDyozqEK9HYQ3JdGPCl7ulKA1aoHr_5AzmIdLaK5yTb0HG6j21Wu5kXrRmEtLliQvbDUBzhEy8WelLNzvC7OP6dZjqk0lAUgmXRNg&h=h9ENZuq-u5uFOeUu3N7v8X1dav4_0lQZ8V1UW5Yw6JY
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:34:09 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --backup-policy-type --locations --kind
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/97b142f7-a2c8-4f30-a98a-cbc8aa71844a?api-version=2023-04-15&t=2023-08-21T13%3A32%3A39&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=G_ovxpeDf-Nds1-qHNtvEmEGzzzSduDTVEHiZ_EQhK9xBSkuImkL65YY2JTX4Cdxu_UEhq7oRdmvKU7NPf3BJBRLFHhscsnJPmTccMgfcUiFvDMbwqrjgyn2IJcTxBZxHfeE8GBECRokI-N4ndm-1gBKgOc8t-BxZa63V7sIRK622q_0XIPTebZOskmPZuMBWgyHPs9vI1c6yT4DF1Y0BTfWdUWnnebSyZlLYxeprWzg5UTtkYDyozqEK9HYQ3JdGPCl7ulKA1aoHr_5AzmIdLaK5yTb0HG6j21Wu5kXrRmEtLliQvbDUBzhEy8WelLNzvC7OP6dZjqk0lAUgmXRNg&h=h9ENZuq-u5uFOeUu3N7v8X1dav4_0lQZ8V1UW5Yw6JY
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:34:39 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --backup-policy-type --locations --kind
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/97b142f7-a2c8-4f30-a98a-cbc8aa71844a?api-version=2023-04-15&t=2023-08-21T13%3A32%3A39&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=G_ovxpeDf-Nds1-qHNtvEmEGzzzSduDTVEHiZ_EQhK9xBSkuImkL65YY2JTX4Cdxu_UEhq7oRdmvKU7NPf3BJBRLFHhscsnJPmTccMgfcUiFvDMbwqrjgyn2IJcTxBZxHfeE8GBECRokI-N4ndm-1gBKgOc8t-BxZa63V7sIRK622q_0XIPTebZOskmPZuMBWgyHPs9vI1c6yT4DF1Y0BTfWdUWnnebSyZlLYxeprWzg5UTtkYDyozqEK9HYQ3JdGPCl7ulKA1aoHr_5AzmIdLaK5yTb0HG6j21Wu5kXrRmEtLliQvbDUBzhEy8WelLNzvC7OP6dZjqk0lAUgmXRNg&h=h9ENZuq-u5uFOeUu3N7v8X1dav4_0lQZ8V1UW5Yw6JY
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:35:09 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --backup-policy-type --locations --kind
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/97b142f7-a2c8-4f30-a98a-cbc8aa71844a?api-version=2023-04-15&t=2023-08-21T13%3A32%3A39&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=G_ovxpeDf-Nds1-qHNtvEmEGzzzSduDTVEHiZ_EQhK9xBSkuImkL65YY2JTX4Cdxu_UEhq7oRdmvKU7NPf3BJBRLFHhscsnJPmTccMgfcUiFvDMbwqrjgyn2IJcTxBZxHfeE8GBECRokI-N4ndm-1gBKgOc8t-BxZa63V7sIRK622q_0XIPTebZOskmPZuMBWgyHPs9vI1c6yT4DF1Y0BTfWdUWnnebSyZlLYxeprWzg5UTtkYDyozqEK9HYQ3JdGPCl7ulKA1aoHr_5AzmIdLaK5yTb0HG6j21Wu5kXrRmEtLliQvbDUBzhEy8WelLNzvC7OP6dZjqk0lAUgmXRNg&h=h9ENZuq-u5uFOeUu3N7v8X1dav4_0lQZ8V1UW5Yw6JY
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:35:40 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --backup-policy-type --locations --kind
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_public_network_access_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli-systemid-000002?api-version=2023-04-15
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_public_network_access_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli-systemid-000002","name":"cli-systemid-000002","location":"East
+        US 2","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2023-08-21T13:35:04.7071384Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli-systemid-000002.documents.azure.com:443/","sqlEndpoint":"https://cli-systemid-000002.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"0bdc1b28-85d2-44f8-ba04-9c4053b9c09e","createMode":"Default","databaseAccountOfferType":"Standard","defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"minimalTlsVersion":"Tls12","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli-systemid-000002-eastus2","locationName":"East
+        US 2","documentEndpoint":"https://cli-systemid-000002-eastus2.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli-systemid-000002-eastus2","locationName":"East
+        US 2","documentEndpoint":"https://cli-systemid-000002-eastus2.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli-systemid-000002-eastus2","locationName":"East
+        US 2","documentEndpoint":"https://cli-systemid-000002-eastus2.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli-systemid-000002-eastus2","locationName":"East
+        US 2","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"networkAclBypassResourceIds":[],"keysMetadata":{"primaryMasterKey":{"generationTime":"2023-08-21T13:35:04.7071384Z"},"secondaryMasterKey":{"generationTime":"2023-08-21T13:35:04.7071384Z"},"primaryReadonlyMasterKey":{"generationTime":"2023-08-21T13:35:04.7071384Z"},"secondaryReadonlyMasterKey":{"generationTime":"2023-08-21T13:35:04.7071384Z"}}},"identity":{"type":"None"}}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '2690'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:35:40 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --backup-policy-type --locations --kind
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_public_network_access_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli-systemid-000002?api-version=2023-04-15
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_public_network_access_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli-systemid-000002","name":"cli-systemid-000002","location":"East
+        US 2","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2023-08-21T13:35:04.7071384Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli-systemid-000002.documents.azure.com:443/","sqlEndpoint":"https://cli-systemid-000002.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"0bdc1b28-85d2-44f8-ba04-9c4053b9c09e","createMode":"Default","databaseAccountOfferType":"Standard","defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"minimalTlsVersion":"Tls12","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli-systemid-000002-eastus2","locationName":"East
+        US 2","documentEndpoint":"https://cli-systemid-000002-eastus2.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli-systemid-000002-eastus2","locationName":"East
+        US 2","documentEndpoint":"https://cli-systemid-000002-eastus2.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli-systemid-000002-eastus2","locationName":"East
+        US 2","documentEndpoint":"https://cli-systemid-000002-eastus2.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli-systemid-000002-eastus2","locationName":"East
+        US 2","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"networkAclBypassResourceIds":[],"keysMetadata":{"primaryMasterKey":{"generationTime":"2023-08-21T13:35:04.7071384Z"},"secondaryMasterKey":{"generationTime":"2023-08-21T13:35:04.7071384Z"},"primaryReadonlyMasterKey":{"generationTime":"2023-08-21T13:35:04.7071384Z"},"secondaryReadonlyMasterKey":{"generationTime":"2023-08-21T13:35:04.7071384Z"}}},"identity":{"type":"None"}}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '2690'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:35:40 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_public_network_access_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli-systemid-000002?api-version=2023-04-15
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_public_network_access_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli-systemid-000002","name":"cli-systemid-000002","location":"East
+        US 2","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2023-08-21T13:35:04.7071384Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli-systemid-000002.documents.azure.com:443/","sqlEndpoint":"https://cli-systemid-000002.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"0bdc1b28-85d2-44f8-ba04-9c4053b9c09e","createMode":"Default","databaseAccountOfferType":"Standard","defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"minimalTlsVersion":"Tls12","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli-systemid-000002-eastus2","locationName":"East
+        US 2","documentEndpoint":"https://cli-systemid-000002-eastus2.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli-systemid-000002-eastus2","locationName":"East
+        US 2","documentEndpoint":"https://cli-systemid-000002-eastus2.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli-systemid-000002-eastus2","locationName":"East
+        US 2","documentEndpoint":"https://cli-systemid-000002-eastus2.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli-systemid-000002-eastus2","locationName":"East
+        US 2","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"networkAclBypassResourceIds":[],"keysMetadata":{"primaryMasterKey":{"generationTime":"2023-08-21T13:35:04.7071384Z"},"secondaryMasterKey":{"generationTime":"2023-08-21T13:35:04.7071384Z"},"primaryReadonlyMasterKey":{"generationTime":"2023-08-21T13:35:04.7071384Z"},"secondaryReadonlyMasterKey":{"generationTime":"2023-08-21T13:35:04.7071384Z"}}},"identity":{"type":"None"}}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '2690'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:35:40 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: '{"properties": {"resource": {"id": "cli000004"}, "options": {}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql database create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '64'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -a -n
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_public_network_access_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli-systemid-000002/sqlDatabases/cli000004?api-version=2023-04-15
+  response:
+    body:
+      string: '{"status":"Enqueued"}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/67935449-eec0-4560-90f8-6017dd7da594?api-version=2023-04-15&t=2023-08-21T13%3a35%3a42&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=Biv9reqsthueif_Zt_690olMDg3WsUanZfolpYLkzE0lHv9xL-cWH5vkuLTNErmJD9dIbViGxsqd08aAkHqgPr_JYE5kLDAxwhtCY2mXWqJa2cqXEUav6aqQ0hH4d_lmQNmdVKTV5G3SuDFcukKLscDt3xpHYYrs-Ohw7oovR6XTH5lTsaSaRAxZkGrbkh8-UobhG42yFuW_RNjWnFmB4WicIDWTDEfZpATrUrdWhu677_02s7RJslpOa2LIoaeLJaIbbjBw5P8g1Xlox5Nukpp15x-hCYEqEiCDM7VmHT8KpwthS4FGuTuJ-BBRrIzltsW6pH_F_XNVOMH5rWj8ig&h=iTAjKvX5xA8R0xICkm-ZdBfzKdENLUaIY-6vDfZRrwc
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:35:42 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_public_network_access_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli-systemid-000002/sqlDatabases/cli000004/operationResults/67935449-eec0-4560-90f8-6017dd7da594?api-version=2023-04-15&t=2023-08-21T13%3a35%3a42&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=fJu7knrlyj65Y8ODshhTg1t2r5OVt3LI1_XBCgrLqZ77nMTyiCZ6sl3oIo3gwRJpQLqiCmbC1ut9UYeWxfl9bp2oaNWuNPU9cvE_Xtp-p3vhEKjmUlueJmeuukKi9uKUeR0kVz7fw8aFBGEF7fsCXSPpAwNBXm0oeocOucIjNPj-CfK4UeMbZZK5WtyeWgtpu0wecyhedS2DLd6TRUtztBBCXopLL8Qkv9qsCkYLCHCuXj7ClLsa7LHXlCRT8QpkcdDYUIh7UXqmkluPCoWVmixqPpPISI5BTSuGuww-QUrwxpB1GPLe9y005rjcOg3_Np51voUtDRqUyQcuo4vAEA&h=-2RKSEDalYTbT2i4Pv6SPGRktKFVK4Qj9kDZG1QOHK4
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql database create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -a -n
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/67935449-eec0-4560-90f8-6017dd7da594?api-version=2023-04-15&t=2023-08-21T13%3A35%3A42&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=Biv9reqsthueif_Zt_690olMDg3WsUanZfolpYLkzE0lHv9xL-cWH5vkuLTNErmJD9dIbViGxsqd08aAkHqgPr_JYE5kLDAxwhtCY2mXWqJa2cqXEUav6aqQ0hH4d_lmQNmdVKTV5G3SuDFcukKLscDt3xpHYYrs-Ohw7oovR6XTH5lTsaSaRAxZkGrbkh8-UobhG42yFuW_RNjWnFmB4WicIDWTDEfZpATrUrdWhu677_02s7RJslpOa2LIoaeLJaIbbjBw5P8g1Xlox5Nukpp15x-hCYEqEiCDM7VmHT8KpwthS4FGuTuJ-BBRrIzltsW6pH_F_XNVOMH5rWj8ig&h=iTAjKvX5xA8R0xICkm-ZdBfzKdENLUaIY-6vDfZRrwc
+  response:
+    body:
+      string: '{"status":"Enqueued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:35:42 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql database create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -a -n
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/67935449-eec0-4560-90f8-6017dd7da594?api-version=2023-04-15&t=2023-08-21T13%3A35%3A42&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=Biv9reqsthueif_Zt_690olMDg3WsUanZfolpYLkzE0lHv9xL-cWH5vkuLTNErmJD9dIbViGxsqd08aAkHqgPr_JYE5kLDAxwhtCY2mXWqJa2cqXEUav6aqQ0hH4d_lmQNmdVKTV5G3SuDFcukKLscDt3xpHYYrs-Ohw7oovR6XTH5lTsaSaRAxZkGrbkh8-UobhG42yFuW_RNjWnFmB4WicIDWTDEfZpATrUrdWhu677_02s7RJslpOa2LIoaeLJaIbbjBw5P8g1Xlox5Nukpp15x-hCYEqEiCDM7VmHT8KpwthS4FGuTuJ-BBRrIzltsW6pH_F_XNVOMH5rWj8ig&h=iTAjKvX5xA8R0xICkm-ZdBfzKdENLUaIY-6vDfZRrwc
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:36:12 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql database create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -a -n
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_public_network_access_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli-systemid-000002/sqlDatabases/cli000004?api-version=2023-04-15
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_public_network_access_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli-systemid-000002/sqlDatabases/cli000004","type":"Microsoft.DocumentDB/databaseAccounts/sqlDatabases","name":"cli000004","properties":{"resource":{"id":"cli000004","_rid":"i31aAA==","_self":"dbs/i31aAA==/","_etag":"\"00008701-0000-0200-0000-64e368320000\"","_colls":"colls/","_users":"users/","_ts":1692624946}}}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '490'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:36:13 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: '{"properties": {"resource": {"id": "cli000003", "indexingPolicy": {"automatic":
+      true, "indexingMode": "consistent", "includedPaths": [{"path": "/*"}], "excludedPaths":
+      [{"path": "/\"_etag\"/?"}]}, "partitionKey": {"paths": ["/pk"], "kind": "Hash"}},
+      "options": {}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql container create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '265'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -a -d -n -p
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_public_network_access_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli-systemid-000002/sqlDatabases/cli000004/containers/cli000003?api-version=2023-04-15
+  response:
+    body:
+      string: '{"status":"Enqueued"}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/da189dd3-6a2e-420d-b6be-645a4745de4e?api-version=2023-04-15&t=2023-08-21T13%3a36%3a14&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=aFgvKJ5rBKq6ROkWiLc9wmKI66PyvU3FFrz6tnpP44j-0wMFBd3rZJ9sHFWZTjtit3h-OspEcv8J2wRjDQKkp_DKHzaTEpBKfALz2xhkC6-nTDVbNkbwHSRAudOzauT0Ol4Qq1Sdt-XB3oVFUWpWuq2aQ9S6zHOhztGoXsjE6QDkOK2Lqrtr-NDRsgpCNtqNvOiNGmkzzRvwpCbstHUcbr4Lry-B-KjI2zvp3wQ88tBbdamD_sr3MxF9oXdU_CROzbF9MkA_pvNI433M7s3_Yr89_6OVQHPMYwGImY4tJbjo4u2_oLjAdTWjWi2jXdD9ahApO-L0w4FIBypxYU-Dqg&h=7fkZS5BUaAr6_Yc49qZDNWAuC0muJjz2l24A7iXgK-c
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:36:14 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_public_network_access_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli-systemid-000002/sqlDatabases/cli000004/containers/cli000003/operationResults/da189dd3-6a2e-420d-b6be-645a4745de4e?api-version=2023-04-15&t=2023-08-21T13%3a36%3a14&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=Rg6n0xTL1LYrqDLClZ9KdTOSUkvTAGDksSJcMhzZ71Svv-kFTUjOJr1oBtn9tR_isOWo_k0eB1dsPu3GlQbqnVG12JHyUM3Xie9-38JR_Q-tjesPxXI9jpW9Kw6n0zsqlS-v6FdV-E0eMrw_sVchGSfEuiT1c5f-N4zyDomiwzepa1jn7XxNxBkNjn2_j685hEG0lOfmNko4QNUhpB5n4ApZ7c1J7dLB4FScXLUr86Iy-TfE4flhrcTfNqgi48-pSyPg3dKWwTtKJcEbL-lb5d685IJV8KGT3xjflceaTTySQTGiDmzd3Wm8dPwGLkBnyzQ09SL_AoXY3S_g6a8ZHA&h=5CQoo9EbUUwOtdvbvGMbXnD1aNGLf9pAWhENykWKYks
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql container create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -a -d -n -p
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/da189dd3-6a2e-420d-b6be-645a4745de4e?api-version=2023-04-15&t=2023-08-21T13%3A36%3A14&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=aFgvKJ5rBKq6ROkWiLc9wmKI66PyvU3FFrz6tnpP44j-0wMFBd3rZJ9sHFWZTjtit3h-OspEcv8J2wRjDQKkp_DKHzaTEpBKfALz2xhkC6-nTDVbNkbwHSRAudOzauT0Ol4Qq1Sdt-XB3oVFUWpWuq2aQ9S6zHOhztGoXsjE6QDkOK2Lqrtr-NDRsgpCNtqNvOiNGmkzzRvwpCbstHUcbr4Lry-B-KjI2zvp3wQ88tBbdamD_sr3MxF9oXdU_CROzbF9MkA_pvNI433M7s3_Yr89_6OVQHPMYwGImY4tJbjo4u2_oLjAdTWjWi2jXdD9ahApO-L0w4FIBypxYU-Dqg&h=7fkZS5BUaAr6_Yc49qZDNWAuC0muJjz2l24A7iXgK-c
+  response:
+    body:
+      string: '{"status":"Enqueued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:36:14 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql container create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -a -d -n -p
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/da189dd3-6a2e-420d-b6be-645a4745de4e?api-version=2023-04-15&t=2023-08-21T13%3A36%3A14&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=aFgvKJ5rBKq6ROkWiLc9wmKI66PyvU3FFrz6tnpP44j-0wMFBd3rZJ9sHFWZTjtit3h-OspEcv8J2wRjDQKkp_DKHzaTEpBKfALz2xhkC6-nTDVbNkbwHSRAudOzauT0Ol4Qq1Sdt-XB3oVFUWpWuq2aQ9S6zHOhztGoXsjE6QDkOK2Lqrtr-NDRsgpCNtqNvOiNGmkzzRvwpCbstHUcbr4Lry-B-KjI2zvp3wQ88tBbdamD_sr3MxF9oXdU_CROzbF9MkA_pvNI433M7s3_Yr89_6OVQHPMYwGImY4tJbjo4u2_oLjAdTWjWi2jXdD9ahApO-L0w4FIBypxYU-Dqg&h=7fkZS5BUaAr6_Yc49qZDNWAuC0muJjz2l24A7iXgK-c
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:36:44 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql container create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -a -d -n -p
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_public_network_access_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli-systemid-000002/sqlDatabases/cli000004/containers/cli000003?api-version=2023-04-15
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_public_network_access_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli-systemid-000002/sqlDatabases/cli000004/containers/cli000003","type":"Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers","name":"cli000003","properties":{"resource":{"id":"cli000003","indexingPolicy":{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"/*"}],"excludedPaths":[{"path":"/\"_etag\"/?"}]},"partitionKey":{"paths":["/pk"],"kind":"Hash"},"uniqueKeyPolicy":{"uniqueKeys":[]},"conflictResolutionPolicy":{"mode":"LastWriterWins","conflictResolutionPath":"/_ts","conflictResolutionProcedure":""},"backupPolicy":{"type":1},"geospatialConfig":{"type":"Geography"},"_rid":"i31aAPk6W14=","_ts":1692624979,"_self":"dbs/i31aAA==/colls/i31aAPk6W14=/","_etag":"\"00008a01-0000-0200-0000-64e368530000\"","_docs":"docs/","_sprocs":"sprocs/","_triggers":"triggers/","_udfs":"udfs/","_conflicts":"conflicts/","statistics":[{"id":"0","sizeInKB":0,"documentCount":0,"sampledDistinctPartitionKeyCount":0,"partitionKeys":[]}]}}}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '1129'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:36:44 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb restorable-database-account show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --location --instance-id
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/0bdc1b28-85d2-44f8-ba04-9c4053b9c09e?api-version=2023-04-15
+  response:
+    body:
+      string: '{"name":"0bdc1b28-85d2-44f8-ba04-9c4053b9c09e","location":"East US
+        2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/0bdc1b28-85d2-44f8-ba04-9c4053b9c09e","properties":{"accountName":"cli-systemid-000002","apiType":"Sql","creationTime":"2023-08-21T13:35:05Z","oldestRestorableTime":"2023-08-21T13:35:05Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"159f7daf-e794-4a4d-9afd-7ec5f953d5fc","creationTime":"2023-08-21T13:35:06Z"}]}}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '626'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:36:46 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb restore
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -a --restore-timestamp --location --public-network-access
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/restorableDatabaseAccounts?api-version=2023-04-15
+  response:
+    body:
+      string: '{"value":[{"name":"891db65f-d13b-4f67-b712-33c8c8d745c7","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/891db65f-d13b-4f67-b712-33c8c8d745c7","properties":{"accountName":"res-con-2","apiType":"Sql","creationTime":"2023-07-18T17:24:49Z","oldestRestorableTime":"2023-07-22T13:40:47Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"d7205a3d-c347-4e3c-ae35-b6d786d78b2a","creationTime":"2023-07-18T17:24:50Z"}]}},{"name":"55a2175f-41e2-48f3-927c-efa7b52b8283","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/55a2175f-41e2-48f3-927c-efa7b52b8283","properties":{"accountName":"barprod-1051050636","apiType":"Sql","creationTime":"2023-08-03T17:56:01Z","oldestRestorableTime":"2023-08-03T17:56:01Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"9aa8f865-0bbc-4c6c-b6e3-d80e8e5ca776","creationTime":"2023-08-03T17:56:02Z"}]}},{"name":"d88e6a3c-687d-4990-a516-da739070bf81","location":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/d88e6a3c-687d-4990-a516-da739070bf81","properties":{"accountName":"kal-continuous7","apiType":"Sql","creationTime":"2022-06-07T20:09:38Z","oldestRestorableTime":"2023-08-14T13:40:47Z","restorableLocations":[{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"09904716-38a7-46f3-bf7e-486b79c84510","creationTime":"2022-06-07T20:09:39Z"}]}},{"name":"fc911c8e-ddac-45d1-a0e6-2217c593bb7e","location":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/fc911c8e-ddac-45d1-a0e6-2217c593bb7e","properties":{"accountName":"test-billing-continuous30","apiType":"Sql","creationTime":"2022-07-28T21:54:20Z","oldestRestorableTime":"2023-07-22T13:40:47Z","restorableLocations":[{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"d0605cd3-ba26-434e-acdd-61b7f64fb1e0","creationTime":"2022-07-28T21:54:21Z"},{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"ae751a67-5fdf-4f38-bcdd-4f6cee0cf44f","creationTime":"2022-08-31T21:09:14Z"},{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"15b05286-8b06-430f-bb5e-c192eb6a98c9","creationTime":"2022-08-31T22:24:21Z"}]}},{"name":"e84733a9-ee18-456c-b12b-1d37e542608b","location":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/e84733a9-ee18-456c-b12b-1d37e542608b","properties":{"accountName":"new-cosmsosdb-account","apiType":"Sql","creationTime":"2022-08-31T20:34:40Z","oldestRestorableTime":"2023-07-22T13:40:47Z","restorableLocations":[{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"af27e000-3eb9-45db-ab59-d21f99e3826c","creationTime":"2022-08-31T20:34:40Z"}]}},{"name":"408d5155-3906-45e1-b9dc-28083579d981","location":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/408d5155-3906-45e1-b9dc-28083579d981","properties":{"accountName":"vinh-2023-06-01","apiType":"Sql","creationTime":"2023-06-01T16:13:51Z","oldestRestorableTime":"2023-08-14T13:40:47Z","restorableLocations":[{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"ddf13580-0d83-4cbe-9aea-80a43ff4cc1a","creationTime":"2023-06-01T16:13:52Z"}]}},{"name":"65c1e266-de59-48a5-928e-31167e02acec","location":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/65c1e266-de59-48a5-928e-31167e02acec","properties":{"accountName":"test-billing-continuous30-r","apiType":"Sql","creationTime":"2023-08-01T20:28:34Z","oldestRestorableTime":"2023-08-01T20:28:34Z","restorableLocations":[{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"ed261fc3-4fa3-44fb-b3de-1212af4e597d","creationTime":"2023-08-01T20:28:34Z"}]}},{"name":"2414c009-8022-442c-9ab6-81c276eb2a99","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/2414c009-8022-442c-9ab6-81c276eb2a99","properties":{"accountName":"vinh-periodic","apiType":"Sql","creationTime":"2022-06-06T19:53:54Z","oldestRestorableTime":"2023-08-14T13:40:47Z","restorableLocations":[{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"20f9a62e-6ab7-4bc7-b537-d43eb766c2e4","creationTime":"2022-06-06T19:53:54Z"}]}},{"name":"d2cfd5f7-3206-42c1-a393-4167ab012de6","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/d2cfd5f7-3206-42c1-a393-4167ab012de6","properties":{"accountName":"ps-cosmosdb-vinhtest","apiType":"Sql","creationTime":"2023-05-02T20:46:14Z","oldestRestorableTime":"2023-08-14T13:40:47Z","restorableLocations":[{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"2651dff1-3471-4023-8d36-03a8c65df5d7","creationTime":"2023-05-02T20:46:14Z"}]}},{"name":"a06aafc3-7133-4b8d-8097-bcd973f040ce","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/a06aafc3-7133-4b8d-8097-bcd973f040ce","properties":{"accountName":"res-con-1","apiType":"Sql","creationTime":"2023-07-18T01:32:36Z","oldestRestorableTime":"2023-07-22T13:40:47Z","restorableLocations":[{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"67928b3d-1b2a-4cbe-848e-6f6e89d4b9fc","creationTime":"2023-07-18T01:32:37Z"}]}},{"name":"c2daec0f-a6b5-4cdc-8a88-3fbf11ce8485","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/c2daec0f-a6b5-4cdc-8a88-3fbf11ce8485","properties":{"accountName":"mk-pitr","apiType":"Sql","creationTime":"2023-08-17T18:06:08Z","oldestRestorableTime":"2023-08-17T18:06:08Z","restorableLocations":[{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"c019da89-2154-4140-81a7-fcbdc337d30e","creationTime":"2023-08-17T18:06:09Z"}]}},{"name":"fce807d5-4358-4ea1-8130-0439181f6be0","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/fce807d5-4358-4ea1-8130-0439181f6be0","properties":{"accountName":"vinh-demo-periodic","apiType":"Sql","creationTime":"2022-05-26T04:53:41Z","oldestRestorableTime":"2023-08-14T13:40:47Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"cff0fc89-a51f-4cd4-940c-00fe4222616d","creationTime":"2022-05-26T04:53:41Z"}]}},{"name":"fd507b20-6cc3-4138-b3c0-c8a9b406ab9c","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/fd507b20-6cc3-4138-b3c0-c8a9b406ab9c","properties":{"accountName":"vinh-demo-continous30","apiType":"Sql","creationTime":"2022-05-26T03:29:41Z","oldestRestorableTime":"2023-08-14T13:40:47Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"9923c156-acee-40b7-a90a-8d33c6c05006","creationTime":"2022-05-26T03:29:42Z"}]}},{"name":"9177692a-0db9-4c0c-af1d-af0310418b43","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/9177692a-0db9-4c0c-af1d-af0310418b43","properties":{"accountName":"vinh-demo-continous7","apiType":"Sql","creationTime":"2022-05-26T04:14:49Z","oldestRestorableTime":"2023-08-14T13:40:47Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"d6119954-fcde-4d83-af4e-2a0768ac1f33","creationTime":"2022-05-26T04:14:50Z"}]}},{"name":"957160c2-96d5-4ce2-843c-1d2977e952ec","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/957160c2-96d5-4ce2-843c-1d2977e952ec","properties":{"accountName":"vinh-demo-periodic2","apiType":"Sql","creationTime":"2022-05-26T18:12:07Z","oldestRestorableTime":"2023-08-14T13:40:47Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"3e0be6bc-420e-4f35-b7d5-f01a21069d18","creationTime":"2022-05-26T18:12:07Z"}]}},{"name":"3c7c638a-a7a0-4bb9-a285-946a6f55a57f","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/3c7c638a-a7a0-4bb9-a285-946a6f55a57f","properties":{"accountName":"vinh-demo-continous7-2","apiType":"Sql","creationTime":"2022-05-26T18:05:53Z","oldestRestorableTime":"2023-08-14T13:40:47Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"02d51bf7-eca0-424e-8080-7282b03118a7","creationTime":"2022-05-26T18:05:53Z"}]}},{"name":"40c43b99-8bcd-428d-a106-c6994bde5374","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/40c43b99-8bcd-428d-a106-c6994bde5374","properties":{"accountName":"ddhamothsqlpitracct","apiType":"Sql","creationTime":"2023-07-21T18:13:48Z","oldestRestorableTime":"2023-07-22T13:40:47Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"1490d2dc-c281-42b6-9533-b1d5629c9d8b","creationTime":"2023-07-21T18:13:49Z"}]}},{"name":"1ffbeabc-9423-43c6-afdf-888bb0a5241e","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/1ffbeabc-9423-43c6-afdf-888bb0a5241e","properties":{"accountName":"vinh-mm-bb","apiType":"Sql","creationTime":"2023-08-15T18:13:29Z","oldestRestorableTime":"2023-08-15T18:13:29Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"ca1d8d85-5ca8-4e99-8d74-ff0f8cd09fbd","creationTime":"2023-08-15T18:13:30Z"},{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"719e8dcc-9a5e-4125-bc58-80b3f5ad0270","creationTime":"2023-08-15T18:25:21Z"}]}},{"name":"d1e1117e-aec7-451e-89c1-0d28e74a6cc6","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/d1e1117e-aec7-451e-89c1-0d28e74a6cc6","properties":{"accountName":"vinh-mm-bb-with-conflict-expect-fail","apiType":"Sql","creationTime":"2023-08-15T18:53:08Z","oldestRestorableTime":"2023-08-15T18:53:08Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"b448f589-a86f-412c-b0f4-6ccc08bd576b","creationTime":"2023-08-15T18:53:08Z"}]}},{"name":"296ea14d-0ab8-4ee6-80f9-dcda9c4bdd8b","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/296ea14d-0ab8-4ee6-80f9-dcda9c4bdd8b","properties":{"accountName":"testing-republish-1","apiType":"Sql","creationTime":"2023-08-17T20:50:09Z","oldestRestorableTime":"2023-08-17T20:50:09Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"a33a974b-ed49-4e8b-bfe5-488c252bf1b6","creationTime":"2023-08-18T01:20:26Z"},{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"95caf190-329c-421d-bfa3-2995c45c2a1b","creationTime":"2023-08-17T20:50:09Z"},{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"db947687-e342-4200-97d3-da854ec3d8c4","creationTime":"2023-08-17T20:50:09Z","deletionTime":"2023-08-17T22:20:23Z"}]}},{"name":"65654f5f-b777-430b-a153-99bbe12c7098","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/65654f5f-b777-430b-a153-99bbe12c7098","properties":{"accountName":"cli-continuous30-lcpgoxr5","apiType":"Sql","creationTime":"2023-08-18T18:41:11Z","oldestRestorableTime":"2023-08-18T18:41:11Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"cce87812-f46f-498f-9f1c-49f156ced6e0","creationTime":"2023-08-18T18:41:12Z"}]}},{"name":"3d7535af-6f8b-4570-b573-92d0cb8d198c","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/3d7535af-6f8b-4570-b573-92d0cb8d198c","properties":{"accountName":"cli-continuous7-vd23riclm","apiType":"Sql","creationTime":"2023-08-18T18:44:44Z","oldestRestorableTime":"2023-08-18T18:44:44Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"2e13b61f-2f2a-4f36-b6df-e301ef43f9c4","creationTime":"2023-08-18T18:44:45Z"}]}},{"name":"9744304c-0e1e-445d-99ed-73d4a5cacf35","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/9744304c-0e1e-445d-99ed-73d4a5cacf35","properties":{"accountName":"cli-continuous30-gfvhists","apiType":"Sql","creationTime":"2023-08-18T18:44:54Z","oldestRestorableTime":"2023-08-18T18:44:54Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"83d41889-22d9-450e-a0d1-9b3d4b52cf07","creationTime":"2023-08-18T18:44:57Z"}]}},{"name":"fde33839-2f49-4fdb-9d7c-0cd19ba4df24","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/fde33839-2f49-4fdb-9d7c-0cd19ba4df24","properties":{"accountName":"clibnvwzw5dz6tp","apiType":"Gremlin,
+        Sql","creationTime":"2023-08-18T18:48:04Z","oldestRestorableTime":"2023-08-18T18:48:04Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"b91af018-cbd7-4cdf-b2bc-006577d5c735","creationTime":"2023-08-18T18:48:05Z"}]}},{"name":"0bdc1b28-85d2-44f8-ba04-9c4053b9c09e","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/0bdc1b28-85d2-44f8-ba04-9c4053b9c09e","properties":{"accountName":"cli-systemid-000002","apiType":"Sql","creationTime":"2023-08-21T13:35:05Z","oldestRestorableTime":"2023-08-21T13:35:05Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"159f7daf-e794-4a4d-9afd-7ec5f953d5fc","creationTime":"2023-08-21T13:35:06Z"}]}},{"name":"91f478e5-7c96-41d4-b1c4-78f4f090260a","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/91f478e5-7c96-41d4-b1c4-78f4f090260a","properties":{"accountName":"cli-continuous30-6kbrwfmg","apiType":"Sql","creationTime":"2023-08-18T18:39:14Z","deletionTime":"2023-08-18T18:39:38Z","oldestRestorableTime":"2023-07-22T13:40:47Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"871fead7-0499-4b3b-a8e4-b9eb1e86432e","creationTime":"2023-08-18T18:39:15Z","deletionTime":"2023-08-18T18:39:38Z"}]}},{"name":"ecb3fde6-7423-4adf-bcaa-9026a1fa2993","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/ecb3fde6-7423-4adf-bcaa-9026a1fa2993","properties":{"accountName":"cli-continuous30-obyx7ou3","apiType":"Sql","creationTime":"2023-08-18T18:42:20Z","deletionTime":"2023-08-18T18:42:59Z","oldestRestorableTime":"2023-07-22T13:40:47Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"16e42677-0fa5-4644-8069-bc5a75a7f62c","creationTime":"2023-08-18T18:42:21Z","deletionTime":"2023-08-18T18:42:59Z"}]}},{"name":"1ce91fa6-c7ad-4ed6-a436-c997f9e67dce","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/1ce91fa6-c7ad-4ed6-a436-c997f9e67dce","properties":{"accountName":"cli-systemid-fdxgzwwacz5q","apiType":"Sql","creationTime":"2023-08-18T18:59:48Z","deletionTime":"2023-08-18T19:06:01Z","oldestRestorableTime":"2023-07-22T13:40:47Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"ee00e20e-0eab-4fc8-8f47-2ff113972264","creationTime":"2023-08-18T18:59:49Z","deletionTime":"2023-08-18T19:06:01Z"}]}},{"name":"93a92a52-3051-4457-aa2a-995c2ef9b060","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/93a92a52-3051-4457-aa2a-995c2ef9b060","properties":{"accountName":"cli-systemid-434krzzwghtf","apiType":"Sql","creationTime":"2023-08-18T19:36:50Z","deletionTime":"2023-08-18T19:43:15Z","oldestRestorableTime":"2023-07-22T13:40:47Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"1938ab5f-d32a-4699-83da-e735dcc85170","creationTime":"2023-08-18T19:36:51Z","deletionTime":"2023-08-18T19:43:15Z"}]}},{"name":"b52bc7e8-d031-49a1-a8d2-fb7374d73ab4","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/b52bc7e8-d031-49a1-a8d2-fb7374d73ab4","properties":{"accountName":"cli-systemid-7pictvhgpxxe","apiType":"Sql","creationTime":"2023-08-18T19:53:46Z","deletionTime":"2023-08-18T20:00:00Z","oldestRestorableTime":"2023-07-22T13:40:47Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"f98df0a9-24ef-4d20-8213-d8282536e528","creationTime":"2023-08-18T19:53:47Z","deletionTime":"2023-08-18T20:00:00Z"}]}},{"name":"2816c315-2787-4df9-a2c3-f486a280835a","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/2816c315-2787-4df9-a2c3-f486a280835a","properties":{"accountName":"cli-systemid-6ny7z6ert7me","apiType":"Sql","creationTime":"2023-08-18T21:43:52Z","deletionTime":"2023-08-18T21:50:07Z","oldestRestorableTime":"2023-07-22T13:40:47Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"33ccd0ea-e4db-4ef9-9379-cbd56c01b959","creationTime":"2023-08-18T21:43:53Z","deletionTime":"2023-08-18T21:50:07Z"}]}},{"name":"f4004a76-8173-4d36-9590-6090cce37a4d","location":"West
+        Europe","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westeurope/restorableDatabaseAccounts/f4004a76-8173-4d36-9590-6090cce37a4d","properties":{"accountName":"aholdtest","apiType":"MongoDB","creationTime":"2021-07-01T19:34:24Z","oldestRestorableTime":"2023-07-22T13:40:47Z","restorableLocations":[{"locationName":"West
+        Europe","regionalDatabaseAccountInstanceId":"f7a9416f-25a2-45fd-902d-f3679e08854e","creationTime":"2021-07-01T19:34:25Z"}]}},{"name":"3564d9f8-5f2d-4d00-a66f-5d370d970371","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3564d9f8-5f2d-4d00-a66f-5d370d970371","properties":{"accountName":"targetacct112","apiType":"Sql","creationTime":"2021-03-01T10:33:41Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"2eb33e65-1263-4a25-a18a-e7a85875f2a8","creationTime":"2021-03-01T10:33:41Z"}]}},{"name":"74ebfb99-1914-4ea9-b802-736b5bda12a7","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/74ebfb99-1914-4ea9-b802-736b5bda12a7","properties":{"accountName":"pitrmongotest","apiType":"MongoDB","creationTime":"2020-10-01T17:27:22Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"73ef95f2-a338-4afc-8bb2-6fc3b0071d58","creationTime":"2020-10-01T17:27:23Z"}]}},{"name":"a081024d-5e38-45c1-b1cb-9c99552d42b3","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a081024d-5e38-45c1-b1cb-9c99552d42b3","properties":{"accountName":"pitrmongowithsnapshots","apiType":"MongoDB","creationTime":"2021-01-07T19:45:07Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"cef7a5af-c690-49cd-b661-53f9241552bf","creationTime":"2021-01-07T19:45:07Z"}]}},{"name":"36d321ce-5c39-4d66-9347-47beebff1142","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/36d321ce-5c39-4d66-9347-47beebff1142","properties":{"accountName":"test0319-r1","apiType":"Sql","creationTime":"2021-07-07T21:28:13Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"bf97db02-ef6b-4af0-9a5e-3d4ef9f1d5de","creationTime":"2021-07-07T21:28:13Z"},{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"225506b6-641c-47a5-b7a4-2fa096d68535","creationTime":"2021-07-07T21:28:13Z"}]}},{"name":"1e2bec8e-adcc-4c5a-aa5b-82091d6c8a37","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1e2bec8e-adcc-4c5a-aa5b-82091d6c8a37","properties":{"accountName":"pitracctdemo2","apiType":"Sql","creationTime":"2020-08-11T02:34:23Z","oldestRestorableTime":"2023-08-14T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"7419408f-e6af-4596-a76b-c31ca62a54ca","creationTime":"2020-08-11T02:34:24Z"}]}},{"name":"b4c688c1-2ea7-477e-b994-4affe5d3ea35","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b4c688c1-2ea7-477e-b994-4affe5d3ea35","properties":{"accountName":"ptr-target","apiType":"Sql","creationTime":"2021-01-05T22:25:24Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"1f68340e-49a4-45df-9a2a-804cd8ab1795","creationTime":"2021-01-05T22:25:24Z"}]}},{"name":"9905e7ca-6f2d-4b24-a4c5-8e7529036a74","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9905e7ca-6f2d-4b24-a4c5-8e7529036a74","properties":{"accountName":"pitrmongotest-restore","apiType":"MongoDB","creationTime":"2020-10-01T21:24:45Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"75c41286-d7f2-4594-b9f2-87f6c9843cf8","creationTime":"2020-10-01T21:24:45Z"}]}},{"name":"6fd844b3-71af-4e89-9b9d-f829945272bf","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6fd844b3-71af-4e89-9b9d-f829945272bf","properties":{"accountName":"pitrdemo1015","apiType":"Sql","creationTime":"2020-10-15T17:28:59Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"af26f717-b6ff-4eac-864c-17e759891ae8","creationTime":"2020-10-15T17:29:00Z"}]}},{"name":"3f392004-9f83-4ae9-ac1c-fa5f6542f245","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3f392004-9f83-4ae9-ac1c-fa5f6542f245","properties":{"accountName":"pitrdemorestored1015","apiType":"Sql","creationTime":"2020-10-15T17:37:20Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"2f4857ad-25c3-4e2f-883a-abe35c5f5e0c","creationTime":"2020-10-15T17:37:20Z"}]}},{"name":"23e99a35-cd36-4df4-9614-f767a03b9995","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/23e99a35-cd36-4df4-9614-f767a03b9995","properties":{"accountName":"subbannageeta","apiType":"Sql","creationTime":"2020-08-08T01:04:53Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"30701557-ecf8-43ce-8810-2c8be01dccf9","creationTime":"2020-08-08T01:04:53Z"},{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"8283b088-b67d-4975-bfbe-0705e3e7a599","creationTime":"2020-08-08T01:15:44Z"}]}},{"name":"afe6a47d-1fbd-41e1-992b-db16beeeae3c","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/afe6a47d-1fbd-41e1-992b-db16beeeae3c","properties":{"accountName":"scottkirill","apiType":"Sql","creationTime":"2021-04-15T17:21:20Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"e3dcb79a-b56a-4dff-9f8e-76a29285e724","creationTime":"2021-04-15T17:21:20Z"}]}},{"name":"01c9a078-6ca2-43fd-92c7-632167c86590","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/01c9a078-6ca2-43fd-92c7-632167c86590","properties":{"accountName":"test0319-pitr-r1","apiType":"Sql","creationTime":"2021-07-07T21:54:07Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"1074b897-ee89-466c-8a35-a1e695d7f3b9","creationTime":"2021-07-07T21:54:07Z"}]}},{"name":"35b64b76-2e55-4fa5-a1de-724c60f5deca","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/35b64b76-2e55-4fa5-a1de-724c60f5deca","properties":{"accountName":"onboardingtestaccount0124","apiType":"Sql","creationTime":"2022-01-24T20:24:43Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"6621e19d-f0d1-48f0-a767-bd5ec0c0c1cf","creationTime":"2022-01-24T20:24:44Z"}]}},{"name":"3a8ddfcb-1b82-47f3-9577-971315b7427f","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3a8ddfcb-1b82-47f3-9577-971315b7427f","properties":{"accountName":"onboardingtestaccount0124-restored","apiType":"Sql","creationTime":"2022-01-24T20:48:23Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"0cfd50fd-bb27-4b8f-9123-20b438a41cb1","creationTime":"2022-01-24T20:48:23Z"}]}},{"name":"01652628-d4ef-449d-846e-38e8250f0b9a","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/01652628-d4ef-449d-846e-38e8250f0b9a","properties":{"accountName":"vinh-table2-restore","apiType":"Table,
+        Sql","creationTime":"2022-04-07T00:48:08Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"8ca19196-24d1-4153-b5ee-d879baa33be6","creationTime":"2022-04-07T00:48:08Z"}]}},{"name":"4b754475-3b23-4485-9205-87ac1661af13","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/4b754475-3b23-4485-9205-87ac1661af13","properties":{"accountName":"vinhpitr30-cli","apiType":"Sql","creationTime":"2022-04-29T23:50:20Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"94b37f83-7256-4645-8cbb-72b101f7a0a1","creationTime":"2022-04-29T23:50:21Z"}]}},{"name":"ce240906-61b1-41c3-a54c-bd90e3d8ec70","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ce240906-61b1-41c3-a54c-bd90e3d8ec70","properties":{"accountName":"vinhperiodic3-cli","apiType":"Sql","creationTime":"2022-06-03T17:21:23Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"2afbd7a9-dcda-4918-9f95-12c08764ac49","creationTime":"2022-06-03T17:21:23Z"}]}},{"name":"023add2e-531e-4574-a7df-4d09c97d548d","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/023add2e-531e-4574-a7df-4d09c97d548d","properties":{"accountName":"vinh-pitr7-portal","apiType":"Sql","creationTime":"2022-05-31T19:24:32Z","oldestRestorableTime":"2023-08-14T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"46e03f50-a458-4cb9-8b02-dbf1b7677291","creationTime":"2022-05-31T19:24:34Z"}]}},{"name":"b67f7b8c-2b1b-417d-833d-1e3e393b192c","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b67f7b8c-2b1b-417d-833d-1e3e393b192c","properties":{"accountName":"vinh-periodic-portal-tobemigrated-to-7","apiType":"Sql","creationTime":"2022-05-31T23:36:11Z","oldestRestorableTime":"2023-08-14T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"5e6569c6-8716-4984-bf16-74085c75c705","creationTime":"2022-05-31T23:36:11Z"}]}},{"name":"d69f8bdc-b00e-43f3-99b1-9ffac0a1b6bc","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d69f8bdc-b00e-43f3-99b1-9ffac0a1b6bc","properties":{"accountName":"vinh-periodic-portal-tobemigrated-to-7-porta","apiType":"Sql","creationTime":"2022-06-03T18:42:58Z","oldestRestorableTime":"2023-08-14T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"8a8401fa-5297-4189-ba47-a7b172ea489b","creationTime":"2022-06-03T18:42:58Z"}]}},{"name":"3808b68e-7cae-4b91-901b-e29b35b311be","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3808b68e-7cae-4b91-901b-e29b35b311be","properties":{"accountName":"vinh-periodic-again","apiType":"Sql","creationTime":"2022-06-10T20:01:48Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"a519926d-1463-4af1-ba30-a1b6ef5d3989","creationTime":"2022-06-10T20:01:48Z"}]}},{"name":"cc09ab90-3342-4aa9-a95d-3f6677cfd792","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/cc09ab90-3342-4aa9-a95d-3f6677cfd792","properties":{"accountName":"vinh-periodic-again2","apiType":"Sql","creationTime":"2022-06-10T23:57:37Z","oldestRestorableTime":"2023-08-14T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"b8bed17e-e976-498a-98ef-02b76476dead","creationTime":"2022-06-10T23:57:37Z"}]}},{"name":"83b9ed65-b665-45e6-b06f-baf9b0205304","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/83b9ed65-b665-45e6-b06f-baf9b0205304","properties":{"accountName":"vinh-gremlin-again","apiType":"Gremlin,
+        Sql","creationTime":"2022-07-28T01:55:28Z","oldestRestorableTime":"2023-08-14T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"9df9dde5-97a0-4404-9f07-31997cd4b8b4","creationTime":"2022-07-28T01:55:28Z"}]}},{"name":"df774a43-6e6f-4725-82d0-67c18c69a906","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/df774a43-6e6f-4725-82d0-67c18c69a906","properties":{"accountName":"vinh-table-tennis-cli-0190","apiType":"Table,
+        Sql","creationTime":"2022-08-11T05:19:28Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"1bc9461e-3e52-4108-90ac-a99375fc0e81","creationTime":"2022-08-11T05:19:28Z"}]}},{"name":"f8c9b302-e047-4f58-b920-fd92e5fbaa3d","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/f8c9b302-e047-4f58-b920-fd92e5fbaa3d","properties":{"accountName":"ddhamothsqlpitracc","apiType":"Sql","creationTime":"2022-10-12T07:15:50Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"936e589a-70ad-4853-b983-64629561b40c","creationTime":"2022-10-12T07:15:51Z"}]}},{"name":"ca7a5371-47b2-4ae2-b0a4-307fb80273fb","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ca7a5371-47b2-4ae2-b0a4-307fb80273fb","properties":{"accountName":"ddhamothmongopitracc","apiType":"MongoDB","creationTime":"2022-10-12T07:18:54Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"ce33f178-92b2-42a4-9b0e-5aed43d00f6d","creationTime":"2022-10-12T07:18:55Z"}]}},{"name":"3bd6c3ea-33e5-49a7-b67f-be767d228c41","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3bd6c3ea-33e5-49a7-b67f-be767d228c41","properties":{"accountName":"ddhamothpitrsqlacc2","apiType":"Sql","creationTime":"2022-11-15T21:30:17Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"00d5a7da-4291-4ea6-8c30-c0c9cdb954fc","creationTime":"2022-11-15T21:30:18Z"}]}},{"name":"019422e0-378d-4191-b142-4f23fd0c1d0c","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/019422e0-378d-4191-b142-4f23fd0c1d0c","properties":{"accountName":"vinkumsql","apiType":"Sql","creationTime":"2022-12-06T19:35:15Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"6f8e2ead-8114-4853-b60f-30b6b0d8e200","creationTime":"2022-12-06T19:35:16Z"}]}},{"name":"75f0ac0c-06d2-4c6b-8eca-1e8c6fae3dff","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/75f0ac0c-06d2-4c6b-8eca-1e8c6fae3dff","properties":{"accountName":"nikhiltestmig","apiType":"Sql","creationTime":"2022-12-15T19:23:56Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"785f9939-a7bc-4696-bdd2-d8e2e2f55d72","creationTime":"2022-12-15T19:23:56Z"},{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"efe37686-f44b-4a3e-8955-40f46c101f47","creationTime":"2022-12-19T06:05:45Z"}]}},{"name":"2bf685e1-2106-4a9c-a218-7f5e49d008a5","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/2bf685e1-2106-4a9c-a218-7f5e49d008a5","properties":{"accountName":"nikhil-multi-region-pitr","apiType":"Sql","creationTime":"2022-12-19T06:00:50Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"930298bb-0c4f-43ee-b7d9-365fbd6e96d5","creationTime":"2022-12-19T06:00:52Z"}]}},{"name":"d8b6f189-ccac-48f3-b8c1-ac0fc219cf4b","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d8b6f189-ccac-48f3-b8c1-ac0fc219cf4b","properties":{"accountName":"test-account23","apiType":"Sql","creationTime":"2022-12-24T18:24:52Z","oldestRestorableTime":"2023-08-14T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"0ecde616-a04b-4a95-8340-69ee01bff25f","creationTime":"2022-12-24T18:24:53Z"},{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"bcd3a857-d005-4eb9-b83b-d50878cc58a4","creationTime":"2022-12-24T18:27:11Z"}]}},{"name":"1a4e021c-a8e2-4a15-9392-5ececb8299d6","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1a4e021c-a8e2-4a15-9392-5ececb8299d6","properties":{"accountName":"periodic-mm","apiType":"Sql","creationTime":"2023-05-18T21:35:27Z","oldestRestorableTime":"2023-08-14T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"c2ff03b0-a991-4f35-aadf-f6e7cc7fbea2","creationTime":"2023-05-18T21:35:27Z"},{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"a32cac3b-857a-49f7-88b0-9729f367a3d1","creationTime":"2023-05-18T21:35:27Z"}]}},{"name":"c0e85028-dfc8-4f38-acb6-9230bf01f3ad","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c0e85028-dfc8-4f38-acb6-9230bf01f3ad","properties":{"accountName":"testpitr","apiType":"Sql","creationTime":"2022-12-27T20:37:00Z","oldestRestorableTime":"2023-08-14T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"d031c28c-cbdd-4c87-b5ae-88bbf4bc28bf","creationTime":"2022-12-27T20:37:02Z"}]}},{"name":"04f78e7e-2737-4057-9b76-b47fa1a672e5","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/04f78e7e-2737-4057-9b76-b47fa1a672e5","properties":{"accountName":"readregionrestore-test","apiType":"Sql","creationTime":"2023-01-09T23:54:38Z","oldestRestorableTime":"2023-08-14T13:40:48Z","restorableLocations":[{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"d0d3b06c-a586-43a4-af59-6c7f9f7ddc7b","creationTime":"2023-01-09T23:54:38Z"}]}},{"name":"082db2b8-f98a-4959-94eb-8eabfb71ad51","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/082db2b8-f98a-4959-94eb-8eabfb71ad51","properties":{"accountName":"vinhpitr30-cli-arm-restore","apiType":"Sql","creationTime":"2023-02-06T21:33:23Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"f6602e1d-30b8-4012-bba8-27d223143b1c","creationTime":"2023-02-06T21:33:23Z"}]}},{"name":"4c6bb551-3e38-4ba5-acbb-76842541abe5","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/4c6bb551-3e38-4ba5-acbb-76842541abe5","properties":{"accountName":"sql-test-1","apiType":"Sql","creationTime":"2023-03-06T19:26:23Z","oldestRestorableTime":"2023-08-14T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"e29473aa-cb2d-49eb-b677-0083ee2fb623","creationTime":"2023-03-06T19:26:24Z"}]}},{"name":"4cadd2d6-8f0c-4382-951c-3d9ce509dbef","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/4cadd2d6-8f0c-4382-951c-3d9ce509dbef","properties":{"accountName":"cosmosdb-1232","apiType":"Sql","creationTime":"2023-03-28T14:32:50Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"508bb3b9-304a-4f22-98dc-e526e7675164","creationTime":"2023-03-28T14:32:51Z"}]}},{"name":"9c508d5f-d54b-4d93-9d6f-70e89a4b688b","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9c508d5f-d54b-4d93-9d6f-70e89a4b688b","properties":{"accountName":"cosmosdb-1231","apiType":"Sql","creationTime":"2023-03-28T14:53:31Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"5909c49b-017d-4eb7-bac9-afcbe6dea25e","creationTime":"2023-03-28T14:53:32Z"}]}},{"name":"f6d09874-07de-4a66-988b-6fa8f3fa1e28","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/f6d09874-07de-4a66-988b-6fa8f3fa1e28","properties":{"accountName":"r-grem-db-account-938","apiType":"Gremlin,
+        Sql","creationTime":"2023-04-05T19:15:55Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"1e6ec79e-9a22-4b72-8059-e1ab5a731fad","creationTime":"2023-04-05T19:15:56Z"}]}},{"name":"528ccf38-78f4-4096-82fd-29e09c61c8fc","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/528ccf38-78f4-4096-82fd-29e09c61c8fc","properties":{"accountName":"r-table-account-9379","apiType":"Table,
+        Sql","creationTime":"2023-04-06T01:45:49Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"bb934786-50aa-47cf-a7af-7c9fccca8557","creationTime":"2023-04-06T01:45:51Z"}]}},{"name":"7edd8b68-1cba-481c-b74a-1db578c11dbc","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7edd8b68-1cba-481c-b74a-1db578c11dbc","properties":{"accountName":"restoredaccount-5362","apiType":"Table,
+        Sql","creationTime":"2023-04-06T02:03:48Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"9eaf2f88-5fd2-4cf9-a25e-da17103ac3c5","creationTime":"2023-04-06T02:03:48Z"}]}},{"name":"a35295a6-1229-4eed-a75e-1780a2e2eddf","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a35295a6-1229-4eed-a75e-1780a2e2eddf","properties":{"accountName":"r-table-account-5626","apiType":"Table,
+        Sql","creationTime":"2023-04-06T02:12:24Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"50ae78d1-30ba-44a6-aaf3-20a19a399d7e","creationTime":"2023-04-06T02:12:25Z"}]}},{"name":"96eed3f1-6edd-4080-bec5-e5fddea98f95","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/96eed3f1-6edd-4080-bec5-e5fddea98f95","properties":{"accountName":"r-table-account-1300","apiType":"Table,
+        Sql","creationTime":"2023-04-06T06:23:30Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"5dad4036-c76f-4e59-a427-03df369647e6","creationTime":"2023-04-06T06:23:31Z"}]}},{"name":"c4a9bf1c-aed1-4a92-99a8-433a4cbd921a","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c4a9bf1c-aed1-4a92-99a8-433a4cbd921a","properties":{"accountName":"restoredaccount-9934","apiType":"Table,
+        Sql","creationTime":"2023-04-06T06:40:38Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"cc7821d3-2238-4041-88db-9aae6faee521","creationTime":"2023-04-06T06:40:38Z"}]}},{"name":"3ecb1118-70eb-4fef-b785-77d8b0f45e93","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3ecb1118-70eb-4fef-b785-77d8b0f45e93","properties":{"accountName":"r-grem-db-account-7826","apiType":"Gremlin,
+        Sql","creationTime":"2023-04-06T18:27:30Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"f8ba34eb-e7a7-4ee9-8dfd-8ae80408040a","creationTime":"2023-04-06T18:27:31Z"}]}},{"name":"8a7d6175-2174-495f-9147-ade59959d7a1","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/8a7d6175-2174-495f-9147-ade59959d7a1","properties":{"accountName":"r-grem-db-account-5687","apiType":"Gremlin,
+        Sql","creationTime":"2023-04-06T18:34:51Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"76ee69fb-0d99-461e-94bf-0d64823293b2","creationTime":"2023-04-06T18:34:52Z"}]}},{"name":"e1fb99c7-b1e6-4058-8aa0-0857ab3a78b3","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/e1fb99c7-b1e6-4058-8aa0-0857ab3a78b3","properties":{"accountName":"r-database-account-848","apiType":"Sql","creationTime":"2023-04-21T01:16:43Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"65cc97fd-c609-4c1f-b1b3-f4aa18afb791","creationTime":"2023-04-21T01:16:44Z"}]}},{"name":"47575ff7-4efb-4430-a90c-e9bce7766753","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/47575ff7-4efb-4430-a90c-e9bce7766753","properties":{"accountName":"r-database-account-5886","apiType":"Sql","creationTime":"2023-04-21T05:49:21Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"0c58830e-7439-43f5-90a0-29eef674e0b8","creationTime":"2023-04-21T05:49:22Z"}]}},{"name":"484096b6-e9b7-48e4-aef1-13b9e000613c","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/484096b6-e9b7-48e4-aef1-13b9e000613c","properties":{"accountName":"pitr-mm-r1","apiType":"Sql","creationTime":"2023-06-14T21:16:32Z","oldestRestorableTime":"2023-08-14T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"0629111e-e376-40ea-a0ab-3ad45c916859","creationTime":"2023-06-14T21:16:32Z"}]}},{"name":"045bd902-39de-4e25-92f9-4d24bcf90a3c","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/045bd902-39de-4e25-92f9-4d24bcf90a3c","properties":{"accountName":"vivektest-1","apiType":"Sql","creationTime":"2023-06-15T00:16:26Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"9c22e6cb-9abd-4ea7-b611-464dd1ec76e7","creationTime":"2023-06-15T00:16:26Z"}]}},{"name":"38be35a6-c721-4426-9ef6-1db94bd3f017","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/38be35a6-c721-4426-9ef6-1db94bd3f017","properties":{"accountName":"vivek-acc2","apiType":"Sql","creationTime":"2023-06-15T00:18:54Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"ae57c8b5-3c30-4ba6-a0d7-47131d270928","creationTime":"2023-06-15T00:18:54Z"}]}},{"name":"491f2964-7c56-4583-a6e3-55381b7233df","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/491f2964-7c56-4583-a6e3-55381b7233df","properties":{"accountName":"acctest9433","apiType":"Sql","creationTime":"2023-06-20T23:17:30Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"South
+        Central US","regionalDatabaseAccountInstanceId":"484e21ec-8960-49c9-b798-c7a14c6cb892","creationTime":"2023-06-20T23:17:31Z"}]}},{"name":"40066502-4c1e-4c09-a80a-dd5ae7706966","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/40066502-4c1e-4c09-a80a-dd5ae7706966","properties":{"accountName":"acctest5471","apiType":"Sql","creationTime":"2023-06-20T23:29:33Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"South
+        Central US","regionalDatabaseAccountInstanceId":"1e585c8c-f05a-4147-8706-e9fc6e475020","creationTime":"2023-06-20T23:29:33Z"}]}},{"name":"35f9cbfb-cdda-413a-b144-58d3693468c8","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/35f9cbfb-cdda-413a-b144-58d3693468c8","properties":{"accountName":"acctest9742","apiType":"Sql","creationTime":"2023-06-21T00:43:58Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"South
+        Central US","regionalDatabaseAccountInstanceId":"d5f9e6ef-d9e8-421d-a4b5-630f6ce4cf5e","creationTime":"2023-06-21T00:43:59Z"}]}},{"name":"dd46daec-2c80-44af-a407-9ed6d846be3d","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/dd46daec-2c80-44af-a407-9ed6d846be3d","properties":{"accountName":"acctest8620","apiType":"Sql","creationTime":"2023-06-21T00:43:57Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"South
+        Central US","regionalDatabaseAccountInstanceId":"963305c1-44e8-4817-aac3-c0c294218317","creationTime":"2023-06-21T00:43:58Z"}]}},{"name":"40d93f73-17f0-4ae0-8f5f-3266aa5d8bff","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/40d93f73-17f0-4ae0-8f5f-3266aa5d8bff","properties":{"accountName":"bb-mdb-periodic-2","apiType":"MongoDB","creationTime":"2023-07-14T23:34:56Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"434af62f-8592-44c2-9289-074e62ccf4d5","creationTime":"2023-07-14T23:34:56Z"},{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"487ec999-d15d-4382-a24d-71f97c5e04b6","creationTime":"2023-07-14T23:34:56Z"},{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"55326afa-b663-453b-aa35-761bb0d5ea0c","creationTime":"2023-07-14T23:34:56Z"}]}},{"name":"8454e193-ef1a-4a5e-be7f-dd3e85cdcc35","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/8454e193-ef1a-4a5e-be7f-dd3e85cdcc35","properties":{"accountName":"pitr-as-pe-4","apiType":"Sql","creationTime":"2023-07-20T20:49:42Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"14cb4445-1bca-4c9c-b9b3-f3b6d2949709","creationTime":"2023-07-25T00:11:25Z"},{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"467074f0-78e3-4c30-ac0b-cb2a3d3b54c3","creationTime":"2023-07-24T20:19:55Z"},{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"4a74b82e-0c5f-4a8d-a37e-4c2bc6f5bb66","creationTime":"2023-07-20T21:12:48Z","deletionTime":"2023-07-24T19:41:21Z"},{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"43bc8a39-e817-437c-8328-8d343d5efac8","creationTime":"2023-07-20T22:36:18Z","deletionTime":"2023-07-24T23:44:35Z"}]}},{"name":"bede86a8-1edf-47a5-80aa-bd6b11b0509d","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/bede86a8-1edf-47a5-80aa-bd6b11b0509d","properties":{"accountName":"amisitestpitracc","apiType":"Sql","creationTime":"2023-07-27T20:34:16Z","oldestRestorableTime":"2023-07-27T20:34:16Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"89fb8537-c6e1-4658-b68a-f245d7223271","creationTime":"2023-07-27T20:34:17Z"}]}},{"name":"941a001d-f788-4146-819c-a845208de0b3","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/941a001d-f788-4146-819c-a845208de0b3","properties":{"accountName":"vinh-hobov1-crossregionwr","apiType":"Sql","creationTime":"2023-08-03T16:52:56Z","oldestRestorableTime":"2023-08-14T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"2acffc9e-b686-4746-bce0-87147aa66633","creationTime":"2023-08-03T16:52:57Z"}]}},{"name":"5361c430-7171-4ff0-9be3-a5d21dabaa43","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/5361c430-7171-4ff0-9be3-a5d21dabaa43","properties":{"accountName":"vivek-test1","apiType":"Sql","creationTime":"2023-06-14T22:50:52Z","deletionTime":"2023-08-09T13:30:16Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"ffca3d37-3c22-4834-9442-528e79aaa618","creationTime":"2023-06-14T22:50:52Z","deletionTime":"2023-08-09T13:30:16Z"}]}},{"name":"797ef370-4a00-43bf-bf99-4919df87c01a","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/797ef370-4a00-43bf-bf99-4919df87c01a","properties":{"accountName":"bb-mdb-periodic-2-restored","apiType":"MongoDB","creationTime":"2023-07-14T23:56:53Z","deletionTime":"2023-08-15T17:54:24Z","oldestRestorableTime":"2023-07-22T13:40:48Z","restorableLocations":[{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"78840afd-8282-4cfd-9010-22890b482ee8","creationTime":"2023-07-15T00:04:15Z","deletionTime":"2023-08-15T17:54:24Z"},{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"f801d7b0-1954-4ffc-98eb-2e90e646f3f4","creationTime":"2023-07-14T23:56:53Z","deletionTime":"2023-08-15T17:54:24Z"}]}},{"name":"83caf7f5-b220-4b0a-980a-2e8e7e6184d3","location":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/83caf7f5-b220-4b0a-980a-2e8e7e6184d3","properties":{"accountName":"drop-continuous7","apiType":"Sql","creationTime":"2022-05-26T18:49:51Z","oldestRestorableTime":"2023-08-14T13:40:47Z","restorableLocations":[{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"a7725382-1f4c-426c-b51b-72acad407539","creationTime":"2022-05-26T18:49:52Z"}]}},{"name":"8b0701eb-0f38-4c72-a076-5ecb75ab55b3","location":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/8b0701eb-0f38-4c72-a076-5ecb75ab55b3","properties":{"accountName":"periodicacctdrop","apiType":"Sql","creationTime":"2022-08-24T22:57:51Z","oldestRestorableTime":"2023-08-14T13:40:47Z","restorableLocations":[{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"653cea6a-f643-47cf-a6ef-65704fa35acd","creationTime":"2022-08-24T22:57:51Z"}]}},{"name":"ee16f791-77f8-40d4-89ad-91495b853ac0","location":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/ee16f791-77f8-40d4-89ad-91495b853ac0","properties":{"accountName":"periodicacctdrop2","apiType":"Sql","creationTime":"2022-05-26T20:16:50Z","oldestRestorableTime":"2023-07-22T13:40:47Z","restorableLocations":[{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"e8fe590a-1d27-407d-9e1f-28787d021b84","creationTime":"2022-05-26T20:16:50Z"}]}},{"name":"b169ba58-4696-4196-99a4-51995d99f004","location":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/b169ba58-4696-4196-99a4-51995d99f004","properties":{"accountName":"readregionrestore-1","apiType":"Sql","creationTime":"2023-03-02T00:15:37Z","oldestRestorableTime":"2023-07-22T13:40:47Z","restorableLocations":[{"locationName":"Southeast
+        Asia","regionalDatabaseAccountInstanceId":"3a65f53c-d0fb-4f7c-8843-1b821d758908","creationTime":"2023-03-02T00:15:37Z"},{"locationName":"Central
+        India","regionalDatabaseAccountInstanceId":"8944d987-4866-438e-9d22-12214cb2d6e8","creationTime":"2023-03-02T00:38:10Z"}]}},{"name":"55106896-6653-4bd8-9f96-3e5390eb7a5b","location":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/55106896-6653-4bd8-9f96-3e5390eb7a5b","properties":{"accountName":"chucks-sql-ptoc","apiType":"Sql","creationTime":"2023-05-11T23:06:57Z","oldestRestorableTime":"2023-08-14T13:40:47Z","restorableLocations":[{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"0fa74db5-eee2-4d5a-aa25-e9b00ef4ee14","creationTime":"2023-05-11T23:06:57Z"}]}},{"name":"bdb84e66-b995-4fae-ab85-17f6e790b5f0","location":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/bdb84e66-b995-4fae-ab85-17f6e790b5f0","properties":{"accountName":"chucks-sql-cont7","apiType":"Sql","creationTime":"2023-05-09T20:00:45Z","oldestRestorableTime":"2023-08-14T13:40:47Z","restorableLocations":[{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"b7fbb4a1-7373-4ca7-b212-e7d5e64f5b32","creationTime":"2023-05-09T20:00:46Z"}]}},{"name":"c9ad62ed-5e03-420a-b9d1-15ae3ddd370d","location":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/c9ad62ed-5e03-420a-b9d1-15ae3ddd370d","properties":{"accountName":"chucks-sql-cont7-restored","apiType":"Sql","creationTime":"2023-05-11T23:36:04Z","oldestRestorableTime":"2023-08-14T13:40:47Z","restorableLocations":[{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"458fde5b-5a10-40f9-9add-4d28e5d9c904","creationTime":"2023-05-11T23:36:04Z"}]}},{"name":"e26978ac-2bf1-44e7-a9e7-99b8be8a3d83","location":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/e26978ac-2bf1-44e7-a9e7-99b8be8a3d83","properties":{"accountName":"res-con-test-1","apiType":"Sql","creationTime":"2023-07-18T00:17:22Z","deletionTime":"2023-08-15T17:54:23Z","oldestRestorableTime":"2023-07-22T13:40:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"fe4a4d81-681a-4009-8703-b89c798d672f","creationTime":"2023-07-18T00:17:23Z","deletionTime":"2023-08-15T17:54:23Z"}]}},{"name":"3b8d66bd-e2c4-4e33-aa40-b9f511e51512","location":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/3b8d66bd-e2c4-4e33-aa40-b9f511e51512","properties":{"accountName":"res-con-test-2","apiType":"Sql","creationTime":"2023-07-18T00:45:08Z","deletionTime":"2023-08-15T17:54:23Z","oldestRestorableTime":"2023-07-22T13:40:47Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"e1e6197a-234a-4453-a385-4346e77ee063","creationTime":"2023-07-18T00:45:09Z","deletionTime":"2023-08-15T17:54:23Z"}]}},{"name":"504efebe-750e-401c-92aa-59ee5d36401e","location":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/504efebe-750e-401c-92aa-59ee5d36401e","properties":{"accountName":"bb-pitr-mm-2-r","apiType":"Sql","creationTime":"2023-07-14T22:50:36Z","deletionTime":"2023-08-15T17:54:23Z","oldestRestorableTime":"2023-07-22T13:40:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"383fb02b-d1a7-4291-86db-ad5d58003f30","creationTime":"2023-07-14T23:08:33Z","deletionTime":"2023-08-15T17:54:23Z"},{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"4275712e-8085-401d-9e38-8e19f1981b9e","creationTime":"2023-07-14T22:50:36Z","deletionTime":"2023-08-15T17:54:23Z"}]}},{"name":"9784be9e-8f3f-4623-994e-fe3557a1c454","location":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/9784be9e-8f3f-4623-994e-fe3557a1c454","properties":{"accountName":"utest-pitr-1","apiType":"Sql","creationTime":"2023-07-12T23:04:39Z","deletionTime":"2023-08-15T17:54:24Z","oldestRestorableTime":"2023-07-22T13:40:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"30c416f6-5c2e-48b6-8562-00e2cadf0dad","creationTime":"2023-07-12T23:07:08Z","deletionTime":"2023-08-15T17:54:24Z"},{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"d040816e-c542-44c7-aaa3-1a0462a3452c","creationTime":"2023-07-12T23:04:40Z","deletionTime":"2023-08-15T17:54:24Z"}]}},{"name":"23ff311a-2493-4bd7-b1c9-ac4549ae4567","location":"Qatar
+        Central","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/qatarcentral/restorableDatabaseAccounts/23ff311a-2493-4bd7-b1c9-ac4549ae4567","properties":{"accountName":"vinh-cmk-qatar-actual-res-live-sysid-res2","apiType":"Sql","creationTime":"2022-09-29T05:44:13Z","oldestRestorableTime":"2023-07-22T13:40:47Z","restorableLocations":[{"locationName":"Qatar
+        Central","regionalDatabaseAccountInstanceId":"3bf0dcac-7a5a-4602-bdf4-3edcbcbbcb5b","creationTime":"2022-09-29T05:44:13Z"}]}},{"name":"a672303a-644d-4996-9d49-b3d2eddea72d","location":"Qatar
+        Central","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/qatarcentral/restorableDatabaseAccounts/a672303a-644d-4996-9d49-b3d2eddea72d","properties":{"accountName":"vinh-cmk-qatar-actual-res-live-sysid-res3","apiType":"Sql","creationTime":"2023-03-10T00:42:29Z","oldestRestorableTime":"2023-07-22T13:40:47Z","restorableLocations":[{"locationName":"Qatar
+        Central","regionalDatabaseAccountInstanceId":"0d60dece-f697-4a05-995c-36c2fcaee312","creationTime":"2023-03-10T00:42:29Z"}]}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '70298'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 21 Aug 2023 13:40:48 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-original-request-ids:
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb restore
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -a --restore-timestamp --location --public-network-access
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/0bdc1b28-85d2-44f8-ba04-9c4053b9c09e/restorableSqlResources?api-version=2023-04-15&restoreLocation=eastus2&restoreTimestampInUtc=2023-08-21%2013%3A39%3A05%2B00%3A00
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/0bdc1b28-85d2-44f8-ba04-9c4053b9c09e/restorableSqlResources/cli000004","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts/restorableSqlResources","name":"cli000004","databaseName":"cli000004","collectionNames":["cli000003"]}]}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '386'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:40:49 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: '{"location": "East US 2", "kind": "GlobalDocumentDB", "properties": {"locations":
+      [{"locationName": "eastus2", "failoverPriority": 0}], "databaseAccountOfferType":
+      "Standard", "publicNetworkAccess": "DISABLED", "apiProperties": {}, "createMode":
+      "Restore", "restoreParameters": {"restoreMode": "PointInTime", "restoreSource":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/0bdc1b28-85d2-44f8-ba04-9c4053b9c09e",
+      "restoreTimestampInUtc": "2023-08-21T13:39:05.000Z"}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb restore
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '548'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -n -g -a --restore-timestamp --location --public-network-access
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_public_network_access_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli-systemid-000002-restored?api-version=2023-04-15
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_public_network_access_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli-systemid-000002-restored","name":"cli-systemid-000002-restored","location":"East
+        US 2","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2023-08-21T13:40:50.6806063Z"},"properties":{"provisioningState":"Creating","publicNetworkAccess":"Disabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{},"instanceId":"f250dfd6-5284-405a-bea3-1e056c9528df","createMode":"Restore","databaseAccountOfferType":"Standard","defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"minimalTlsVersion":"Tls","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli-systemid-000002-restored-eastus2","locationName":"East
+        US 2","documentEndpoint":"","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli-systemid-000002-restored-eastus2","locationName":"East
+        US 2","documentEndpoint":"","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli-systemid-000002-restored-eastus2","locationName":"East
+        US 2","documentEndpoint":"","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli-systemid-000002-restored-eastus2","locationName":"East
+        US 2","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/0bdc1b28-85d2-44f8-ba04-9c4053b9c09e","restoreTimestampInUtc":"2023-08-21T13:39:05Z","sourceBackupLocation":"East
+        US 2","databasesToRestore":[]},"networkAclBypassResourceIds":[],"capacity":{"totalThroughputLimit":-1},"keysMetadata":{"primaryMasterKey":{"generationTime":"2023-08-21T13:40:50.6806063Z"},"secondaryMasterKey":{"generationTime":"2023-08-21T13:40:50.6806063Z"},"primaryReadonlyMasterKey":{"generationTime":"2023-08-21T13:40:50.6806063Z"},"secondaryReadonlyMasterKey":{"generationTime":"2023-08-21T13:40:50.6806063Z"}}},"identity":{"type":"None"}}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/2dec4bba-e800-4236-a43f-2faed8879105?api-version=2023-04-15&t=2023-08-21T13%3a40%3a52&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=MjWgyXaLB1GqL2pNTir0-ManL55IOFfP8HvIr90C0DMUjgt3pCUM4ERn8pZH4UeLkgpqHA2syMDRbEEvlLFS3qbC07HOYXGs0ABSGNyisFtzpAgLmdAVCmDF8xJfR3C5lUFIEPJ2it4s6najDy0lYKUBdvTjasymxxgrV7J7HKwvNTZPj5a_Ezxit318JIc_MdLFKC_KPO_yY-GgHSnw4rR6denYS7m6zXzgjGnudG4Ekq-imJSJmbBvV-QRTM3pdaINlUjMB28dbR0tk95rg-9A8xH-u5MuUOdHuyjpovcnkpXxuyaYNZcru10Q2JLmjv4wt_crfLb6WWL_EI9gHw&h=HUt13Q7EwyHbbAX1koRz71sxguMafi47rKalMNmjt2Y
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '2768'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:40:52 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_public_network_access_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli-systemid-000002-restored/operationResults/2dec4bba-e800-4236-a43f-2faed8879105?api-version=2023-04-15
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb restore
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -a --restore-timestamp --location --public-network-access
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/2dec4bba-e800-4236-a43f-2faed8879105?api-version=2023-04-15&t=2023-08-21T13%3A40%3A52&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=MjWgyXaLB1GqL2pNTir0-ManL55IOFfP8HvIr90C0DMUjgt3pCUM4ERn8pZH4UeLkgpqHA2syMDRbEEvlLFS3qbC07HOYXGs0ABSGNyisFtzpAgLmdAVCmDF8xJfR3C5lUFIEPJ2it4s6najDy0lYKUBdvTjasymxxgrV7J7HKwvNTZPj5a_Ezxit318JIc_MdLFKC_KPO_yY-GgHSnw4rR6denYS7m6zXzgjGnudG4Ekq-imJSJmbBvV-QRTM3pdaINlUjMB28dbR0tk95rg-9A8xH-u5MuUOdHuyjpovcnkpXxuyaYNZcru10Q2JLmjv4wt_crfLb6WWL_EI9gHw&h=HUt13Q7EwyHbbAX1koRz71sxguMafi47rKalMNmjt2Y
+  response:
+    body:
+      string: '{"status":"Enqueued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:40:52 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb restore
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -a --restore-timestamp --location --public-network-access
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/2dec4bba-e800-4236-a43f-2faed8879105?api-version=2023-04-15&t=2023-08-21T13%3A40%3A52&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=MjWgyXaLB1GqL2pNTir0-ManL55IOFfP8HvIr90C0DMUjgt3pCUM4ERn8pZH4UeLkgpqHA2syMDRbEEvlLFS3qbC07HOYXGs0ABSGNyisFtzpAgLmdAVCmDF8xJfR3C5lUFIEPJ2it4s6najDy0lYKUBdvTjasymxxgrV7J7HKwvNTZPj5a_Ezxit318JIc_MdLFKC_KPO_yY-GgHSnw4rR6denYS7m6zXzgjGnudG4Ekq-imJSJmbBvV-QRTM3pdaINlUjMB28dbR0tk95rg-9A8xH-u5MuUOdHuyjpovcnkpXxuyaYNZcru10Q2JLmjv4wt_crfLb6WWL_EI9gHw&h=HUt13Q7EwyHbbAX1koRz71sxguMafi47rKalMNmjt2Y
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:41:22 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb restore
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -a --restore-timestamp --location --public-network-access
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/2dec4bba-e800-4236-a43f-2faed8879105?api-version=2023-04-15&t=2023-08-21T13%3A40%3A52&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=MjWgyXaLB1GqL2pNTir0-ManL55IOFfP8HvIr90C0DMUjgt3pCUM4ERn8pZH4UeLkgpqHA2syMDRbEEvlLFS3qbC07HOYXGs0ABSGNyisFtzpAgLmdAVCmDF8xJfR3C5lUFIEPJ2it4s6najDy0lYKUBdvTjasymxxgrV7J7HKwvNTZPj5a_Ezxit318JIc_MdLFKC_KPO_yY-GgHSnw4rR6denYS7m6zXzgjGnudG4Ekq-imJSJmbBvV-QRTM3pdaINlUjMB28dbR0tk95rg-9A8xH-u5MuUOdHuyjpovcnkpXxuyaYNZcru10Q2JLmjv4wt_crfLb6WWL_EI9gHw&h=HUt13Q7EwyHbbAX1koRz71sxguMafi47rKalMNmjt2Y
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:41:52 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb restore
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -a --restore-timestamp --location --public-network-access
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/2dec4bba-e800-4236-a43f-2faed8879105?api-version=2023-04-15&t=2023-08-21T13%3A40%3A52&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=MjWgyXaLB1GqL2pNTir0-ManL55IOFfP8HvIr90C0DMUjgt3pCUM4ERn8pZH4UeLkgpqHA2syMDRbEEvlLFS3qbC07HOYXGs0ABSGNyisFtzpAgLmdAVCmDF8xJfR3C5lUFIEPJ2it4s6najDy0lYKUBdvTjasymxxgrV7J7HKwvNTZPj5a_Ezxit318JIc_MdLFKC_KPO_yY-GgHSnw4rR6denYS7m6zXzgjGnudG4Ekq-imJSJmbBvV-QRTM3pdaINlUjMB28dbR0tk95rg-9A8xH-u5MuUOdHuyjpovcnkpXxuyaYNZcru10Q2JLmjv4wt_crfLb6WWL_EI9gHw&h=HUt13Q7EwyHbbAX1koRz71sxguMafi47rKalMNmjt2Y
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:42:22 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb restore
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -a --restore-timestamp --location --public-network-access
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/2dec4bba-e800-4236-a43f-2faed8879105?api-version=2023-04-15&t=2023-08-21T13%3A40%3A52&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=MjWgyXaLB1GqL2pNTir0-ManL55IOFfP8HvIr90C0DMUjgt3pCUM4ERn8pZH4UeLkgpqHA2syMDRbEEvlLFS3qbC07HOYXGs0ABSGNyisFtzpAgLmdAVCmDF8xJfR3C5lUFIEPJ2it4s6najDy0lYKUBdvTjasymxxgrV7J7HKwvNTZPj5a_Ezxit318JIc_MdLFKC_KPO_yY-GgHSnw4rR6denYS7m6zXzgjGnudG4Ekq-imJSJmbBvV-QRTM3pdaINlUjMB28dbR0tk95rg-9A8xH-u5MuUOdHuyjpovcnkpXxuyaYNZcru10Q2JLmjv4wt_crfLb6WWL_EI9gHw&h=HUt13Q7EwyHbbAX1koRz71sxguMafi47rKalMNmjt2Y
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:42:53 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb restore
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -a --restore-timestamp --location --public-network-access
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/2dec4bba-e800-4236-a43f-2faed8879105?api-version=2023-04-15&t=2023-08-21T13%3A40%3A52&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=MjWgyXaLB1GqL2pNTir0-ManL55IOFfP8HvIr90C0DMUjgt3pCUM4ERn8pZH4UeLkgpqHA2syMDRbEEvlLFS3qbC07HOYXGs0ABSGNyisFtzpAgLmdAVCmDF8xJfR3C5lUFIEPJ2it4s6najDy0lYKUBdvTjasymxxgrV7J7HKwvNTZPj5a_Ezxit318JIc_MdLFKC_KPO_yY-GgHSnw4rR6denYS7m6zXzgjGnudG4Ekq-imJSJmbBvV-QRTM3pdaINlUjMB28dbR0tk95rg-9A8xH-u5MuUOdHuyjpovcnkpXxuyaYNZcru10Q2JLmjv4wt_crfLb6WWL_EI9gHw&h=HUt13Q7EwyHbbAX1koRz71sxguMafi47rKalMNmjt2Y
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:43:23 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb restore
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -a --restore-timestamp --location --public-network-access
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/2dec4bba-e800-4236-a43f-2faed8879105?api-version=2023-04-15&t=2023-08-21T13%3A40%3A52&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=MjWgyXaLB1GqL2pNTir0-ManL55IOFfP8HvIr90C0DMUjgt3pCUM4ERn8pZH4UeLkgpqHA2syMDRbEEvlLFS3qbC07HOYXGs0ABSGNyisFtzpAgLmdAVCmDF8xJfR3C5lUFIEPJ2it4s6najDy0lYKUBdvTjasymxxgrV7J7HKwvNTZPj5a_Ezxit318JIc_MdLFKC_KPO_yY-GgHSnw4rR6denYS7m6zXzgjGnudG4Ekq-imJSJmbBvV-QRTM3pdaINlUjMB28dbR0tk95rg-9A8xH-u5MuUOdHuyjpovcnkpXxuyaYNZcru10Q2JLmjv4wt_crfLb6WWL_EI9gHw&h=HUt13Q7EwyHbbAX1koRz71sxguMafi47rKalMNmjt2Y
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:43:53 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb restore
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -a --restore-timestamp --location --public-network-access
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/2dec4bba-e800-4236-a43f-2faed8879105?api-version=2023-04-15&t=2023-08-21T13%3A40%3A52&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=MjWgyXaLB1GqL2pNTir0-ManL55IOFfP8HvIr90C0DMUjgt3pCUM4ERn8pZH4UeLkgpqHA2syMDRbEEvlLFS3qbC07HOYXGs0ABSGNyisFtzpAgLmdAVCmDF8xJfR3C5lUFIEPJ2it4s6najDy0lYKUBdvTjasymxxgrV7J7HKwvNTZPj5a_Ezxit318JIc_MdLFKC_KPO_yY-GgHSnw4rR6denYS7m6zXzgjGnudG4Ekq-imJSJmbBvV-QRTM3pdaINlUjMB28dbR0tk95rg-9A8xH-u5MuUOdHuyjpovcnkpXxuyaYNZcru10Q2JLmjv4wt_crfLb6WWL_EI9gHw&h=HUt13Q7EwyHbbAX1koRz71sxguMafi47rKalMNmjt2Y
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:44:23 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb restore
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -a --restore-timestamp --location --public-network-access
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/2dec4bba-e800-4236-a43f-2faed8879105?api-version=2023-04-15&t=2023-08-21T13%3A40%3A52&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=MjWgyXaLB1GqL2pNTir0-ManL55IOFfP8HvIr90C0DMUjgt3pCUM4ERn8pZH4UeLkgpqHA2syMDRbEEvlLFS3qbC07HOYXGs0ABSGNyisFtzpAgLmdAVCmDF8xJfR3C5lUFIEPJ2it4s6najDy0lYKUBdvTjasymxxgrV7J7HKwvNTZPj5a_Ezxit318JIc_MdLFKC_KPO_yY-GgHSnw4rR6denYS7m6zXzgjGnudG4Ekq-imJSJmbBvV-QRTM3pdaINlUjMB28dbR0tk95rg-9A8xH-u5MuUOdHuyjpovcnkpXxuyaYNZcru10Q2JLmjv4wt_crfLb6WWL_EI9gHw&h=HUt13Q7EwyHbbAX1koRz71sxguMafi47rKalMNmjt2Y
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:44:53 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb restore
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -a --restore-timestamp --location --public-network-access
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/2dec4bba-e800-4236-a43f-2faed8879105?api-version=2023-04-15&t=2023-08-21T13%3A40%3A52&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=MjWgyXaLB1GqL2pNTir0-ManL55IOFfP8HvIr90C0DMUjgt3pCUM4ERn8pZH4UeLkgpqHA2syMDRbEEvlLFS3qbC07HOYXGs0ABSGNyisFtzpAgLmdAVCmDF8xJfR3C5lUFIEPJ2it4s6najDy0lYKUBdvTjasymxxgrV7J7HKwvNTZPj5a_Ezxit318JIc_MdLFKC_KPO_yY-GgHSnw4rR6denYS7m6zXzgjGnudG4Ekq-imJSJmbBvV-QRTM3pdaINlUjMB28dbR0tk95rg-9A8xH-u5MuUOdHuyjpovcnkpXxuyaYNZcru10Q2JLmjv4wt_crfLb6WWL_EI9gHw&h=HUt13Q7EwyHbbAX1koRz71sxguMafi47rKalMNmjt2Y
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:45:24 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb restore
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -a --restore-timestamp --location --public-network-access
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/2dec4bba-e800-4236-a43f-2faed8879105?api-version=2023-04-15&t=2023-08-21T13%3A40%3A52&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=MjWgyXaLB1GqL2pNTir0-ManL55IOFfP8HvIr90C0DMUjgt3pCUM4ERn8pZH4UeLkgpqHA2syMDRbEEvlLFS3qbC07HOYXGs0ABSGNyisFtzpAgLmdAVCmDF8xJfR3C5lUFIEPJ2it4s6najDy0lYKUBdvTjasymxxgrV7J7HKwvNTZPj5a_Ezxit318JIc_MdLFKC_KPO_yY-GgHSnw4rR6denYS7m6zXzgjGnudG4Ekq-imJSJmbBvV-QRTM3pdaINlUjMB28dbR0tk95rg-9A8xH-u5MuUOdHuyjpovcnkpXxuyaYNZcru10Q2JLmjv4wt_crfLb6WWL_EI9gHw&h=HUt13Q7EwyHbbAX1koRz71sxguMafi47rKalMNmjt2Y
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:45:54 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb restore
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -a --restore-timestamp --location --public-network-access
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/2dec4bba-e800-4236-a43f-2faed8879105?api-version=2023-04-15&t=2023-08-21T13%3A40%3A52&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=MjWgyXaLB1GqL2pNTir0-ManL55IOFfP8HvIr90C0DMUjgt3pCUM4ERn8pZH4UeLkgpqHA2syMDRbEEvlLFS3qbC07HOYXGs0ABSGNyisFtzpAgLmdAVCmDF8xJfR3C5lUFIEPJ2it4s6najDy0lYKUBdvTjasymxxgrV7J7HKwvNTZPj5a_Ezxit318JIc_MdLFKC_KPO_yY-GgHSnw4rR6denYS7m6zXzgjGnudG4Ekq-imJSJmbBvV-QRTM3pdaINlUjMB28dbR0tk95rg-9A8xH-u5MuUOdHuyjpovcnkpXxuyaYNZcru10Q2JLmjv4wt_crfLb6WWL_EI9gHw&h=HUt13Q7EwyHbbAX1koRz71sxguMafi47rKalMNmjt2Y
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:46:24 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb restore
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -a --restore-timestamp --location --public-network-access
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/2dec4bba-e800-4236-a43f-2faed8879105?api-version=2023-04-15&t=2023-08-21T13%3A40%3A52&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=MjWgyXaLB1GqL2pNTir0-ManL55IOFfP8HvIr90C0DMUjgt3pCUM4ERn8pZH4UeLkgpqHA2syMDRbEEvlLFS3qbC07HOYXGs0ABSGNyisFtzpAgLmdAVCmDF8xJfR3C5lUFIEPJ2it4s6najDy0lYKUBdvTjasymxxgrV7J7HKwvNTZPj5a_Ezxit318JIc_MdLFKC_KPO_yY-GgHSnw4rR6denYS7m6zXzgjGnudG4Ekq-imJSJmbBvV-QRTM3pdaINlUjMB28dbR0tk95rg-9A8xH-u5MuUOdHuyjpovcnkpXxuyaYNZcru10Q2JLmjv4wt_crfLb6WWL_EI9gHw&h=HUt13Q7EwyHbbAX1koRz71sxguMafi47rKalMNmjt2Y
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:46:54 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb restore
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -a --restore-timestamp --location --public-network-access
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/2dec4bba-e800-4236-a43f-2faed8879105?api-version=2023-04-15&t=2023-08-21T13%3A40%3A52&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=MjWgyXaLB1GqL2pNTir0-ManL55IOFfP8HvIr90C0DMUjgt3pCUM4ERn8pZH4UeLkgpqHA2syMDRbEEvlLFS3qbC07HOYXGs0ABSGNyisFtzpAgLmdAVCmDF8xJfR3C5lUFIEPJ2it4s6najDy0lYKUBdvTjasymxxgrV7J7HKwvNTZPj5a_Ezxit318JIc_MdLFKC_KPO_yY-GgHSnw4rR6denYS7m6zXzgjGnudG4Ekq-imJSJmbBvV-QRTM3pdaINlUjMB28dbR0tk95rg-9A8xH-u5MuUOdHuyjpovcnkpXxuyaYNZcru10Q2JLmjv4wt_crfLb6WWL_EI9gHw&h=HUt13Q7EwyHbbAX1koRz71sxguMafi47rKalMNmjt2Y
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:47:25 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb restore
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -a --restore-timestamp --location --public-network-access
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/2dec4bba-e800-4236-a43f-2faed8879105?api-version=2023-04-15&t=2023-08-21T13%3A40%3A52&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=MjWgyXaLB1GqL2pNTir0-ManL55IOFfP8HvIr90C0DMUjgt3pCUM4ERn8pZH4UeLkgpqHA2syMDRbEEvlLFS3qbC07HOYXGs0ABSGNyisFtzpAgLmdAVCmDF8xJfR3C5lUFIEPJ2it4s6najDy0lYKUBdvTjasymxxgrV7J7HKwvNTZPj5a_Ezxit318JIc_MdLFKC_KPO_yY-GgHSnw4rR6denYS7m6zXzgjGnudG4Ekq-imJSJmbBvV-QRTM3pdaINlUjMB28dbR0tk95rg-9A8xH-u5MuUOdHuyjpovcnkpXxuyaYNZcru10Q2JLmjv4wt_crfLb6WWL_EI9gHw&h=HUt13Q7EwyHbbAX1koRz71sxguMafi47rKalMNmjt2Y
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:47:55 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb restore
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -a --restore-timestamp --location --public-network-access
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/2dec4bba-e800-4236-a43f-2faed8879105?api-version=2023-04-15&t=2023-08-21T13%3A40%3A52&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=MjWgyXaLB1GqL2pNTir0-ManL55IOFfP8HvIr90C0DMUjgt3pCUM4ERn8pZH4UeLkgpqHA2syMDRbEEvlLFS3qbC07HOYXGs0ABSGNyisFtzpAgLmdAVCmDF8xJfR3C5lUFIEPJ2it4s6najDy0lYKUBdvTjasymxxgrV7J7HKwvNTZPj5a_Ezxit318JIc_MdLFKC_KPO_yY-GgHSnw4rR6denYS7m6zXzgjGnudG4Ekq-imJSJmbBvV-QRTM3pdaINlUjMB28dbR0tk95rg-9A8xH-u5MuUOdHuyjpovcnkpXxuyaYNZcru10Q2JLmjv4wt_crfLb6WWL_EI9gHw&h=HUt13Q7EwyHbbAX1koRz71sxguMafi47rKalMNmjt2Y
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:48:25 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb restore
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -a --restore-timestamp --location --public-network-access
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/2dec4bba-e800-4236-a43f-2faed8879105?api-version=2023-04-15&t=2023-08-21T13%3A40%3A52&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=MjWgyXaLB1GqL2pNTir0-ManL55IOFfP8HvIr90C0DMUjgt3pCUM4ERn8pZH4UeLkgpqHA2syMDRbEEvlLFS3qbC07HOYXGs0ABSGNyisFtzpAgLmdAVCmDF8xJfR3C5lUFIEPJ2it4s6najDy0lYKUBdvTjasymxxgrV7J7HKwvNTZPj5a_Ezxit318JIc_MdLFKC_KPO_yY-GgHSnw4rR6denYS7m6zXzgjGnudG4Ekq-imJSJmbBvV-QRTM3pdaINlUjMB28dbR0tk95rg-9A8xH-u5MuUOdHuyjpovcnkpXxuyaYNZcru10Q2JLmjv4wt_crfLb6WWL_EI9gHw&h=HUt13Q7EwyHbbAX1koRz71sxguMafi47rKalMNmjt2Y
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:48:55 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb restore
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -a --restore-timestamp --location --public-network-access
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/2dec4bba-e800-4236-a43f-2faed8879105?api-version=2023-04-15&t=2023-08-21T13%3A40%3A52&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=MjWgyXaLB1GqL2pNTir0-ManL55IOFfP8HvIr90C0DMUjgt3pCUM4ERn8pZH4UeLkgpqHA2syMDRbEEvlLFS3qbC07HOYXGs0ABSGNyisFtzpAgLmdAVCmDF8xJfR3C5lUFIEPJ2it4s6najDy0lYKUBdvTjasymxxgrV7J7HKwvNTZPj5a_Ezxit318JIc_MdLFKC_KPO_yY-GgHSnw4rR6denYS7m6zXzgjGnudG4Ekq-imJSJmbBvV-QRTM3pdaINlUjMB28dbR0tk95rg-9A8xH-u5MuUOdHuyjpovcnkpXxuyaYNZcru10Q2JLmjv4wt_crfLb6WWL_EI9gHw&h=HUt13Q7EwyHbbAX1koRz71sxguMafi47rKalMNmjt2Y
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:49:25 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb restore
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -a --restore-timestamp --location --public-network-access
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/2dec4bba-e800-4236-a43f-2faed8879105?api-version=2023-04-15&t=2023-08-21T13%3A40%3A52&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=MjWgyXaLB1GqL2pNTir0-ManL55IOFfP8HvIr90C0DMUjgt3pCUM4ERn8pZH4UeLkgpqHA2syMDRbEEvlLFS3qbC07HOYXGs0ABSGNyisFtzpAgLmdAVCmDF8xJfR3C5lUFIEPJ2it4s6najDy0lYKUBdvTjasymxxgrV7J7HKwvNTZPj5a_Ezxit318JIc_MdLFKC_KPO_yY-GgHSnw4rR6denYS7m6zXzgjGnudG4Ekq-imJSJmbBvV-QRTM3pdaINlUjMB28dbR0tk95rg-9A8xH-u5MuUOdHuyjpovcnkpXxuyaYNZcru10Q2JLmjv4wt_crfLb6WWL_EI9gHw&h=HUt13Q7EwyHbbAX1koRz71sxguMafi47rKalMNmjt2Y
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:49:55 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb restore
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -a --restore-timestamp --location --public-network-access
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/2dec4bba-e800-4236-a43f-2faed8879105?api-version=2023-04-15&t=2023-08-21T13%3A40%3A52&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=MjWgyXaLB1GqL2pNTir0-ManL55IOFfP8HvIr90C0DMUjgt3pCUM4ERn8pZH4UeLkgpqHA2syMDRbEEvlLFS3qbC07HOYXGs0ABSGNyisFtzpAgLmdAVCmDF8xJfR3C5lUFIEPJ2it4s6najDy0lYKUBdvTjasymxxgrV7J7HKwvNTZPj5a_Ezxit318JIc_MdLFKC_KPO_yY-GgHSnw4rR6denYS7m6zXzgjGnudG4Ekq-imJSJmbBvV-QRTM3pdaINlUjMB28dbR0tk95rg-9A8xH-u5MuUOdHuyjpovcnkpXxuyaYNZcru10Q2JLmjv4wt_crfLb6WWL_EI9gHw&h=HUt13Q7EwyHbbAX1koRz71sxguMafi47rKalMNmjt2Y
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:50:26 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb restore
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -a --restore-timestamp --location --public-network-access
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/2dec4bba-e800-4236-a43f-2faed8879105?api-version=2023-04-15&t=2023-08-21T13%3A40%3A52&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=MjWgyXaLB1GqL2pNTir0-ManL55IOFfP8HvIr90C0DMUjgt3pCUM4ERn8pZH4UeLkgpqHA2syMDRbEEvlLFS3qbC07HOYXGs0ABSGNyisFtzpAgLmdAVCmDF8xJfR3C5lUFIEPJ2it4s6najDy0lYKUBdvTjasymxxgrV7J7HKwvNTZPj5a_Ezxit318JIc_MdLFKC_KPO_yY-GgHSnw4rR6denYS7m6zXzgjGnudG4Ekq-imJSJmbBvV-QRTM3pdaINlUjMB28dbR0tk95rg-9A8xH-u5MuUOdHuyjpovcnkpXxuyaYNZcru10Q2JLmjv4wt_crfLb6WWL_EI9gHw&h=HUt13Q7EwyHbbAX1koRz71sxguMafi47rKalMNmjt2Y
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:50:56 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb restore
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -a --restore-timestamp --location --public-network-access
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/2dec4bba-e800-4236-a43f-2faed8879105?api-version=2023-04-15&t=2023-08-21T13%3A40%3A52&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=MjWgyXaLB1GqL2pNTir0-ManL55IOFfP8HvIr90C0DMUjgt3pCUM4ERn8pZH4UeLkgpqHA2syMDRbEEvlLFS3qbC07HOYXGs0ABSGNyisFtzpAgLmdAVCmDF8xJfR3C5lUFIEPJ2it4s6najDy0lYKUBdvTjasymxxgrV7J7HKwvNTZPj5a_Ezxit318JIc_MdLFKC_KPO_yY-GgHSnw4rR6denYS7m6zXzgjGnudG4Ekq-imJSJmbBvV-QRTM3pdaINlUjMB28dbR0tk95rg-9A8xH-u5MuUOdHuyjpovcnkpXxuyaYNZcru10Q2JLmjv4wt_crfLb6WWL_EI9gHw&h=HUt13Q7EwyHbbAX1koRz71sxguMafi47rKalMNmjt2Y
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:51:26 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb restore
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -a --restore-timestamp --location --public-network-access
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/2dec4bba-e800-4236-a43f-2faed8879105?api-version=2023-04-15&t=2023-08-21T13%3A40%3A52&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=MjWgyXaLB1GqL2pNTir0-ManL55IOFfP8HvIr90C0DMUjgt3pCUM4ERn8pZH4UeLkgpqHA2syMDRbEEvlLFS3qbC07HOYXGs0ABSGNyisFtzpAgLmdAVCmDF8xJfR3C5lUFIEPJ2it4s6najDy0lYKUBdvTjasymxxgrV7J7HKwvNTZPj5a_Ezxit318JIc_MdLFKC_KPO_yY-GgHSnw4rR6denYS7m6zXzgjGnudG4Ekq-imJSJmbBvV-QRTM3pdaINlUjMB28dbR0tk95rg-9A8xH-u5MuUOdHuyjpovcnkpXxuyaYNZcru10Q2JLmjv4wt_crfLb6WWL_EI9gHw&h=HUt13Q7EwyHbbAX1koRz71sxguMafi47rKalMNmjt2Y
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:51:56 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb restore
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -a --restore-timestamp --location --public-network-access
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/2dec4bba-e800-4236-a43f-2faed8879105?api-version=2023-04-15&t=2023-08-21T13%3A40%3A52&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=MjWgyXaLB1GqL2pNTir0-ManL55IOFfP8HvIr90C0DMUjgt3pCUM4ERn8pZH4UeLkgpqHA2syMDRbEEvlLFS3qbC07HOYXGs0ABSGNyisFtzpAgLmdAVCmDF8xJfR3C5lUFIEPJ2it4s6najDy0lYKUBdvTjasymxxgrV7J7HKwvNTZPj5a_Ezxit318JIc_MdLFKC_KPO_yY-GgHSnw4rR6denYS7m6zXzgjGnudG4Ekq-imJSJmbBvV-QRTM3pdaINlUjMB28dbR0tk95rg-9A8xH-u5MuUOdHuyjpovcnkpXxuyaYNZcru10Q2JLmjv4wt_crfLb6WWL_EI9gHw&h=HUt13Q7EwyHbbAX1koRz71sxguMafi47rKalMNmjt2Y
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:52:26 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb restore
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -a --restore-timestamp --location --public-network-access
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/2dec4bba-e800-4236-a43f-2faed8879105?api-version=2023-04-15&t=2023-08-21T13%3A40%3A52&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=MjWgyXaLB1GqL2pNTir0-ManL55IOFfP8HvIr90C0DMUjgt3pCUM4ERn8pZH4UeLkgpqHA2syMDRbEEvlLFS3qbC07HOYXGs0ABSGNyisFtzpAgLmdAVCmDF8xJfR3C5lUFIEPJ2it4s6najDy0lYKUBdvTjasymxxgrV7J7HKwvNTZPj5a_Ezxit318JIc_MdLFKC_KPO_yY-GgHSnw4rR6denYS7m6zXzgjGnudG4Ekq-imJSJmbBvV-QRTM3pdaINlUjMB28dbR0tk95rg-9A8xH-u5MuUOdHuyjpovcnkpXxuyaYNZcru10Q2JLmjv4wt_crfLb6WWL_EI9gHw&h=HUt13Q7EwyHbbAX1koRz71sxguMafi47rKalMNmjt2Y
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:52:57 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb restore
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -a --restore-timestamp --location --public-network-access
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/2dec4bba-e800-4236-a43f-2faed8879105?api-version=2023-04-15&t=2023-08-21T13%3A40%3A52&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=MjWgyXaLB1GqL2pNTir0-ManL55IOFfP8HvIr90C0DMUjgt3pCUM4ERn8pZH4UeLkgpqHA2syMDRbEEvlLFS3qbC07HOYXGs0ABSGNyisFtzpAgLmdAVCmDF8xJfR3C5lUFIEPJ2it4s6najDy0lYKUBdvTjasymxxgrV7J7HKwvNTZPj5a_Ezxit318JIc_MdLFKC_KPO_yY-GgHSnw4rR6denYS7m6zXzgjGnudG4Ekq-imJSJmbBvV-QRTM3pdaINlUjMB28dbR0tk95rg-9A8xH-u5MuUOdHuyjpovcnkpXxuyaYNZcru10Q2JLmjv4wt_crfLb6WWL_EI9gHw&h=HUt13Q7EwyHbbAX1koRz71sxguMafi47rKalMNmjt2Y
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:53:27 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb restore
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -a --restore-timestamp --location --public-network-access
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/2dec4bba-e800-4236-a43f-2faed8879105?api-version=2023-04-15&t=2023-08-21T13%3A40%3A52&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=MjWgyXaLB1GqL2pNTir0-ManL55IOFfP8HvIr90C0DMUjgt3pCUM4ERn8pZH4UeLkgpqHA2syMDRbEEvlLFS3qbC07HOYXGs0ABSGNyisFtzpAgLmdAVCmDF8xJfR3C5lUFIEPJ2it4s6najDy0lYKUBdvTjasymxxgrV7J7HKwvNTZPj5a_Ezxit318JIc_MdLFKC_KPO_yY-GgHSnw4rR6denYS7m6zXzgjGnudG4Ekq-imJSJmbBvV-QRTM3pdaINlUjMB28dbR0tk95rg-9A8xH-u5MuUOdHuyjpovcnkpXxuyaYNZcru10Q2JLmjv4wt_crfLb6WWL_EI9gHw&h=HUt13Q7EwyHbbAX1koRz71sxguMafi47rKalMNmjt2Y
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:53:57 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb restore
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -a --restore-timestamp --location --public-network-access
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/operationsStatus/2dec4bba-e800-4236-a43f-2faed8879105?api-version=2023-04-15&t=2023-08-21T13%3A40%3A52&c=MIIHHjCCBgagAwIBAgITfwHPvaLJR7ljo4BWoQAEAc-9ojANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjMwODAyMTY1OTIzWhcNMjQwNzI3MTY1OTIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKpKck0ipzF1pcXYRTRkYEODpOXf8WVRO2dxC6G6Y-R0aVW8zW6SgyknoVADfYwB4at251oPvcenMCnD0huujkBdEUs7d4b1Q_2e9g-EFE7g8xRCx7-Q4Q6M-5JJX3IhmW9053r6u4Nsz9-9ZVPi9onRgiHxQOrFRWC_ySAhSTb-8143ctmD5W08jR430ebqA6CDIlnMDekDngh9neMfQSxJtEj1PgZjoZDJubZQnTU3smxOqf9RmPFA_GjZeVGJ23pO4QsgL1t2ppkqmZlD5--VnoNF67EdFgHzkffqZujbR_5dZywisriDARMKh9yDMAu_aujBK0jOy3haK0cdZHkCAwEAAaOCBAswggQHMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBT0ZP2n-iWQ--LIpeNzHEM88cTrETAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAIlybWyV7ErTmWdAOdkxaIBiUkNzReblSGzfnEbHjIVNtUQYiCDJGDoFew2apbfR1CzegVeat47b4nNTrB59d-KhmaNuv5eaIcngryMp7wSpNTATnuRU0TOIMf3H_ROpt0C5zWnYI9SjOV-mYwnp2Xd4GhIXXNeYGhXSQIJUsIEZ2rv7sV6nX9kXuG6Ks4LfJvnnxt2yC3S8KDrPfS0g7iyBL8ap3JpJQzE4nyXYYr0w6JDwnYetsRN1IP9CUFOYQuenOuAKnd-uKBPcrWOA0-627hCDkYPJbZpLkItyQpJN1PwzhsvkKn9ZrAw5RNTxzwa6OHtkhhXNJaCeMMNZopo&s=MjWgyXaLB1GqL2pNTir0-ManL55IOFfP8HvIr90C0DMUjgt3pCUM4ERn8pZH4UeLkgpqHA2syMDRbEEvlLFS3qbC07HOYXGs0ABSGNyisFtzpAgLmdAVCmDF8xJfR3C5lUFIEPJ2it4s6najDy0lYKUBdvTjasymxxgrV7J7HKwvNTZPj5a_Ezxit318JIc_MdLFKC_KPO_yY-GgHSnw4rR6denYS7m6zXzgjGnudG4Ekq-imJSJmbBvV-QRTM3pdaINlUjMB28dbR0tk95rg-9A8xH-u5MuUOdHuyjpovcnkpXxuyaYNZcru10Q2JLmjv4wt_crfLb6WWL_EI9gHw&h=HUt13Q7EwyHbbAX1koRz71sxguMafi47rKalMNmjt2Y
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:54:27 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb restore
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -a --restore-timestamp --location --public-network-access
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_public_network_access_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli-systemid-000002-restored?api-version=2023-04-15
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_public_network_access_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli-systemid-000002-restored","name":"cli-systemid-000002-restored","location":"East
+        US 2","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2023-08-21T13:54:05.5860924Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli-systemid-000002-restored.documents.azure.com:443/","sqlEndpoint":"https://cli-systemid-000002-restored.documents.azure.com:443/","publicNetworkAccess":"Disabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{},"instanceId":"f250dfd6-5284-405a-bea3-1e056c9528df","createMode":"Restore","databaseAccountOfferType":"Standard","defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"minimalTlsVersion":"Tls","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli-systemid-000002-restored-eastus2","locationName":"East
+        US 2","documentEndpoint":"https://cli-systemid-000002-restored-eastus2.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli-systemid-000002-restored-eastus2","locationName":"East
+        US 2","documentEndpoint":"https://cli-systemid-000002-restored-eastus2.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli-systemid-000002-restored-eastus2","locationName":"East
+        US 2","documentEndpoint":"https://cli-systemid-000002-restored-eastus2.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli-systemid-000002-restored-eastus2","locationName":"East
+        US 2","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/0bdc1b28-85d2-44f8-ba04-9c4053b9c09e","restoreTimestampInUtc":"2023-08-21T13:39:05Z","sourceBackupLocation":"East
+        US 2","databasesToRestore":[]},"networkAclBypassResourceIds":[],"capacity":{"totalThroughputLimit":-1},"keysMetadata":{"primaryMasterKey":{"generationTime":"2023-08-21T13:54:05.5860924Z"},"secondaryMasterKey":{"generationTime":"2023-08-21T13:54:05.5860924Z"},"primaryReadonlyMasterKey":{"generationTime":"2023-08-21T13:54:05.5860924Z"},"secondaryReadonlyMasterKey":{"generationTime":"2023-08-21T13:54:05.5860924Z"}}},"identity":{"type":"None"}}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '3140'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:54:27 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb restore
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -a --restore-timestamp --location --public-network-access
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_public_network_access_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli-systemid-000002-restored?api-version=2023-04-15
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_public_network_access_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli-systemid-000002-restored","name":"cli-systemid-000002-restored","location":"East
+        US 2","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2023-08-21T13:54:05.5860924Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli-systemid-000002-restored.documents.azure.com:443/","sqlEndpoint":"https://cli-systemid-000002-restored.documents.azure.com:443/","publicNetworkAccess":"Disabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{},"instanceId":"f250dfd6-5284-405a-bea3-1e056c9528df","createMode":"Restore","databaseAccountOfferType":"Standard","defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"minimalTlsVersion":"Tls","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli-systemid-000002-restored-eastus2","locationName":"East
+        US 2","documentEndpoint":"https://cli-systemid-000002-restored-eastus2.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli-systemid-000002-restored-eastus2","locationName":"East
+        US 2","documentEndpoint":"https://cli-systemid-000002-restored-eastus2.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli-systemid-000002-restored-eastus2","locationName":"East
+        US 2","documentEndpoint":"https://cli-systemid-000002-restored-eastus2.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli-systemid-000002-restored-eastus2","locationName":"East
+        US 2","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/0bdc1b28-85d2-44f8-ba04-9c4053b9c09e","restoreTimestampInUtc":"2023-08-21T13:39:05Z","sourceBackupLocation":"East
+        US 2","databasesToRestore":[]},"networkAclBypassResourceIds":[],"capacity":{"totalThroughputLimit":-1},"keysMetadata":{"primaryMasterKey":{"generationTime":"2023-08-21T13:54:05.5860924Z"},"secondaryMasterKey":{"generationTime":"2023-08-21T13:54:05.5860924Z"},"primaryReadonlyMasterKey":{"generationTime":"2023-08-21T13:54:05.5860924Z"},"secondaryReadonlyMasterKey":{"generationTime":"2023-08-21T13:54:05.5860924Z"}}},"identity":{"type":"None"}}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '3140'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:54:27 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-mgmt-cosmosdb/9.2.0 Python/3.10.11 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_public_network_access_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli-systemid-000002-restored?api-version=2023-04-15
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_public_network_access_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli-systemid-000002-restored","name":"cli-systemid-000002-restored","location":"East
+        US 2","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2023-08-21T13:54:05.5860924Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli-systemid-000002-restored.documents.azure.com:443/","sqlEndpoint":"https://cli-systemid-000002-restored.documents.azure.com:443/","publicNetworkAccess":"Disabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{},"instanceId":"f250dfd6-5284-405a-bea3-1e056c9528df","createMode":"Restore","databaseAccountOfferType":"Standard","defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"minimalTlsVersion":"Tls","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli-systemid-000002-restored-eastus2","locationName":"East
+        US 2","documentEndpoint":"https://cli-systemid-000002-restored-eastus2.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli-systemid-000002-restored-eastus2","locationName":"East
+        US 2","documentEndpoint":"https://cli-systemid-000002-restored-eastus2.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli-systemid-000002-restored-eastus2","locationName":"East
+        US 2","documentEndpoint":"https://cli-systemid-000002-restored-eastus2.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli-systemid-000002-restored-eastus2","locationName":"East
+        US 2","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/0bdc1b28-85d2-44f8-ba04-9c4053b9c09e","restoreTimestampInUtc":"2023-08-21T13:39:05Z","sourceBackupLocation":"East
+        US 2","databasesToRestore":[]},"networkAclBypassResourceIds":[],"capacity":{"totalThroughputLimit":-1},"keysMetadata":{"primaryMasterKey":{"generationTime":"2023-08-21T13:54:05.5860924Z"},"secondaryMasterKey":{"generationTime":"2023-08-21T13:54:05.5860924Z"},"primaryReadonlyMasterKey":{"generationTime":"2023-08-21T13:54:05.5860924Z"},"secondaryReadonlyMasterKey":{"generationTime":"2023-08-21T13:54:05.5860924Z"}}},"identity":{"type":"None"}}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '3140'
+      content-type:
+      - application/json
+      date:
+      - Mon, 21 Aug 2023 13:54:28 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/tests/latest/test_cosmosdb_backuprestore_scenario.py
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/tests/latest/test_cosmosdb_backuprestore_scenario.py
@@ -369,7 +369,7 @@ class CosmosDBBackupRestoreScenarioTest(ScenarioTest):
             'pna': 'DISABLED'
         })
 
-        self.cmd('az cosmosdb restore -n {restored_acc} -g {rg} -a {acc} --restore-timestamp {rts} --location {loc} -p {pna}')
+        self.cmd('az cosmosdb restore -n {restored_acc} -g {rg} -a {acc} --restore-timestamp {rts} --location {loc} --public-network-access {pna}')
         restored_account = self.cmd('az cosmosdb show -n {restored_acc} -g {rg}', checks=[
             self.check('restoreParameters.restoreMode', 'PointInTime')
         ]).get_output_in_json()

--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/tests/latest/test_cosmosdb_backuprestore_scenario.py
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/tests/latest/test_cosmosdb_backuprestore_scenario.py
@@ -332,7 +332,7 @@ class CosmosDBBackupRestoreScenarioTest(ScenarioTest):
             'user2' : self.create_random_name(prefix='user2-', length = 10)
         })
 
-        # Create PITR account
+        # Create normal PITR account
         self.cmd('az cosmosdb create -n {acc} -g {rg} --backup-policy-type Continuous --locations regionName={loc} --kind GlobalDocumentDB')
         account = self.cmd('az cosmosdb show -n {acc} -g {rg}').get_output_in_json()
         print(account)

--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/tests/latest/test_cosmosdb_backuprestore_scenario.py
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/tests/latest/test_cosmosdb_backuprestore_scenario.py
@@ -294,7 +294,7 @@ class CosmosDBBackupRestoreScenarioTest(ScenarioTest):
             'default_id2' : default_id2
         })
 
-        self.cmd('az cosmosdb restore -n {restored_acc} -g {rg} -a {acc} --restore-timestamp {rts} --location {loc} --assign-identity {user_id_2} --default-identity {default_id2} --public-network-access "DISABLED"')
+        self.cmd('az cosmosdb restore -n {restored_acc} -g {rg} -a {acc} --restore-timestamp {rts} --location {loc} --assign-identity {user_id_2} --default-identity {default_id2}')
         restored_account = self.cmd('az cosmosdb show -n {restored_acc} -g {rg}', checks=[
             self.check('restoreParameters.restoreMode', 'PointInTime')
         ]).get_output_in_json()
@@ -307,6 +307,75 @@ class CosmosDBBackupRestoreScenarioTest(ScenarioTest):
 
         restored_account_defaultIdentity = restored_account['defaultIdentity']
         assert user_id_2 in restored_account_defaultIdentity
+        
+    @AllowLargeResponse()
+    @ResourceGroupPreparer(name_prefix='cli_test_cosmosdb_public_network_access_restore', location='eastus2')
+    def test_cosmosdb_public_network_access_restore(self, resource_group):
+        # Source account parameters
+        source_acc = self.create_random_name(prefix='cli-systemid-', length=25)
+        target_acc = source_acc + "-restored"
+        subscription = self.get_subscription_id()
+        col = self.create_random_name(prefix='cli', length=15)
+        db_name = self.create_random_name(prefix='cli', length=15)
+
+        self.kwargs.update({
+            'acc': source_acc,
+            'restored_acc': target_acc,
+            'db_name': db_name,
+            'col': col,
+            'loc': 'eastus2',
+            'subscriptionid': subscription
+        })
+
+        self.kwargs.update({
+            'user1' : self.create_random_name(prefix='user1-', length = 10),
+            'user2' : self.create_random_name(prefix='user2-', length = 10)
+        })
+
+        # Create PITR account
+        self.cmd('az cosmosdb create -n {acc} -g {rg} --backup-policy-type Continuous --locations regionName={loc} --kind GlobalDocumentDB')
+        account = self.cmd('az cosmosdb show -n {acc} -g {rg}').get_output_in_json()
+        print(account)
+
+        print('Finished creating source account ' + account['id'])
+
+        self.kwargs.update({
+            'ins_id': account['instanceId']
+        })
+
+        # Create database
+        self.cmd('az cosmosdb sql database create -g {rg} -a {acc} -n {db_name}')
+
+        # Create container
+        self.cmd('az cosmosdb sql container create -g {rg} -a {acc} -d {db_name} -n {col} -p /pk ').get_output_in_json()   
+
+        print('Starting to perform restore.')
+
+        restorable_database_account = self.cmd('az cosmosdb restorable-database-account show --location {loc} --instance-id {ins_id}').get_output_in_json()
+
+        account_creation_time = restorable_database_account['creationTime']
+        creation_timestamp_datetime = parser.parse(account_creation_time)
+        restore_ts = creation_timestamp_datetime + timedelta(minutes=4)
+        import time
+        time.sleep(240)
+        restore_ts_string = restore_ts.isoformat()
+        self.kwargs.update({
+            'rts': restore_ts_string
+        })
+
+        self.kwargs.update({
+            'rts': restore_ts_string,
+            'loc': 'eastus2',
+            'pna': 'DISABLED'
+        })
+
+        self.cmd('az cosmosdb restore -n {restored_acc} -g {rg} -a {acc} --restore-timestamp {rts} --location {loc} -p {pna}')
+        restored_account = self.cmd('az cosmosdb show -n {restored_acc} -g {rg}', checks=[
+            self.check('restoreParameters.restoreMode', 'PointInTime')
+        ]).get_output_in_json()
+
+        print(restored_account)
+        print('Finished restoring account ' + restored_account['id'])
 
         public_network_access = restored_account['publicNetworkAccess']
         assert public_network_access == 'Disabled'

--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/tests/latest/test_cosmosdb_backuprestore_scenario.py
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/tests/latest/test_cosmosdb_backuprestore_scenario.py
@@ -349,7 +349,7 @@ class CosmosDBBackupRestoreScenarioTest(ScenarioTest):
         # Create container
         self.cmd('az cosmosdb sql container create -g {rg} -a {acc} -d {db_name} -n {col} -p /pk ').get_output_in_json()   
 
-        print('Starting to perform restore.')
+        print('Starting to perform restore with public network access as DISABLED.')
 
         restorable_database_account = self.cmd('az cosmosdb restorable-database-account show --location {loc} --instance-id {ins_id}').get_output_in_json()
 

--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/tests/latest/test_cosmosdb_backuprestore_scenario.py
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/tests/latest/test_cosmosdb_backuprestore_scenario.py
@@ -294,7 +294,7 @@ class CosmosDBBackupRestoreScenarioTest(ScenarioTest):
             'default_id2' : default_id2
         })
 
-        self.cmd('az cosmosdb restore -n {restored_acc} -g {rg} -a {acc} --restore-timestamp {rts} --location {loc} --assign-identity {user_id_2} --default-identity {default_id2}')
+        self.cmd('az cosmosdb restore -n {restored_acc} -g {rg} -a {acc} --restore-timestamp {rts} --location {loc} --assign-identity {user_id_2} --default-identity {default_id2} --enable-public-network False')
         restored_account = self.cmd('az cosmosdb show -n {restored_acc} -g {rg}', checks=[
             self.check('restoreParameters.restoreMode', 'PointInTime')
         ]).get_output_in_json()
@@ -307,3 +307,6 @@ class CosmosDBBackupRestoreScenarioTest(ScenarioTest):
 
         restored_account_defaultIdentity = restored_account['defaultIdentity']
         assert user_id_2 in restored_account_defaultIdentity
+
+        public_network_access = restored_account['publicNetworkAccess']
+        assert public_network_access == 'Disabled'

--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/tests/latest/test_cosmosdb_backuprestore_scenario.py
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/tests/latest/test_cosmosdb_backuprestore_scenario.py
@@ -294,7 +294,7 @@ class CosmosDBBackupRestoreScenarioTest(ScenarioTest):
             'default_id2' : default_id2
         })
 
-        self.cmd('az cosmosdb restore -n {restored_acc} -g {rg} -a {acc} --restore-timestamp {rts} --location {loc} --assign-identity {user_id_2} --default-identity {default_id2} --enable-public-network False')
+        self.cmd('az cosmosdb restore -n {restored_acc} -g {rg} -a {acc} --restore-timestamp {rts} --location {loc} --assign-identity {user_id_2} --default-identity {default_id2} --public-network-access "DISABLED"')
         restored_account = self.cmd('az cosmosdb show -n {restored_acc} -g {rg}', checks=[
             self.check('restoreParameters.restoreMode', 'PointInTime')
         ]).get_output_in_json()

--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/tests/latest/test_cosmosdb_backuprestore_scenario.py
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/tests/latest/test_cosmosdb_backuprestore_scenario.py
@@ -332,7 +332,7 @@ class CosmosDBBackupRestoreScenarioTest(ScenarioTest):
             'user2' : self.create_random_name(prefix='user2-', length = 10)
         })
 
-        # Create normal PITR account
+        # Create PITR account
         self.cmd('az cosmosdb create -n {acc} -g {rg} --backup-policy-type Continuous --locations regionName={loc} --kind GlobalDocumentDB')
         account = self.cmd('az cosmosdb show -n {acc} -g {rg}').get_output_in_json()
         print(account)


### PR DESCRIPTION
**Related command**
az cosmosdb restore --target-database-account-name --account-name --restore-timestamp -g --location --enable-public-network <TRUE/FALSE>

**Description**<!--Mandatory-->
This pr is to add a parameter (--public-network-access) to the az cosmos db restore cli command. This change requires NO sdk/api changes as this parameter is already existing and used by (create cosmos db cli command). The change is very minor and I have updated one of our tests to take in the parameter & captured its recording.

**Testing Guide**

self.cmd('az cosmosdb restore -n {restored_acc} -g {rg} -a {acc} --restore-timestamp {rts} --location {loc} --assign-identity {user_id_2} --default-identity {default_id2} --public-network-access "DISABLED"')

This will restore the cosmos db account with Public Network Access as disabled. 

**History Notes**
[cosmosdb] `az cosmosdb restore`: Support enabling/disabling public network access

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
