### PR TITLE
{ARM} `az bicep`: Change tests to live only mode

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
@@ -4991,7 +4991,7 @@ class BicepScenarioTest(ScenarioTest):
             self.greater_than('length(@)', 0)
         ])
 
-class BicepDecompileParamsTest(ScenarioTest):
+class BicepDecompileParamsTest(LiveScenarioTest):
     def setup(self):
         super().setup()
         self.cmd('az bicep uninstall')
@@ -5014,7 +5014,7 @@ class BicepDecompileParamsTest(ScenarioTest):
         if os.path.exists(params_path):
             os.remove(params_path)
 
-class BicepBuildParamsTest(ScenarioTest):
+class BicepBuildParamsTest(LiveScenarioTest):
     def setup(self):
         super().setup()
         self.cmd('az bicep uninstall')

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_custom.py
@@ -36,6 +36,8 @@ from azure.cli.core import AzCommandsLoader
 from azure.cli.core.commands import AzCliCommand
 from azure.cli.core.profiles._shared import ResourceType
 
+from azure.cli.testsdk import live_only
+
 cli_ctx = DummyCli()
 loader = AzCommandsLoader(cli_ctx, resource_type=ResourceType.MGMT_RESOURCE_RESOURCES)
 cmd = AzCliCommand(loader, 'test', None)
@@ -365,6 +367,7 @@ class TestCustom(unittest.TestCase):
         self.assertEqual(_is_bicepparam_file_provided([['test.bicepparam']]), True)
         self.assertEqual(_is_bicepparam_file_provided([['test.bicepparam'], ['test.json'],  ['{ \"foo\": { \"value\": \"bar\" } }']]), True)
 
+    @live_only()
     def test_bicep_generate_params_defaults(self):
         curr_dir = os.path.dirname(os.path.realpath(__file__))
         bicep_file = os.path.join(curr_dir, 'sample_params.bicep').replace('\\', '\\\\')
@@ -374,6 +377,7 @@ class TestCustom(unittest.TestCase):
         is_generated_params_file_exists = os.path.exists(json_file)
         self.assertTrue(is_generated_params_file_exists)
 
+    @live_only()
     def test_bicep_generate_params_output_format(self):
         curr_dir = os.path.dirname(os.path.realpath(__file__))
         bicep_file = os.path.join(curr_dir, 'sample_params.bicep').replace('\\', '\\\\')
@@ -383,6 +387,7 @@ class TestCustom(unittest.TestCase):
         is_generated_params_file_exists = os.path.exists(json_file)
         self.assertTrue(is_generated_params_file_exists)
 
+    @live_only()
     def test_bicep_generate_params_include_params(self):
         curr_dir = os.path.dirname(os.path.realpath(__file__))
         bicep_file = os.path.join(curr_dir, 'sample_params.bicep').replace('\\', '\\\\')
@@ -392,6 +397,7 @@ class TestCustom(unittest.TestCase):
         is_generated_params_file_exists = os.path.exists(json_file)
         self.assertTrue(is_generated_params_file_exists)
 
+    @live_only()
     def test_bicep_build_params_defaults(self):
         curr_dir = os.path.dirname(os.path.realpath(__file__))
         param_file = os.path.join(curr_dir, 'sample_params.bicepparam').replace('\\', '\\\\')
@@ -402,6 +408,7 @@ class TestCustom(unittest.TestCase):
 
         self.assertTrue(is_generated_params_file_exists)
 
+    @live_only()
     def test_bicep_decompile_params_defaults(self):
         curr_dir = os.path.dirname(os.path.realpath(__file__))
         param_file = os.path.join(curr_dir, 'param-validation-params.bicepparam').replace('\\', '\\\\')


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

`az bicep`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Change below tests to live only mode:

- `BicepDecompileParamsTest`
- `BicepBuildParamsTest`
- `test_bicep_generate_params_defaults`
- `test_bicep_generate_params_output_format`
- `test_bicep_generate_params_include_params`
- `test_bicep_build_params_defaults`
- `test_bicep_decompile_params_defaults`

Fix: #26781

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
