### PR TITLE
[Cognitive Services] `az account deployment create` support `--model-source` parameter

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/cognitiveservices/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/cognitiveservices/_params.py
@@ -177,6 +177,7 @@ def load_arguments(self, _):
         c.argument('model_name', help='Cognitive Services account deployment model name.')
         c.argument('model_format', help='Cognitive Services account deployment model format.')
         c.argument('model_version', help='Cognitive Services account deployment model version.')
+        c.argument('model_source', help='Cognitive Services account deployment model source.')
 
     with self.argument_context('cognitiveservices account deployment', arg_group='DeploymentScaleSettings') as c:
         c.argument(

--- a/src/azure-cli/azure/cli/command_modules/cognitiveservices/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/cognitiveservices/custom.py
@@ -246,7 +246,7 @@ def identity_show(client, resource_group_name, account_name):
 
 def deployment_begin_create_or_update(
         client, resource_group_name, account_name, deployment_name,
-        model_format, model_name, model_version,
+        model_format, model_name, model_version, model_source=None,
         sku_name=None, sku_capacity=None,
         scale_settings_scale_type=None, scale_settings_capacity=None):
     """
@@ -258,6 +258,8 @@ def deployment_begin_create_or_update(
     dpy.properties.model.format = model_format
     dpy.properties.model.name = model_name
     dpy.properties.model.version = model_version
+    if model_source is not None:
+        dpy.properties.model.source = model_source
     if sku_name is not None:
         dpy.sku = Sku(name=sku_name)
         dpy.sku.capacity = sku_capacity


### PR DESCRIPTION
**Related command**
`az cognitiveservices account deployment create`

**Description**<!--Mandatory-->
`az cognitiveservices account deployment create` add `--model-source` parameter.

**Testing Guide**
Sample usage
`az cognitiveservices account deployment create --resource-group felixwa-byom --name felixwa-byom-test-2 --deployment-name fromWS1 --model-format OpenAI --model-name felixwamodel1 --model-version 1 --model-source /subscriptions/f9b96b36-1f5e-4021-8959-51527e26e6d3/resourcegroups/felixwa-byom/providers/Microsoft.MachineLearningServices/workspaces/felixwa-byom-test-1
`
UT didn't cover this case as the setup is too complicated to be done in UT.

**History Notes**
[Cognitive Services] `az cognitiveservices account deployment create`: Add `--model-source` parameter

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
