### PR TITLE
{CI} Fix no-name-in-module style error

### DIFF
--- a/src/azure-cli-core/azure/cli/core/auth/binary_cache.py
+++ b/src/azure-cli-core/azure/cli/core/auth/binary_cache.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-import collections.abc
+from collections.abc import MutableMapping
 import pickle
 
 from azure.cli.core.decorators import retry
@@ -12,7 +12,7 @@ from knack.log import get_logger
 logger = get_logger(__name__)
 
 
-class BinaryCache(collections.abc.MutableMapping):
+class BinaryCache(MutableMapping):
     """
     Derived from azure.cli.core._session.Session.
     A simple dict-like class that is backed by a binary file.

--- a/src/azure-cli-core/azure/cli/core/auth/binary_cache.py
+++ b/src/azure-cli-core/azure/cli/core/auth/binary_cache.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-import collections.abc as collections
+import collections.abc
 import pickle
 
 from azure.cli.core.decorators import retry
@@ -12,7 +12,7 @@ from knack.log import get_logger
 logger = get_logger(__name__)
 
 
-class BinaryCache(collections.MutableMapping):
+class BinaryCache(collections.abc.MutableMapping):
     """
     Derived from azure.cli.core._session.Session.
     A simple dict-like class that is backed by a binary file.


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
`import collections.abc as collections` raises this error in `azdev style`:
```
ERROR: ************* Module azure.cli.core.auth.binary_cache
src/azure-cli-core/azure/cli/core/auth/binary_cache.py:6:0: E0611: No name 'abc' in module 'collections.abc' (no-name-in-module)
```

This line is introduced in https://github.com/Azure/azure-cli/pull/20847. I guess there is a new rule in flake8 which found this.

It appears that flake8 treats `collections.abc` as `collections` then it can't find `abc` module in it.


**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
