### PR TITLE
{ACR} Remove incorrect examples from the documentation

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_help.py
@@ -351,13 +351,7 @@ short-summary: Manage network rules for Azure Container Registries.
 helps['acr network-rule add'] = """
 type: command
 short-summary: Add a network rule.
-examples:
-  - name: Add a rule to allow access for a subnet in the same resource group as the registry.
-    text: >
-        az acr network-rule add -n MyRegistry --vnet-name myvnet --subnet mysubnet
-  - name: Add a rule to allow access for a subnet in a different subscription or resource group.
-    text: >
-        az acr network-rule add -n MyRegistry --subnet /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRG/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet
+examples: 
   - name: Add a rule to allow access for a specific IP address-range.
     text: >
         az acr network-rule add -n MyRegistry --ip-address 23.45.1.0/24
@@ -376,12 +370,6 @@ helps['acr network-rule remove'] = """
 type: command
 short-summary: Remove a network rule.
 examples:
-  - name: Remove a rule that allows access for a subnet in the same resource group as the registry.
-    text: >
-        az acr network-rule remove -n MyRegistry --vnet-name myvnet --subnet mysubnet
-  - name: Remove a rule that allows access for a subnet in a different subscription or resource group.
-    text: >
-        az acr network-rule remove -n MyRegistry --subnet /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRG/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet
   - name: Remove a rule that allows access for a specific IP address-range.
     text: >
         az acr network-rule remove -n MyRegistry --ip-address 23.45.1.0/24

--- a/src/azure-cli/azure/cli/command_modules/acr/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_help.py
@@ -351,7 +351,7 @@ short-summary: Manage network rules for Azure Container Registries.
 helps['acr network-rule add'] = """
 type: command
 short-summary: Add a network rule.
-examples: 
+examples:
   - name: Add a rule to allow access for a specific IP address-range.
     text: >
         az acr network-rule add -n MyRegistry --ip-address 23.45.1.0/24


### PR DESCRIPTION
**Related command**
`az acr network-rule add` and `az acr network-rule remove`

**Description**<!--Mandatory-->
 Remove incorrect examples having `--subnet` parameter from the documentation as this parameter has been deprecated.
Fixes GitHub Issue [27224](https://github.com/Azure/azure-cli/issues/27224)

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
