### PR TITLE
{Test} Support get sharekey in `LogAnalyticsWorkspacePreparer`

### DIFF
--- a/src/azure-cli-testsdk/azure/cli/testsdk/preparers.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/preparers.py
@@ -492,13 +492,14 @@ class VnetNicPreparer(NoTrafficRecordingPreparer, SingleValueReplacer):
 
 class LogAnalyticsWorkspacePreparer(NoTrafficRecordingPreparer, SingleValueReplacer):
     def __init__(self, name_prefix='laworkspace', location='eastus2euap', parameter_name='laworkspace',
-                 resource_group_parameter_name='resource_group', skip_delete=False):
+                 resource_group_parameter_name='resource_group', skip_delete=False, get_shared_key=False):
         super(LogAnalyticsWorkspacePreparer, self).__init__(name_prefix, 15)
         self.cli_ctx = get_dummy_cli()
         self.location = location
         self.parameter_name = parameter_name
         self.resource_group_parameter_name = resource_group_parameter_name
         self.skip_delete = skip_delete
+        self.get_shared_key = get_shared_key
 
     def create_resource(self, name, **kwargs):
         group = self._get_resource_group(**kwargs)
@@ -507,16 +508,18 @@ class LogAnalyticsWorkspacePreparer(NoTrafficRecordingPreparer, SingleValueRepla
             customer_id = self.live_only_execute(self.cli_ctx, template.format(self.location, group, name)).get_output_in_json()["customerId"]
         except AttributeError:  # live only execute returns None if playing from record
             customer_id = None
+        if self.get_shared_key:
+            get_share_key_template = ('az monitor log-analytics workspace get-shared-keys -g {} -n {}')
+            try:
+                log_shared_key = self.live_only_execute(self.cli_ctx, get_share_key_template.format(group, name)).get_output_in_json()["primarySharedKey"]
+            except AttributeError:  # live only execute returns None if playing from record
+                log_shared_key = None
 
-        get_share_key_template = ('az monitor log-analytics workspace get-shared-keys -g {} -n {}')
-        try:
-            log_shared_key = self.live_only_execute(self.cli_ctx, get_share_key_template.format(group, name)).get_output_in_json()["primarySharedKey"]
-        except AttributeError:  # live only execute returns None if playing from record
-            log_shared_key = None
+            return {self.parameter_name: name,
+                    self.parameter_name + '_customer_id': (customer_id or 'veryFakedCustomerId=='),
+                    self.parameter_name + '_shared_key': (log_shared_key or 'veryFakedPrivateSharedKey==')}
 
-        return {self.parameter_name: name,
-                self.parameter_name + '_customer_id': (customer_id or 'veryFakedCustomerId=='),
-                self.parameter_name + '_shared_key': (log_shared_key or 'veryFakedPrivateSharedKey==')}
+        return {self.parameter_name: name}
 
     def remove_resource(self, name, **kwargs):
         if not self.skip_delete:


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az containerapp

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Create containerapp managed environment needs arguments --logs-workspace-id and --logs-workspace-key.
The --logs-workspace-key is log workspace customerId, --logs-workspace-key is primarySharedKey.
We hope it can be prepared well and the `NoTrafficRecording`, So need to change the `LogAnalyticsWorkspacePreparer` to return multiple parameters include `customerId` and `primarySharedKey`

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
