### PR TITLE
[Resource] Install correct bicep for apple M1, M2 and respect bicep.use_binary_from_path in all commands

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
@@ -282,6 +282,8 @@ def _get_bicep_download_url(system, release_tag, target_platform=None):
             return download_url.format("bicep-linux-musl-x64")
         return download_url.format("bicep-linux-x64")
     if system == "Darwin":
+        if platform.processor() == 'arm':
+            return download_url.format("bicep-osx-arm64")
         return download_url.format("bicep-osx-x64")
 
     raise ValidationError(f'The platform "{system}" is not supported.')

--- a/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
@@ -58,24 +58,17 @@ def validate_bicep_target_scope(template_schema, deployment_scope):
 
 
 def run_bicep_command(cli_ctx, args, auto_install=True):
-    if _use_binary_from_path(cli_ctx):
-        from shutil import which
+    system = platform.system()
+    bicep_executable_path = _get_bicep_executable_path(cli_ctx, system)
 
-        if which("bicep") is None:
-            raise ValidationError(
-                'Could not find the "bicep" executable on PATH. To install Bicep via Azure CLI, set the "bicep.use_binary_from_path" configuration to False and run "az bicep install".'  # pylint: disable=line-too-long
-            )
+    if bicep_executable_path and not _is_bicep_installation_path(bicep_executable_path, system):
 
-        bicep_version_message = _run_command("bicep", ["--version"])
-
+        bicep_version_message = _get_bicep_installed_version(bicep_executable_path)
         _logger.debug("Using Bicep CLI from PATH. %s", bicep_version_message)
 
-        return _run_command("bicep", args)
+        return _run_command(bicep_executable_path, args)
 
-    installation_path = _get_bicep_installation_path(platform.system())
-    _logger.debug("Bicep CLI installation path: %s", installation_path)
-
-    installed = os.path.isfile(installation_path)
+    installed = os.path.isfile(bicep_executable_path)
     _logger.debug("Bicep CLI installed: %s.", installed)
 
     check_version = cli_ctx.config.getboolean("bicep", "check_version", True)
@@ -91,7 +84,7 @@ def run_bicep_command(cli_ctx, args, auto_install=True):
         with suppress(ClientRequestError):
             # Checking upgrade should ignore connection issues.
             # Users may continue using the current installed version.
-            installed_version = _get_bicep_installed_version(installation_path)
+            installed_version = _get_bicep_installed_version(bicep_executable_path)
             latest_release_tag = get_bicep_latest_release_tag() if cache_expired else latest_release_tag
             latest_version = _extract_version(latest_release_tag)
 
@@ -104,12 +97,12 @@ def run_bicep_command(cli_ctx, args, auto_install=True):
             if cache_expired:
                 _refresh_bicep_version_check_cache(latest_release_tag)
 
-    return _run_command(installation_path, args)
+    return _run_command(bicep_executable_path, args)
 
 
 def ensure_bicep_installation(cli_ctx, release_tag=None, target_platform=None, stdout=True):
     system = platform.system()
-    installation_path = _get_bicep_installation_path(system)
+    installation_path = _get_bicep_executable_path(cli_ctx, system)
 
     if os.path.isfile(installation_path):
         if not release_tag:
@@ -119,6 +112,9 @@ def ensure_bicep_installation(cli_ctx, release_tag=None, target_platform=None, s
         target_version = _extract_version(release_tag)
         if installed_version and target_version and installed_version == target_version:
             return
+
+    if not _is_bicep_installation_path(installation_path, system):
+        installation_path = _get_bicep_installation_path(system)
 
     installation_dir = os.path.dirname(installation_path)
     if not os.path.exists(installation_dir):
@@ -156,10 +152,15 @@ def ensure_bicep_installation(cli_ctx, release_tag=None, target_platform=None, s
 
 def remove_bicep_installation(cli_ctx):
     system = platform.system()
-    installation_path = _get_bicep_installation_path(system)
+    bicep_executable_path = _get_bicep_executable_path(cli_ctx, system)
 
-    if os.path.exists(installation_path):
-        os.remove(installation_path)
+    if not _is_bicep_installation_path(bicep_executable_path, system):
+        raise ValidationError(
+            f'The bicep executable "{bicep_executable_path}" is not managed by Azure CLI. To install Bicep via Azure CLI, set the "bicep.use_binary_from_path" configuration to False and run "az bicep install".'  # pylint: disable=line-too-long
+        )
+
+    if os.path.exists(bicep_executable_path):
+        os.remove(bicep_executable_path)
     if os.path.exists(_bicep_version_check_file_path):
         os.remove(_bicep_version_check_file_path)
 
@@ -196,10 +197,10 @@ def get_bicep_latest_release_tag():
         raise ClientRequestError(f"Error while attempting to retrieve the latest Bicep version: {err}.")
 
 
-def bicep_version_greater_than_or_equal_to(version):
+def bicep_version_greater_than_or_equal_to(cli_ctx, version):
     system = platform.system()
-    installation_path = _get_bicep_installation_path(system)
-    installed_version = _get_bicep_installed_version(installation_path)
+    bicep_executable_path = _get_bicep_executable_path(cli_ctx, system)
+    installed_version = _get_bicep_installed_version(bicep_executable_path)
     parsed_version = semver.VersionInfo.parse(version)
     return installed_version >= parsed_version
 
@@ -288,6 +289,25 @@ def _get_bicep_download_url(system, release_tag, target_platform=None):
 
     raise ValidationError(f'The platform "{system}" is not supported.')
 
+def _get_bicep_executable_path(cli_ctx, system):
+    if _use_binary_from_path(cli_ctx):
+        from shutil import which
+
+        bicep_executable_path = which("bicep")
+
+        if bicep_executable_path is None:
+            raise ValidationError(
+                'Could not find the "bicep" executable on PATH. To install Bicep via Azure CLI, set the "bicep.use_binary_from_path" configuration to False and run "az bicep install".'  # pylint: disable=line-too-long
+            )
+
+        return bicep_executable_path
+
+    bicep_executable_path = _get_bicep_installation_path(system)
+    _logger.debug("Bicep CLI installation path: %s", bicep_executable_path)
+
+
+def _is_bicep_installation_path(bicep_executable_path, system):
+    return bicep_executable_path == _get_bicep_installation_path(system)
 
 def _get_bicep_installation_path(system):
     if system == "Windows":
@@ -303,8 +323,8 @@ def _extract_version(text):
     return semver.VersionInfo.parse(semver_match.group(0)) if semver_match else None
 
 
-def _run_command(bicep_installation_path, args):
-    process = subprocess.run([rf"{bicep_installation_path}"] + args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+def _run_command(bicep_executable_path, args):
+    process = subprocess.run([rf"{bicep_executable_path}"] + args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     try:
         process.check_returncode()

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -972,7 +972,7 @@ def _prepare_deployment_properties_unmodified(cmd, deployment_scope, template_fi
             ensure_bicep_installation(cli_ctx)
 
             minimum_supported_version = "0.14.85"
-            if not bicep_version_greater_than_or_equal_to(minimum_supported_version):
+            if not bicep_version_greater_than_or_equal_to(cli_ctx, minimum_supported_version):
                 raise ArgumentUsageError(f"Unable to compile .bicepparam file with the current version of Bicep CLI. Please upgrade Bicep CLI to {minimum_supported_version} or later.")
             if len(parameters) > 1:
                 raise ArgumentUsageError("Can not use --parameters argument more than once when using a .bicepparam file")
@@ -1175,7 +1175,7 @@ def _prepare_stacks_templates_and_parameters(cmd, rcf, deployment_stack_model, t
             ensure_bicep_installation(cmd.cli_ctx)
 
             minimum_supported_version = "0.14.85"
-            if not bicep_version_greater_than_or_equal_to(minimum_supported_version):
+            if not bicep_version_greater_than_or_equal_to(cmd.cli_ctx, minimum_supported_version):
                 raise ArgumentUsageError(
                     "Unable to compile .bicepparam file with the current version of Bicep CLI. Please use az bicep upgrade to upgrade Bicep CLI.")
             if len(parameters) > 1:
@@ -4289,7 +4289,7 @@ def format_bicep_file(cmd, file, stdout=None, outdir=None, outfile=None, newline
     ensure_bicep_installation(cmd.cli_ctx)
 
     minimum_supported_version = "0.12.1"
-    if bicep_version_greater_than_or_equal_to(minimum_supported_version):
+    if bicep_version_greater_than_or_equal_to(cmd.cli_ctx, minimum_supported_version):
         args = ["format", file]
         if outdir:
             args += ["--outdir", outdir]
@@ -4318,17 +4318,17 @@ def publish_bicep_file(cmd, file, target, documentationUri=None, force=None):
     ensure_bicep_installation(cmd.cli_ctx)
 
     minimum_supported_version = "0.4.1008"
-    if bicep_version_greater_than_or_equal_to(minimum_supported_version):
+    if bicep_version_greater_than_or_equal_to(cmd.cli_ctx, minimum_supported_version):
         args = ["publish", file, "--target", target]
         if documentationUri:
             minimum_supported_version_for_documentationUri_parameter = "0.14.46"
-            if bicep_version_greater_than_or_equal_to(minimum_supported_version_for_documentationUri_parameter):
+            if bicep_version_greater_than_or_equal_to(cmd.cli_ctx, minimum_supported_version_for_documentationUri_parameter):
                 args += ["--documentationUri", documentationUri]
             else:
                 logger.error("az bicep publish with --documentationUri/-d parameter could not be executed with the current version of Bicep CLI. Please upgrade Bicep CLI to v%s or later.", minimum_supported_version_for_documentationUri_parameter)
         if force:
             minimum_supported_version_for_publish_force = "0.17.1"
-            if bicep_version_greater_than_or_equal_to(minimum_supported_version_for_publish_force):
+            if bicep_version_greater_than_or_equal_to(cmd.cli_ctx, minimum_supported_version_for_publish_force):
                 args += ["--force"]
             else:
                 logger.error("az bicep publish with --force parameter could not be executed with the current version of Bicep CLI. Please upgrade Bicep CLI to v%s or later.", minimum_supported_version_for_publish_force)
@@ -4341,7 +4341,7 @@ def restore_bicep_file(cmd, file, force=None):
     ensure_bicep_installation(cmd.cli_ctx)
 
     minimum_supported_version = "0.4.1008"
-    if bicep_version_greater_than_or_equal_to(minimum_supported_version):
+    if bicep_version_greater_than_or_equal_to(cmd.cli_ctx, minimum_supported_version):
         args = ["restore", file]
         if force:
             args += ["--force"]
@@ -4369,7 +4369,7 @@ def generate_params_file(cmd, file, no_restore=None, outdir=None, outfile=None, 
     ensure_bicep_installation(cmd.cli_ctx)
 
     minimum_supported_version = "0.7.4"
-    if bicep_version_greater_than_or_equal_to(minimum_supported_version):
+    if bicep_version_greater_than_or_equal_to(cmd.cli_ctx, minimum_supported_version):
         args = ["generate-params", file]
         if no_restore:
             args += ["--no-restore"]

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_custom.py
@@ -555,7 +555,7 @@ class TestFormatBicepFile(unittest.TestCase):
         format_bicep_file(cmd, file_path, stdout=stdout)
 
         # Assert.
-        mock_bicep_version_greater_than_or_equal_to.assert_called_once_with("0.12.1")
+        mock_bicep_version_greater_than_or_equal_to.assert_called_once_with(cmd.cli_ctx, "0.12.1")
         mock_run_bicep_command.assert_called_once_with(cmd.cli_ctx, ["format", file_path, "--stdout"])        
         
 if __name__ == '__main__':


### PR DESCRIPTION
**Related command**
- az deployment group create (with bicep)
- az bicep x

**Description**
The commands above and almost all other `az bicep ..` commands call `ensure_bicep_installation(cmd.cli_ctx)` which doesn't respect the `bicep.use_binary_from_path` and installs a new the bicep executable the `.azure/bin` regardless if `bicep.use_binary_from_path=true`.

This is annoying, but the wrong archetecure was being selected for osx arm machines, resulting in `az deployment group|sub create` and all `az bicep xx` commands failing with:
> [Errno 86] Bad CPU type in executable: '/Users/colbylwilliams/.azure/bin/bicep'

![Screenshot 2023-08-17 at 7 02 39 PM](https://github.com/Azure/azure-cli/assets/1829082/6efc3470-8d94-4c63-82ec-67e3e3834dde)

> {
  "azure-cli": "2.50.0",
  "azure-cli-core": "2.50.0",
  "azure-cli-telemetry": "1.0.8",
  "extensions": {
    "devcenter": "2.0.0"
  }
}


**Testing Guide**
See screenshot.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
