### PR TITLE
[RDBMS] PostgreSQL - Add support for cross subscription restore

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_client_factory.py
@@ -109,13 +109,14 @@ def get_postgresql_management_client(cli_ctx, **_):
     return get_mgmt_service_client(cli_ctx, PostgreSQLManagementClient)
 
 
-def get_postgresql_flexible_management_client(cli_ctx, **_):
+def get_postgresql_flexible_management_client(cli_ctx, subscription_id=None, **_):
     from os import getenv
     from azure.mgmt.rdbms.postgresql_flexibleservers import PostgreSQLManagementClient
     # Allow overriding resource manager URI using environment variable
     # for testing purposes. Subscription id is also determined by environment
     # variable.
     rm_uri_override = getenv(RM_URI_OVERRIDE)
+    subscription = subscription_id if subscription_id is not None else getenv(SUB_ID_OVERRIDE)
     if rm_uri_override:
         client_id = getenv(AZURE_CLIENT_ID)
         if client_id:
@@ -125,11 +126,11 @@ def get_postgresql_flexible_management_client(cli_ctx, **_):
             credentials = Authentication()
 
         return PostgreSQLManagementClient(
-            subscription_id=getenv(SUB_ID_OVERRIDE),
+            subscription_id=subscription,
             base_url=rm_uri_override,
             credential=credentials)
     # Normal production scenario.
-    return get_mgmt_service_client(cli_ctx, PostgreSQLManagementClient)
+    return get_mgmt_service_client(cli_ctx, PostgreSQLManagementClient, subscription_id=subscription)
 
 
 def cf_mariadb_servers(cli_ctx, _):

--- a/src/azure-cli/azure/cli/command_modules/rdbms/_helptext_pg.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_helptext_pg.py
@@ -266,6 +266,19 @@ examples:
     text: az postgres flexible-server restore --resource-group testGroup --name testserverNew --source-server testserver --restore-time "2017-06-15T13:10:00Z"
   - name: Restore 'testserver' to current point-in-time as a new server 'testserverNew'.
     text: az postgres flexible-server restore --resource-group testGroup --name testserverNew --source-server testserver
+  - name: >
+      Restore 'testserver' to current point-in-time as a new server 'testserverNew' in a different resource group. \\
+      Here --restore-group is for the target server's resource group, and --source-server must be passed as resource ID.
+    text: >
+      az postgres flexible-server restore --resource-group testGroup --name testserverNew \\
+        --source-server /subscriptions/{testSubscription}/resourceGroups/{sourceResourceGroup}/providers/Microsoft.DBforPostgreSQL/flexibleServers/{sourceServerName}
+  - name: >
+      Restore 'testserver' to current point-in-time as a new server 'testserverNew' in a different subscription. \\
+      Here --restore-group is for the target server's resource group, and --source-server must be passed as resource ID. \\
+      This resource ID can be in a subscription different than the subscription used for az account set.
+    text: >
+      az postgres flexible-server restore --resource-group testGroup --name testserverNew \\
+        --source-server /subscriptions/{sourceSubscriptionId}/resourceGroups/{sourceResourceGroup}/providers/Microsoft.DBforPostgreSQL/flexibleServers/{sourceServerName}
 """
 
 helps['postgres flexible-server restart'] = """

--- a/src/azure-cli/azure/cli/command_modules/rdbms/_helptext_pg.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_helptext_pg.py
@@ -632,6 +632,13 @@ examples:
         --source-server testserver --vnet newVnet --subnet newSubnet \\
         --address-prefixes 172.0.0.0/16 --subnet-prefixes 172.0.0.0/24 \\
         --private-dns-zone testDNS.postgres.database.azure.com --location newLocation
+  - name: >
+      Geo-restore 'testserver' to current point-in-time as a new server 'testserverNew' in a different subscription / resource group. \\
+      Here --restore-group is for the target server's resource group, and --source-server must be passed as resource ID. \\
+      This resource ID can be in a subscription different than the subscription used for az account set.
+    text: >
+      az postgres flexible-server geo-restore --resource-group testGroup --name testserverNew --location newLocation \\
+        --source-server /subscriptions/{sourceSubscriptionId}/resourceGroups/{sourceResourceGroup}/providers/Microsoft.DBforPostgreSQL/flexibleServers/{sourceServerName}
 """
 
 helps['postgres flexible-server revive-dropped'] = """

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
@@ -196,7 +196,9 @@ def flexible_server_restore(cmd, client,
 
     try:
         id_parts = parse_resource_id(source_server_id)
-        source_server_object = client.get(id_parts['resource_group'], id_parts['name'])
+        source_subscription_id = id_parts['subscription']
+        postgres_source_client = get_postgresql_flexible_management_client(cmd.cli_ctx, source_subscription_id)
+        source_server_object = postgres_source_client.servers.get(id_parts['resource_group'], id_parts['name'])
 
         location = ''.join(source_server_object.location.lower().split())
 

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
@@ -544,9 +544,11 @@ def flexible_server_georestore(cmd, client, resource_group_name, server_name, so
     else:
         source_server_id = source_server
 
-    source_server_id_parts = parse_resource_id(source_server_id)
     try:
-        source_server_object = client.get(source_server_id_parts['resource_group'], source_server_id_parts['name'])
+        id_parts = parse_resource_id(source_server_id)
+        source_subscription_id = id_parts['subscription']
+        postgres_source_client = get_postgresql_flexible_management_client(cmd.cli_ctx, source_subscription_id)
+        source_server_object = postgres_source_client.servers.get(id_parts['resource_group'], id_parts['name'])
     except Exception as e:
         raise ResourceNotFoundError(e)
 


### PR DESCRIPTION
**Related command**
az postgres flexible-server geo-restore --resource-group testGroup --name testserverNew --location newLocation --source-server /subscriptions/{sourceSubscriptionId}/resourceGroups/{sourceResourceGroup}/providers/Microsoft.DBforPostgreSQL/flexibleServers/{sourceServerName}

az postgres flexible-server restore --resource-group testGroup --name testserverNew --source-server /subscriptions/{sourceSubscriptionId}/resourceGroups/{sourceResourceGroup}/providers/Microsoft.DBforPostgreSQL/flexibleServers/{sourceServerName}

**Description**<!--Mandatory-->
1. Add support for cross resource group and cross-subscription restore / geo-restore for flexible server

**Testing Guide**
Verified manually.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[RDBMS] `az postgres flexible-server geo-restore`: Add cross subscription geo-restore support for PostgreSQL flexible server
[RDBMS] `az postgres flexible-server restore`: Add cross subscription restore support for PostgreSQL flexible server

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
