### PR TITLE
{Core} `doc_string_source` must be full path

### DIFF
--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -705,15 +705,22 @@ class AzCommandsLoader(CLICommandsLoader):  # pylint: disable=too-many-instance-
                            'Import by string name instead.'.format(doc_string_source.__name__))
 
         model = doc_string_source
-        # print('kk doc string source', doc_string_source)
+        print('kk doc string source', doc_string_source)
+        # if doc_string_source is azure.mgmt.netapp.models#Snapshot, APIVersionException is raised
+        # if doc_string_source is azure.mgmt.keyvault.v2023_02_01.models#VaultProperties, ignored,
+        # self.get_models(doc_string_source) is always None
+        # TODO why some doc_string_source is blob#PageBlobService.get_blob_properties?
+        if doc_string_source == 'azure.mgmt.netapp.models#Snapshot':
+            pass
+        if doc_string_source == 'azure.mgmt.keyvault.v2023_02_01.models#VaultProperties':
+            pass
         try:
             model = self.get_models(doc_string_source, ignore=True)
         except APIVersionException:
+            print('wat')
             model = None
         if model:
             print('wat',doc_string_source)
-            import sys
-            sys.exit(0)
         if not model:
             from importlib import import_module
             (path, model_name) = doc_string_source.split('#', 1)

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -704,32 +704,12 @@ class AzCommandsLoader(CLICommandsLoader):  # pylint: disable=too-many-instance-
             raise CLIError("command authoring error: applying doc_string_source '{}' directly will cause slowdown. "
                            'Import by string name instead.'.format(doc_string_source.__name__))
 
-        # print('kk doc string source', doc_string_source)
-        # if doc_string_source is azure.mgmt.netapp.models#Snapshot, APIVersionException is raised
-        # if doc_string_source is azure.mgmt.keyvault.v2023_02_01.models#VaultProperties, ignored,
-        # self.get_models(doc_string_source) is always None
-        # doc_string_source is file#FileService.list_directories_and_files in azure stack
-        # it becomes _get_attr azure.multiapi.storage.v2017_04_17.file#FileService.list_directories_and_files
-        if doc_string_source == 'azure.mgmt.netapp.models#Snapshot':
-            pass
-        if doc_string_source == 'azure.mgmt.keyvault.v2023_02_01.models#VaultProperties':
-            pass
-        if doc_string_source == 'file#FileService.list_directories_and_files':
-            pass
-        # try:
-        #     model = self.get_models(doc_string_source, ignore=True)
-        # except APIVersionException:
-        #     model = None
-        # if model:
-        #     print('wat model not empty', doc_string_source)
-        # if not model:
         from importlib import import_module
         (path, model_name) = doc_string_source.split('#', 1)
         method_name = None
         if '.' in model_name:
             (model_name, method_name) = model_name.split('.', 1)
         module = import_module(path)
-        # print('kk import module', module,'model_name',model_name)
         model = getattr(module, model_name)
         if method_name:
             model = getattr(model, method_name, None)
@@ -788,7 +768,6 @@ class AzCommandsLoader(CLICommandsLoader):  # pylint: disable=too-many-instance-
         from azure.cli.core.profiles import get_sdk
         resource_type = kwargs.get('resource_type', self._get_resource_type())
         operation_group = kwargs.get('operation_group', self.module_kwargs.get('operation_group', None))
-        # print('get_models', resource_type, attr_args)
         return get_sdk(self.cli_ctx, resource_type, *attr_args, mod='models', operation_group=operation_group)
 
     def command_group(self, group_name, command_type=None, **kwargs):

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -696,7 +696,6 @@ class AzCommandsLoader(CLICommandsLoader):  # pylint: disable=too-many-instance-
                 command.update_argument(argument_name, overrides)
 
     def _apply_doc_string(self, dest, command_kwargs):
-        from azure.cli.core.profiles._shared import APIVersionException
         doc_string_source = command_kwargs.get('doc_string_source', None)
         if not doc_string_source:
             return
@@ -713,6 +712,8 @@ class AzCommandsLoader(CLICommandsLoader):  # pylint: disable=too-many-instance-
         model = getattr(module, model_name)
         if method_name:
             model = getattr(model, method_name, None)
+        if not model:
+            raise CLIError("command authoring error: source '{}' not found.".format(doc_string_source))
         dest.__doc__ = model.__doc__
 
     def _get_resource_type(self):

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -704,36 +704,35 @@ class AzCommandsLoader(CLICommandsLoader):  # pylint: disable=too-many-instance-
             raise CLIError("command authoring error: applying doc_string_source '{}' directly will cause slowdown. "
                            'Import by string name instead.'.format(doc_string_source.__name__))
 
-        model = doc_string_source
-        print('kk doc string source', doc_string_source)
+        # print('kk doc string source', doc_string_source)
         # if doc_string_source is azure.mgmt.netapp.models#Snapshot, APIVersionException is raised
         # if doc_string_source is azure.mgmt.keyvault.v2023_02_01.models#VaultProperties, ignored,
         # self.get_models(doc_string_source) is always None
         # doc_string_source is file#FileService.list_directories_and_files in azure stack
-        # it becomes _get_attr azure.multiapi.storage.v2017_04_17 file#FileService.list_directories_and_files
+        # it becomes _get_attr azure.multiapi.storage.v2017_04_17.file#FileService.list_directories_and_files
         if doc_string_source == 'azure.mgmt.netapp.models#Snapshot':
             pass
         if doc_string_source == 'azure.mgmt.keyvault.v2023_02_01.models#VaultProperties':
             pass
         if doc_string_source == 'file#FileService.list_directories_and_files':
             pass
-        try:
-            model = self.get_models(doc_string_source, ignore=True)
-        except APIVersionException:
-            model = None
-        if model:
-            print('wat model not empty', doc_string_source)
-        if not model:
-            from importlib import import_module
-            (path, model_name) = doc_string_source.split('#', 1)
-            # print('fail to get', doc_string_source, 'use', path, model_name, 'instead')
-            method_name = None
-            if '.' in model_name:
-                (model_name, method_name) = model_name.split('.', 1)
-            module = import_module(path)
-            model = getattr(module, model_name)
-            if method_name:
-                model = getattr(model, method_name, None)
+        # try:
+        #     model = self.get_models(doc_string_source, ignore=True)
+        # except APIVersionException:
+        #     model = None
+        # if model:
+        #     print('wat model not empty', doc_string_source)
+        # if not model:
+        from importlib import import_module
+        (path, model_name) = doc_string_source.split('#', 1)
+        method_name = None
+        if '.' in model_name:
+            (model_name, method_name) = model_name.split('.', 1)
+        module = import_module(path)
+        # print('kk import module', module,'model_name',model_name)
+        model = getattr(module, model_name)
+        if method_name:
+            model = getattr(model, method_name, None)
         if not model:
             raise CLIError("command authoring error: source '{}' not found.".format(doc_string_source))
         dest.__doc__ = model.__doc__

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -709,18 +709,20 @@ class AzCommandsLoader(CLICommandsLoader):  # pylint: disable=too-many-instance-
         # if doc_string_source is azure.mgmt.netapp.models#Snapshot, APIVersionException is raised
         # if doc_string_source is azure.mgmt.keyvault.v2023_02_01.models#VaultProperties, ignored,
         # self.get_models(doc_string_source) is always None
-        # TODO why some doc_string_source is blob#PageBlobService.get_blob_properties?
+        # doc_string_source is file#FileService.list_directories_and_files in azure stack
+        # it becomes _get_attr azure.multiapi.storage.v2017_04_17 file#FileService.list_directories_and_files
         if doc_string_source == 'azure.mgmt.netapp.models#Snapshot':
             pass
         if doc_string_source == 'azure.mgmt.keyvault.v2023_02_01.models#VaultProperties':
             pass
+        if doc_string_source == 'file#FileService.list_directories_and_files':
+            pass
         try:
             model = self.get_models(doc_string_source, ignore=True)
         except APIVersionException:
-            print('wat')
             model = None
         if model:
-            print('wat',doc_string_source)
+            print('wat model not empty', doc_string_source)
         if not model:
             from importlib import import_module
             (path, model_name) = doc_string_source.split('#', 1)

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -705,13 +705,19 @@ class AzCommandsLoader(CLICommandsLoader):  # pylint: disable=too-many-instance-
                            'Import by string name instead.'.format(doc_string_source.__name__))
 
         model = doc_string_source
+        # print('kk doc string source', doc_string_source)
         try:
-            model = self.get_models(doc_string_source)
+            model = self.get_models(doc_string_source, ignore=True)
         except APIVersionException:
             model = None
+        if model:
+            print('wat',doc_string_source)
+            import sys
+            sys.exit(0)
         if not model:
             from importlib import import_module
             (path, model_name) = doc_string_source.split('#', 1)
+            # print('fail to get', doc_string_source, 'use', path, model_name, 'instead')
             method_name = None
             if '.' in model_name:
                 (model_name, method_name) = model_name.split('.', 1)
@@ -774,6 +780,7 @@ class AzCommandsLoader(CLICommandsLoader):  # pylint: disable=too-many-instance-
         from azure.cli.core.profiles import get_sdk
         resource_type = kwargs.get('resource_type', self._get_resource_type())
         operation_group = kwargs.get('operation_group', self.module_kwargs.get('operation_group', None))
+        # print('get_models', resource_type, attr_args)
         return get_sdk(self.cli_ctx, resource_type, *attr_args, mod='models', operation_group=operation_group)
 
     def command_group(self, group_name, command_type=None, **kwargs):

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -713,8 +713,6 @@ class AzCommandsLoader(CLICommandsLoader):  # pylint: disable=too-many-instance-
         model = getattr(module, model_name)
         if method_name:
             model = getattr(model, method_name, None)
-        if not model:
-            raise CLIError("command authoring error: source '{}' not found.".format(doc_string_source))
         dest.__doc__ = model.__doc__
 
     def _get_resource_type(self):

--- a/src/azure-cli-core/azure/cli/core/profiles/_shared.py
+++ b/src/azure-cli-core/azure/cli/core/profiles/_shared.py
@@ -644,15 +644,6 @@ def supported_resource_type(api_profile, resource_type):
 
 
 def _get_attr(sdk_path, mod_attr_path, checked=True):
-    # print('_get_attr', sdk_path, mod_attr_path)
-    # In _apply_doc_string, doc_string_source can be a full path and be passed as mod_attr_path
-    # ex: azure.mgmt.keyvault.v2023_02_01.models#VaultProperties
-    # Then full_mod_path become azure.mgmt.keyvault.v2023_02_01.azure.mgmt.keyvault.v2023_02_01.models
-    # We need to skip this import
-    # Later _apply_doc_string will import the full path directly
-    # if sdk_path.startswith('azure.') and mod_attr_path.startswith('azure.'):
-    #     print('ignore', sdk_path, mod_attr_path)
-    #     return None
     try:
         attr_mod, attr_path = mod_attr_path.split('#') \
             if '#' in mod_attr_path else (mod_attr_path, '')
@@ -697,7 +688,6 @@ def get_versioned_sdk(api_profile, resource_type, *attr_args, **kwargs):
     sub_mod_prefix = kwargs.get('mod', None)
     operation_group = kwargs.get('operation_group', None)
     sdk_path = get_versioned_sdk_path(api_profile, resource_type, operation_group)
-    # print('get version sdk',  sdk_path, attr_args )
     if not attr_args:
         # No attributes to load. Return the versioned sdk
         return import_module(sdk_path)

--- a/src/azure-cli-core/azure/cli/core/profiles/_shared.py
+++ b/src/azure-cli-core/azure/cli/core/profiles/_shared.py
@@ -643,7 +643,16 @@ def supported_resource_type(api_profile, resource_type):
         return False
 
 
-def _get_attr(sdk_path, mod_attr_path, checked=True):
+def _get_attr(sdk_path, mod_attr_path, checked=True, ignore=False):
+    # print('_get_attr', sdk_path, mod_attr_path)
+    # In _apply_doc_string, doc_string_source can be a full path and be passed as mod_attr_path
+    # ex: azure.mgmt.keyvault.v2023_02_01.models#VaultProperties
+    # Then full_mod_path become azure.mgmt.keyvault.v2023_02_01.azure.mgmt.keyvault.v2023_02_01.models
+    # We need to skip this import
+    # Later _apply_doc_string will import the full path directly
+    if sdk_path.startswith('azure.') and mod_attr_path.startswith('azure.'):
+        print('ignore', sdk_path, mod_attr_path)
+        return None
     try:
         attr_mod, attr_path = mod_attr_path.split('#') \
             if '#' in mod_attr_path else (mod_attr_path, '')
@@ -656,7 +665,6 @@ def _get_attr(sdk_path, mod_attr_path, checked=True):
         return op
     except (ImportError, AttributeError) as ex:
         import traceback
-        logger.debug(traceback.format_exc())
         if checked:
             return None
         raise ex
@@ -688,6 +696,7 @@ def get_versioned_sdk(api_profile, resource_type, *attr_args, **kwargs):
     sub_mod_prefix = kwargs.get('mod', None)
     operation_group = kwargs.get('operation_group', None)
     sdk_path = get_versioned_sdk_path(api_profile, resource_type, operation_group)
+    # print('get version sdk',  sdk_path, attr_args )
     if not attr_args:
         # No attributes to load. Return the versioned sdk
         return import_module(sdk_path)

--- a/src/azure-cli-core/azure/cli/core/profiles/_shared.py
+++ b/src/azure-cli-core/azure/cli/core/profiles/_shared.py
@@ -650,9 +650,9 @@ def _get_attr(sdk_path, mod_attr_path, checked=True, ignore=False):
     # Then full_mod_path become azure.mgmt.keyvault.v2023_02_01.azure.mgmt.keyvault.v2023_02_01.models
     # We need to skip this import
     # Later _apply_doc_string will import the full path directly
-    if sdk_path.startswith('azure.') and mod_attr_path.startswith('azure.'):
-        print('ignore', sdk_path, mod_attr_path)
-        return None
+    # if sdk_path.startswith('azure.') and mod_attr_path.startswith('azure.'):
+    #     print('ignore', sdk_path, mod_attr_path)
+    #     return None
     try:
         attr_mod, attr_path = mod_attr_path.split('#') \
             if '#' in mod_attr_path else (mod_attr_path, '')

--- a/src/azure-cli-core/azure/cli/core/profiles/_shared.py
+++ b/src/azure-cli-core/azure/cli/core/profiles/_shared.py
@@ -643,7 +643,7 @@ def supported_resource_type(api_profile, resource_type):
         return False
 
 
-def _get_attr(sdk_path, mod_attr_path, checked=True, ignore=False):
+def _get_attr(sdk_path, mod_attr_path, checked=True):
     # print('_get_attr', sdk_path, mod_attr_path)
     # In _apply_doc_string, doc_string_source can be a full path and be passed as mod_attr_path
     # ex: azure.mgmt.keyvault.v2023_02_01.models#VaultProperties
@@ -665,6 +665,7 @@ def _get_attr(sdk_path, mod_attr_path, checked=True, ignore=False):
         return op
     except (ImportError, AttributeError) as ex:
         import traceback
+        logger.debug(traceback.format_exc())
         if checked:
             return None
         raise ex

--- a/src/azure-cli/azure/cli/command_modules/storage/_client_factory_azure_stack.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_client_factory_azure_stack.py
@@ -248,3 +248,9 @@ def cf_adls_directory(cli_ctx, kwargs):
 def cf_adls_file(cli_ctx, kwargs):
     return cf_adls_service(cli_ctx, kwargs).get_file_client(file_system=kwargs.pop('file_system_name', None),
                                                             file_path=kwargs.pop('path', None))
+
+
+def get_docs_tmpl(cli_ctx, resource_type):
+    from azure.cli.core.profiles import get_api_version
+    api_version = get_api_version(cli_ctx, resource_type, as_sdk_profile=True)
+    return 'azure.multiapi.storage.v{}.{{}}'.format(api_version.replace('-', '_').replace('.', '_'))

--- a/src/azure-cli/azure/cli/command_modules/storage/commands_azure_stack.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/commands_azure_stack.py
@@ -11,7 +11,8 @@ from azure.cli.command_modules.storage._client_factory_azure_stack \
             cf_mgmt_policy, cf_blob_data_gen_update, cf_sa_for_keys,
             cf_mgmt_blob_services, cf_mgmt_file_shares,
             cf_private_link, cf_private_endpoint,
-            cf_mgmt_encryption_scope, cf_mgmt_file_services)
+            cf_mgmt_encryption_scope, cf_mgmt_file_services,
+            get_docs_tmpl)
 from azure.cli.command_modules.storage.sdkutil import cosmosdb_table_exists
 from azure.cli.core.commands import CliCommandType
 from azure.cli.core.commands.arm import show_exception_handler
@@ -79,6 +80,8 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
         operations_tmpl='azure.multiapi.storage.blob.blockblobservice#BlockBlobService.{}',
         client_factory=blob_data_service_factory,
         resource_type=ResourceType.DATA_STORAGE)
+
+    storage_docs_tmpl = get_docs_tmpl(self.cli_ctx, ResourceType.DATA_STORAGE)
 
     def get_custom_sdk(custom_module, client_factory, resource_type=ResourceType.DATA_STORAGE):
         """Returns a CliCommandType instance with specified operation template based on the given custom module name.
@@ -269,7 +272,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
 
         g.storage_custom_command_oauth('set-tier', 'set_blob_tier')
         g.storage_custom_command_oauth('upload', 'upload_blob',
-                                       doc_string_source='blob#BlockBlobService.create_blob_from_path')
+                                       doc_string_source=storage_docs_tmpl.format( 'blob#BlockBlobService.create_blob_from_path'))  # pylint: disable=line-too-long
         g.storage_custom_command_oauth('upload-batch', 'storage_blob_upload_batch',
                                        validator=process_blob_upload_batch_parameters)
         g.storage_custom_command_oauth('download-batch', 'storage_blob_download_batch',
@@ -278,7 +281,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
                                        validator=process_blob_delete_batch_parameters)
         g.storage_custom_command_oauth('show', 'show_blob', table_transformer=transform_blob_output,
                                        client_factory=page_blob_service_factory,
-                                       doc_string_source='blob#PageBlobService.get_blob_properties',
+                                       doc_string_source=storage_docs_tmpl.format('blob#PageBlobService.get_blob_properties'),  # pylint: disable=line-too-long
                                        exception_handler=show_exception_handler)
 
         g.storage_command_oauth(
@@ -489,7 +492,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
                                  transform=transform_file_directory_result(
                                      self.cli_ctx),
                                  table_transformer=transform_file_output,
-                                 doc_string_source='file#FileService.list_directories_and_files')
+                                 doc_string_source=storage_docs_tmpl.format('file#FileService.list_directories_and_files'))  # pylint: disable=line-too-long
 
     with self.command_group('storage file', command_type=file_sdk,
                             custom_command_type=get_custom_sdk('file_azure_stack', file_data_service_factory)) as g:
@@ -497,7 +500,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
         from ._transformers_azure_stack import transform_url
         g.storage_custom_command('list', 'list_share_files', transform=transform_file_directory_result(self.cli_ctx),
                                  table_transformer=transform_file_output,
-                                 doc_string_source='file#FileService.list_directories_and_files')
+                                 doc_string_source=storage_docs_tmpl.format('file#FileService.list_directories_and_files'))  # pylint: disable=line-too-long
         g.storage_command('delete', 'delete_file', transform=create_boolean_result_output_transformer('deleted'),
                           table_transformer=transform_boolean_for_table)
         g.storage_command('resize', 'resize_file')

--- a/src/azure-cli/azure/cli/command_modules/storage/commands_azure_stack.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/commands_azure_stack.py
@@ -272,7 +272,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
 
         g.storage_custom_command_oauth('set-tier', 'set_blob_tier')
         g.storage_custom_command_oauth('upload', 'upload_blob',
-                                       doc_string_source=storage_docs_tmpl.format( 'blob#BlockBlobService.create_blob_from_path'))  # pylint: disable=line-too-long
+                                       doc_string_source=storage_docs_tmpl.format('blob#BlockBlobService.create_blob_from_path'))  # pylint: disable=line-too-long
         g.storage_custom_command_oauth('upload-batch', 'storage_blob_upload_batch',
                                        validator=process_blob_upload_batch_parameters)
         g.storage_custom_command_oauth('download-batch', 'storage_blob_download_batch',


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
This PR fixes the errors when running `az self-test --debug`
The `doc_string_source` in `commands.py` must be full path now.

Before this PR, in https://github.com/Azure/azure-cli/blob/1fdda16d0812ab52cb5079802588fecafa27d669/src/azure-cli-core/azure/cli/core/__init__.py#L707-L718
1. If `doc_string_source` is `azure.mgmt.netapp.models#Snapshot`, `APIVersionException` is raised. Run line 718
2. if `doc_string_source` is `azure.mgmt.keyvault.v2023_02_01.models#VaultProperties`, it tries to import `azure.mgmt.keyvault.v2023_02_01.azure.mgmt.keyvault.v2023_02_01.models` in `_get_attr()` and fails. Run line 718
3. If `doc_string_source` is `file#FileService.list_directories_and_files` in azure stack, it finally imports `azure.multiapi.storage.v2017_04_17.file#FileService.list_directories_and_files`

In case2, lots of `ModuleNotFoundError: No module named 'azure.mgmt.keyvault.v2023_02_01.azure'` is raised.

In CLI and extension, the `doc_string_source` is full path except azure stack. I change the `doc_string_source` to full path, so CLI does not need to call `get_models` to concat the `sdk_path` and `class_path` and `model = self.get_models(doc_string_source)` can be eliminated.

Close #27793

**Testing Guide**
Run `az self-test --debug` to check the output


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
