### PR TITLE
[ACR] Add resource-group param to acr cache and acr credential-set command groups

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/cache.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/cache.py
@@ -11,9 +11,10 @@ from azure.core.serialization import NULL as AzureCoreNull
 def acr_cache_show(cmd,
                    client,
                    registry_name,
-                   name):
+                   name,
+                   resource_group_name=None):
 
-    rg = get_resource_group_name_by_registry_name(cmd.cli_ctx, registry_name, None)
+    rg = get_resource_group_name_by_registry_name(cmd.cli_ctx, registry_name, resource_group_name)
 
     return client.get(resource_group_name=rg,
                       registry_name=registry_name,
@@ -22,9 +23,10 @@ def acr_cache_show(cmd,
 
 def acr_cache_list(cmd,
                    client,
-                   registry_name):
+                   registry_name,
+                   resource_group_name=None):
 
-    rg = get_resource_group_name_by_registry_name(cmd.cli_ctx, registry_name, None)
+    rg = get_resource_group_name_by_registry_name(cmd.cli_ctx, registry_name, resource_group_name)
 
     return client.list(resource_group_name=rg,
                        registry_name=registry_name)
@@ -33,9 +35,10 @@ def acr_cache_list(cmd,
 def acr_cache_delete(cmd,
                      client,
                      registry_name,
-                     name):
+                     name,
+                     resource_group_name=None):
 
-    rg = get_resource_group_name_by_registry_name(cmd.cli_ctx, registry_name, None)
+    rg = get_resource_group_name_by_registry_name(cmd.cli_ctx, registry_name, resource_group_name)
 
     return client.begin_delete(resource_group_name=rg,
                                registry_name=registry_name,
@@ -48,9 +51,10 @@ def acr_cache_create(cmd,
                      name,
                      source_repo,
                      target_repo,
+                     resource_group_name=None,
                      cred_set=None):
 
-    registry, rg = get_registry_by_name(cmd.cli_ctx, registry_name, None)
+    registry, rg = get_registry_by_name(cmd.cli_ctx, registry_name, resource_group_name)
 
     cred_set_id = AzureCoreNull if not cred_set else f'{registry.id}/credentialSets/{cred_set}'
 
@@ -71,13 +75,14 @@ def acr_cache_create(cmd,
 def acr_cache_update_custom(cmd,
                             instance,
                             registry_name,
+                            resource_group_name=None,
                             cred_set=None,
                             remove_cred_set=False):
 
     if cred_set is None and remove_cred_set is False:
         raise InvalidArgumentValueError("You must either update the credential set ID or remove it.")
 
-    registry, _ = get_registry_by_name(cmd.cli_ctx, registry_name, None)
+    registry, _ = get_registry_by_name(cmd.cli_ctx, registry_name, resource_group_name)
 
     cred_set_id = AzureCoreNull if remove_cred_set else f'{registry.id}/credentialSets/{cred_set}'
 
@@ -99,9 +104,10 @@ def acr_cache_update_set(cmd,
                          client,
                          registry_name,
                          name,
+                         resource_group_name=None,
                          parameters=None):
 
-    rg = get_resource_group_name_by_registry_name(cmd.cli_ctx, registry_name)
+    rg = get_resource_group_name_by_registry_name(cmd.cli_ctx, registry_name, resource_group_name)
     return client.begin_update(resource_group_name=rg,
                                registry_name=registry_name,
                                cache_rule_name=name,

--- a/src/azure-cli/azure/cli/command_modules/acr/credential_set.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/credential_set.py
@@ -10,9 +10,10 @@ from ._utils import get_resource_group_name_by_registry_name
 def acr_cred_set_show(cmd,
                       client,
                       registry_name,
-                      name):
+                      name,
+                      resource_group_name=None):
 
-    rg = get_resource_group_name_by_registry_name(cmd.cli_ctx, registry_name, None)
+    rg = get_resource_group_name_by_registry_name(cmd.cli_ctx, registry_name, resource_group_name)
 
     return client.get(resource_group_name=rg,
                       registry_name=registry_name,
@@ -21,9 +22,10 @@ def acr_cred_set_show(cmd,
 
 def acr_cred_set_list(cmd,
                       client,
-                      registry_name):
+                      registry_name,
+                      resource_group_name=None):
 
-    rg = get_resource_group_name_by_registry_name(cmd.cli_ctx, registry_name, None)
+    rg = get_resource_group_name_by_registry_name(cmd.cli_ctx, registry_name, resource_group_name)
 
     return client.list(resource_group_name=rg,
                        registry_name=registry_name)
@@ -32,9 +34,10 @@ def acr_cred_set_list(cmd,
 def acr_cred_set_delete(cmd,
                         client,
                         registry_name,
-                        name):
+                        name,
+                        resource_group_name=None):
 
-    rg = get_resource_group_name_by_registry_name(cmd.cli_ctx, registry_name, None)
+    rg = get_resource_group_name_by_registry_name(cmd.cli_ctx, registry_name, resource_group_name)
 
     return client.begin_delete(resource_group_name=rg,
                                registry_name=registry_name,
@@ -47,9 +50,10 @@ def acr_cred_set_create(cmd,
                         name,
                         password_id,
                         username_id,
-                        login_server):
+                        login_server,
+                        resource_group_name=None):
 
-    rg = get_resource_group_name_by_registry_name(cmd.cli_ctx, registry_name, None)
+    rg = get_resource_group_name_by_registry_name(cmd.cli_ctx, registry_name, resource_group_name)
 
     CredSet = cmd.get_models('CredentialSet', operation_group='credential_sets')
     AuthCred = cmd.get_models('AuthCredential', operation_group='credential_sets')
@@ -78,13 +82,14 @@ def acr_cred_set_update_custom(cmd,
                                instance,
                                registry_name,
                                name,
+                               resource_group_name=None,
                                password_id=None,
                                username_id=None):
 
     if password_id is None and username_id is None:
         raise InvalidArgumentValueError("You must update either the username secret ID, password secret ID, or both.")
 
-    rg = get_resource_group_name_by_registry_name(cmd.cli_ctx, registry_name, None)
+    rg = get_resource_group_name_by_registry_name(cmd.cli_ctx, registry_name, resource_group_name)
 
     cred_set = client.get(resource_group_name=rg,
                           registry_name=registry_name,
@@ -114,9 +119,10 @@ def acr_cred_set_update_set(cmd,
                             client,
                             registry_name,
                             name,
+                            resource_group_name=None,
                             parameters=None):
 
-    rg = get_resource_group_name_by_registry_name(cmd.cli_ctx, registry_name)
+    rg = get_resource_group_name_by_registry_name(cmd.cli_ctx, registry_name, resource_group_name)
     return client.begin_update(resource_group_name=rg,
                                registry_name=registry_name,
                                credential_set_name=name,


### PR DESCRIPTION
**Related command**
az acr cache command group
az acr credential-set command group

**Description**<!--Mandatory-->
Add resource-group param to acr cache and acr credential-set command groups as an optional parameter for performance and reliability conscious users

**Testing Guide**
az acr cache show -r testreg -g testgroup -n testrule

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[ACR] `az acr cache`: Add optional `resource-group` parameter 
[ACR] `az acr credential-set`: Add optional `resource-group` parameter 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
