### PR TITLE
[Profile] `az account get-access-token`: Return `expires_on` as POSIX timestamp

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/profile/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/_help.py
@@ -71,6 +71,10 @@ short-summary: Get a token for utilities to access Azure.
 long-summary: >
     The token will be valid for at least 5 minutes with the maximum at 60 minutes.
     If the subscription argument isn't specified, the current account is used.
+
+
+    In the output, `expires_on` represents a POSIX timestamp and `expiresOn` represents a local datetime.
+    It is recommended for downstream applications to use `expires_on` because it is in UTC.
 examples:
     - name: Get an access token for the current account
       text: >

--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -69,7 +69,7 @@ def get_access_token(cmd, subscription=None, resource=None, scopes=None, resourc
     result = {
         'tokenType': creds[0],
         'accessToken': creds[1],
-        # 'expires_on': creds[2].get('expires_on', None),
+        'expires_on': creds[2]['expires_on'],
         'expiresOn': creds[2]['expiresOn'],
         'tenant': tenant
     }

--- a/src/azure-cli/azure/cli/command_modules/profile/tests/latest/test_profile_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/tests/latest/test_profile_custom.py
@@ -37,7 +37,15 @@ class ProfileCommandTest(unittest.TestCase):
         cmd = mock.MagicMock()
         cmd.cli_ctx = DummyCli()
 
-        get_raw_token_mock.return_value = (['bearer', 'token123', {'expiresOn': '2100-01-01'}], 'sub123', 'tenant123')
+        timestamp = 1695270561
+        datetime_local = '2023-09-21 04:29:21.000000'
+
+        token_entry = {
+            'accessToken': 'token123',
+            'expires_on': timestamp,
+            'expiresOn': datetime_local
+        }
+        get_raw_token_mock.return_value = (('bearer', 'token123', token_entry), 'sub123',  'tenant123')
 
         result = get_access_token(cmd)
 
@@ -46,7 +54,8 @@ class ProfileCommandTest(unittest.TestCase):
         expected_result = {
             'tokenType': 'bearer',
             'accessToken': 'token123',
-            'expiresOn': '2100-01-01',
+            'expires_on': timestamp,
+            'expiresOn': datetime_local,
             'subscription': 'sub123',
             'tenant': 'tenant123'
         }
@@ -55,8 +64,7 @@ class ProfileCommandTest(unittest.TestCase):
         # assert it takes customized resource, subscription
         resource = 'https://graph.microsoft.com/'
         subscription_id = '00000001-0000-0000-0000-000000000000'
-        get_raw_token_mock.return_value = (['bearer', 'token123', {'expiresOn': '2100-01-01'}], subscription_id,
-                                           'tenant123')
+        get_raw_token_mock.return_value = (('bearer', 'token123', token_entry), subscription_id, 'tenant123')
         result = get_access_token(cmd, subscription=subscription_id, resource=resource)
         get_raw_token_mock.assert_called_with(mock.ANY, resource, None, subscription_id, None)
 
@@ -67,12 +75,13 @@ class ProfileCommandTest(unittest.TestCase):
 
         # test get token with tenant
         tenant_id = '00000000-0000-0000-0000-000000000000'
-        get_raw_token_mock.return_value = (['bearer', 'token123', {'expiresOn': '2100-01-01'}], None, tenant_id)
+        get_raw_token_mock.return_value = (('bearer', 'token123', token_entry), None, tenant_id)
         result = get_access_token(cmd, tenant=tenant_id)
         expected_result = {
             'tokenType': 'bearer',
             'accessToken': 'token123',
-            'expiresOn': '2100-01-01',
+            'expires_on': timestamp,
+            'expiresOn': datetime_local,
             'tenant': tenant_id
         }
         self.assertEqual(result, expected_result)


### PR DESCRIPTION
Close #19700

**Related command**
`az account get-access-token`

**Description**<!--Mandatory-->
Returning `expiresOn` as a local datetime is a legacy from the ADAL age. It causes lots of unnecessary complexities. See https://github.com/Azure/azure-cli/issues/19700 for detailed explanation.

This PR makes `az account get-access-token` return `expires_on` as POSIX timestamp which has been supported long ago by Azure CLI Core during the MSAL migration (https://github.com/Azure/azure-cli/pull/19853).

However, as shown in https://github.com/Azure/azure-cli/issues/19700#issuecomment-1729040872, downstream applications that only support 32-bit integer precision timestamp will encounter error in year 2038, but that's not something we can control.

**Testing Guide**
```
az account get-access-token
```

Before:

```
{
  "accessToken": "...",
  "expiresOn": "2023-10-31 21:59:10.000000",
  "subscription": "...",
  "tenant": "...",
  "tokenType": "Bearer"
}
```

After:

```
{
  "accessToken": "...",
  "expiresOn": "2023-10-31 21:59:10.000000",
  "expires_on": 1698760750,
  "subscription": "...",
  "tenant": "...",
  "tokenType": "Bearer"
}
```
