### PR TITLE
{Upgrade} Skip upgrade if latest version is None

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/util/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/util/custom.py
@@ -51,15 +51,17 @@ def upgrade_version(cmd, update_all=None, yes=None):  # pylint: disable=too-many
 
     update_cli = True
     from azure.cli.core.util import get_latest_from_github
-    try:
-        latest_version = get_latest_from_github()
-        if latest_version and parse(latest_version) <= parse(local_version):
-            logger.warning("You already have the latest azure-cli version: %s", local_version)
-            update_cli = False
-            if not update_all:
-                return
-    except Exception as ex:  # pylint: disable=broad-except
-        logger.debug("Failed to get the latest version. %s", str(ex))
+    latest_version = get_latest_from_github()
+    if not latest_version:
+        logger.warning("Failed to get the latest azure-cli version.")
+        update_cli = False
+        if not update_all:
+            return
+    elif parse(latest_version) <= parse(local_version):
+        logger.warning("You already have the latest azure-cli version: %s", local_version)
+        update_cli = False
+        if not update_all:
+            return
     exts = [ext.name for ext in get_extensions(ext_type=WheelExtension)] if update_all else []
 
     exit_code = 0


### PR DESCRIPTION
**Related command**
`az upgrade`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Currently, if it fails to get latest version from GitHub, latest version becomes `None`. It still prompts for upgrade.
![image](https://github.com/Azure/azure-cli/assets/2227874/3d2ca6db-f67b-4a57-beb5-7bc69c088587)
This PR skips the upgrade if latest version is `None`.
![image](https://github.com/Azure/azure-cli/assets/2227874/99decc9a-e21e-40f9-8ae0-dea5392911df)


**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
