### PR TITLE
[MYSQL] `az mysql flexible-server gtid reset`: Remove geo-backup check

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/mysql/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/mysql/custom.py
@@ -1776,19 +1776,10 @@ def flexible_server_ad_admin_show(client, resource_group_name, server_name):
 
 
 def flexible_gtid_reset(client, resource_group_name, server_name, gtid_set, no_wait=False, yes=False):
-    try:
-        server_object = client.get(resource_group_name, server_name)
-    except Exception as e:
-        raise ResourceNotFoundError(e)
-
-    if server_object.backup.geo_redundant_backup.lower() == "enabled":
-        raise CLIError("GTID reset can't be performed on a Geo-redundancy backup enabled server. Please disable Geo-redundancy to perform GTID reset on the server. "
-                       "You can enable Geo-redundancy option again after GTID reset. GTID reset action invalidates all the available backups and therefore, "
-                       "once Geo-redundancy is enabled again, it may take a day before geo-restore can be performed on the server.")
-
-    user_confirmation("Resetting GTID will invalidate all the automated/on-demand backups that were taken before the reset action and you will not be able "
-                      "to perform PITR (point-in-time-restore) using fastest restore point or by custom restore point if the selected restore time is before"
-                      " the GTID reset time. Do you want to continue?", yes=yes)
+    user_confirmation("Resetting GTID will invalidate all the automated, on-demand backups and geo-backups that were taken before the reset "
+                      "action. After GTID reset, you will not be able to perform PITR (point-in-time-restore) using fastest restore point "
+                      "or by custom restore point if the selected restore time is before the GTID reset time. And successful geo-restore will "
+                      "be possible only after 5 days. Do you want to continue?", yes=yes)
 
     parameters = mysql_flexibleservers.models.ServerGtidSetParameter(
         gtid_set=gtid_set

--- a/src/azure-cli/azure/cli/command_modules/mysql/tests/latest/test_mysql_scenario.py
+++ b/src/azure-cli/azure/cli/command_modules/mysql/tests/latest/test_mysql_scenario.py
@@ -935,10 +935,6 @@ class FlexibleServerMgmtScenarioTest(ScenarioTest):
         self.cmd('{} flexible-server create -g {} -n {} -l {} --public-access none --tier {} --sku-name {}'
                  .format(database_engine, resource_group, source_server, location, 'GeneralPurpose', general_purpose_sku))
         
-        self.cmd('{} flexible-server show -g {} -n {}'
-                 .format(database_engine, resource_group, source_server),
-                 checks=[JMESPathCheck('backup.geoRedundantBackup', 'Disabled')])
-        
         # update server paramters to enable gtid
         source = 'user-override'
         parameter_name = 'enforce_gtid_consistency'
@@ -958,18 +954,9 @@ class FlexibleServerMgmtScenarioTest(ScenarioTest):
         self.cmd('{} flexible-server parameter set --name {} -v {} --source {} -s {} -g {}'
                  .format(database_engine, parameter_name, 'ON', source, source_server, resource_group),
                  checks=[JMESPathCheck('value', 'ON'), JMESPathCheck('source', source), JMESPathCheck('name', parameter_name)])
-
-        # set gtid string to source server
-        self.cmd('{} flexible-server gtid reset --resource-group {} --server-name {} --gtid-set {} --yes'
-                 .format(database_engine, resource_group, source_server, str(uuid.uuid4()).upper() + ":1"), expect_failure=False)
-
-        # udpate server geo-redundant-backup to enable
-        self.cmd('{} flexible-server update -g {} -n {} --geo-redundant-backup Enabled'
-                 .format(database_engine, resource_group, source_server),
-                 checks=[JMESPathCheck('backup.geoRedundantBackup', 'Enabled')])
         
         self.cmd('{} flexible-server gtid reset --resource-group {} --server-name {} --gtid-set {} --yes'
-                 .format(database_engine, resource_group, source_server, str(uuid.uuid4()).upper() + ":1"), expect_failure=True)
+                 .format(database_engine, resource_group, source_server, str(uuid.uuid4()).upper() + ":1"), expect_failure=False)
         
         self.cmd('{} flexible-server delete -g {} -n {} --yes'.format(database_engine, resource_group, source_server))
 


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az mysql flexible-server gtid reset --resource-group {} --server-name {} --gtid-set {} --no-wait {} --yes {}
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
remove geo backup check when customer want to reset gtid and update warning notification.


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
