### PR TITLE
{AKS} `az aks install-cli`: Fix typo in warning message

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -1615,7 +1615,7 @@ def get_arch_for_cli_binary():
         )
     logger.warning(
         'The detected architecture of current device is "%s", and the binary for "%s" '
-        'will be downloaded. If the detectiton is wrong, please download and install '
+        'will be downloaded. If the detection is wrong, please download and install '
         'the binary corresponding to the appropriate architecture.',
         arch,
         formatted_arch,


### PR DESCRIPTION
**Related command**
 az aks install-cli

**Description**
The word detection had a typo.

**Testing Guide**
Run az aks install-cli

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
