### PR TITLE
{Core} Replace `allow_broker` with `enable_broker_on_windows`

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -856,13 +856,14 @@ def _create_identity_instance(cli_ctx, *args, **kwargs):
     # EXPERIMENTAL: Use core.use_msal_http_cache=False to turn off MSAL HTTP cache.
     use_msal_http_cache = cli_ctx.config.getboolean('core', 'use_msal_http_cache', fallback=True)
 
-    # PREVIEW: On Windows, use core.allow_broker=true to use broker (WAM) for authentication.
-    allow_broker = cli_ctx.config.getboolean('core', 'allow_broker', fallback=False)
+    # PREVIEW: On Windows, use core.enable_broker_on_windows=true to use broker (WAM) for authentication.
+    enable_broker_on_windows = cli_ctx.config.getboolean('core', 'enable_broker_on_windows', fallback=False)
     from .telemetry import set_broker_info
-    set_broker_info(allow_broker=allow_broker)
+    set_broker_info(enable_broker_on_windows)
 
     # PREVIEW: In Azure Stack environment, use core.instance_discovery=false to disable MSAL's instance discovery.
     instance_discovery = cli_ctx.config.getboolean('core', 'instance_discovery', True)
 
-    return Identity(*args, encrypt=encrypt, use_msal_http_cache=use_msal_http_cache, allow_broker=allow_broker,
+    return Identity(*args, encrypt=encrypt, use_msal_http_cache=use_msal_http_cache,
+                    enable_broker_on_windows=enable_broker_on_windows,
                     instance_discovery=instance_discovery, **kwargs)

--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -54,7 +54,7 @@ class Identity:  # pylint: disable=too-many-instance-attributes
     _service_principal_store_instance = None
 
     def __init__(self, authority, tenant_id=None, client_id=None, encrypt=False, use_msal_http_cache=True,
-                 allow_broker=None, instance_discovery=None):
+                 enable_broker_on_windows=None, instance_discovery=None):
         """
         :param authority: Authentication authority endpoint. For example,
             - AAD: https://login.microsoftonline.com
@@ -69,7 +69,7 @@ class Identity:  # pylint: disable=too-many-instance-attributes
         self.client_id = client_id or AZURE_CLI_CLIENT_ID
         self._encrypt = encrypt
         self._use_msal_http_cache = use_msal_http_cache
-        self._allow_broker = allow_broker
+        self._enable_broker_on_windows = enable_broker_on_windows
         self._instance_discovery = instance_discovery
 
         # Build the authority in MSAL style
@@ -107,8 +107,8 @@ class Identity:  # pylint: disable=too-many-instance-attributes
     @property
     def _msal_public_app_kwargs(self):
         """kwargs for creating PublicClientApplication."""
-        # allow_broker can only be used on PublicClientApplication.
-        return {**self._msal_app_kwargs, "allow_broker": self._allow_broker}
+        # enable_broker_on_windows can only be used on PublicClientApplication.
+        return {**self._msal_app_kwargs, "enable_broker_on_windows": self._enable_broker_on_windows}
 
     @property
     def _msal_app(self):

--- a/src/azure-cli-core/azure/cli/core/auth/landing_pages/success.html
+++ b/src/azure-cli-core/azure/cli/core/auth/landing_pages/success.html
@@ -25,7 +25,7 @@
     <p>[Windows only] Azure CLI is collecting feedback on using the <a href="https://learn.microsoft.com/windows/uwp/security/web-account-manager">Web Account Manager</a> (WAM) broker for the login experience.</p>
     <p>You may opt-in to use WAM by running the following commands:</p>
     <code>
-        az config set core.allow_broker=true<br>
+        az config set core.enable_broker_on_windows=true<br>
         az account clear<br>
         az login
     </code>

--- a/src/azure-cli-core/azure/cli/core/telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry.py
@@ -70,7 +70,7 @@ class TelemetrySession:  # pylint: disable=too-many-instance-attributes
         self.suppress_new_event = False
         self.poll_start_time = None
         self.poll_end_time = None
-        self.allow_broker = None
+        self.enable_broker_on_windows = None
         self.msal_telemetry = None
         self.secrets_detected = None
         self.user_agent = None
@@ -221,7 +221,7 @@ class TelemetrySession:  # pylint: disable=too-many-instance-attributes
         set_custom_properties(result, 'ShowSurveyMessage', str(self.show_survey_message))
         set_custom_properties(result, 'RegionInput', self.region_input)
         set_custom_properties(result, 'RegionIdentified', self.region_identified)
-        set_custom_properties(result, 'AllowBroker', str(self.allow_broker))
+        set_custom_properties(result, 'EnableBrokerOnWindows', str(self.enable_broker_on_windows))
         set_custom_properties(result, 'MsalTelemetry', self.msal_telemetry)
         set_custom_properties(result, 'SecretsWarning', _get_secrets_warning_config())
         set_custom_properties(result, 'SecretsDetected', self.secrets_detected)
@@ -462,9 +462,9 @@ def set_region_identified(region_input, region_identified):
 
 
 @decorators.suppress_all_exceptions()
-def set_broker_info(allow_broker):
-    # whether customer has configured `allow_broker` to enable WAM(Web Account Manager) login for authentication
-    _session.allow_broker = allow_broker
+def set_broker_info(enable_broker_on_windows):
+    # Log the value of `enable_broker_on_windows`
+    _session.enable_broker_on_windows = enable_broker_on_windows
 
 
 @decorators.suppress_all_exceptions()


### PR DESCRIPTION
**Related command**
`az login`

**Description**<!--Mandatory-->
This PR adopts the MSAL change https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/613 where MSAL will deprecate `allow_broker` and use `enable_broker_on_windows`.

**Testing Guide**
```
az config set core.enable_broker_on_windows=true
az login
az config unset core.enable_broker_on_windows
az login
```
