### PR TITLE
[Redis] Fix az redis : Defaulting the value of PublicNetworkAccess to None or to current redis::PublicNetworkAccess

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/redis/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/redis/custom.py
@@ -68,6 +68,7 @@ def cli_redis_update(cmd, instance, sku=None, vm_size=None):
         shard_count=instance.shard_count,
         minimum_tls_version=instance.minimum_tls_version,
         redis_version=instance.redis_version,
+        public_network_access=instance.public_network_access,
         sku=instance.sku,
         tags=instance.tags
     )
@@ -222,7 +223,9 @@ def cli_redis_identity_assign(client, resource_group_name, cache_name, mi_system
             for user_id in old_user_identity:
                 mi_user_assigned.append(user_id)
     update_params = RedisUpdateParameters(
-        identity=build_identity(mi_system_assigned, mi_user_assigned))
+        identity=build_identity(mi_system_assigned, mi_user_assigned),
+        public_network_access=None
+    )
     redis_resourse = client.begin_update(resource_group_name, cache_name, update_params).result()
     return redis_resourse.identity
 
@@ -253,7 +256,8 @@ def cli_redis_identity_remove(client, resource_group_name, cache_name, mi_system
         if len(user_assigned) == 0:
             user_assigned = None
     update_params = RedisUpdateParameters(
-        identity=build_identity(system_assigned, user_assigned)
+        identity=build_identity(system_assigned, user_assigned),
+        public_network_access=None
     )
     updated_resourse = client.begin_update(resource_group_name, cache_name, update_params).result()
     if updated_resourse.identity is None:


### PR DESCRIPTION
**Related command**
az redis update
az redis identity add
az redis identity remove

**Description**<!--Mandatory-->
As part of the update & identity az redis commands, a default value of PublicNetworkAccess=Enabled was being passed even though this was not intentionally provided as part of the command. This resulted in errors with the following signature. 
![image](https://github.com/Azure/azure-cli/assets/93312257/6e69f018-c7b5-43db-93ac-4bbe6866ae14)

As part of this fix, we're defaulting the value of PublicNetworkAccess to None or to existing redis::PublicNetworkAccess.

**Testing Guide**
Post this bug fix, we would be able to use the above commands freely without any side-effects of PublicNetworkAccess. To test, feel free to use the below commands on a Private Link Enabled cache, test validations should depict successful command runs.
- az redis identity assign --mi-system-assigned -g helloworld -n ak-test-cache-hw-1
- az redis identity remove --mi-system-assigned -g helloworld -n ak-test-cache-hw-1
- az redis update -g helloworld -n ak-test-cache-hw-1 --vm-size P3
![image](https://github.com/Azure/azure-cli/assets/93312257/7a4dd34b-05c7-4af4-9f3e-02ace5537adc)


**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
