### PR TITLE
[sql] BREAKING CHANGE: `az sql failover-group create/update`: Change default value of `--failover-policy` from Automatic to Manual

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/sql/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/custom.py
@@ -2534,7 +2534,7 @@ def failover_group_create(
         failover_group_name,
         partner_server,
         partner_resource_group=None,
-        failover_policy=FailoverPolicyType.automatic.value,
+        failover_policy=FailoverPolicyType.manual.value,
         grace_period=1,
         add_db=None):
     '''
@@ -2588,7 +2588,7 @@ def failover_group_update(
         instance,
         resource_group_name,
         server_name,
-        failover_policy=None,
+        failover_policy=FailoverPolicyType.manual.value,
         grace_period=None,
         add_db=None,
         remove_db=None):


### PR DESCRIPTION
**Related command**

az sql failover-group create: Creates a failover group.

Arguments

--failover-policy : The failover policy of the Failover Group. Default:
Manual.

az sql failover-group update: Updates the parameters of the failover group.

Arguments

--failover-policy : The failover policy of the Failover Group. Default:
Manual.

---

**Description**<!--Mandatory-->
This PR is changing the default value of Failover Group failover policy from Automatic to Manual. This is part of the effort to push Manual as the first choice for customer's, since Automatic has some misleading implications given how it works on the backend.

**Testing Guide**
az sql failover-group create: Creates a failover group.

Arguments

--failover-policy : The failover policy of the Failover Group. Default:
Manual.

az sql failover-group update: Updates the parameters of the failover group.

Arguments

--failover-policy : The failover policy of the Failover Group. Default:
Manual.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
