### PR TITLE
[ACR] Allow registry names with hyphen in `az acr login` to support legacy registry names

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_constants.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_constants.py
@@ -30,7 +30,7 @@ ACR_RUN_DEFAULT_TIMEOUT_IN_SEC = 60 * 60  # 60 minutes
 ACR_AUDIENCE_RESOURCE_NAME = "containerregistry"
 
 # Regex pattern to validate that registry name is alphanumeric and between 5 and 50 characters
-ACR_NAME_VALIDATION_REGEX = r'^[a-zA-Z0-9]{5,50}$'
+ACR_NAME_VALIDATION_REGEX = r'^[a-zA-Z0-9-]{5,50}$'
 
 ALLOWED_TASK_FILE_TYPES = ('.yaml', '.yml', '.toml', '.json', '.sh', '.bash', '.zsh', '.ps1',
                            '.ps', '.cmd', '.bat', '.ts', '.js', '.php', '.py', '.rb', '.lua')

--- a/src/azure-cli/azure/cli/command_modules/acr/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_validators.py
@@ -106,6 +106,8 @@ def validate_retention_days(namespace):
 def validate_registry_name(cmd, namespace):
     """Omit login server endpoint suffix."""
     registry = namespace.registry_name
+    if registry is None:
+        return
     suffixes = cmd.cli_ctx.cloud.suffixes
     # Some clouds do not define 'acr_login_server_endpoint' (e.g. AzureGermanCloud)
     if registry and hasattr(suffixes, 'acr_login_server_endpoint'):


### PR DESCRIPTION
**Related command**
`az acr login`

**Description**<!--Mandatory-->
Add hyphen to ACR name validation regex to support legacy registry names

**Testing Guide**
<!--Example commands with explanations.-->
`az acr login myregistry-tenant`

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[ACR] `az acr login`: Allow registry names with hyphen

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
