### PR TITLE
[AKS] `az aks nodepool add`: Fix incorrectly specified property name for option `--drain-timeout`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
@@ -943,7 +943,7 @@ class AKSAgentPoolContext(BaseAKSContext):
             if (
                 self.agentpool and
                 self.agentpool.upgrade_settings and
-                self.agentpool.upgrade_settings.drain_timeout is not None
+                self.agentpool.upgrade_settings.drain_timeout_in_minutes is not None
             ):
                 drain_timeout = self.agentpool.upgrade_settings.drain_timeout_in_minutes
 

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_agentpool_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_agentpool_decorator.py
@@ -1308,6 +1308,20 @@ class AKSAgentPoolContextCommonTestCase(unittest.TestCase):
         ctx_1.attach_agentpool(agentpool_1)
         self.assertEqual(ctx_1.get_gpu_instance_profile(), "test_gpu_instance_profile")
 
+    def common_get_drain_timeout(self):
+        # default
+        ctx_1 = AKSAgentPoolContext(
+            self.cmd,
+            AKSAgentPoolParamDict({"drain_timeout": None}),
+            self.models,
+            DecoratorMode.CREATE,
+            self.agentpool_decorator_mode,
+        )
+        self.assertEqual(ctx_1.get_drain_timeout(), None)
+        agentpool_1 = self.create_initialized_agentpool_instance(upgrade_settings=self.models.AgentPoolUpgradeSettings(drain_timeout_in_minutes=123))
+        ctx_1.attach_agentpool(agentpool_1)
+        self.assertEqual(ctx_1.get_drain_timeout(), 123)
+
 class AKSAgentPoolContextStandaloneModeTestCase(AKSAgentPoolContextCommonTestCase):
     def setUp(self):
         self.cli_ctx = MockCLI()
@@ -1488,6 +1502,9 @@ class AKSAgentPoolContextStandaloneModeTestCase(AKSAgentPoolContextCommonTestCas
     def test_get_gpu_instance_profile(self):
         self.common_get_gpu_instance_profile()
 
+    def test_get_drain_timeout(self):
+        self.common_get_drain_timeout()
+
 class AKSAgentPoolContextManagedClusterModeTestCase(AKSAgentPoolContextCommonTestCase):
     def setUp(self):
         self.cli_ctx = MockCLI()
@@ -1641,6 +1658,9 @@ class AKSAgentPoolContextManagedClusterModeTestCase(AKSAgentPoolContextCommonTes
 
     def test_get_gpu_instance_profile(self):
         self.common_get_gpu_instance_profile()
+
+    def test_get_drain_timeout(self):
+        self.common_get_drain_timeout()
 
 class AKSAgentPoolAddDecoratorCommonTestCase(unittest.TestCase):
     def _remove_defaults_in_agentpool(self, agentpool):


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
- `az aks nodepool add`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Fix incorrectly specified property name for option `--drain-timeout` in command `az aks nodepool add`. Bug fix for the change in previous PR #27475.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
