### PR TITLE
{Container} `az container create`: Fix typo for the `--privileged` parameter

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/container/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/container/_params.py
@@ -80,7 +80,7 @@ def load_arguments(self, _):
     with self.argument_context('container create', arg_group='Confidential Container Group') as c:
         c.argument('cce_policy', help="The CCE policy for the confidential container group")
         c.argument('allow_privilege_escalation', options_list=['--allow-escalation'], help="Allow whether a process can gain more privileges than its parent process.", action='store_true')
-        c.argument('privileged', help='The flag to determine if the contianer permissions is elevated to Privileged', action='store_true')
+        c.argument('privileged', help='The flag to determine if the container permissions is elevated to Privileged', action='store_true')
         c.argument('run_as_user', help="Set the User GID for the container")
         c.argument('run_as_group', help="Set the User UID for the container")
         c.argument('seccomp_profile', help="A base64 encoded string containing the contents of the JSON in the seccomp profile")


### PR DESCRIPTION
Corrected typo (contianer to container)

**Description**<!--Mandatory-->
Corrected documentation typo.