### PR TITLE
[Storage] Fix #27590: `az storage fs directory download`: Check user sytem PATH for azcopy and use CLI config directory for new install

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
@@ -30,10 +30,19 @@ class AzCopy:
     def __init__(self, creds=None):
         self.system = platform.system()
         install_location = _get_default_install_location()
-        self.executable = install_location
+        if os.path.isfile(install_location):
+            self.executable = install_location
+        else:
+            try:
+                subprocess.run(["azcopy", "--version"])
+                self.executable = "azcopy"
+            except:
+                self.executable = None
         self.creds = creds
-        if not os.path.isfile(install_location) or self.check_version() != AZCOPY_VERSION:
+        if not self.executable:
+            logger.warning("Azcopy not found, installing")
             self.install_azcopy(install_location)
+            self.executable = install_location
 
     def install_azcopy(self, install_location):
         install_dir = os.path.dirname(install_location)

--- a/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
@@ -45,7 +45,7 @@ class AzCopy:
                 out_bytes = subprocess.check_output(args)
                 out_text = out_bytes.decode('utf-8')
                 version = re.findall(r"azcopy version (.+?)\n", out_text)[0]
-                if version or parse_version(version) >= parse_version(AZCOPY_VERSION):
+                if version and parse_version(version) >= parse_version(AZCOPY_VERSION):
                     self.executable = "azcopy"
             except Exception:  # pylint: disable=broad-except
                 self.executable = None

--- a/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
@@ -33,7 +33,7 @@ class AzCopy:
         self.executable = install_location
         self.creds = creds
         if not os.path.isfile(install_location) or self.check_version() != AZCOPY_VERSION:
-            logger.warning("Azcopy not found, installing at "+install_location)
+            logger.warning("Azcopy not found, installing at " + install_location)
             self.install_azcopy(install_location)
 
     def install_azcopy(self, install_location):

--- a/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
@@ -36,7 +36,7 @@ class AzCopy:
             try:
                 subprocess.run(["azcopy", "--version"])
                 self.executable = "azcopy"
-            except:
+            except Exception:
                 self.executable = None
         self.creds = creds
         if not self.executable:

--- a/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
@@ -33,7 +33,7 @@ class AzCopy:
         self.executable = install_location
         self.creds = creds
         if not os.path.isfile(install_location) or self.check_version() != AZCOPY_VERSION:
-            logger.warning("Azcopy not found, installing at " + install_location)
+            logger.warning("Azcopy not found, installing at %s", install_location)
             self.install_azcopy(install_location)
 
     def install_azcopy(self, install_location):

--- a/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
@@ -30,19 +30,11 @@ class AzCopy:
     def __init__(self, creds=None):
         self.system = platform.system()
         install_location = _get_default_install_location()
-        if os.path.isfile(install_location):
-            self.executable = install_location
-        else:
-            try:
-                subprocess.run(["azcopy", "--version"])
-                self.executable = "azcopy"
-            except Exception:
-                self.executable = None
+        self.executable = install_location
         self.creds = creds
-        if not self.executable:
-            logger.warning("Azcopy not found, installing")
+        if not os.path.isfile(install_location) or self.check_version() != AZCOPY_VERSION:
+            logger.warning("Azcopy not found, installing at "+install_location)
             self.install_azcopy(install_location)
-            self.executable = install_location
 
     def install_azcopy(self, install_location):
         install_dir = os.path.dirname(install_location)
@@ -196,9 +188,9 @@ def _get_default_install_location():
         if not home_dir:
             raise CLIError('In the Windows platform, please specify the environment variable "USERPROFILE" '
                            'as the installation location.')
-        install_location = os.path.join(home_dir, r'.azcopy\azcopy.exe')
+        install_location = os.path.join(home_dir, r'.azcopy_for_azure_cli\azcopy.exe')
     elif system in ('Linux', 'Darwin'):
-        install_location = os.path.expanduser(os.path.join('~', 'bin/azcopy'))
+        install_location = os.path.expanduser(os.path.join('~', 'bin/azcopy_for_azure_cli/azcopy'))
     else:
         raise CLIError('The {} platform is not currently supported. If you want to know which platforms are supported, '
                        'please refer to the document for supported platforms: '


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix #27590 Check user sytem PATH for azcopy and use it if the version is newer than 10.13.0. If not found or has old version, use CLI config directory for azcopy

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Storage] Fix #27590: `az storage fs directory download`: Check user sytem PATH for azcopy and use CLI config directory for new install

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
