### PR TITLE
[Keyvault] `az keyvault storage`: Announce deprecation since keyvault service doesn't maintain this since long ago

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/keyvault/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/commands.py
@@ -335,7 +335,7 @@ def load_command_table(self, _):
         replace('.', '_').replace('-', '_')
 
     if data_api_version != '2016_10_01':
-        with self.command_group('keyvault storage', data_entity.command_type) as g:
+        with self.command_group('keyvault storage', data_entity.command_type, deprecate_info=self.deprecate()) as g:
             g.keyvault_command('add', 'set_storage_account')
             g.keyvault_command('list', 'get_storage_accounts', transform=keep_max_results)
             g.keyvault_command('show', 'get_storage_account')


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az keyvault storage`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
`az keyvault storage` is still using track1 SDK and there's no track2 SDK for `azure-keyvault-storage`.

Service team said they don't maintain keyvault storage related APIs anymore. It's suggested to deprecate related commands in CLI too.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
