### PR TITLE
[Storage] Fix #26732: `az storage blob copy start-batch`: Add `--rehydrate-priority` to batch copy

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_params.py
@@ -1359,11 +1359,11 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
         c.argument('source_sas')
         c.argument('source_container')
         c.argument('source_share')
-
-        c.extra('tier', tier_type)
+        c.extra('rehydrate_priority', rehydrate_priority_type, arg_group=None)
+        c.extra('tier', tier_type, arg_group=None)
         c.extra('destination_blob_type', arg_type=get_enum_type(['Detect', 'BlockBlob', 'PageBlob', 'AppendBlob']),
                 help='Defines the type of blob at the destination. '
-                     'Value of "Detect" determines the type based on source blob type.')
+                     'Value of "Detect" determines the type based on source blob type.', arg_group=None)
 
     with self.argument_context('storage blob incremental-copy start') as c:
         from azure.cli.command_modules.storage._validators import process_blob_source_uri

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_blob_copy_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_blob_copy_scenarios.py
@@ -492,3 +492,31 @@ class StorageBlobCopyTests(StorageScenarioMixin, LiveScenarioTest):
                 assert_with_checks([JMESPathCheck('properties.blobTier', tier)])
             self.storage_cmd('storage blob show -c {} -n srcPrePageBlob', accountpremium_info, dst_container). \
                 assert_with_checks([JMESPathCheck('properties.blobTier', tier)])
+
+    @ResourceGroupPreparer()
+    @StorageAccountPreparer(kind='storageV2')
+    def test_storage_blob_copy_batch_rehydrate_priority(self, resource_group, storage_account):
+        source_file_1 = self.create_temp_file(16)
+        source_file_2 = self.create_temp_file(16)
+        account_info = self.get_account_info(resource_group, storage_account)
+        src_name_1 = self.create_random_name('blob', 16)
+        src_name_2 = self.create_random_name('blob', 16)
+
+        source_container = self.create_container(account_info)
+        target_container = self.create_container(account_info)
+
+        for src in [(source_file_1, src_name_1), (source_file_2, src_name_2)]:
+            self.storage_cmd('storage blob upload -c {} -f "{}" -n {} ', account_info,
+                             source_container, src[0], src[1])
+            self.storage_cmd('storage blob set-tier -c {} -n {} --tier Archive', account_info,
+                             source_container, src[1])
+            self.storage_cmd('az storage blob show -c {} -n {} ', account_info, source_container, src[1]) \
+                .assert_with_checks(JMESPathCheck('properties.blobTier', 'Archive'))
+
+        self.storage_cmd('storage blob copy start-batch --destination-container {} --source-container {} '
+                         '--source-account-name {} --source-account-key {} --tier Cool -r High', account_info,
+                         target_container, source_container, account_info[0], account_info[1])
+        for src in [src_name_1, src_name_2]:
+            self.storage_cmd('storage blob show -c {} -n {} ', account_info, target_container, src) \
+                .assert_with_checks(JMESPathCheck('properties.blobTier', 'Archive'),
+                                    JMESPathCheck('properties.rehydrationStatus', 'rehydrate-pending-to-cool'))


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Add `--rehydrate-priority` to `az storage blob copy start-batch`
Fix #26732 

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Storage] Fix #26732: `az storage blob copy start-batch`: Add `--rehydrate-priority` to batch copy

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
