### PR TITLE
{CI} Fix full test issue

### DIFF
--- a/scripts/ci/automation_full_test.py
+++ b/scripts/ci/automation_full_test.py
@@ -526,7 +526,7 @@ class AutomaticScheduling(object):
         result = get_path_table()
         # only get modules and core, ignore extensions
         self.modules = {**result['mod'], **result['core']}
-        logger.info(self.modules)
+        logger.info(json.dumps(self.modules, indent=2))
 
     def get_extension_modules(self):
         out = subprocess.Popen(['azdev', 'extension', 'list', '-o', 'tsv'], stdout=subprocess.PIPE)
@@ -570,7 +570,7 @@ class AutomaticScheduling(object):
             self.works[idx][k] = v
         # instance_idx: 1~n, python list index: 0~n-1
         self.instance_idx -= 1
-        logger.info(self.works)
+        logger.info(json.dumps(self.works, indent=2))
         return self.works[self.instance_idx]
 
     def run_instance_modules(self, instance_modules):

--- a/scripts/ci/automation_full_test.py
+++ b/scripts/ci/automation_full_test.py
@@ -525,7 +525,16 @@ class AutomaticScheduling(object):
     def get_all_modules(self):
         result = get_path_table()
         # only get modules and core, ignore extensions
-        self.modules = {**result['mod'], **result['core']}
+        from collections import OrderedDict
+        result_mod = result['mod']
+        result_core = result['core']
+
+        # make sure the dictionary is in order, otherwise job assignments will be random.
+        ordered_mod = OrderedDict(sorted(result_mod.items()))
+        ordered_core = OrderedDict(sorted(result_core.items()))
+
+        # merge two ordered dictionaries
+        self.modules = OrderedDict(list(ordered_mod.items()) + list(ordered_core.items()))
         logger.info(json.dumps(self.modules, indent=2))
 
     def get_extension_modules(self):

--- a/scripts/ci/automation_full_test.py
+++ b/scripts/ci/automation_full_test.py
@@ -525,16 +525,12 @@ class AutomaticScheduling(object):
     def get_all_modules(self):
         result = get_path_table()
         # only get modules and core, ignore extensions
-        from collections import OrderedDict
         result_mod = result['mod']
         result_core = result['core']
 
         # make sure the dictionary is in order, otherwise job assignments will be random.
-        ordered_mod = OrderedDict(sorted(result_mod.items()))
-        ordered_core = OrderedDict(sorted(result_core.items()))
-
-        # merge two ordered dictionaries
-        self.modules = OrderedDict(list(ordered_mod.items()) + list(ordered_core.items()))
+        from collections import OrderedDict
+        self.modules = OrderedDict(sorted((result_mod | result_core).items()))
         logger.info(json.dumps(self.modules, indent=2))
 
     def get_extension_modules(self):

--- a/scripts/ci/automation_full_test.py
+++ b/scripts/ci/automation_full_test.py
@@ -526,6 +526,7 @@ class AutomaticScheduling(object):
         result = get_path_table()
         # only get modules and core, ignore extensions
         self.modules = {**result['mod'], **result['core']}
+        logger.info(self.modules)
 
     def get_extension_modules(self):
         out = subprocess.Popen(['azdev', 'extension', 'list', '-o', 'tsv'], stdout=subprocess.PIPE)
@@ -569,6 +570,7 @@ class AutomaticScheduling(object):
             self.works[idx][k] = v
         # instance_idx: 1~n, python list index: 0~n-1
         self.instance_idx -= 1
+        logger.info(self.works)
         return self.works[self.instance_idx]
 
     def run_instance_modules(self, instance_modules):


### PR DESCRIPTION
The order of modules returned by get_path_table() is not fixed.
However, when generating all test jobs, the order of self.jobs is guaranteed by `self.jobs = sorted(jobs.items(), key=lambda item: -item[1])`, so this issue is not exposed.
But self.jobs only records cli modules before 2022/04/20.
Newly added modules will be assigned to each instance based on the average test time of existing modules.
This may result in a module not being tested by any instance.

For example:
The test load allocated on instance1 is 100 minutes.
The test load assigned on instance2 is 105 minutes
If there is another test, it will definitely be allocated to instance1 first, because the greedy algorithm will give priority to instances with lower load.
Assume that there are two modules at this time, one mysql and one containerapp, both of which take 6 minutes( The avg test time). 
If their order is not fixed, the following situation will occur

Instance1 thinks the tests run are as follows:
instance1: 100+mysql
instance2: 105 + containerapp

But instance2 thinks the tests run are as follows:
instance1: 100+containerapp
instance2: 105+mysql

This resulted in
instance1 thinks it is running mysql and instance2 will run containerapp,
instance2 also thinks that it is running mysql and instance1 will run containerapp,

Finally the containerapp will not be tested by any instance.

![image](https://github.com/Azure/azure-cli/assets/18628534/7b19331b-aa12-4455-a63a-886a01a4171a)


**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
