### PR TITLE
[Service Connector] BREAKING CHANGE: `az spring connection`: Remove default value of `--deployment` to support spring app connection

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/_params.py
@@ -91,8 +91,11 @@ def add_source_resource_block(context, source, enable_id=True, validate_source_i
     for resource, args in SOURCE_RESOURCES_OPTIONAL_PARAMS.items():
         for arg in args:
             if resource == source:
+                deprecate_info = args.get(arg).get('deprecate_info')
                 context.argument(arg, options_list=args.get(arg).get(
-                    'options'), type=str, help=args.get(arg).get('help'))
+                    'options'), type=str,
+                    deprecate_info=context.deprecate() if deprecate_info else None,
+                    help=args.get(arg).get('help'))
             else:
                 context.ignore(arg)
 

--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/_resource_config.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/_resource_config.py
@@ -104,13 +104,14 @@ TARGET_RESOURCES_DEPRECATED = [RESOURCE.Mysql, RESOURCE.Postgres]
 SOURCE_RESOURCES = {
     RESOURCE.WebApp: '/subscriptions/{subscription}/resourceGroups/{source_resource_group}/providers/Microsoft.Web/sites/{site}',
     RESOURCE.FunctionApp: '/subscriptions/{subscription}/resourceGroups/{source_resource_group}/providers/Microsoft.Web/sites/{site}',
-    RESOURCE.SpringCloud: '/subscriptions/{subscription}/resourceGroups/{source_resource_group}/providers/Microsoft.AppPlatform/Spring/{spring}/apps/{app}/deployments/{deployment}',
+    RESOURCE.SpringCloud: '/subscriptions/{subscription}/resourceGroups/{source_resource_group}/providers/Microsoft.AppPlatform/Spring/{spring}/apps/{app}',
     RESOURCE.SpringCloudDeprecated: '/subscriptions/{subscription}/resourceGroups/{source_resource_group}/providers/Microsoft.AppPlatform/Spring/{spring}/apps/{app}/deployments/{deployment}',
     # RESOURCE.KubernetesCluster: '/subscriptions/{subscription}/resourceGroups/{source_resource_group}/providers/Microsoft.ContainerService/managedClusters/{cluster}',
     RESOURCE.ContainerApp: '/subscriptions/{subscription}/resourceGroups/{source_resource_group}/providers/Microsoft.App/containerApps/{app}'
 }
 
 WEB_APP_SLOT_RESOURCE = '/subscriptions/{subscription}/resourceGroups/{source_resource_group}/providers/Microsoft.Web/sites/{site}/slots/{slot}'
+SPRING_APP_DEPLOYMENT_RESOURCE = '/subscriptions/{subscription}/resourceGroups/{source_resource_group}/providers/Microsoft.AppPlatform/Spring/{spring}/apps/{app}/deployments/{deployment}'
 LOCAL_CONNECTION_RESOURCE = '/subscriptions/{subscriptionId}/resourceGroups/{resource_group}/providers/Microsoft.ServiceLinker/locations/{location}/connectors/{connection_name}'
 
 # The dict defines the resource id pattern of target resources.
@@ -205,12 +206,6 @@ SOURCE_RESOURCES_PARAMS = {
             'help': 'Name of the app in the Azure Spring Apps',
             'placeholder': 'MyApp'
         },
-        'deployment': {
-            'options': ['--deployment'],
-            'help': 'The deployment name of the app',
-            'placeholder': 'MyDeployment',
-            'deprecate_info': ' Note: The default value of `--deployment` is deprecated and will be removed in a future release. Use `--deployment default` if you want stay in current behavior.',
-        }
     },
     RESOURCE.SpringCloudDeprecated: {
         'source_resource_group': {
@@ -232,7 +227,7 @@ SOURCE_RESOURCES_PARAMS = {
             'options': ['--deployment'],
             'help': 'The deployment name of the app',
             'placeholder': 'MyDeployment',
-            'deprecate_info': ' Note: The default value of `--deployment` is deprecated and will be removed in a future release. Use `--deployment default` if you want stay in current behavior.',
+            'deprecate_info': ' Note: The default value of `--deployment` is removed. Use `--deployment default` if you want stay in default behavior.',
         }
     },
     RESOURCE.KubernetesCluster: {
@@ -282,6 +277,14 @@ SOURCE_RESOURCES_OPTIONAL_PARAMS = {
             'placeholder': 'WebAppSlot'
         },
     },
+    RESOURCE.SpringCloud: {
+        'deployment': {
+            'options': ['--deployment'],
+            'help': 'The deployment name of the app. Note: The default value of `--deployment` is removed. Use `--deployment default` if you want stay in default behavior.',
+            'placeholder': 'MyDeployment',
+            'deprecate_info': ' Note: The default value of `--deployment` is removed. Use `--deployment default` if you want stay in default behavior.',
+        },
+    }
 }
 
 # The dict defines the parameters used to position the target resources.

--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/custom.py
@@ -55,7 +55,7 @@ def connection_list(client,
                     source_id=None,
                     cluster=None,
                     site=None, slot=None,
-                    spring=None, app=None, deployment='default'):
+                    spring=None, app=None, deployment=None):
     if not source_id:
         raise RequiredArgumentMissingError(err_msg.format('--source-id'))
     return auto_register(client.list, resource_uri=source_id)
@@ -109,7 +109,7 @@ def connection_show(client,
                     indentifier=None,
                     cluster=None,
                     site=None, slot=None,
-                    spring=None, app=None, deployment='default'):
+                    spring=None, app=None, deployment=None):
     if not source_id or not connection_name:
         raise RequiredArgumentMissingError(
             err_msg.format('--source-id, --connection'))
@@ -139,7 +139,7 @@ def connection_delete(client,
                       indentifier=None,
                       cluster=None,
                       site=None, slot=None,
-                      spring=None, app=None, deployment='default',
+                      spring=None, app=None, deployment=None,
                       no_wait=False):
     if not source_id or not connection_name:
         raise RequiredArgumentMissingError(err_msg.format('--source-id, --connection'))
@@ -175,7 +175,7 @@ def connection_list_configuration(client,
                                   indentifier=None,
                                   cluster=None,
                                   site=None, slot=None,
-                                  spring=None, app=None, deployment='default'):
+                                  spring=None, app=None, deployment=None):
     if not source_id or not connection_name:
         raise RequiredArgumentMissingError(err_msg.format('--source-id, --connection'))
     configurations = auto_register(client.list_configurations,
@@ -253,7 +253,7 @@ def connection_validate(cmd, client,
                         indentifier=None,
                         cluster=None,
                         site=None, slot=None,
-                        spring=None, app=None, deployment='default'):
+                        spring=None, app=None, deployment=None):
     if not source_id or not connection_name:
         raise RequiredArgumentMissingError(err_msg.format('--source-id, --connection'))
 
@@ -300,7 +300,7 @@ def connection_create(cmd, client,  # pylint: disable=too-many-locals,too-many-s
                       new_addon=False, no_wait=False,
                       cluster=None, scope=None, enable_csi=False,            # Resource.KubernetesCluster
                       site=None, slot=None,                                  # Resource.WebApp
-                      spring=None, app=None, deployment='default',           # Resource.SpringCloud
+                      spring=None, app=None, deployment=None,                # Resource.SpringCloud
                       server=None, database=None,                            # Resource.*Postgres, Resource.*Sql*
                       vault=None,                                            # Resource.KeyVault
                       account=None,                                          # Resource.Storage*
@@ -365,7 +365,7 @@ def connection_create_func(cmd, client,  # pylint: disable=too-many-locals,too-m
                            new_addon=False, no_wait=False,
                            cluster=None, scope=None, enable_csi=False,            # Resource.KubernetesCluster
                            site=None, slot=None,                                  # Resource.WebApp
-                           spring=None, app=None, deployment='default',           # Resource.SpringCloud
+                           spring=None, app=None, deployment=None,                # Resource.SpringCloud
                            # Resource.*Postgres, Resource.*Sql*
                            server=None, database=None,
                            vault=None,                                            # Resource.KeyVault
@@ -611,7 +611,7 @@ def connection_update(cmd, client,  # pylint: disable=too-many-locals, too-many-
                       scope=None,
                       cluster=None, enable_csi=False,                         # Resource.Kubernetes
                       site=None, slot=None,                                   # Resource.WebApp
-                      spring=None, app=None, deployment='default',            # Resource.SpringCloud
+                      spring=None, app=None, deployment=None,                 # Resource.SpringCloud
                       customized_keys=None,
                       ):
 
@@ -997,7 +997,7 @@ def connection_create_kafka(cmd, client,  # pylint: disable=too-many-locals
                             customized_keys=None,
                             cluster=None, scope=None,          # Resource.Kubernetes
                             site=None, slot=None,              # Resource.WebApp
-                            deployment='default',
+                            deployment=None,
                             spring=None, app=None):            # Resource.SpringCloud
 
     from ._transformers import transform_linker_properties
@@ -1092,7 +1092,7 @@ def connection_update_kafka(cmd, client,  # pylint: disable=too-many-locals
                             customized_keys=None,
                             cluster=None,
                             site=None, slot=None,              # Resource.WebApp
-                            deployment='default',
+                            deployment=None,
                             spring=None, app=None):            # Resource.SpringCloud
 
     # use the suffix to decide the connection type


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az spring connection`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Reference #27371, remove the default value of `--deployment`, so the `az spring connection` command can support creating spring app connection besides spring app deployment connection. When user doesn't pass value of `--deployment`, the connection will be created at spring app level.

**Testing Guide**
<!--Example commands with explanations.-->
run `azdev test --discover --live test_springapp_storageblob_e2e test_springcloud_storageblob_e2e` can test both spring app and spring app deployment connection lively.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
