### PR TITLE
[APIM] `az apim api create`: Make `--authorization-scope` parameter optional for setting auth server

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/apim/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/apim/custom.py
@@ -285,7 +285,7 @@ def apim_api_create(client, resource_group_name, service_name, api_id, descripti
                     api_type=None, subscription_required=False, no_wait=False):
     """Creates a new API. """
 
-    if authorization_server_id is not None and authorization_scope is not None:
+    if authorization_server_id is not None:
         o_auth2 = OAuth2AuthenticationSettingsContract(
             authorization_server_id=authorization_server_id,
             scope=authorization_scope


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az apim api create

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Make --authorization_scope paramter option for setting auth server of an API

**Testing Guide**
<!--Example commands with explanations.-->
"az apim api create --resource-group {} --service-name {} --api-id {} --path {} --authorization-server-id {oAuth2Provider} --display-name {} --protocols {} --service-url {}" should work without --authorization_scope paramter specified

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[APIM] `az apim api create`: Make `--authorization-scope` parameter optional for setting auth server

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
