### PR TITLE
[App Service] BREAKING CHANGE: `az appservice ase create`: Update the default App Service Environment to V3

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -2295,7 +2295,7 @@ helps['appservice ase create'] = """
     type: command
     short-summary: Create app service environment.
     examples:
-    - name: Create Resource Group, vNet and app service environment v2 with default values.
+    - name: Create resource group, Virtual Network and App Service Environment v3 with default values.
       text: |
           az group create -g MyResourceGroup --location westeurope
 
@@ -2303,35 +2303,19 @@ helps['appservice ase create'] = """
             --address-prefixes 10.0.0.0/16 --subnet-name MyAseSubnet --subnet-prefixes 10.0.0.0/24
 
           az appservice ase create -n MyAseName -g MyResourceGroup --vnet-name MyVirtualNetwork \\
-            --subnet MyAseSubnet
-    - name: Create External app service environments v2 with large front-ends and scale factor of 10 in existing resource group and vNet.
+            --subnet MyAseSubnet --kind asev3
+    - name: Create external App Service Environments v3 in existing resource group and Virtual Network.
       text: |
           az appservice ase create -n MyAseName -g MyResourceGroup --vnet-name MyVirtualNetwork \\
-            --subnet MyAseSubnet --front-end-sku I3 --front-end-scale-factor 10 --virtual-ip-type External
-    - name: Create vNet and app service environment v2, but do not create network security group and route table in existing resource group.
-      text: |
-          az network vnet create -g MyResourceGroup -n MyVirtualNetwork \\
-            --address-prefixes 10.0.0.0/16 --subnet-name MyAseSubnet --subnet-prefixes 10.0.0.0/24
-
-          az appservice ase create -n MyAseName -g MyResourceGroup --vnet-name MyVirtualNetwork \\
-            --subnet MyAseSubnet --ignore-network-security-group --ignore-route-table
-    - name: Create vNet and app service environment v2 in a smaller than recommended subnet in existing resource group.
+            --subnet MyAseSubnet --virtual-ip-type External --kind asev3
+    - name: Create Virtual Network and App Service Environment v3 in a smaller than recommended subnet in existing resource group.
       text: |
           az network vnet create -g MyResourceGroup -n MyVirtualNetwork \\
             --address-prefixes 10.0.0.0/16 --subnet-name MyAseSubnet --subnet-prefixes 10.0.0.0/26
 
           az appservice ase create -n MyAseName -g MyResourceGroup --vnet-name MyVirtualNetwork \\
-            --subnet MyAseSubnet --ignore-subnet-size-validation
-    - name: Create Resource Group, vNet and app service environment v3 with default values.
-      text: |
-          az group create -g ASEv3ResourceGroup --location westeurope
-
-          az network vnet create -g ASEv3ResourceGroup -n MyASEv3VirtualNetwork \\
-            --address-prefixes 10.0.0.0/16 --subnet-name MyASEv3Subnet --subnet-prefixes 10.0.0.0/24
-
-          az appservice ase create -n MyASEv3Name -g ASEv3ResourceGroup \\
-            --vnet-name MyASEv3VirtualNetwork --subnet MyASEv3Subnet --kind asev3
-    - name: Create External zone redundant app service environment v3 with default values.
+            --subnet MyAseSubnet --ignore-subnet-size-validation --kind asev3
+    - name: Create external zone redundant App Service Environment v3 with default values.
       text: |
           az appservice ase create -n MyASEv3Name -g ASEv3ResourceGroup \\
             --vnet-name MyASEv3VirtualNetwork --subnet MyASEv3Subnet --kind asev3 \\

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -1013,7 +1013,7 @@ subscription than the app service environment, please use the resource ID for --
                    local_context_attribute=LocalContextAttribute(name='ase_name', actions=[LocalContextAction.SET],
                                                                  scopes=['appservice']))
         c.argument('kind', options_list=['--kind', '-k'], arg_type=get_enum_type(ASE_KINDS),
-                   default='ASEv2', help="Specify App Service Environment version")
+                   default='ASEv3', help="Specify App Service Environment version")
         c.argument('subnet', help='Name or ID of existing subnet. To create vnet and/or subnet \
                    use `az network vnet [subnet] create`')
         c.argument('vnet_name', help='Name of the vNet. Mandatory if only subnet name is specified.')

--- a/src/azure-cli/azure/cli/command_modules/appservice/appservice_environment.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/appservice_environment.py
@@ -50,7 +50,7 @@ def show_appserviceenvironment(cmd, name, resource_group_name=None):
     return ase_client.get(resource_group_name, name)
 
 
-def create_appserviceenvironment_arm(cmd, resource_group_name, name, subnet, kind='ASEv2',
+def create_appserviceenvironment_arm(cmd, resource_group_name, name, subnet, kind='ASEv3',
                                      vnet_name=None, ignore_route_table=False,
                                      ignore_network_security_group=False, virtual_ip_type='Internal',
                                      front_end_scale_factor=None, front_end_sku=None, force_route_table=False,

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -2185,7 +2185,7 @@ app service environment, please use --location parameter and specify the region 
 has been deployed ".format(app_service_environment)
                 raise ResourceNotFoundError(err_msg)
         if hyper_v and ase.kind in ('ASEV1', 'ASEV2'):
-            raise ArgumentUsageError('Windows containers are only supported on v3 App Service Environments v3 or newer')
+            raise ArgumentUsageError('Windows containers are only supported on App Service Environment v3')
     else:  # Non-ASE
         ase_def = None
         if location is None:

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_app_service_environment_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_app_service_environment_commands_thru_mock.py
@@ -247,7 +247,7 @@ class AppServiceEnvironmentScenarioMockTest(unittest.TestCase):
         }
         show.return_value = fake_data
         create_appserviceenvironment_arm(self.mock_cmd, resource_group_name=rg_name, name=ase_name,
-                                         subnet=subnet_name, vnet_name=vnet_name, kind='ASEv3',
+                                         subnet=subnet_name, vnet_name=vnet_name,
                                          location='westeurope')
 
         # Assert begin_create_or_update is called with correct rg and deployment name
@@ -289,7 +289,7 @@ class AppServiceEnvironmentScenarioMockTest(unittest.TestCase):
         }
         show.return_value = fake_data
         create_appserviceenvironment_arm(self.mock_cmd, resource_group_name=rg_name, name=ase_name,
-                                         subnet=subnet_name, vnet_name=vnet_name, kind='ASEv3',
+                                         subnet=subnet_name, vnet_name=vnet_name,
                                          location='westeurope', zone_redundant=True)
 
         # Assert begin_create_or_update is called with correct rg and deployment name

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_app_service_environment_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_app_service_environment_commands_thru_mock.py
@@ -113,14 +113,14 @@ class AppServiceEnvironmentScenarioMockTest(unittest.TestCase):
             create_appserviceenvironment_arm(self.mock_cmd, resource_group_name=rg_name, name=ase_name,
                                              subnet=subnet_name, vnet_name=vnet_name,
                                              ignore_network_security_group=True, ignore_route_table=True,
-                                             location='westeurope')
+                                             location='westeurope', kind='ASEv2')
 
         fake_data = {"id": "1", "addressPrefix": "10.10.10.10/24"}
         show.return_value = fake_data
         create_appserviceenvironment_arm(self.mock_cmd, resource_group_name=rg_name, name=ase_name,
                                          subnet=subnet_name, vnet_name=vnet_name,
                                          ignore_network_security_group=True, ignore_route_table=True,
-                                         location='westeurope')
+                                         location='westeurope', kind='ASEv2')
 
         # Assert begin_create_or_update is called with correct rg and deployment name
         resource_client_mock.deployments.begin_create_or_update.assert_called_once()


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az appservice ase create

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Currently default ASE kind is set to ASEv2. ASEv2 is retiring in August 2024 and creates of ASEv2 will be blocked starting in January. So we need the default to be updated to ASEv3 to prevent errors and ensure customers are getting onto the latest version.

**Testing Guide**
<!--Example commands with explanations.-->
az appservice ase create -g <rg> -n <asename> --vnet-name <vnet> --subnet <subnet> : use this to create an ASEv3 since the default is now set to ASEv3. You no longer need to include the kind parameter for ASEv3 creates.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
