### PR TITLE
[AD] `az ad`: Rename Azure Active Directory to Microsoft Entra ID

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_help.py
@@ -9,23 +9,25 @@ from knack.help_files import helps  # pylint: disable=unused-import
 
 helps['ad'] = """
 type: group
-short-summary: Manage Azure Active Directory Graph entities needed for Role Based Access Control
+short-summary: >-
+    Manage Microsoft Entra ID (formerly known as Azure Active Directory, Azure AD, AAD) entities needed for
+    Azure role-based access control (Azure RBAC) through Microsoft Graph API.
 """
 
 helps['ad app'] = """
 type: group
-short-summary: Manage applications with AAD Graph.
+short-summary: Manage Microsoft Entra applications.
 """
 
 helps['ad app create'] = """
 type: command
-short-summary: Create a web application, web API or native application
+short-summary: Create an application.
 long-summary: For more detailed documentation, see https://docs.microsoft.com/graph/api/resources/application
 examples:
   - name: Create an application.
     text: |
         az ad app create --display-name mytestapp
-  - name: Create an application that can fall back to public client with Microsoft Graph delegated permission Application.Read.All
+  - name: Create an application that can fall back to public client with Microsoft Graph delegated permission User.Read
     text: |
         az ad app create --display-name my-public --is-fallback-public-client --required-resource-accesses @manifest.json
         ("manifest.json" contains the following content)
@@ -33,7 +35,7 @@ examples:
             "resourceAppId": "00000003-0000-0000-c000-000000000000",
             "resourceAccess": [
                 {
-                    "id": "c79f8feb-a9db-4090-85f9-90d820caa0eb",
+                    "id": "e1fe6dd8-ba31-4d61-89e7-88639da4683d",
                     "type": "Scope"
                 }
            ]
@@ -192,10 +194,13 @@ long-summary: >-
     to get available permissions for Microsoft Graph API, run `az ad sp show --id 00000003-0000-0000-c000-000000000000`.
     Application permissions under the `appRoles` property correspond to `Role` in --api-permissions.
     Delegated permissions under the `oauth2Permissions` property correspond to `Scope` in --api-permissions.
+
+
+    For details on Microsoft Graph permissions, see https://learn.microsoft.com/graph/permissions-reference
 examples:
-  - name: Add Microsoft Graph delegated permission User.Read (Sign in and read user profile).
+  - name: Add Microsoft Graph delegated permission User.Read
     text: az ad app permission add --id {appId} --api 00000003-0000-0000-c000-000000000000 --api-permissions e1fe6dd8-ba31-4d61-89e7-88639da4683d=Scope
-  - name: Add Microsoft Graph application permission Application.ReadWrite.All (Read and write all applications).
+  - name: Add Microsoft Graph application permission Application.ReadWrite.All
     text: az ad app permission add --id {appId} --api 00000003-0000-0000-c000-000000000000 --api-permissions 1bfefb4e-e0b5-418b-a88f-73c46d2cc8e9=Role
 """
 
@@ -213,10 +218,10 @@ helps['ad app permission delete'] = """
 type: command
 short-summary: Remove an API permission
 examples:
-  - name: Remove Azure Active Directory Graph permissions.
-    text: az ad app permission delete --id eeba0b46-78e5-4a1a-a1aa-cafe6c123456 --api 00000002-0000-0000-c000-000000000000
-  - name: Remove Azure Active Directory Graph delegated permission User.Read (Sign in and read user profile).
-    text: az ad app permission delete --id eeba0b46-78e5-4a1a-a1aa-cafe6c123456 --api 00000002-0000-0000-c000-000000000000 --api-permissions 311a71cc-e848-46a1-bdf8-97ff7156d8e6
+  - name: Remove Microsoft Graph permissions.
+    text: az ad app permission delete --id eeba0b46-78e5-4a1a-a1aa-cafe6c123456 --api 00000003-0000-0000-c000-000000000000
+  - name: Remove Microsoft Graph delegated permission User.Read
+    text: az ad app permission delete --id eeba0b46-78e5-4a1a-a1aa-cafe6c123456 --api 00000003-0000-0000-c000-000000000000 --api-permissions e1fe6dd8-ba31-4d61-89e7-88639da4683d
 """
 
 helps['ad app permission grant'] = """
@@ -236,7 +241,7 @@ helps['ad app permission list'] = """
 type: command
 short-summary: List API permissions the application has requested
 examples:
-  - name: List the OAuth2 permissions for an existing AAD app
+  - name: List the OAuth2 permissions for an application.
     text: az ad app permission list --id e042ec79-34cd-498f-9d9f-1234234
 """
 
@@ -264,15 +269,15 @@ helps['ad app update'] = """
 type: command
 short-summary: Update an application.
 examples:
-  - name: update a native application with delegated permission of "access the AAD directory as the signed-in user"
+  - name: Update an application with Microsoft Graph delegated permission User.Read
     text: |
         az ad app update --id e042ec79-34cd-498f-9d9f-123456781234 --required-resource-accesses @manifest.json
         ("manifest.json" contains the following content)
         [{
-            "resourceAppId": "00000002-0000-0000-c000-000000000000",
+            "resourceAppId": "00000003-0000-0000-c000-000000000000",
             "resourceAccess": [
                 {
-                    "id": "a42657d6-7f20-40e3-b6f0-cee03008a62a",
+                    "id": "e1fe6dd8-ba31-4d61-89e7-88639da4683d",
                     "type": "Scope"
                 }
            ]
@@ -397,21 +402,51 @@ examples:
 
 helps['ad group'] = """
 type: group
-short-summary: Manage Azure Active Directory groups.
+short-summary: Manage Microsoft Entra groups.
 """
 
 helps['ad group create'] = """
 type: command
-short-summary: Create a group in the directory.
+short-summary: Create a group.
 examples:
   - name: Create a group in the directory. (autogenerated)
     text: az ad group create --display-name MyDisplay --mail-nickname MyDisplay
     crafted: true
 """
 
+helps['ad group show'] = """
+type: command
+short-summary: Get the details of a group.
+"""
+
+helps['ad group delete'] = """
+type: command
+short-summary: Delete a group.
+"""
+
+helps['ad group get-member-groups'] = """
+type: command
+short-summary: Get a collection of object IDs of groups of which the specified group is a member.
+"""
+
 helps['ad group member'] = """
 type: group
-short-summary: Manage Azure Active Directory group members.
+short-summary: Manage group members.
+"""
+
+helps['ad group member list'] = """
+type: command
+short-summary: Get the members of a group.
+"""
+
+helps['ad group member add'] = """
+type: command
+short-summary: Add a member to a group.
+"""
+
+helps['ad group member remove'] = """
+type: command
+short-summary: Remove a member from a group.
 """
 
 helps['ad group member check'] = """
@@ -425,7 +460,7 @@ examples:
 
 helps['ad group owner'] = """
 type: group
-short-summary: Manage Azure Active Directory group owners.
+short-summary: Manage group owners.
 """
 
 helps['ad group owner add'] = """
@@ -467,7 +502,7 @@ short-summary: Get the list of directory objects that are owned by the user
 
 helps['ad sp'] = """
 type: group
-short-summary: Manage Azure Active Directory service principals for automation authentication.
+short-summary: Manage Microsoft Entra service principals.
 """
 
 helps['ad sp create'] = """
@@ -609,12 +644,12 @@ examples:
 
 helps['ad user'] = """
 type: group
-short-summary: Manage Azure Active Directory users and user authentication.
+short-summary: Manage Microsoft Entra users.
 """
 
 helps['ad user create'] = """
 type: command
-short-summary: Create an Azure Active Directory user.
+short-summary: Create a user.
 parameters:
   - name: --force-change-password-next-sign-in
     short-summary: Marks this user as needing to update their password the next time they authenticate. If omitted, false will be used.
@@ -635,34 +670,34 @@ examples:
 
 helps['ad user list'] = """
 type: command
-short-summary: List Azure Active Directory users.
+short-summary: List users.
 examples:
-  - name: List all the Azure Active Directory users
+  - name: List all users.
     text: az ad user list
 """
 
 helps['ad user update'] = """
 type: command
-short-summary: Update Azure Active Directory users.
+short-summary: Update a user.
 examples:
-  - name: Update Azure Active Directory users.
+  - name: Update a user.
     text: az ad user update --id myuser@contoso.com --display-name username2
 """
 
 helps['ad user delete'] = """
 type: command
-short-summary: Delete Azure Active Directory user.
+short-summary: Delete a user.
 examples:
-  - name: Delete Azure Active Directory users.
+  - name: Delete a user.
     text: az ad user delete --id myuser@contoso.com
 """
 
 
 helps['ad user show'] = """
 type: command
-short-summary: Show details for a Azure Active Directory user.
+short-summary: Get the details of a user.
 examples:
-  - name: Show Azure Active Directory user.
+  - name: Show a user.
     text: az ad user show --id myuser@contoso.com
 """
 
@@ -673,7 +708,7 @@ short-summary: Get the details for the currently logged-in user.
 
 helps['role'] = """
 type: group
-short-summary: Manage user roles for access control with Azure Active Directory and service principals.
+short-summary: Manage Azure role-based access control (Azure RBAC).
 """
 
 helps['role assignment'] = """

--- a/src/azure-cli/azure/cli/command_modules/role/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_params.py
@@ -103,7 +103,7 @@ def load_arguments(self, _):
                         "can be assigned to users, groups, or service principals associated with other applications. " +
                         JSON_PROPERTY_HELP)
         c.argument('optional_claims', arg_group='JSON property', type=validate_file_or_dict,
-                   help="Application developers can configure optional claims in their Azure AD applications to "
+                   help="Application developers can configure optional claims in their Microsoft Entra applications to "
                         "specify the claims that are sent to their application by the Microsoft security token "
                         "service. For more information, see https://docs.microsoft.com/azure/active-directory/develop"
                         "/active-directory-optional-claims. " + JSON_PROPERTY_HELP)
@@ -249,10 +249,11 @@ def load_arguments(self, _):
                    help='If the user must change her password on the next login.')
 
     with self.argument_context('ad user create') as c:
-        c.argument('immutable_id', help="This must be specified if you are using a federated domain for "
-                                        "the user's userPrincipalName (UPN) property when creating a new user account."
-                                        " It is used to associate an on-premises Active Directory user account with "
-                                        "their Azure AD user object.")
+        c.argument('immutable_id',
+                   help="This property is used to associate an on-premises Active Directory user account to their "
+                        "Microsoft Entra user object. This property must be specified when creating a new user account "
+                        "in the Graph if you're using a federated domain for the user's userPrincipalName (UPN) "
+                        "property. NOTE: The $ and _ characters can't be used when specifying this property.")
         c.argument('user_principal_name',
                    help="The user principal name (someuser@contoso.com). It must contain one of the verified domains "
                         "for the tenant.")
@@ -341,7 +342,7 @@ def load_arguments(self, _):
             foreign_group = "ForeignGroup"
 
         c.argument('assignee_principal_type', min_api='2018-09-01-preview', arg_type=get_enum_type(PrincipalType),
-                   help='use with --assignee-object-id to avoid errors caused by propagation latency in AAD Graph')
+                   help='use with --assignee-object-id to avoid errors caused by propagation latency in Microsoft Graph')
 
     with self.argument_context('role assignment update') as c:
         c.argument('role_assignment',

--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -1918,17 +1918,14 @@ def list_groups(client, display_name=None, query_filter=None):
 
 
 def get_group(client, object_id):
-    """Get group information from the directory."""
     return client.group_get(object_id)
 
 
 def delete_group(client, object_id):
-    """Delete a group from the directory."""
     return client.group_delete(object_id)
 
 
 def get_group_member_groups(client, object_id, security_enabled_only=False):
-    """Get a collection of object IDs of groups of which the specified group is a member."""
     return _get_member_groups(client.group_get_member_groups, object_id, security_enabled_only)
 
 
@@ -1957,12 +1954,10 @@ def check_group_membership(client, group_id, member_object_id):
 
 
 def list_group_members(client, group_id):
-    """Get the members of a group."""
     return client.group_member_list(group_id)
 
 
 def add_group_member(client, group_id, member_object_id):
-    """Add a member to a group."""
     # API is not idempotent and fails with:
     #   One or more added object references already exist for the following modified properties: 'members'.
     # TODO: make it idempotent like add_group_owner
@@ -1971,7 +1966,6 @@ def add_group_member(client, group_id, member_object_id):
 
 
 def remove_group_member(client, group_id, member_object_id):
-    """Remove a member from a group."""
     return client.group_member_remove(group_id, member_object_id)
 
 

--- a/src/azure-cli/service_name.json
+++ b/src/azure-cli/service_name.json
@@ -11,8 +11,8 @@
   },
   {
     "Command": "az ad",
-    "AzureServiceName": "Azure Active Directory",
-    "URL": "https://learn.microsoft.com/azure/active-directory"
+    "AzureServiceName": "Microsoft Entra ID (formerly known as Azure Active Directory)",
+    "URL": "https://learn.microsoft.com/entra/identity/"
   },
   {
     "Command": "az advisor",


### PR DESCRIPTION
**Related command**
`az ad`

**Description**<!--Mandatory-->
This PR renames Azure Active Directory to Microsoft Entra ID following rules defined in

- https://learn.microsoft.com/en-us/entra/fundamentals/new-name
- https://learn.microsoft.com/en-us/entra/fundamentals/how-to-rename-azure-ad

The help messages for `app`, `sp`, `user` and `group` are very inconsistent:

- `app`: Manage applications with AAD Graph.
- `sp`: Manage Azure Active Directory service principals for automation authentication.
- `user`: Manage Azure Active Directory users and user authentication.
- `group`: Manage Azure Active Directory groups.

This PR unifies those help messages to a format of `Manage Microsoft Entra xxx`. ~I don't feel the necessity of prefixing the entities with `Microsoft Entra` as they are already under the `az ad` command group.~

Azure PowerShell cmdlets `New-AzADxxx` don't mention Azure Active Directory in their help messages either: https://learn.microsoft.com/en-us/powershell/module/az.resources/. For example, the help message of `New-AzADApplication` is `Adds new entity to applications`.
