### PR TITLE
[Service Connector] `az spring connection`: Add deprecated message for `--deployment` breaking change

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/_params.py
@@ -47,9 +47,11 @@ def add_source_resource_block(context, source, enable_id=True, validate_source_i
     required_args = []
     for arg, content in SOURCE_RESOURCES_PARAMS.get(source).items():
         id_arg = '\'--id\'' if enable_id else '\'--source-id\''
+        deprecate_info = content.get('deprecate_info')
         context.argument(arg, configured_default=content.get('configured_default'),
                          options_list=content.get('options'), type=str,
-                         help='{}. Required if {} is not specified.'.format(content.get('help'), id_arg))
+                         deprecate_info=context.deprecate() if deprecate_info else None,
+                         help='{}. Required if {} is not specified.{}'.format(content.get('help'), id_arg, deprecate_info))
         required_args.append(content.get('options')[0])
 
     validator_kwargs = {

--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/_params.py
@@ -51,7 +51,8 @@ def add_source_resource_block(context, source, enable_id=True, validate_source_i
         context.argument(arg, configured_default=content.get('configured_default'),
                          options_list=content.get('options'), type=str,
                          deprecate_info=context.deprecate() if deprecate_info else None,
-                         help='{}. Required if {} is not specified.{}'.format(content.get('help'), id_arg, deprecate_info))
+                         help='{}. Required if {} is not specified.{}'.format(
+                             content.get('help'), id_arg, deprecate_info))
         required_args.append(content.get('options')[0])
 
     validator_kwargs = {

--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/_resource_config.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/_resource_config.py
@@ -209,7 +209,7 @@ SOURCE_RESOURCES_PARAMS = {
             'options': ['--deployment'],
             'help': 'The deployment name of the app',
             'placeholder': 'MyDeployment',
-            'deprecate_info': ' Note: The default value of `--deployment` is deprecated and will be removed in a future release. Use `--deployment default` if you want stay in current behavior',
+            'deprecate_info': ' Note: The default value of `--deployment` is deprecated and will be removed in a future release. Use `--deployment default` if you want stay in current behavior.',
         }
     },
     RESOURCE.SpringCloudDeprecated: {
@@ -232,7 +232,7 @@ SOURCE_RESOURCES_PARAMS = {
             'options': ['--deployment'],
             'help': 'The deployment name of the app',
             'placeholder': 'MyDeployment',
-            'deprecate_info': ' Note: The default value of `--deployment` is deprecated and will be removed in a future release. Use `--deployment default` if you want stay in current behavior',
+            'deprecate_info': ' Note: The default value of `--deployment` is deprecated and will be removed in a future release. Use `--deployment default` if you want stay in current behavior.',
         }
     },
     RESOURCE.KubernetesCluster: {

--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/_resource_config.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/_resource_config.py
@@ -208,7 +208,8 @@ SOURCE_RESOURCES_PARAMS = {
         'deployment': {
             'options': ['--deployment'],
             'help': 'The deployment name of the app',
-            'placeholder': 'MyDeployment'
+            'placeholder': 'MyDeployment',
+            'deprecate_info': ' Note: The default value of `--deployment` is deprecated and will be removed in a future release. Use `--deployment default` if you want stay in current behavior',
         }
     },
     RESOURCE.SpringCloudDeprecated: {
@@ -230,7 +231,8 @@ SOURCE_RESOURCES_PARAMS = {
         'deployment': {
             'options': ['--deployment'],
             'help': 'The deployment name of the app',
-            'placeholder': 'MyDeployment'
+            'placeholder': 'MyDeployment',
+            'deprecate_info': ' Note: The default value of `--deployment` is deprecated and will be removed in a future release. Use `--deployment default` if you want stay in current behavior',
         }
     },
     RESOURCE.KubernetesCluster: {


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az spring connection`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

As https://github.com/Azure/azure-cli/issues/27371 said, we would delete the default value of --deployment. Therefore, we would like to add a deprecated message as warning for customer before the breaking change.
It displays as 
![image](https://github.com/Azure/azure-cli/assets/15213781/6e6deccd-ddc8-4f82-85e1-9301069d7c20)

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
