### PR TITLE
[ARM] `az bicep publish`: Add optional parameter `--with-source` to publish source code with the module (experimental)

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_help.py
@@ -2837,6 +2837,8 @@ examples:
     text: az bicep publish --file {bicep_file} --target "br:{registry}/{module_path}:{tag} --force"
   - name: Publish a bicep file with documentation uri.
     text: az bicep publish --file {bicep_file} --target "br:{registry}/{module_path}:{tag}" --documentationUri {documentationUri}
+  - name: Publish a bicep file with documentation uri and include source code
+    text: az bicep publish --file {bicep_file} --target "br:{registry}/{module_path}:{tag}" --documentationUri {documentationUri} --with-source
 """
 
 helps['bicep restore'] = """

--- a/src/azure-cli/azure/cli/command_modules/resource/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_params.py
@@ -846,7 +846,7 @@ def load_arguments(self, _):
                                                       help="The target location where the Bicep module will be published."))
         c.argument('documentationUri', arg_type=CLIArgumentType(options_list=['--documentationUri', '-d'],
                                                                 help="The documentation uri of the Bicep module."))
-        c.argument('with_source', options_list=['--with-source', '-s'], action='store_true', help="Publish source code with the module.", is_preview=True)
+        c.argument('with_source', options_list=['--with-source'], action='store_true', help="Publish source code with the module.", is_preview=True)
         c.argument('force', arg_type=bicep_force_type, help="Allow overwriting an existing Bicep module version.")
 
     with self.argument_context('bicep install') as c:

--- a/src/azure-cli/azure/cli/command_modules/resource/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_params.py
@@ -846,9 +846,7 @@ def load_arguments(self, _):
                                                       help="The target location where the Bicep module will be published."))
         c.argument('documentationUri', arg_type=CLIArgumentType(options_list=['--documentationUri', '-d'],
                                                                 help="The documentation uri of the Bicep module."))
-        c.argument('with_source', arg_type=CLIArgumentType(options_list=['--with-source', '--src'],
-                                                           action='store_true',
-                                                           help="[Experimental] Publish source code with the module."))
+        c.argument('with_source', options_list=['--with-source', '--src'], action='store_true', help="Publish source code with the module.", is_preview=True)
         c.argument('force', arg_type=bicep_force_type, help="Allow overwriting an existing Bicep module version.")
 
     with self.argument_context('bicep install') as c:

--- a/src/azure-cli/azure/cli/command_modules/resource/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_params.py
@@ -846,7 +846,7 @@ def load_arguments(self, _):
                                                       help="The target location where the Bicep module will be published."))
         c.argument('documentationUri', arg_type=CLIArgumentType(options_list=['--documentationUri', '-d'],
                                                                 help="The documentation uri of the Bicep module."))
-        c.argument('with_source', options_list=['--with-source', '--src'], action='store_true', help="Publish source code with the module.", is_preview=True)
+        c.argument('with_source', options_list=['--with-source', '-s'], action='store_true', help="Publish source code with the module.", is_preview=True)
         c.argument('force', arg_type=bicep_force_type, help="Allow overwriting an existing Bicep module version.")
 
     with self.argument_context('bicep install') as c:

--- a/src/azure-cli/azure/cli/command_modules/resource/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_params.py
@@ -846,6 +846,9 @@ def load_arguments(self, _):
                                                       help="The target location where the Bicep module will be published."))
         c.argument('documentationUri', arg_type=CLIArgumentType(options_list=['--documentationUri', '-d'],
                                                                 help="The documentation uri of the Bicep module."))
+        c.argument('with_source', arg_type=CLIArgumentType(options_list=['--with-source', '--src'],
+                                                           action='store_true',
+                                                           help="[Experimental] Publish source code with the module."))
         c.argument('force', arg_type=bicep_force_type, help="Allow overwriting an existing Bicep module version.")
 
     with self.argument_context('bicep install') as c:

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -4525,7 +4525,7 @@ def format_bicep_file(cmd, file, stdout=None, outdir=None, outfile=None, newline
         logger.error("az bicep format could not be executed with the current version of Bicep CLI. Please upgrade Bicep CLI to v%s or later.", minimum_supported_version)
 
 
-def publish_bicep_file(cmd, file, target, documentationUri=None, force=None):
+def publish_bicep_file(cmd, file, target, documentationUri=None, with_source=None, force=None):
     ensure_bicep_installation(cmd.cli_ctx)
 
     minimum_supported_version = "0.4.1008"
@@ -4537,6 +4537,12 @@ def publish_bicep_file(cmd, file, target, documentationUri=None, force=None):
                 args += ["--documentationUri", documentationUri]
             else:
                 logger.error("az bicep publish with --documentationUri/-d parameter could not be executed with the current version of Bicep CLI. Please upgrade Bicep CLI to v%s or later.", minimum_supported_version_for_documentationUri_parameter)
+        if with_source:
+            minimum_supported_version_for_publish_with_source = "0.23.1"
+            if bicep_version_greater_than_or_equal_to(minimum_supported_version_for_publish_with_source):
+                args += ["--with-source"]
+            else:
+                logger.error("az bicep publish with --with-source/-s parameter could not be executed with the current version of Bicep CLI. Please upgrade Bicep CLI to v%s or later.", minimum_supported_version_for_publish_with_source)
         if force:
             minimum_supported_version_for_publish_force = "0.17.1"
             if bicep_version_greater_than_or_equal_to(minimum_supported_version_for_publish_force):

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_custom.py
@@ -27,6 +27,7 @@ from azure.cli.command_modules.resource.custom import (
     deploy_arm_template_at_management_group,
     deploy_arm_template_at_tenant_scope,
     format_bicep_file,
+    publish_bicep_file,
 )
 
 from azure.cli.command_modules.resource._bicep import (run_bicep_command)
@@ -674,6 +675,39 @@ class TestFormatBicepFile(unittest.TestCase):
         mock_bicep_version_greater_than_or_equal_to.assert_called_once_with("0.12.1")
         mock_run_bicep_command.assert_called_once_with(cmd.cli_ctx, ["format", file_path, "--stdout"])
 
+class TestPublishWithSource(unittest.TestCase):
+    @mock.patch("azure.cli.command_modules.resource.custom.bicep_version_greater_than_or_equal_to", return_value=True)
+    @mock.patch("azure.cli.command_modules.resource.custom.run_bicep_command", return_value="formatted content")
+    def test_publish_withsource(self, mock_run_bicep_command, mock_bicep_version_greater_than_or_equal_to):
+        # Arrange.
+        file_path = "path/to/file.bicep"
+        target = "br:contoso.azurecr.io/bicep/mymodule:v1"
+
+        # Act.
+        publish_bicep_file(cmd, file_path, target, documentationUri=None, with_source=None)
+
+        # Assert.
+        mock_bicep_version_greater_than_or_equal_to.assert_has_calls([
+            mock.call("0.4.1008"), # Min version for 'bicep publish'
+        ])
+        mock_run_bicep_command.assert_called_once_with(cmd.cli_ctx, ['publish', file_path, '--target', 'br:contoso.azurecr.io/bicep/mymodule:v1'])
+
+    @mock.patch("azure.cli.command_modules.resource.custom.bicep_version_greater_than_or_equal_to", return_value=True)
+    @mock.patch("azure.cli.command_modules.resource.custom.run_bicep_command", return_value="formatted content")
+    def test_publish_without_source(self, mock_run_bicep_command, mock_bicep_version_greater_than_or_equal_to):
+        # Arrange.
+        file_path = "path/to/file.bicep"
+        target = "br:contoso.azurecr.io/bicep/mymodule:v1"
+
+        # Act.
+        publish_bicep_file(cmd, file_path, target, documentationUri=None, with_source=True)
+
+        # Assert.
+        mock_bicep_version_greater_than_or_equal_to.assert_has_calls([
+            mock.call("0.4.1008"), # Min version for 'bicep publish'
+            mock.call("0.23.1") # Min version for 'bicep publish --with-source'
+        ])
+        mock_run_bicep_command.assert_called_once_with(cmd.cli_ctx, ['publish', file_path, '--target', 'br:contoso.azurecr.io/bicep/mymodule:v1', '--with-source'])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Related command**
`az bicep publish`

**Description**<!--Mandatory-->
This is to expose the new experimental --with-source argument in the Bicep CLI for bicep publish.  See https://github.com/Azure/bicep/issues/11435.

**Testing Guide**
See https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/quickstart-private-module-registry?tabs=azure-cli#publish-modules for instructions on publishing bicep modules to a private registry.

Example: Publishing bicep module in ~/repos/template-examples/complicated/main.bicep to br:myacr.azurecr.io/complicated:v1 and include source code with that module in the ACR.
```sh
az bicep publish -f ~/repos/template-examples/complicated/main.bicep --target br:myacr.azurecr.io/complicated:v1 --with-source
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
