### PR TITLE
{Core} Sort command loaders to avoid random diff in docs

### DIFF
--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -489,7 +489,11 @@ class MainCommandsLoader(CLICommandsLoader):
 
         return self.command_table
 
-    def sort_command_loaders(self, command_loaders):
+    @staticmethod
+    def _sort_command_loaders(self, command_loaders):
+        if len(command_loaders) == 1:
+            return list(command_loaders)
+
         module_command_loaders = []
         extension_command_loaders = []
 
@@ -523,7 +527,7 @@ class MainCommandsLoader(CLICommandsLoader):
             command_loaders = self.cmd_to_loader_map.get(command, None)
 
         if command_loaders:
-            command_loaders = self.sort_command_loaders(command_loaders)
+            command_loaders = self._sort_command_loaders(command_loaders)
             for loader in command_loaders:
 
                 # register global args

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -490,7 +490,7 @@ class MainCommandsLoader(CLICommandsLoader):
         return self.command_table
 
     @staticmethod
-    def _sort_command_loaders(self, command_loaders):
+    def _sort_command_loaders(command_loaders):
         if len(command_loaders) == 1:
             return list(command_loaders)
 

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -491,9 +491,6 @@ class MainCommandsLoader(CLICommandsLoader):
 
     @staticmethod
     def _sort_command_loaders(command_loaders):
-        if len(command_loaders) == 1:
-            return list(command_loaders)
-
         module_command_loaders = []
         extension_command_loaders = []
 
@@ -522,12 +519,13 @@ class MainCommandsLoader(CLICommandsLoader):
             command_loaders = set()
             for loaders in self.cmd_to_loader_map.values():
                 command_loaders = command_loaders.union(set(loaders))
+            # sort command loaders for consistent order when loading all commands for docs generation to avoid random diff
+            command_loaders = self._sort_command_loaders(command_loaders)
             logger.info('Applying %s command loaders...', len(command_loaders))
         else:
             command_loaders = self.cmd_to_loader_map.get(command, None)
 
         if command_loaders:
-            command_loaders = self._sort_command_loaders(command_loaders)
             for loader in command_loaders:
 
                 # register global args

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -489,6 +489,25 @@ class MainCommandsLoader(CLICommandsLoader):
 
         return self.command_table
 
+    def sort_command_loaders(self, command_loaders):
+        core_command_loaders = []
+        extension_command_loaders = []
+
+        # Separate core and extension command loaders
+        for loader in command_loaders:
+            if loader.__module__.startswith('azext'):
+                extension_command_loaders.append(loader)
+            else:
+                core_command_loaders.append(loader)
+        
+        # Sort name in each command loader list
+        core_command_loaders.sort(key=lambda loader: loader.__class__.__name__)
+        extension_command_loaders.sort(key=lambda loader: loader.__class__.__name__)
+
+        # Core first, then extension
+        sorted_command_loaders = core_command_loaders + extension_command_loaders
+        return sorted_command_loaders
+
     def load_arguments(self, command=None):
         from azure.cli.core.commands.parameters import (
             resource_group_name_type, get_location_type, deployment_name_type, vnet_name_type, subnet_name_type)
@@ -504,6 +523,7 @@ class MainCommandsLoader(CLICommandsLoader):
             command_loaders = self.cmd_to_loader_map.get(command, None)
 
         if command_loaders:
+            command_loaders = self.sort_command_loaders(command_loaders)
             for loader in command_loaders:
 
                 # register global args

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -490,22 +490,22 @@ class MainCommandsLoader(CLICommandsLoader):
         return self.command_table
 
     def sort_command_loaders(self, command_loaders):
-        core_command_loaders = []
+        module_command_loaders = []
         extension_command_loaders = []
 
-        # Separate core and extension command loaders
+        # Separate module and extension command loaders
         for loader in command_loaders:
             if loader.__module__.startswith('azext'):
                 extension_command_loaders.append(loader)
             else:
-                core_command_loaders.append(loader)
+                module_command_loaders.append(loader)
         
         # Sort name in each command loader list
-        core_command_loaders.sort(key=lambda loader: loader.__class__.__name__)
+        module_command_loaders.sort(key=lambda loader: loader.__class__.__name__)
         extension_command_loaders.sort(key=lambda loader: loader.__class__.__name__)
 
-        # Core first, then extension
-        sorted_command_loaders = core_command_loaders + extension_command_loaders
+        # Module first, then extension
+        sorted_command_loaders = module_command_loaders + extension_command_loaders
         return sorted_command_loaders
 
     def load_arguments(self, command=None):

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -503,7 +503,7 @@ class MainCommandsLoader(CLICommandsLoader):
                 extension_command_loaders.append(loader)
             else:
                 module_command_loaders.append(loader)
-        
+
         # Sort name in each command loader list
         module_command_loaders.sort(key=lambda loader: loader.__class__.__name__)
         extension_command_loaders.sort(key=lambda loader: loader.__class__.__name__)


### PR DESCRIPTION
**Related command**
Should be all commands when batch export the help files. Examples: `az acr query`, `az ad ds create`, `az mysql down`.

**Description**<!--Mandatory-->
We found random output of arguments while batch getting help files, it is because of the random sequence of command loaders. 
![image](https://github.com/Azure/azure-cli/assets/34960224/55c52ca0-de92-48ec-b8dc-f97362431cc0)
The random output is introduced by ___for looping a set___, as set in Python is unordered, every execution can lead to different result, and that makes the help files randomly get wrong parameter detail and wrong parameter group info when exporting it in a batch by calling `load_arguments()` in *line 487*. 
After making change to sort the command loader list, the output become steady and correct in my local test. So, we need a steady sequence with the correct order (extension loaders first) here to get a steady and correct output for help files.

For example 1 `az ad ds create`, when export all help files while installed extension `ad`, the parameter "subscription" might be loaded by `azext_ad.DomainServicesResorceProviderCommandsLoader` or `azure.cli.command_modules.role.RoleCommandsLoader`. If the arguments are first updated by `azure.cli.command_modules.role.RoleCommandsLoader`, the parameter "subscription" is lacking; If the arguments are first updated by `azext_ad.DomainServicesResorceProviderCommandsLoader`, the parameter "subscription" will exist and align with the output of `az ad ds create -h`. 
![image](https://github.com/Azure/azure-cli/assets/34960224/6ec1f8a3-0b24-47bd-8870-a82ede6867f9)

For example 2 `az mysql down`, when export all help files while installed extension `db-up`, parameters might be loaded by `azext_db_up.DbupCommandsLoader` or `azure.cli.command_modules.rdbms.RdbmsCommandsLoader`. If the arguments are first updated by `azure.cli.command_modules.rdbms.RdbmsCommandsLoader`, the parameters in help files are:

Command | Parameter | group_name
-- | -- | --
az mysql down | --subscription | Resource Id Arguments
az mysql down | --resource-group -g | Resource Id Arguments
az mysql down | --server-name -s | Resource Id Arguments
az mysql down | --ids | Resource Id Arguments

If the arguments are first updated by `azext_db_up.DbupCommandsLoader`, the parameters align with the output of `az mysql down -h`:

Command | Parameter | group_name
-- | -- | --
az mysql down | --subscription | Global Arguments
az mysql down | --resource-group -g | null
az mysql down | --server-name -s | null

![image](https://github.com/Azure/azure-cli/assets/34960224/5284d398-3451-4e1c-b1a9-55d57e5ce4db)

For example 3 `az acr query`, when export all help files while installed extension `acrquery`, the parameter "username" and "password" might be loaded by `azure.cli.command_modules.acr.ACRCommandsLoader` or `azext_acrquery.AcrqueryCommandsLoader`. If the arguments are first updated by `azure.cli.command_modules.acr.ACRCommandsLoader`, the option lists in the object of these parameters will be ['--username', '-u'] and ['--password', '-p'], which is from [azure-cli/src/azure-cli/azure/cli/command_modules/acr/_params.py at main · Azure/azure-cli (github.com)](https://github.com/Azure/azure-cli/blob/main/src/azure-cli/azure/cli/command_modules/acr/_params.py#L90), otherwise if the arguments are first updated by `azext_acrquery.AcrqueryCommandsLoader`, the option lists in the object of these parameters will be ['--username'] and ['--password'], which is from [azure-cli-extensions/src/acrquery/azext_acrquery/_params.py at main · Azure/azure-cli-extensions (github.com)](https://github.com/Azure/azure-cli-extensions/blob/main/src/acrquery/azext_acrquery/_params.py#L16). 

For example 4 `az iot hub certificate root-authority set` in extension `azure-iot`, the parameter `--hub-name` will sometimes has `-n` and sometimes not, caused by random loader sequence. 
![image](https://github.com/user-attachments/assets/3b0b16b0-0514-4c9e-ab6d-167671c29fbe)

For example 5 `az webapp scan show-result` in extension `webapp`, several parameters change back and forth as below, caused by random loader sequence. 
![image](https://github.com/user-attachments/assets/1f59d866-c907-4f50-964e-1ca0e2bbdd38)


**Testing Guide**
<!--Example commands with explanations.-->
Check the arguments detail in the help objects of the example commands to make sure no random changes with different runs.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
