### PR TITLE
{CI} Temporarily skip k8s-extension in TestExtensionsLoading

### DIFF
--- a/scripts/ci/test_extensions.sh
+++ b/scripts/ci/test_extensions.sh
@@ -19,7 +19,8 @@ output=$(az extension list-available --query [].name -otsv)
 exit_code=0
 
 # azure-cli-ml: https://github.com/Azure/azure-cli-extensions/issues/826
-ignore_list='azure-cli-ml fzf arcappliance arcdata connectedk8s'
+# Disable k8s-extension temporarily: https://github.com/Azure/azure-cli-extensions/pull/6702
+ignore_list='azure-cli-ml fzf arcappliance arcdata connectedk8s k8s-extension'
 
 for ext in $output; do
     echo


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
k8s-extension is rolled back to 1.4.3 in https://github.com/Azure/azure-cli-extensions/pull/6702, which is not compatible with latest azure-cli

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
