### PR TITLE
[App Service] `az webapp log tail`: Fix #27189 catch exception when scm connection is lost 

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -2919,7 +2919,7 @@ def _get_log(url, headers, log_file=None):
                                    .encode(std_encoding, errors='replace')
                                    .decode(std_encoding, errors='replace')
                                    .rstrip('\n\r'))  # each line of log has CRLF.
-        except Exception as ex:  # pylint: disable=bare-except
+        except Exception as ex:  # pylint: disable=broad-except
             logger.error("Log stream interrupted. Exiting live log stream.")
             logger.debug(ex)
         finally:

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -2919,8 +2919,9 @@ def _get_log(url, headers, log_file=None):
                                    .encode(std_encoding, errors='replace')
                                    .decode(std_encoding, errors='replace')
                                    .rstrip('\n\r'))  # each line of log has CRLF.
-        except:  # pylint: disable=bare-except
+        except Exception as ex:  # pylint: disable=bare-except
             logger.error("Log stream interrupted. Exiting live log stream.")
+            logger.debug(ex)
         finally:
             r.release_conn()
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -2916,9 +2916,9 @@ def _get_log(url, headers, log_file=None):
                 if chunk:
                     # Extra encode() and decode for stdout which does not support 'utf-8'
                     logger.warning(chunk.decode(encoding='utf-8', errors='replace')
-                                .encode(std_encoding, errors='replace')
-                                .decode(std_encoding, errors='replace')
-                                .rstrip('\n\r'))  # each line of log has CRLF.
+                                   .encode(std_encoding, errors='replace')
+                                   .decode(std_encoding, errors='replace')
+                                   .rstrip('\n\r'))  # each line of log has CRLF.
         except:  # pylint: disable=bare-except
             logger.error("Log stream interrupted. Exiting live log stream.")
         finally:

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -2911,14 +2911,18 @@ def _get_log(url, headers, log_file=None):
                 f.write(data)
     else:  # streaming
         std_encoding = sys.stdout.encoding
-        for chunk in r.stream():
-            if chunk:
-                # Extra encode() and decode for stdout which does not surpport 'utf-8'
-                logger.warning(chunk.decode(encoding='utf-8', errors='replace')
-                               .encode(std_encoding, errors='replace')
-                               .decode(std_encoding, errors='replace')
-                               .rstrip('\n\r'))  # each line of log has CRLF.
-    r.release_conn()
+        try:
+            for chunk in r.stream():
+                if chunk:
+                    # Extra encode() and decode for stdout which does not support 'utf-8'
+                    logger.warning(chunk.decode(encoding='utf-8', errors='replace')
+                                .encode(std_encoding, errors='replace')
+                                .decode(std_encoding, errors='replace')
+                                .rstrip('\n\r'))  # each line of log has CRLF.
+        except:  # pylint: disable=bare-except
+            logger.error("Log stream interrupted. Exiting live log stream.")
+        finally:
+            r.release_conn()
 
 
 def upload_ssl_cert(cmd, resource_group_name,


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az webapp log tail`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
While log streaming for a web app, if the connection to the scm logstream endpoint is lost, we currently don't catch the exception properly. This results in the user seeing this error:

```
cli.azure.cli.command_modules.appservice.custom: 2023-08-23T15:39:34 No new trace in the past 1 min(s).
cli.azure.cli.command_modules.appservice.custom: 2023-08-23T15:40:34 No new trace in the past 2 min(s).
cli.azure.cli.command_modules.appservice.custom: 2023-08-23T15:41:34 No new trace in the past 3 min(s).
cli.azure.cli.command_modules.appservice.custom: 2023-08-23T15:42:34 No new trace in the past 4 min(s).
Exception in thread Thread-1 (_get_log):
Traceback (most recent call last):
File "D:\a_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\urllib3/response.py", line 761, in _update_chunk_length
ValueError: invalid literal for int() with base 16: b''

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
File "D:\a_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\urllib3/response.py", line 444, in _error_catcher
File "D:\a_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\urllib3/response.py", line 828, in read_chunked
File "D:\a_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\urllib3/response.py", line 765, in _update_chunk_length
urllib3.exceptions.InvalidChunkLength: InvalidChunkLength(got length b'', 0 bytes read)
```

Wrapping the log stream in a try block to catch any exceptions during logstream.
![image](https://github.com/Azure/azure-cli/assets/48413781/57467a57-08ad-4a2a-9192-426fe54f160f)


**Testing Guide**
<!--Example commands with explanations.-->
While `az webapp log tail`, if we lose connection to the scm site (eg. the site is restarted)
**History Notes**

<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[App Service] `az webapp log tail`: Fix #27189 catch exception when scm connection is lost

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
