### PR TITLE
{Network} `az network watcher configure`: Fix watcher name to match portal naming when new deployment

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -4865,7 +4865,7 @@ def _create_network_watchers(cmd, resource_group_name, locations, tags):
     from .aaz.latest.network.watcher import Create
     for location in locations:
         Create(cli_ctx=cmd.cli_ctx)(command_args={
-            'name': '{}-watcher'.format(location),
+            'name': 'NetworkWatcher_{}'.format(location),
             'resource_group': resource_group_name,
             'location': location,
             'tags': tags


### PR DESCRIPTION
**Related command**
az network watcher configure --locations westeurope -g NetworkWatcherRG --enabled true

**Description**
This pr fixes the naming of network-watcher to match the default and portal naming when deploying a new network-watcher.

**Testing Guide**
run az network watcher configure --locations westeurope -g NetworkWatcherRG --enabled true
and deploy the same from portal or check the default deployment of network-watcher

**History Notes**

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
