### PR TITLE
{Iot} Remove general mentions of extension

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/iot/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/__init__.py
@@ -3,30 +3,10 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from knack.events import EVENT_INVOKER_POST_PARSE_ARGS
-from knack.log import get_logger
+
 from azure.cli.core import AzCommandsLoader
 from azure.cli.core.commands import CliCommandType
 import azure.cli.command_modules.iot._help  # pylint: disable=unused-import
-from azure.cli.core.extension import extension_exists
-
-
-def handler(ctx, **kwargs):
-    cmd = kwargs.get('command', None)
-    if cmd and cmd.startswith('iot'):
-        if not extension_exists('azure-iot'):
-            ran_before = ctx.config.getboolean('iot', 'first_run', fallback=False)
-            if not ran_before:
-                extension_text = """
-Comprehensive IoT functionality is available in the Azure IoT CLI Extension.
-
-To install the extension, run: "az extension add --name azure-iot"
-
-For more info and install guide go to: https://github.com/Azure/azure-iot-cli-extension
-"""
-                logger = get_logger(__name__)
-                logger.warning(extension_text)
-                ctx.config.set_value('iot', 'first_run', 'yes')
 
 
 class IoTCommandsLoader(AzCommandsLoader):
@@ -34,7 +14,6 @@ class IoTCommandsLoader(AzCommandsLoader):
     def __init__(self, cli_ctx=None):
         from azure.cli.core.profiles import ResourceType
         iot_custom = CliCommandType(operations_tmpl='azure.cli.command_modules.iot.custom#{}')
-        cli_ctx.register_event(EVENT_INVOKER_POST_PARSE_ARGS, handler)
         super(IoTCommandsLoader, self).__init__(cli_ctx=cli_ctx,
                                                 custom_command_type=iot_custom,
                                                 resource_type=ResourceType.MGMT_IOTHUB)

--- a/src/azure-cli/azure/cli/command_modules/iot/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/_help.py
@@ -10,7 +10,6 @@ from knack.help_files import helps  # pylint: disable=unused-import
 helps['iot'] = """
 type: group
 short-summary: Manage Internet of Things (IoT) assets.
-long-summary: Comprehensive IoT data-plane functionality is available in the Azure IoT CLI Extension. For more info and install guide go to https://github.com/Azure/azure-iot-cli-extension
 """
 
 helps['iot dps'] = """


### PR DESCRIPTION
**Related command**
`az iot`

**Description**<!--Mandatory-->
We are in the process of releasing a new extension for new services. To avoid confusion between the two, the references for the old ones in general help will be removed. Specific commands and sub commands that have a direct connection to an extension command will not be changed.

![image](https://github.com/Azure/azure-cli/assets/73560279/e1a3efec-6616-4a66-a90b-a5721a33e53c)
history sucks so redo of https://github.com/Azure/azure-cli/pull/27721

**Testing Guide**
None. These are help changes.

**History Notes**
None.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
