### PR TITLE
[AKS] BREAKING CHANGE: `az aks create`: Remove deprecated parameter `--docker-bridge-cidr`

### DIFF
--- a/linter_exclusions.yml
+++ b/linter_exclusions.yml
@@ -279,9 +279,6 @@ aks create:
     api_server_authorized_ip_ranges:
       rule_exclusions:
       - option_length_too_long
-    docker_bridge_address:
-      rule_exclusions:
-      - option_length_too_long
     enable_cluster_autoscaler:
       rule_exclusions:
       - option_length_too_long

--- a/src/azure-cli/azure/cli/command_modules/acs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_params.py
@@ -203,7 +203,6 @@ def load_arguments(self, _):
                    completer=FilesCompleter(), validator=validate_ssh_key)
         c.argument('no_ssh_key', options_list=['--no-ssh-key', '-x'])
         c.argument('dns_service_ip')
-        c.argument('docker_bridge_address', deprecate_info=c.deprecate(target='--docker-bridge-address', hide=True))
         c.argument('pod_cidr')
         c.argument('service_cidr')
         c.argument('ip_families')

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -490,7 +490,6 @@ def aks_create(
     pod_cidrs=None,
     service_cidrs=None,
     dns_service_ip=None,
-    docker_bridge_address=None,
     load_balancer_sku=None,
     load_balancer_managed_outbound_ip_count=None,
     load_balancer_managed_outbound_ipv6_count=None,

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -2143,7 +2143,7 @@ class AKSManagedClusterContext(BaseAKSContext):
 
         This function supports the option of enable_validation. When enabled, in case network_plugin is assigned, if
         pod_cidr is assigned and the value of network_plugin is azure, an InvalidArgumentValueError will be
-        raised; otherwise, if any of pod_cidr, service_cidr, dns_service_ip, docker_bridge_address or network_policy
+        raised; otherwise, if any of pod_cidr, service_cidr, dns_service_ip, or network_policy
         is assigned, a RequiredArgumentMissingError will be raised.
 
         :return: string or None
@@ -2165,9 +2165,8 @@ class AKSManagedClusterContext(BaseAKSContext):
                 pod_cidr,
                 service_cidr,
                 dns_service_ip,
-                docker_bridge_address,
                 network_policy,
-            ) = self._get_pod_cidr_and_service_cidr_and_dns_service_ip_and_docker_bridge_address_and_network_policy(
+            ) = self._get_pod_cidr_and_service_cidr_and_dns_service_ip_and_and_network_policy(
                 enable_validation=False
             )
             network_plugin_mode = self._get_network_plugin_mode(enable_validation=False)
@@ -2183,7 +2182,6 @@ class AKSManagedClusterContext(BaseAKSContext):
                     pod_cidr or
                     service_cidr or
                     dns_service_ip or
-                    docker_bridge_address or
                     network_policy
                 ):
                     raise RequiredArgumentMissingError(
@@ -2198,7 +2196,7 @@ class AKSManagedClusterContext(BaseAKSContext):
 
         This function will verify the parameter by default. In case network_plugin is assigned, if pod_cidr is assigned
         and the value of network_plugin is azure, an InvalidArgumentValueError will be raised; otherwise, if any of
-        pod_cidr, service_cidr, dns_service_ip, docker_bridge_address or network_policy is assigned, a
+        pod_cidr, service_cidr, dns_service_ip, or network_policy is assigned, a
         RequiredArgumentMissingError will be raised.
 
         :return: string or None
@@ -2219,16 +2217,15 @@ class AKSManagedClusterContext(BaseAKSContext):
         """
         return self.raw_param.get("network_dataplane")
 
-    def _get_pod_cidr_and_service_cidr_and_dns_service_ip_and_docker_bridge_address_and_network_policy(
+    def _get_pod_cidr_and_service_cidr_and_dns_service_ip_and_and_network_policy(
         self, enable_validation: bool = False
     ) -> Tuple[
         Union[str, None],
         Union[str, None],
         Union[str, None],
         Union[str, None],
-        Union[str, None],
     ]:
-        """Internal function to obtain the value of pod_cidr, service_cidr, dns_service_ip, docker_bridge_address and
+        """Internal function to obtain the value of pod_cidr, service_cidr, dns_service_ip, and
         network_policy.
 
         Note: SDK provides default value "10.244.0.0/16" and performs the following validation
@@ -2241,11 +2238,11 @@ class AKSManagedClusterContext(BaseAKSContext):
 
         This function supports the option of enable_validation. When enabled, if pod_cidr is assigned and the value of
         network_plugin is azure, an InvalidArgumentValueError will be raised; otherwise, if any of pod_cidr,
-        service_cidr, dns_service_ip, docker_bridge_address or network_policy is assigned, a
+        service_cidr, dns_service_ip,  or network_policy is assigned, a
         RequiredArgumentMissingError will be raised.
 
         :return: a tuple of five elements: pod_cidr of string type or None, service_cidr of string type or None,
-        dns_service_ip of string type or None, docker_bridge_address of string type or None, network_policy of
+        dns_service_ip of string type or None  network_policy of
         string type or None.
         """
         # get network profile from `mc`
@@ -2300,7 +2297,7 @@ class AKSManagedClusterContext(BaseAKSContext):
                     )
         return pod_cidr, service_cidr, dns_service_ip, None, network_policy
 
-    def get_pod_cidr_and_service_cidr_and_dns_service_ip_and_docker_bridge_address_and_network_policy(
+    def get_pod_cidr_and_service_cidr_and_dns_service_ip_and_and_network_policy(
         self,
     ) -> Tuple[
         Union[str, None],
@@ -2309,7 +2306,7 @@ class AKSManagedClusterContext(BaseAKSContext):
         Union[str, None],
         Union[str, None],
     ]:
-        """Obtain the value of pod_cidr, service_cidr, dns_service_ip, docker_bridge_address and network_policy.
+        """Obtain the value of pod_cidr, service_cidr, dns_service_ip, and network_policy.
 
         Note: SDK provides default value "10.244.0.0/16" and performs the following validation
         {'pattern': r'^([0-9]{1,3}\\.){3}[0-9]{1,3}(\\/([0-9]|[1-2][0-9]|3[0-2]))?$'} for pod_cidr.
@@ -2318,19 +2315,17 @@ class AKSManagedClusterContext(BaseAKSContext):
         Note: SDK provides default value "10.0.0.10" and performs the following validation
         {'pattern': r'^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$'}
         for dns_service_ip.
-        Note: SDK provides default value "172.17.0.1/16" and performs the following validation
-        {'pattern': r'^([0-9]{1,3}\\.){3}[0-9]{1,3}(\\/([0-9]|[1-2][0-9]|3[0-2]))?$'} for docker_bridge_address.
 
         This function will verify the parameters by default. If pod_cidr is assigned and the value of network_plugin
         is azure, an InvalidArgumentValueError will be raised; otherwise, if any of pod_cidr, service_cidr,
-        dns_service_ip, docker_bridge_address or network_policy is assigned, a RequiredArgumentMissingError will be
+        dns_service_ip, or network_policy is assigned, a RequiredArgumentMissingError will be
         raised.
 
         :return: a tuple of five elements: pod_cidr of string type or None, service_cidr of string type or None,
-        dns_service_ip of string type or None, docker_bridge_address of string type or None, network_policy of
+        dns_service_ip of string type or None,  network_policy of
         string type or None.
         """
-        return self._get_pod_cidr_and_service_cidr_and_dns_service_ip_and_docker_bridge_address_and_network_policy(
+        return self._get_pod_cidr_and_service_cidr_and_dns_service_ip_and_and_network_policy(
             enable_validation=True
         )
 
@@ -5358,17 +5353,16 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
         # verify load balancer sku
         load_balancer_sku = safe_lower(self.context.get_load_balancer_sku())
 
-        # verify network_plugin, pod_cidr, service_cidr, dns_service_ip, docker_bridge_address, network_policy
+        # verify network_plugin, pod_cidr, service_cidr, dns_service_ip,  network_policy
         network_plugin = self.context.get_network_plugin()
         network_plugin_mode = self.context.get_network_plugin_mode()
         (
             pod_cidr,
             service_cidr,
             dns_service_ip,
-            docker_bridge_address,
             network_policy,
         ) = (
-            self.context.get_pod_cidr_and_service_cidr_and_dns_service_ip_and_docker_bridge_address_and_network_policy()
+            self.context.get_pod_cidr_and_service_cidr_and_dns_service_ip_and_network_policy()
         )
         network_profile = None
         # set up pod_cidrs, service_cidrs and ip_families
@@ -5392,14 +5386,13 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
                 service_cidrs,
                 ip_families,
                 dns_service_ip,
-                docker_bridge_address,
                 network_policy,
                 network_dataplane,
             ]
         ):
             # Attention: RP would return UnexpectedLoadBalancerSkuForCurrentOutboundConfiguration internal server error
             # if load_balancer_sku is set to basic and load_balancer_profile is assigned.
-            # Attention: SDK provides default values for pod_cidr, service_cidr, dns_service_ip, docker_bridge_cidr
+            # Attention: SDK provides default values for pod_cidr, service_cidr, dns_service_ip
             # and outbound_type, and they might be overwritten to None.
             network_profile = self.models.ContainerServiceNetworkProfile(
                 network_plugin=network_plugin,
@@ -5410,7 +5403,6 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
                 service_cidrs=service_cidrs,
                 ip_families=ip_families,
                 dns_service_ip=dns_service_ip,
-                docker_bridge_cidr=docker_bridge_address,
                 network_policy=network_policy,
                 network_dataplane=network_dataplane,
                 load_balancer_sku=load_balancer_sku,
@@ -6789,9 +6781,8 @@ class AKSManagedClusterUpdateDecorator(BaseAKSManagedClusterDecorator):
             pod_cidr,
             _,
             _,
-            _,
             _
-        ) = self.context.get_pod_cidr_and_service_cidr_and_dns_service_ip_and_docker_bridge_address_and_network_policy()
+        ) = self.context.get_pod_cidr_and_service_cidr_and_dns_service_ip_and_network_policy()
 
         network_dataplane = self.context.get_network_dataplane()
         if network_dataplane:

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
@@ -2063,7 +2063,7 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
         )
         self.assertEqual(ctx_3.get_ip_families(), ["IPv4", "IPv6"])
 
-    def test_get_pod_cidr_and_service_cidr_and_dns_service_ip_and_docker_bridge_address_and_network_policy(
+    def test_get_pod_cidr_and_service_cidr_and_dns_service_ip_and_network_policy(
         self,
     ):
         # default
@@ -2081,7 +2081,7 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
             DecoratorMode.CREATE,
         )
         self.assertEqual(
-            ctx_1.get_pod_cidr_and_service_cidr_and_dns_service_ip_and_docker_bridge_address_and_network_policy(),
+            ctx_1.get_pod_cidr_and_service_cidr_and_dns_service_ip_and_docker_and_network_policy(),
             (None, None, None, None, None),
         )
         network_profile_1 = self.models.ContainerServiceNetworkProfile(
@@ -2093,7 +2093,7 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
         mc = self.models.ManagedCluster(location="test_location", network_profile=network_profile_1)
         ctx_1.attach_mc(mc)
         self.assertEqual(
-            ctx_1.get_pod_cidr_and_service_cidr_and_dns_service_ip_and_docker_bridge_address_and_network_policy(),
+            ctx_1.get_pod_cidr_and_service_cidr_and_dns_service_ip_and_docker_and_network_policy(),
             (
                 "test_pod_cidr",
                 "test_service_cidr",
@@ -2116,7 +2116,7 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
         )
         # fail on network_plugin not specified
         with self.assertRaises(RequiredArgumentMissingError):
-            ctx_2.get_pod_cidr_and_service_cidr_and_dns_service_ip_and_docker_bridge_address_and_network_policy()
+            ctx_2.get_pod_cidr_and_service_cidr_and_dns_service_ip_and_docker_and_network_policy()
 
         # invalid parameter
         ctx_3 = AKSManagedClusterContext(
@@ -2133,7 +2133,7 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
         )
         # fail on network_plugin not specified
         with self.assertRaises(RequiredArgumentMissingError):
-            ctx_3.get_pod_cidr_and_service_cidr_and_dns_service_ip_and_docker_bridge_address_and_network_policy()
+            ctx_3.get_pod_cidr_and_service_cidr_and_dns_service_ip_and_docker_and_network_policy()
 
     def test_get_addon_consts(self):
         # default


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az aks create`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

This field was deprecated in newest api so now getting this warning with every create

docker_bridge_cidr is not a known attribute of class <class 'azure.mgmt.containerservice.v2023_06_01.models._models_py3.ContainerServiceNetworkProfile'> and will be ignored

Forked from PR #27192.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).