### PR TITLE
[Core] `aaz`: Fix command name case issue for aaz command table lazy load

### DIFF
--- a/src/azure-cli-core/azure/cli/core/aaz/_command.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_command.py
@@ -394,7 +394,7 @@ def load_aaz_command_table(loader, aaz_pkg_name, args):
         arg_str = ''
         fully_load = True
     else:
-        arg_str = ' '.join(args)
+        arg_str = ' '.join(args).lower()  # Sometimes args may contain capital letters.
         fully_load = os.environ.get(AAZ_PACKAGE_FULL_LOAD_ENV_NAME, 'False').lower() == 'true'  # disable cut logic
     if profile_pkg is not None:
         _load_aaz_pkg(loader, profile_pkg, command_table, command_group_table, arg_str, fully_load)
@@ -449,7 +449,7 @@ def _load_aaz_pkg(loader, pkg, parent_command_table, command_group_table, arg_st
             if issubclass(value, AAZCommandGroup):
                 if value.AZ_NAME:
                     # AAZCommandGroup already be registered by register_command_command
-                    if not arg_str.startswith(f'{value.AZ_NAME} '):
+                    if not arg_str.startswith(f'{value.AZ_NAME.lower()} '):
                         # when args not contain command group prefix, then cut more loading.
                         cut = True
                     # add command group into command group table


### PR DESCRIPTION

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

AAZ commands are not loaded when customer use capital letters in command names, like below.
![image](https://github.com/Azure/azure-cli/assets/69238381/725111d1-66c1-4505-8e37-96eefb2cc27a)

This PR fixed the above issue, it will ignore the case of command names.

![image](https://github.com/Azure/azure-cli/assets/69238381/ef2417ee-9271-4d89-9596-175833c2182a)

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
