### PR TITLE
[App Service] Fix App Service config appsettings set and delete to redact secret values

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -242,7 +242,7 @@ subscription than the app service environment, please use the resource ID for --
             c.argument('https_only', help="Redirect all traffic made to an app using HTTP to HTTPS.",
                        arg_type=get_three_state_flag())
             
-    for scope in ['webapp', 'functionapp']:
+    for scope in ['webapp', 'functionapp', 'logicapp']:
         for cmd in ['set', 'delete']:
             with self.argument_context(scope + ' config appsettings ' + cmd) as c:
                 c.argument('show_values', action='store_true', options_list=['--show-values'])

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -241,6 +241,11 @@ subscription than the app service environment, please use the resource ID for --
             c.argument('tags', arg_type=tags_type)
             c.argument('https_only', help="Redirect all traffic made to an app using HTTP to HTTPS.",
                        arg_type=get_three_state_flag())
+            
+    for scope in ['webapp', 'functionapp']:
+        for cmd in ['set', 'delete']:
+            with self.argument_context(scope + ' config appsettings ' + cmd) as c:
+                c.argument('show_values', action='store_true', options_list=['--show-values'])
 
     for scope in ['webapp', 'functionapp']:
         with self.argument_context(scope) as c:

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -245,7 +245,8 @@ subscription than the app service environment, please use the resource ID for --
     for scope in ['webapp', 'functionapp', 'logicapp']:
         for cmd in ['set', 'delete']:
             with self.argument_context(scope + ' config appsettings ' + cmd) as c:
-                c.argument('show_values', action='store_true', options_list=['--show-values'])
+                c.argument('show_values', action='store_true', options_list=['--show-values'],
+                           help='Show unredacted appsetting values. WARNING: this may contain secrets -- use with caution in non-interactive CI contexts.')
 
     for scope in ['webapp', 'functionapp']:
         with self.argument_context(scope) as c:

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -241,7 +241,7 @@ subscription than the app service environment, please use the resource ID for --
             c.argument('tags', arg_type=tags_type)
             c.argument('https_only', help="Redirect all traffic made to an app using HTTP to HTTPS.",
                        arg_type=get_three_state_flag())
-            
+
     for scope in ['webapp', 'functionapp', 'logicapp']:
         for cmd in ['set', 'delete']:
             with self.argument_context(scope + ' config appsettings ' + cmd) as c:

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -430,9 +430,6 @@ def update_app_settings(cmd, resource_group_name, name, settings=None, slot=None
         app_settings.properties[setting_name] = value
     client = web_client_factory(cmd.cli_ctx)
 
-    if show_values:
-        Console.log("hello")
-
     # TODO: Centauri currently return wrong payload for update appsettings, remove this once backend has the fix.
     if is_centauri_functionapp(cmd, resource_group_name, name):
         update_application_settings_polling(cmd, resource_group_name, name, app_settings, slot, client)
@@ -1631,7 +1628,7 @@ def _build_app_settings_input(settings, connection_string_type):
         results = []
         for name_value in settings:
             conn_string_name, value = name_value.split('=', 1)
-            if value[0] in ["'", '"']:  # strip away the quots used as separators
+            if value[0] in ["'", '"']:  # strip away the quotes used as separators
                 value = value[1:-1]
             results.append({'name': conn_string_name, 'value': value, 'type': connection_string_type})
         return results

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -397,7 +397,8 @@ def parse_docker_image_name(deployment_container_image_name, environment=None):
     return "https://{}".format(hostname)
 
 
-def update_app_settings(cmd, resource_group_name, name, settings=None, slot=None, slot_settings=None, show_values=False):
+def update_app_settings(cmd, resource_group_name, name, settings=None, slot=None,
+                        slot_settings=None, show_values=False):
     if not settings and not slot_settings:
         raise MutuallyExclusiveArgumentError('Usage Error: --settings |--slot-settings')
 
@@ -1560,8 +1561,8 @@ def delete_app_settings(cmd, resource_group_name, name, setting_names, slot=None
         result = _generic_settings_operation(cmd.cli_ctx, resource_group_name, name,
                                              'update_application_settings',
                                              app_settings, slot, client)
-    return _build_app_settings_output(result.properties, 
-                                      slot_cfg_names.app_setting_names if slot_cfg_names else [], 
+    return _build_app_settings_output(result.properties,
+                                      slot_cfg_names.app_setting_names if slot_cfg_names else [],
                                       show_values)
 
 
@@ -1603,7 +1604,8 @@ def _build_app_settings_output(app_settings, slot_cfg_names, show_values=True):
     app_settings = _mask_creds_related_appsettings(app_settings)
     return [{'name': p,
              'value': app_settings[p],
-             'slotSetting': p in slot_cfg_names} for p in (app_settings if show_values else _redact_appsettings(app_settings))]
+             'slotSetting': p in slot_cfg_names} for p in
+            (app_settings if show_values else _redact_appsettings(app_settings))]
 
 
 def _build_app_settings_input(settings, connection_string_type):

--- a/src/azure-cli/azure/cli/command_modules/appservice/logicapp/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/logicapp/custom.py
@@ -236,9 +236,9 @@ def get_logicapp_app_settings(cmd, resource_group_name, name, slot=None):
     return get_app_settings(cmd, resource_group_name, name, slot)
 
 
-def update_logicapp_app_settings(cmd, resource_group_name, name, settings=None, slot=None, slot_settings=None):
-    return update_app_settings(cmd, resource_group_name, name, settings, slot, slot_settings)
+def update_logicapp_app_settings(cmd, resource_group_name, name, settings=None, slot=None, slot_settings=None, show_values=False):
+    return update_app_settings(cmd, resource_group_name, name, settings, slot, slot_settings, show_values)
 
 
-def delete_logicapp_app_settings(cmd, resource_group_name, name, setting_names, slot=None):
-    return delete_app_settings(cmd, resource_group_name, name, setting_names, slot)
+def delete_logicapp_app_settings(cmd, resource_group_name, name, setting_names, slot=None, show_values=False):
+    return delete_app_settings(cmd, resource_group_name, name, setting_names, slot, show_values)

--- a/src/azure-cli/azure/cli/command_modules/appservice/logicapp/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/logicapp/custom.py
@@ -236,7 +236,8 @@ def get_logicapp_app_settings(cmd, resource_group_name, name, slot=None):
     return get_app_settings(cmd, resource_group_name, name, slot)
 
 
-def update_logicapp_app_settings(cmd, resource_group_name, name, settings=None, slot=None, slot_settings=None, show_values=False):
+def update_logicapp_app_settings(cmd, resource_group_name, name, settings=None,
+                                 slot=None, slot_settings=None, show_values=False):
     return update_app_settings(cmd, resource_group_name, name, settings, slot, slot_settings, show_values)
 
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands.py
@@ -1405,7 +1405,7 @@ class FunctionAppSlotTests(ScenarioTest):
         self.cmd('functionapp deployment slot create -g {} -n {} --slot {}'.format(resource_group, functionapp, slotname), checks=[
             JMESPathCheck('name', slotname)
         ])
-        self.cmd('functionapp config appsettings set -g {} -n {} --slot {} --slot-settings FOO=BAR'.format(resource_group, functionapp,
+        self.cmd('functionapp config appsettings set -g {} -n {} --slot {} --slot-settings FOO=BAR --show-values'.format(resource_group, functionapp,
                                                                                                            slotname), checks=[
             JMESPathCheck("[?name=='FOO'].value|[0]", 'BAR'),
             JMESPathCheck("[?name=='FOO'].slotSetting|[0]", True)
@@ -1435,7 +1435,7 @@ class FunctionAppSlotTests(ScenarioTest):
                                                                                    slotname), checks=[
             JMESPathCheck('name', slotname)
         ])
-        self.cmd('functionapp config appsettings set -g {} -n {} --slot {} --settings FOO=BAR'.format(resource_group, functionapp,
+        self.cmd('functionapp config appsettings set -g {} -n {} --slot {} --settings FOO=BAR --show-values'.format(resource_group, functionapp,
                                                                                                       slotname), checks=[
             JMESPathCheck("[?name=='FOO'].value|[0]", 'BAR')
         ])

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_logicapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_logicapp_commands.py
@@ -170,7 +170,7 @@ class LogicappBasicE2ETest(ScenarioTest):
         )
 
         # update through key value pairs
-        self.cmd('logicapp config appsettings set -g {} -n {} --settings s1=foo s2=bar s3=bar2'.format(resource_group, logicapp_name)).assert_with_checks([
+        self.cmd('logicapp config appsettings set -g {} -n {} --settings s1=foo s2=bar s3=bar2 --show-values'.format(resource_group, logicapp_name)).assert_with_checks([
             JMESPathCheck("length([?name=='s1'])", 1),
             JMESPathCheck("length([?name=='s2'])", 1),
             JMESPathCheck("length([?name=='s3'])", 1),

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
@@ -685,7 +685,7 @@ class WebappConfigureTest(ScenarioTest):
 
         # site appsettings testing
         # update through key value pairs
-        self.cmd('webapp config appsettings set -g {} -n {} --settings s1=foo s2=bar s3=bar2'.format(resource_group, webapp_name)).assert_with_checks([
+        self.cmd('webapp config appsettings set -g {} -n {} --settings s1=foo s2=bar s3=bar2 --show-values'.format(resource_group, webapp_name)).assert_with_checks([
             JMESPathCheck("length([?name=='s1'])", 1),
             JMESPathCheck("length([?name=='s2'])", 1),
             JMESPathCheck("length([?name=='s3'])", 1),
@@ -835,7 +835,7 @@ class WebappConfigureTest(ScenarioTest):
 
         # site appsettings testing
         # update through key value pairs
-        self.cmd('webapp config appsettings set -g {} -n {} --settings s1=foo s2=bar s3=bar2'.format(resource_group, webapp_name)).assert_with_checks([
+        self.cmd('webapp config appsettings set -g {} -n {} --settings s1=foo s2=bar s3=bar2 --show-values'.format(resource_group, webapp_name)).assert_with_checks([
             JMESPathCheck("length([?name=='s1'])", 1),
             JMESPathCheck("length([?name=='s2'])", 1),
             JMESPathCheck("length([?name=='s3'])", 1),
@@ -874,7 +874,7 @@ class WebappConfigureTest(ScenarioTest):
             JMESPathCheck('name', slot)
         ])
 
-        output = self.cmd('webapp config appsettings set -g {} -n {} --settings s=value "@{}"'.format(
+        output = self.cmd('webapp config appsettings set -g {} -n {} --settings s=value "@{}" --show-values'.format(
             resource_group, webapp_name, settings_file)).get_output_in_json()
         output = [s for s in output if s['name'] in ['s', 's2']]
         output.sort(key=lambda s: s['name'])
@@ -898,7 +898,7 @@ class WebappConfigureTest(ScenarioTest):
         with open(settings_file, 'w') as file:
             file.write(json.dumps(output))
 
-        output = self.cmd('webapp config appsettings set -g {} -n {} --settings "@{}"'.format(
+        output = self.cmd('webapp config appsettings set -g {} -n {} --settings "@{}" --show-values'.format(
             resource_group, webapp_name, settings_file)).get_output_in_json()
         output = [s for s in output if s['name'] in ['s', 's2', 's3']]
         output.sort(key=lambda s: s['name'])
@@ -921,7 +921,7 @@ class WebappConfigureTest(ScenarioTest):
         with open(settings_file, 'w') as file:
             file.write(json.dumps(output))
 
-        output = self.cmd('webapp config appsettings set -g {} -n {} --slot {} --settings "@{}"'.format(
+        output = self.cmd('webapp config appsettings set -g {} -n {} --slot {} --settings "@{}" --show-values'.format(
             resource_group, webapp_name, slot, settings_file)).get_output_in_json()
         output = [s for s in output if s['name'] in ['s', 's2', 's3']]
         output.sort(key=lambda s: s['name'])
@@ -943,7 +943,7 @@ class WebappConfigureTest(ScenarioTest):
         })
 
         # app settings set with --slot-settings
-        output = self.cmd('webapp config appsettings set -g {} -n {} --slot-settings "@{}"'.format(
+        output = self.cmd('webapp config appsettings set -g {} -n {} --slot-settings "@{}" --show-values'.format(
             resource_group, webapp_name, settings_file)).get_output_in_json()
         output = [s for s in output if s['name'] in ['s', 's2', 's3']]
         output.sort(key=lambda s: s['name'])
@@ -964,7 +964,7 @@ class WebappConfigureTest(ScenarioTest):
             'slotSetting': True
         })
 
-        output = self.cmd('webapp config appsettings set -g {} -n {} --slot {} --slot-settings "@{}"'.format(
+        output = self.cmd('webapp config appsettings set -g {} -n {} --slot {} --slot-settings "@{}" --show-values'.format(
             resource_group, webapp_name, slot, settings_file)).get_output_in_json()
         output = [s for s in output if s['name'] in ['s', 's2', 's3']]
         output.sort(key=lambda s: s['name'])


### PR DESCRIPTION
**Related command**
az webapp config appsettings set/delete
az logicapp config appsettings set/delete 
az functionapp config appsettings set/delete

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Sets default output for the above commands to hide values. Guards against accidental security leaks through CI logs where non-authorized users can see returned secrets in appsettings. Adds parameter --show-values; when present, values will be displayed as before.

**Testing Guide**
<!--Example commands with explanations.-->
azdev test test_webapp_config_appsettings -> addition of the --show-values parameter results in an output with all appsettings shown, whereas excluding it results in the values being redacted

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->
[App Service] `az webapp config appsettings set/delete`: Update App Service config appsettings set and delete to redact secret values
[App Service] `az logicapp config appsettings set/delete`: Update App Service config appsettings set and delete to redact secret values
[App Service] `az functionapp config appsettings set/delete`: Update App Service config appsettings set and delete to redact secret values

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
