### PR TITLE
[Core] Support disabling instance discovery

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -861,5 +861,8 @@ def _create_identity_instance(cli_ctx, *args, **kwargs):
     from .telemetry import set_broker_info
     set_broker_info(allow_broker=allow_broker)
 
+    # PREVIEW: In Azure Stack environment, use core.instance_discovery=false to disable MSAL's instance discovery.
+    instance_discovery = cli_ctx.config.getboolean('core', 'instance_discovery', True)
+
     return Identity(*args, encrypt=encrypt, use_msal_http_cache=use_msal_http_cache, allow_broker=allow_broker,
-                    **kwargs)
+                    instance_discovery=instance_discovery, **kwargs)

--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -54,7 +54,7 @@ class Identity:  # pylint: disable=too-many-instance-attributes
     _service_principal_store_instance = None
 
     def __init__(self, authority, tenant_id=None, client_id=None, encrypt=False, use_msal_http_cache=True,
-                 allow_broker=None):
+                 allow_broker=None, instance_discovery=None):
         """
         :param authority: Authentication authority endpoint. For example,
             - AAD: https://login.microsoftonline.com
@@ -70,6 +70,7 @@ class Identity:  # pylint: disable=too-many-instance-attributes
         self._encrypt = encrypt
         self._use_msal_http_cache = use_msal_http_cache
         self._allow_broker = allow_broker
+        self._instance_discovery = instance_discovery
 
         # Build the authority in MSAL style
         self._msal_authority, self._is_adfs = _get_authority_url(authority, tenant_id)
@@ -98,6 +99,7 @@ class Identity:  # pylint: disable=too-many-instance-attributes
             "authority": self._msal_authority,
             "token_cache": Identity._msal_token_cache,
             "http_cache": Identity._msal_http_cache,
+            "instance_discovery": self._instance_discovery,
             # CP1 means we can handle claims challenges (CAE)
             "client_capabilities": None if "AZURE_IDENTITY_DISABLE_CP1" in os.environ else ["CP1"]
         }


### PR DESCRIPTION
Close https://github.com/Azure/azure-cli/issues/26433

**Related command**
`az login`

**Description**<!--Mandatory-->
Some Azure Stack cloud uses an AAD endpoint that is not well known. The endpoint can't be discovered with `https://login.microsoftonline.com/common/discovery/instance` either.

Running `az login` in such cloud will result in a failure:

```
ValueError: invalid_instance: The authority you provided, https://login.devfabric.azs.microsoft.com/
organizations, is not whitelisted. If it is indeed your legit customized domain name, you can turn 
off this check by passing in validate_authority=False
```

**Testing Guide**

Register a cloud with private AAD endpoint `https://login.devfabric.azs.microsoft.com/` and log in:

```
az cloud register -n myazurestack --endpoint-resource-manager https://management.azure.com/ --endpoint-active-directory https://login.devfabric.azs.microsoft.com/
az cloud set -n myazurestack
az login --debug
```

`az login` fails with

```
ValueError: invalid_instance: The authority you provided, https://login.devfabric.azs.microsoft.com/
organizations, is not whitelisted. If it is indeed your legit customized domain name, you can turn 
off this check by passing in validate_authority=False
```

Then disable instance discovery with `az config`:

```sh
az config set core.instance_discovery=false
# To unset it:
# az config unset core.instance_discovery
```

Instance discovery can also be disabled using env var:

```sh
# Bash
export AZURE_CORE_INSTANCE_DISCOVERY=false
# PowerShell
$env:AZURE_CORE_INSTANCE_DISCOVERY="false"
```

`az login` should now fail with

```
requests.exceptions.ConnectionError: HTTPSConnectionPool(host='login.devfabric.azs.microsoft.com', port=443): 
Max retries exceeded with url: /organizations/v2.0/.well-known/openid-configuration (Caused by 
NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x000001F5D27F3100>: Failed to establish a 
new connection: [Errno 11001] getaddrinfo failed'))
```

This is expected as we can't resolve `login.devfabric.azs.microsoft.com` from public internet.

**History Notes**
[Core] Support disabling instance discovery by running `az config set core.instance_discovery=false`