### PR TITLE
{Core} Fix reference doc for generic update arguments

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -386,9 +386,9 @@ def register_global_subscription_argument(cli_ctx):
     cli_ctx.register_event(EVENT_INVOKER_PRE_LOAD_ARGUMENTS, add_subscription_parameter)
 
 
-add_usage = '--add property.listProperty <key=value, string or JSON string>'
-set_usage = '--set property1.property2=<value>'
-remove_usage = '--remove property.list <indexToRemove> OR --remove propertyToRemove'
+add_usage = '`--add property.listProperty <key=value, string or JSON string>`'
+set_usage = '`--set property1.property2=<value>`'
+remove_usage = '`--remove property.list <indexToRemove>` OR `--remove propertyToRemove`'
 
 
 def _get_operations_tmpl(cmd, custom_command=False):

--- a/src/azure-cli-core/azure/cli/core/tests/test_aaz_operation.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_aaz_operation.py
@@ -451,7 +451,7 @@ class TestAAZGenericUpdateOperation(unittest.TestCase):
                 }
             )
 
-        with self.assertRaisesRegex(InvalidArgumentValueError, "--set property1.property2=<value>"):
+        with self.assertRaisesRegex(InvalidArgumentValueError, "`--set property1.property2=<value>`"):
             AAZGenericInstanceUpdateOperation(ctx)._update_instance_by_generic(
                 instance,
                 {
@@ -514,7 +514,7 @@ class TestAAZGenericUpdateOperation(unittest.TestCase):
                 }
             )
 
-        with self.assertRaisesRegex(InvalidArgumentValueError, "--remove property.list <indexToRemove> OR --remove propertyToRemove"):
+        with self.assertRaisesRegex(InvalidArgumentValueError, "`--remove property.list <indexToRemove>` OR `--remove propertyToRemove`"):
             AAZGenericInstanceUpdateOperation(ctx)._update_instance_by_generic(
                 instance,
                 {

--- a/src/azure-cli-core/azure/cli/core/tests/test_generic_update.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_generic_update.py
@@ -272,7 +272,7 @@ class GenericUpdateTest(unittest.TestCase):
                             'index out of range in path')
 
         _execute_with_error('genupdate --remove myList[0]',
-                            'invalid syntax: --remove property.list <indexToRemove> OR --remove propertyToRemove',
+                            'invalid syntax: `--remove property.list <indexToRemove>` OR `--remove propertyToRemove`',
                             'remove requires index to be space-separated')
 
         cli.invoke("genupdate --set myDict={'foo':'bar'}".split())
@@ -285,7 +285,7 @@ class GenericUpdateTest(unittest.TestCase):
                             'Cannot list index from a scalar value')
 
         _execute_with_error('genupdate --add myDict la=da',
-                            "invalid syntax: --add property.listProperty <key=value, string or JSON string>",
+                            "invalid syntax: `--add property.listProperty <key=value, string or JSON string>`",
                             'Add only works with lists')
 
         # add an entry which makes 'myKey' no longer unique


### PR DESCRIPTION
Fix #27054
Partially fix #27056, #27057, #27058
Not fix #27467, #27468

**Related command**
All commands that support generic update arguments `--add`, `--set`, `--remove`.

Specifically:

- `az webpubsub update`
- `az mariadb server update`
- `az mysql flexible-server update`
- `az mysql server update `
- `az postgres flexible-server update`
- `az postgres server update`

**Description**<!--Mandatory-->
As angle brackets `<>` are interpreted as HTML tag by the reference doc generation pipeline, the pipeline treats the help message of generic update arguments as HTML tags and gives error for these invalid HTML tags:

- `<key=value, string or JSON string>`
- `<value>`
- `<indexToRemove>`

They will be discarded from the rendered page, resulting in incorrect documentation:

![image](https://github.com/Azure/azure-cli/assets/58762114/e433ef3a-5829-4924-b6fd-1b45781c6fdf)

This PR quotes these help messages with backticks, so that they can be rendered as code. `--resource-group` argument already adopts this appoach since #2991:

https://github.com/Azure/azure-cli/blob/d1463eb84e96befd34e49352fbad22219dd6a4cc/src/azure-cli-core/azure/cli/core/commands/parameters.py#L241

Rendered result:

https://learn.microsoft.com/en-us/cli/azure/vm?view=azure-cli-latest#az-vm-create

![image](https://github.com/Azure/azure-cli/assets/4003950/5c19cf39-6a2d-473b-9f6b-97c40d44a046)

More information and alternative solutions: https://github.com/Azure/azure-cli/issues/27054#issuecomment-1734944095

**Testing Guide**
After this PR is merged, visit {link TBD} for a preview of the rendered `dev` branch.
