### PR TITLE
[ARM] `az bicep lint`: Add new command to lint a bicep file

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_help.py
@@ -3104,13 +3104,13 @@ examples:
 
 helps['bicep lint'] = """
 type: command
-short-summary: Lints a Bicep file.
+short-summary: Lint a Bicep file.
 examples:
-  - name: Lints a Bicep file.
+  - name: Lint a Bicep file.
     text: az bicep lint --file {bicep_file}
-  - name: Lints a Bicep file without restoring external modules.
+  - name: Lint a Bicep file without restoring external modules.
     text: az bicep lint --file {bicep_file} --no-restore
-  - name: Lints a Bicep file with specified diagnostics format. Valid values are ( default | sarif ).
+  - name: Lint a Bicep file with specified diagnostics format. Valid values are ( default | sarif ).
     text: az bicep lint --file {bicep_file} --diagnostics-format {diagnostics_format}
 """
 

--- a/src/azure-cli/azure/cli/command_modules/resource/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_help.py
@@ -3102,6 +3102,18 @@ examples:
     text: az bicep generate-params --file {bicep_file} --output-format {output_format} --include-params {include_params}
 """
 
+helps['bicep lint'] = """
+type: command
+short-summary: Lints a Bicep file.
+examples:
+  - name: Lints a Bicep file.
+    text: az bicep lint --file {bicep_file}
+  - name: Lints a Bicep file without restoring external modules.
+    text: az bicep lint --file {bicep_file} --no-restore
+  - name: Lints a Bicep file with specified diagnostics format. Valid values are ( default | sarif ).
+    text: az bicep lint --file {bicep_file} --diagnostics-format {diagnostics_format}
+"""
+
 helps['resourcemanagement'] = """
 type: group
 short-summary: resourcemanagement CLI command group.

--- a/src/azure-cli/azure/cli/command_modules/resource/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_params.py
@@ -866,7 +866,7 @@ def load_arguments(self, _):
     with self.argument_context('bicep lint') as c:
         c.argument('file', arg_type=bicep_file_type, help="The path to the Bicep module file to lint in the file system.")
         c.argument('no_restore', arg_type=bicep_no_restore_type, help="When set, generates the parameters file without restoring external modules.")
-        c.argument('diagnostics_format', help="Set diagnostics format. Valid values are ( default | sarif ).")
+        c.argument('diagnostics_format', arg_type=get_enum_type(['default', 'sarif']), help="Set diagnostics format.")
 
     with self.argument_context('resourcemanagement private-link create') as c:
         c.argument('resource_group', arg_type=resource_group_name_type,

--- a/src/azure-cli/azure/cli/command_modules/resource/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_params.py
@@ -865,6 +865,7 @@ def load_arguments(self, _):
 
     with self.argument_context('bicep lint') as c:
         c.argument('file', arg_type=bicep_file_type, help="The path to the Bicep module file to lint in the file system.")
+        c.argument('no_restore', arg_type=bicep_no_restore_type, help="When set, generates the parameters file without restoring external modules.")
         c.argument('diagnostics_format', help="Set diagnostics format. Valid values are ( default | sarif ).")
 
     with self.argument_context('resourcemanagement private-link create') as c:

--- a/src/azure-cli/azure/cli/command_modules/resource/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_params.py
@@ -863,6 +863,10 @@ def load_arguments(self, _):
         c.argument('output_format', help="Set output format. Valid values are ( json | bicepparam ).")
         c.argument('include_params', help="Set include params. Valid values are ( all | required-only ).")
 
+    with self.argument_context('bicep lint') as c:
+        c.argument('file', arg_type=bicep_file_type, help="The path to the Bicep module file to lint in the file system.")
+        c.argument('diagnostics_format', help="Set diagnostics format. Valid values are ( default | sarif ).")
+
     with self.argument_context('resourcemanagement private-link create') as c:
         c.argument('resource_group', arg_type=resource_group_name_type,
                    help='The name of the resource group.')

--- a/src/azure-cli/azure/cli/command_modules/resource/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/commands.py
@@ -616,6 +616,7 @@ def load_command_table(self, _):
         g.custom_command('version', 'show_bicep_cli_version')
         g.custom_command('list-versions', 'list_bicep_cli_versions')
         g.custom_command('generate-params', 'generate_params_file')
+        g.custom_command('lint', 'lint_bicep_file')
 
     with self.command_group('resourcemanagement private-link', resource_resourcemanagementprivatelink_sdk, resource_type=ResourceType.MGMT_RESOURCE_PRIVATELINKS) as g:
         g.custom_command('create', 'create_resourcemanager_privatelink')

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -4405,24 +4405,6 @@ def list_bicep_cli_versions(cmd):
     return get_bicep_available_release_tags()
 
 
-def lint_params_file(cmd, file, no_restore=None, diagnostics_format=None):
-    ensure_bicep_installation(cmd.cli_ctx)
-
-    minimum_supported_version = "0.7.4"
-    if bicep_version_greater_than_or_equal_to(minimum_supported_version):
-        args = ["lint", file]
-        if no_restore:
-            args += ["--no-restore"]
-        if diagnostics_format:
-            args += ["--diagnostics-format", diagnostics_format]
-
-        output = run_bicep_command(cmd.cli_ctx, args)
-
-        print(output)
-    else:
-        logger.error("az bicep lint could not be executed with the current version of Bicep CLI. Please upgrade Bicep CLI to v%s or later.", minimum_supported_version)
-
-
 def generate_params_file(cmd, file, no_restore=None, outdir=None, outfile=None, stdout=None, output_format=None, include_params=None):
     ensure_bicep_installation(cmd.cli_ctx)
 
@@ -4461,7 +4443,9 @@ def lint_bicep_file(cmd, file, no_restore=None, diagnostics_format=None):
         if diagnostics_format:
             args += ["--diagnostics-format", diagnostics_format]
 
-        run_bicep_command(cmd.cli_ctx, args)
+        output = run_bicep_command(cmd.cli_ctx, args)
+
+        print(output)
     else:
         logger.error("az bicep lint could not be executed with the current version of Bicep CLI. Please upgrade Bicep CLI to v%s or later.", minimum_supported_version)
 

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -4405,6 +4405,24 @@ def list_bicep_cli_versions(cmd):
     return get_bicep_available_release_tags()
 
 
+def lint_params_file(cmd, file, no_restore=None, diagnostics_format=None):
+    ensure_bicep_installation(cmd.cli_ctx)
+
+    minimum_supported_version = "0.7.4"
+    if bicep_version_greater_than_or_equal_to(minimum_supported_version):
+        args = ["lint", file]
+        if no_restore:
+            args += ["--no-restore"]
+        if diagnostics_format:
+            args += ["--diagnostics-format", diagnostics_format]
+
+        output = run_bicep_command(cmd.cli_ctx, args)
+
+        print(output)
+    else:
+        logger.error("az bicep lint could not be executed with the current version of Bicep CLI. Please upgrade Bicep CLI to v%s or later.", minimum_supported_version)
+
+
 def generate_params_file(cmd, file, no_restore=None, outdir=None, outfile=None, stdout=None, output_format=None, include_params=None):
     ensure_bicep_installation(cmd.cli_ctx)
 

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -4450,6 +4450,22 @@ def generate_params_file(cmd, file, no_restore=None, outdir=None, outfile=None, 
         logger.error("az bicep generate-params could not be executed with the current version of Bicep CLI. Please upgrade Bicep CLI to v%s or later.", minimum_supported_version)
 
 
+def lint_bicep_file(cmd, file, no_restore=None, diagnostics_format=None):
+    ensure_bicep_installation(cmd.cli_ctx)
+
+    minimum_supported_version = "0.7.4"
+    if bicep_version_greater_than_or_equal_to(minimum_supported_version):
+        args = ["lint", file]
+        if no_restore:
+            args += ["--no-restore"]
+        if diagnostics_format:
+            args += ["--diagnostics-format", diagnostics_format]
+
+        run_bicep_command(cmd.cli_ctx, args)
+    else:
+        logger.error("az bicep lint could not be executed with the current version of Bicep CLI. Please upgrade Bicep CLI to v%s or later.", minimum_supported_version)
+
+
 def create_resourcemanager_privatelink(
         cmd, resource_group, name, location):
     rcf = _resource_privatelinks_client_factory(cmd.cli_ctx)

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
@@ -5130,13 +5130,13 @@ class BicepLintTest(LiveScenarioTest):
         curr_dir = os.path.dirname(os.path.realpath(__file__))
         tf = os.path.join(curr_dir, 'sample_params.bicep').replace('\\', '\\\\')
 
-        self.cmd('az bicep generate-params -f {tf} --diagnostics-format default')
+        self.cmd('az bicep lint -f {tf} --diagnostics-format default')
 
     def test_bicep_lint_diagnostics_format_sarif(self):
         curr_dir = os.path.dirname(os.path.realpath(__file__))
         tf = os.path.join(curr_dir, 'sample_params.bicep').replace('\\', '\\\\')
 
-        self.cmd('az bicep generate-params -f {tf} --diagnostics-format sarif')
+        self.cmd('az bicep lint -f {tf} --diagnostics-format sarif')
 
 class BicepInstallationTest(LiveScenarioTest):
     def setup(self):

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
@@ -5105,6 +5105,34 @@ class BicepGenerateParamsTest(LiveScenarioTest):
         if os.path.exists(params_path):
             os.remove(params_path)
 
+    def test_bicep_generate_params_include_params_only(self):
+        curr_dir = os.path.dirname(os.path.realpath(__file__))
+        tf = os.path.join(curr_dir, 'sample_params.bicep').replace('\\', '\\\\')
+        params_path = os.path.join(curr_dir, 'sample_params.parameters.json').replace('\\', '\\\\')
+        self.kwargs.update({
+            'tf': tf,
+            'params_path': params_path,
+        })
+
+        self.cmd('az bicep generate-params -f {tf} --outfile {params_path} --include-params all')
+
+        if os.path.exists(params_path):
+            os.remove(params_path)
+
+    def test_bicep_generate_params(self):
+        curr_dir = os.path.dirname(os.path.realpath(__file__))
+        tf = os.path.join(curr_dir, 'sample_params.bicep').replace('\\', '\\\\')
+        params_path = os.path.join(curr_dir, 'sample_params.parameters.json').replace('\\', '\\\\')
+        self.kwargs.update({
+            'tf': tf,
+            'params_path': params_path,
+        })
+
+        self.cmd('az bicep generate-params -f {tf} --outfile {params_path}')
+
+        if os.path.exists(params_path):
+            os.remove(params_path)
+
 class BicepLintTest(LiveScenarioTest):
     def setup(self):
         super().setup()

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
@@ -5105,33 +5105,38 @@ class BicepGenerateParamsTest(LiveScenarioTest):
         if os.path.exists(params_path):
             os.remove(params_path)
 
-    def test_bicep_generate_params_include_params_only(self):
+class BicepLintTest(LiveScenarioTest):
+    def setup(self):
+        super().setup()
+        self.cmd('az bicep uninstall')
+
+    def tearDown(self):
+        super().tearDown()
+        self.cmd('az bicep uninstall')
+
+    def test_bicep_lint(self):
         curr_dir = os.path.dirname(os.path.realpath(__file__))
         tf = os.path.join(curr_dir, 'sample_params.bicep').replace('\\', '\\\\')
-        params_path = os.path.join(curr_dir, 'sample_params.parameters.json').replace('\\', '\\\\')
-        self.kwargs.update({
-            'tf': tf,
-            'params_path': params_path,
-        })
 
-        self.cmd('az bicep generate-params -f {tf} --outfile {params_path} --include-params all')
+        self.cmd('az bicep lint -f {tf}')
 
-        if os.path.exists(params_path):
-            os.remove(params_path)
-
-    def test_bicep_generate_params(self):
+    def test_bicep_lint_no_restore(self):
         curr_dir = os.path.dirname(os.path.realpath(__file__))
         tf = os.path.join(curr_dir, 'sample_params.bicep').replace('\\', '\\\\')
-        params_path = os.path.join(curr_dir, 'sample_params.parameters.json').replace('\\', '\\\\')
-        self.kwargs.update({
-            'tf': tf,
-            'params_path': params_path,
-        })
 
-        self.cmd('az bicep generate-params -f {tf} --outfile {params_path}')
+        self.cmd('az bicep lint -f {tf} --no-restore')
 
-        if os.path.exists(params_path):
-            os.remove(params_path)
+    def test_bicep_lint_diagnostics_format_default(self):
+        curr_dir = os.path.dirname(os.path.realpath(__file__))
+        tf = os.path.join(curr_dir, 'sample_params.bicep').replace('\\', '\\\\')
+
+        self.cmd('az bicep generate-params -f {tf} --diagnostics-format default')
+
+    def test_bicep_lint_diagnostics_format_sarif(self):
+        curr_dir = os.path.dirname(os.path.realpath(__file__))
+        tf = os.path.join(curr_dir, 'sample_params.bicep').replace('\\', '\\\\')
+
+        self.cmd('az bicep generate-params -f {tf} --diagnostics-format sarif')
 
 class BicepInstallationTest(LiveScenarioTest):
     def setup(self):

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_custom.py
@@ -398,6 +398,15 @@ class TestCustom(unittest.TestCase):
         self.assertTrue(is_generated_params_file_exists)
 
     @live_only()
+    def test_bicep_lint_defaults(self):
+        curr_dir = os.path.dirname(os.path.realpath(__file__))
+        param_file = os.path.join(curr_dir, 'sample_params.bicep').replace('\\', '\\\\')
+
+        run_bicep_command(cli_ctx, ["lint", param_file])
+
+        self.assertTrue(param_file)
+
+    @live_only()
     def test_bicep_build_params_defaults(self):
         curr_dir = os.path.dirname(os.path.realpath(__file__))
         param_file = os.path.join(curr_dir, 'sample_params.bicepparam').replace('\\', '\\\\')


### PR DESCRIPTION
**Related command**

`az bicep lint` command is added

**Description**<!--Mandatory-->
_"bicep cli"_ has a _lint_ command that lints the given _bicep_ file.

**History Notes**

[ARM] `az bicep lint`: Add new command to lint a bicep file

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
