### PR TITLE
{CI} Fix policy migration issue

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -186,7 +186,7 @@ configuration:
       - or:
         - payloadType: Issues
       - isAction:
-          action: Opened
+          action: Labeled
       then:
       - if:
         - hasLabel:


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
There is a breaking change happening during the automated migration.
The `action: Opened` condition is added by [this PR](https://github.com/Azure/azure-cli/pull/26925) during the automated migration, so policy will not act when someone add labels.
Possible solution: use `action: Labeled`.

**Testing Guide**
<!--Example commands with explanations.-->
https://github.com/Azure/azure-cli-extensions/issues/6653
https://github.com/Azure/azure-cli-extensions/issues/6652

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
