### PR TITLE
[App Service] BREAKING CHANGE: Redact tokens output on deployment source update-token

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -2057,7 +2057,12 @@ def update_git_token(cmd, git_token=None):
     client = web_client_factory(cmd.cli_ctx)
     from azure.mgmt.web.models import SourceControl
     sc = SourceControl(name='not-really-needed', source_control_name='GitHub', token=git_token or '')
-    return client.update_source_control('GitHub', sc)
+    response = client.update_source_control('GitHub', sc)
+    logger.warning('Tokens have been redacted.')
+    response.refresh_token = None
+    response.token = None
+    response.token_secret = None
+    return response
 
 
 def show_source_control(cmd, resource_group_name, name, slot=None):

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -2052,7 +2052,7 @@ def config_source_control(cmd, resource_group_name, name, repo_url, repository_t
 def update_git_token(cmd, git_token=None):
     '''
     Update source control token cached in Azure app service. If no token is provided,
-    the command will clean up existing token.
+    the command will clean up existing token. Note that tokens are now redacted in the result.
     '''
     client = web_client_factory(cmd.cli_ctx)
     from azure.mgmt.web.models import SourceControl

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_functionapp_deployment_source_update_token.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_functionapp_deployment_source_update_token.yaml
@@ -1,0 +1,58 @@
+interactions:
+- request:
+    body: '{"properties": {"token": "password1234"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp deployment source update-token
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '41'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - --git-token
+      User-Agent:
+      - AZURECLI/2.53.0 azsdk-python-azure-mgmt-web/7.0.0 Python/3.8.0 (Windows-10-10.0.22621-SP0)
+    method: PUT
+    uri: https://management.azure.com/providers/Microsoft.Web/sourcecontrols/GitHub?api-version=2022-03-01
+  response:
+    body:
+      string: '{"id":null,"name":"GitHub","type":"Microsoft.Web/sourcecontrols","properties":{"name":"GitHub","token":"password1234","tokenSecret":null,"refreshToken":null,"environment":null}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '177'
+      content-type:
+      - application/json
+      date:
+      - Thu, 02 Nov 2023 17:26:42 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-tenant-writes:
+      - '1199'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands.py
@@ -1844,6 +1844,13 @@ class FunctionappLinuxConsumptionZipDeploy(LiveScenarioTest):
             self.cmd('functionapp deployment source config-zip -g {} -n {} --src "{}" --build-remote'.format(resource_group, functionapp_name, zip_file))
 
 
+class FunctionappDeploymentSourceScenarioTest(ScenarioTest):
+    def test_functionapp_deployment_source_update_token(self):
+        self.cmd('functionapp deployment source update-token --git-token password1234').assert_with_checks([
+            JMESPathCheck('token', None)
+        ])
+
+
 # LiveScenarioTest due to issue https://github.com/Azure/azure-cli/issues/10705
 class FunctionappDeploymentLogsScenarioTest(LiveScenarioTest):
     @ResourceGroupPreparer(location=WINDOWS_ASP_LOCATION_FUNCTIONAPP)

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands_thru_mock.py
@@ -102,7 +102,7 @@ class TestWebappMocked(unittest.TestCase):
         result = update_git_token(cmd_mock, 'veryNiceToken')
 
         # assert things gets wired up
-        self.assertEqual(result.token, 'veryNiceToken')
+        self.assertEqual(result.token, None)
 
     @mock.patch('azure.cli.command_modules.appservice.custom.web_client_factory', autospec=True)
     def test_set_domain_name(self, client_factory_mock):


### PR DESCRIPTION
**Related command**
`az functionapp deployment source update-token`
`az webapp deployment source update-token`

**Description**<!--Mandatory-->
Currently, these two commands return the tokens as part of the output. In this PR, we are redacting the tokens so prevent accidental security leaks through CI logs.

**Testing Guide**
1. Create functionapp (`az functionapp create`)
2. Update token (`az functionapp deployment source update-token`)

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
