### PR TITLE
return expires_on from get-access-token

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -69,7 +69,7 @@ def get_access_token(cmd, subscription=None, resource=None, scopes=None, resourc
     result = {
         'tokenType': creds[0],
         'accessToken': creds[1],
-        # 'expires_on': creds[2].get('expires_on', None),
+        'expires_on': creds[2].get('expires_on', None),
         'expiresOn': creds[2]['expiresOn'],
         'tenant': tenant
     }


### PR DESCRIPTION
This is a fix for #19700. @jiasli made the code. It works. It will let us fix https://github.com/Azure/azure-sdk-for-rust/issues/1371 .

``` json
  "expiresOn": "2023-09-17 20:52:34.000000",
  "expires_on": 1694976754,
```

If you want to rename it to `expiresOnEpoch`, either works for us.

**Related command**
az account get-access-token

**Description**<!--Mandatory-->
This returns the `expire_on`. 

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ x The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
