### PR TITLE
{CI} Disable `alias` extension test

### DIFF
--- a/scripts/ci/test_extensions.sh
+++ b/scripts/ci/test_extensions.sh
@@ -18,8 +18,9 @@ export AZURE_CLI_DIAGNOSTICS_TELEMETRY=
 output=$(az extension list-available --query [].name -otsv)
 exit_code=0
 
-# azure-cli-ml: https://github.com/Azure/azure-cli-extensions/issues/826
-# Disable arcappliance arcdata connectedk8s https://github.com/Azure/azure-cli/pull/20436
+# Disable azure-cli-ml: https://github.com/Azure/azure-cli-extensions/issues/826
+# Disable fzf: https://github.com/Azure/azure-cli/pull/17979
+# Disable arcappliance arcdata connectedk8s: https://github.com/Azure/azure-cli/pull/20436
 # Disable k8s-extension temporarily: https://github.com/Azure/azure-cli-extensions/pull/6702
 # Disable alias temporarily: https://github.com/Azure/azure-cli/pull/27717
 ignore_list='azure-cli-ml fzf arcappliance arcdata connectedk8s k8s-extension alias'

--- a/scripts/ci/test_extensions.sh
+++ b/scripts/ci/test_extensions.sh
@@ -19,6 +19,7 @@ output=$(az extension list-available --query [].name -otsv)
 exit_code=0
 
 # azure-cli-ml: https://github.com/Azure/azure-cli-extensions/issues/826
+# Disable arcappliance arcdata connectedk8s https://github.com/Azure/azure-cli/pull/20436
 # Disable k8s-extension temporarily: https://github.com/Azure/azure-cli-extensions/pull/6702
 # Disable alias temporarily: https://github.com/Azure/azure-cli/pull/27717
 ignore_list='azure-cli-ml fzf arcappliance arcdata connectedk8s k8s-extension alias'

--- a/scripts/ci/test_extensions.sh
+++ b/scripts/ci/test_extensions.sh
@@ -20,7 +20,8 @@ exit_code=0
 
 # azure-cli-ml: https://github.com/Azure/azure-cli-extensions/issues/826
 # Disable k8s-extension temporarily: https://github.com/Azure/azure-cli-extensions/pull/6702
-ignore_list='azure-cli-ml fzf arcappliance arcdata connectedk8s k8s-extension'
+# Disable alias temporarily: https://github.com/Azure/azure-cli/pull/27717
+ignore_list='azure-cli-ml fzf arcappliance arcdata connectedk8s k8s-extension alias'
 
 for ext in $output; do
     echo

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -138,6 +138,7 @@ DEPENDENCIES = [
     'fabric~=2.4',
     'javaproperties~=0.5.1',
     'jsondiff~=2.0.0',
+    'Jinja2~=3.0.3',
     'packaging>=20.9',
     'pycomposefile>=0.0.29',
     'PyGithub~=1.38',

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -138,7 +138,6 @@ DEPENDENCIES = [
     'fabric~=2.4',
     'javaproperties~=0.5.1',
     'jsondiff~=2.0.0',
-    'Jinja2~=3.0.3',
     'packaging>=20.9',
     'pycomposefile>=0.0.29',
     'PyGithub~=1.38',


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
This PR temporarily fixes the `Test Extensions Loading Python311` error, similar PR: https://github.com/Azure/azure-cli/pull/20436
```
2023-10-30T02:31:59.9288865Z ERROR: az_command_data_logger: cannot import name 'soft_unicode' from 'markupsafe' (/opt/az/azcliextensions/alias/markupsafe/__init__.py)
2023-10-30T02:31:59.9292703Z Traceback (most recent call last):
2023-10-30T02:31:59.9296297Z   File "/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/knack/cli.py", line 233, in invoke
2023-10-30T02:31:59.9297243Z     cmd_result = self.invocation.execute(args)
2023-10-30T02:31:59.9299944Z                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2023-10-30T02:31:59.9301257Z   File "/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/azure/cli/core/commands/__init__.py", line 663, in execute
2023-10-30T02:31:59.9307162Z     raise ex
2023-10-30T02:31:59.9324332Z   File "/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/azure/cli/core/commands/__init__.py", line 726, in _run_jobs_serially
2023-10-30T02:31:59.9325597Z     results.append(self._run_job(expanded_arg, cmd_copy))
2023-10-30T02:31:59.9326044Z                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2023-10-30T02:31:59.9327178Z   File "/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/azure/cli/core/commands/__init__.py", line 697, in _run_job
2023-10-30T02:31:59.9328177Z     result = cmd_copy(params)
2023-10-30T02:31:59.9328424Z              ^^^^^^^^^^^^^^^^
2023-10-30T02:31:59.9329467Z   File "/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/azure/cli/core/commands/__init__.py", line 333, in __call__
2023-10-30T02:31:59.9330507Z     return self.handler(*args, **kwargs)
2023-10-30T02:31:59.9330812Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2023-10-30T02:31:59.9332078Z   File "/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/azure/cli/core/commands/command_operation.py", line 121, in handler
2023-10-30T02:31:59.9333525Z     return op(**command_args)
2023-10-30T02:31:59.9333810Z            ^^^^^^^^^^^^^^^^^^
2023-10-30T02:31:59.9334976Z   File "/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/azure/cli/command_modules/profile/custom.py", line 183, in check_cli
2023-10-30T02:31:59.9336009Z     raise ex
2023-10-30T02:31:59.9337146Z   File "/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/azure/cli/command_modules/profile/custom.py", line 178, in check_cli
2023-10-30T02:31:59.9338498Z     create_invoker_and_load_cmds_and_args(cmd.cli_ctx)
2023-10-30T02:31:59.9339968Z   File "/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/azure/cli/core/file_util.py", line 74, in create_invoker_and_load_cmds_and_args
2023-10-30T02:31:59.9341200Z     invoker.commands_loader.load_arguments()
2023-10-30T02:31:59.9342406Z   File "/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/azure/cli/core/__init__.py", line 516, in load_arguments
2023-10-30T02:31:59.9343540Z     cmd.load_arguments()  # this loads the arguments via reflection
2023-10-30T02:31:59.9344014Z     ^^^^^^^^^^^^^^^^^^^^
2023-10-30T02:31:59.9389458Z   File "/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/azure/cli/core/commands/__init__.py", line 318, in load_arguments
2023-10-30T02:31:59.9390806Z     super(AzCliCommand, self).load_arguments()
2023-10-30T02:31:59.9392048Z   File "/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/knack/commands.py", line 104, in load_arguments
2023-10-30T02:31:59.9393047Z     cmd_args = self.arguments_loader()
2023-10-30T02:31:59.9393395Z                ^^^^^^^^^^^^^^^^^^^^^^^
2023-10-30T02:31:59.9394813Z   File "/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/azure/cli/core/commands/command_operation.py", line 125, in arguments_loader
2023-10-30T02:31:59.9396102Z     op = self.get_op_handler(self.op_path)
2023-10-30T02:31:59.9396795Z          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2023-10-30T02:31:59.9398365Z   File "/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/azure/cli/core/commands/command_operation.py", line 59, in get_op_handler
2023-10-30T02:31:59.9399661Z     handler = import_module(mod_to_import)
2023-10-30T02:31:59.9400056Z               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2023-10-30T02:31:59.9400862Z   File "/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/importlib/__init__.py", line 126, in import_module
2023-10-30T02:31:59.9401864Z     return _bootstrap._gcd_import(name[level:], package, level)
2023-10-30T02:31:59.9402364Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2023-10-30T02:31:59.9402868Z   File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
2023-10-30T02:31:59.9403543Z   File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
2023-10-30T02:31:59.9404262Z   File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
2023-10-30T02:31:59.9404989Z   File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
2023-10-30T02:31:59.9405689Z   File "<frozen importlib._bootstrap_external>", line 940, in exec_module
2023-10-30T02:31:59.9406447Z   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
2023-10-30T02:31:59.9407285Z   File "/opt/az/azcliextensions/aosm/azext_aosm/custom.py", line 33, in <module>
2023-10-30T02:31:59.9408081Z     from azext_aosm.generate_nfd.cnf_nfd_generator import CnfNfdGenerator
2023-10-30T02:31:59.9409084Z   File "/opt/az/azcliextensions/aosm/azext_aosm/generate_nfd/cnf_nfd_generator.py", line 17, in <module>
2023-10-30T02:31:59.9409940Z     from jinja2 import StrictUndefined, Template
2023-10-30T02:31:59.9410566Z   File "/opt/az/azcliextensions/alias/jinja2/__init__.py", line 12, in <module>
2023-10-30T02:31:59.9411213Z     from .environment import Environment
2023-10-30T02:31:59.9411945Z   File "/opt/az/azcliextensions/alias/jinja2/environment.py", line 25, in <module>
2023-10-30T02:31:59.9412655Z     from .defaults import BLOCK_END_STRING
2023-10-30T02:31:59.9413245Z   File "/opt/az/azcliextensions/alias/jinja2/defaults.py", line 3, in <module>
2023-10-30T02:31:59.9413979Z     from .filters import FILTERS as DEFAULT_FILTERS  # noqa: F401
2023-10-30T02:31:59.9414447Z     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2023-10-30T02:31:59.9415034Z   File "/opt/az/azcliextensions/alias/jinja2/filters.py", line 13, in <module>
2023-10-30T02:31:59.9415680Z     from markupsafe import soft_unicode
2023-10-30T02:31:59.9416733Z ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/opt/az/azcliextensions/alias/markupsafe/__init__.py)
```

**Cause**

![image-20231030144053958](https://github.com/Azure/azure-cli/assets/2227874/299cb727-ed7a-4d20-a2c9-33816b81b769)


1. This test uses an ancient version of azdev from `/tools`, which does not install dependency in `requirements`. `jinja2` is not in `setup.py`, so `jinja2` is not installed.
2. `alias` extension installs `jinja2~=2.10`, which is deprecated and it does compatible with latest `markupsafe`, which raises `ImportError: cannot import name 'soft_unicode' from 'markupsafe'`
3. `aosm` extension requires `jinja2>=3.1.2`, it tries to `import jinja2` when building command tree.
4. CLI adds extension path to `sys.path` one by one, so `aosm` imports `jinja2` from `alias` extension path and fails.

As `alias` extension should not install a outdated `jinja2`, disable it in test so `aosm` can import its `jinja2`.

**Plan**
`Jinja2` and `MarkupSafe` were introduced in `requirements.txt` in #9785 and updated in #22602, but CLI does not use it.(Some scripts rely on them). We should remove it from requirements.txt to reduce package size.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
