### PR TITLE
[ACR] `az acr token create`: Fix random order of repo valid actions and gateway valid actions in the help message

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_params.py
@@ -431,8 +431,8 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
         c.argument('scope_map_name', options_list=['--name', '-n'], help='The name of the scope map.', required=True)
 
     # Action strings generated this way to ensure consistent ordering each time the help text is generated.
-    repo_valid_actions = "Valid actions are {}".format(sorted(list(action.value for action in RepoScopeMapActions)))
-    gateway_valid_actions = "Valid actions are {}".format(sorted(list(action.value for action in GatewayScopeMapActions)))
+    repo_valid_actions = "Valid actions are {}".format(sorted(action.value for action in RepoScopeMapActions))
+    gateway_valid_actions = "Valid actions are {}".format(sorted(action.value for action in GatewayScopeMapActions))
     with self.argument_context('acr scope-map update') as c:
         c.argument('add_repository', options_list=['--add-repository', c.deprecate(target='--add', redirect='--add-repository', hide=True)], nargs='+', action='append', required=False,
                    help='repository permissions to be added. Use the format "--add-repository REPO [ACTION1 ACTION2 ...]" per flag. ' + repo_valid_actions)

--- a/src/azure-cli/azure/cli/command_modules/acr/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_params.py
@@ -430,8 +430,9 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
         c.argument('description', options_list=['--description'], help='Description for the scope map. Maximum 256 characters are allowed.', required=False)
         c.argument('scope_map_name', options_list=['--name', '-n'], help='The name of the scope map.', required=True)
 
-    repo_valid_actions = "Valid actions are {}".format({action.value for action in RepoScopeMapActions})
-    gateway_valid_actions = "Valid actions are {}".format({action.value for action in GatewayScopeMapActions})
+    # Action strings generated this way to ensure consistent ordering each time the help text is generated.
+    repo_valid_actions = "Valid actions are {" + ', '.join('\'{}\''.format(action.value) for action in RepoScopeMapActions) + "}."
+    gateway_valid_actions = "Valid actions are {" + ', '.join('\'{}\''.format(action.value) for action in GatewayScopeMapActions) + "}."
     with self.argument_context('acr scope-map update') as c:
         c.argument('add_repository', options_list=['--add-repository', c.deprecate(target='--add', redirect='--add-repository', hide=True)], nargs='+', action='append', required=False,
                    help='repository permissions to be added. Use the format "--add-repository REPO [ACTION1 ACTION2 ...]" per flag. ' + repo_valid_actions)

--- a/src/azure-cli/azure/cli/command_modules/acr/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_params.py
@@ -431,8 +431,8 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
         c.argument('scope_map_name', options_list=['--name', '-n'], help='The name of the scope map.', required=True)
 
     # Action strings generated this way to ensure consistent ordering each time the help text is generated.
-    repo_valid_actions = "Valid actions are {" + ', '.join('\'{}\''.format(action.value) for action in RepoScopeMapActions) + "}."
-    gateway_valid_actions = "Valid actions are {" + ', '.join('\'{}\''.format(action.value) for action in GatewayScopeMapActions) + "}."
+    repo_valid_actions = "Valid actions are {}".format(sorted(list(action.value for action in RepoScopeMapActions)))
+    gateway_valid_actions = "Valid actions are {}".format(sorted(list(action.value for action in GatewayScopeMapActions)))
     with self.argument_context('acr scope-map update') as c:
         c.argument('add_repository', options_list=['--add-repository', c.deprecate(target='--add', redirect='--add-repository', hide=True)], nargs='+', action='append', required=False,
                    help='repository permissions to be added. Use the format "--add-repository REPO [ACTION1 ACTION2 ...]" per flag. ' + repo_valid_actions)


### PR DESCRIPTION
**Related command**
az acr token create -h

**Description**<!--Mandatory-->
Currently, the order of allowed actions listed in the help text is random and changes every time the -h is invoked. This causes problem for the docs people who are diffing the help text at regular intervals.

**Testing Guide**
az acr token create -h

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[ACR] `az acr token create`: Fix random order of repo valid actions and gateway valid actions in the help message


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
