### PR TITLE
[RDBMS] Add support for PG version 15 for MVU of PostgreSQL flexible server

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
@@ -395,7 +395,7 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
         )
 
         pg_version_upgrade_arg_type = CLIArgumentType(
-            arg_type=get_enum_type(['12', '13', '14']),
+            arg_type=get_enum_type(['12', '13', '14', '15']),
             options_list=['--version', '-v'],
             help='Server major version.'
         )


### PR DESCRIPTION
**Related command**
 az postgres flexible-server upgrade -g testrg -n pg-flex-test-server-14 -v 15

**Description**<!--Mandatory-->
[RDBMS] Add support for PG version 15 for MVU of PostgreSQL flexible server

**Testing Guide**
Verified manually

**History Notes**
[RDBMS] `az postgres flexible-server upgrade`: Add MVU support for PG version 15

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
