### PR TITLE
{Keyvault} Clear `doc_string_source` for keyvault commands

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/keyvault/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_help.py
@@ -875,6 +875,11 @@ examples:
     crafted: true
 """
 
+helps['keyvault check-name'] = """
+type: command
+short-summary: Check that the given name is valid and is not already in use.
+"""
+
 helps['keyvault wait'] = """
 type: command
 short-summary: Place the CLI in a waiting state until a condition of the Vault is met.

--- a/src/azure-cli/azure/cli/command_modules/keyvault/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/commands.py
@@ -76,25 +76,19 @@ def load_command_table(self, _):
     # Management Plane Commands
     with self.command_group('keyvault', mgmt_vaults_entity.command_type,
                             client_factory=mgmt_vaults_entity.client_factory) as g:
-        g.custom_command('create', 'create_vault_or_hsm', supports_no_wait=True,
-                         doc_string_source=mgmt_vaults_entity.models_docs_tmpl.format('VaultProperties'))
+        g.custom_command('create', 'create_vault_or_hsm', supports_no_wait=True)
         g.custom_command('recover', 'recover_vault_or_hsm', supports_no_wait=True)
         g.custom_command('list', 'list_vault_or_hsm')
-        g.custom_show_command('show', 'get_vault_or_hsm',
-                              doc_string_source=mgmt_vaults_entity.operations_docs_tmpl.format('get'))
-        g.custom_command('delete', 'delete_vault_or_hsm', supports_no_wait=True,
-                         doc_string_source=mgmt_vaults_entity.operations_docs_tmpl.format('delete'))
-        g.custom_command('purge', 'purge_vault_or_hsm', supports_no_wait=True,
-                         doc_string_source=mgmt_vaults_entity.operations_docs_tmpl.format('begin_purge_deleted'))
+        g.custom_show_command('show', 'get_vault_or_hsm')
+        g.custom_command('delete', 'delete_vault_or_hsm', supports_no_wait=True)
+        g.custom_command('purge', 'purge_vault_or_hsm', supports_no_wait=True)
         g.custom_command('set-policy', 'set_policy', supports_no_wait=True)
         g.custom_command('delete-policy', 'delete_policy', supports_no_wait=True)
-        g.custom_command('list-deleted', 'list_deleted_vault_or_hsm',
-                         doc_string_source=mgmt_vaults_entity.operations_docs_tmpl.format('list_deleted'))
+        g.custom_command('list-deleted', 'list_deleted_vault_or_hsm')
         g.custom_command('show-deleted', 'get_deleted_vault_or_hsm')
         g.generic_update_command(
             'update', setter_name='update_vault_setter', setter_type=kv_vaults_custom,
             custom_func_name='update_vault',
-            doc_string_source=mgmt_vaults_entity.models_docs_tmpl.format('VaultProperties'),
             supports_no_wait=True)
         g.wait_command('wait')
 
@@ -103,12 +97,9 @@ def load_command_table(self, _):
                                 client_factory=mgmt_hsms_entity.client_factory) as g:
             g.generic_update_command(
                 'update-hsm', setter_name='update_hsm_setter', setter_type=kv_hsms_custom,
-                custom_func_name='update_hsm', supports_no_wait=True,
-                doc_string_source=mgmt_hsms_entity.models_docs_tmpl.format('ManagedHsmProperties'))
+                custom_func_name='update_hsm', supports_no_wait=True)
             g.custom_wait_command('wait-hsm', 'wait_hsm')
-            g.custom_command('check-name', 'check_name_availability',
-                             doc_string_source=mgmt_hsms_entity.operations_docs_tmpl.
-                             format('check_mhsm_name_availability'))
+            g.custom_command('check-name', 'check_name_availability')
 
     with self.command_group('keyvault network-rule',
                             mgmt_vaults_entity.command_type,
@@ -145,12 +136,10 @@ def load_command_table(self, _):
     # Data Plane Commands
     if not is_azure_stack_profile(self):
         with self.command_group('keyvault backup', data_backup_entity.command_type) as g:
-            g.keyvault_custom('start', 'full_backup',
-                              doc_string_source=data_backup_entity.operations_docs_tmpl.format('begin_backup'))
+            g.keyvault_custom('start', 'full_backup')
 
         with self.command_group('keyvault restore', data_backup_entity.command_type) as g:
-            g.keyvault_custom('start', 'full_restore',
-                              doc_string_source=data_backup_entity.operations_docs_tmpl.format('begin_restore'))
+            g.keyvault_custom('start', 'full_restore')
 
         with self.command_group('keyvault security-domain', private_data_entity.command_type) as g:
             g.keyvault_custom('init-recovery', 'security_domain_init_recovery')
@@ -160,8 +149,7 @@ def load_command_table(self, _):
             g.keyvault_custom('wait', '_wait_security_domain_operation')
 
     with self.command_group('keyvault key', data_key_entity.command_type) as g:
-        g.keyvault_custom('create', 'create_key', transform=transform_key_output,
-                          doc_string_source=data_key_entity.operations_docs_tmpl.format('create_key'))
+        g.keyvault_custom('create', 'create_key', transform=transform_key_output)
         g.keyvault_command('set-attributes', 'update_key_properties', transform=transform_key_output)
         g.keyvault_command('show', 'get_key', transform=transform_key_output)
         g.keyvault_custom('import', 'import_key', transform=transform_key_output)
@@ -179,10 +167,8 @@ def load_command_table(self, _):
         g.keyvault_custom('recover', 'recover_key', transform=transform_key_output)
         g.keyvault_command('purge', 'purge_deleted_key')
         g.keyvault_custom('download', 'download_key')
-        g.keyvault_custom('backup', 'backup_key',
-                          doc_string_source=data_key_entity.operations_docs_tmpl.format('backup_key'))
-        g.keyvault_custom('restore', 'restore_key', supports_no_wait=True, transform=transform_key_output,
-                          doc_string_source=data_key_entity.operations_docs_tmpl.format('restore_key_backup'))
+        g.keyvault_custom('backup', 'backup_key')
+        g.keyvault_custom('restore', 'restore_key', supports_no_wait=True, transform=transform_key_output)
 
     if not is_azure_stack_profile(self):
         with self.command_group('keyvault key', data_key_entity.command_type) as g:


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az keyvault create`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
The `doc_string_source` settings for keyvault commands didn't take any actual effect because we have full help entries in `_help.py`. Meanwhile, the `doc_string_source` setting for `az keyvault create` would print such warnings in debug log which is quite annoying:
```
cli.azure.cli.core.profiles._shared: Traceback (most recent call last):
  File "d:\workspace\azure-cli\src\azure-cli-core\azure\cli\core\profiles\_shared.py", line 651, in _get_attr
    op = import_module(full_mod_path)
  File "C:\Users\yishiwang\AppData\Local\Programs\Python\Python39\lib\importlib\__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 972, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 972, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 972, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 972, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 984, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'azure.mgmt.keyvault.v2023_02_01.azure'
```
So this PR clears all `doc_string_source`s to fix https://github.com/Azure/azure-cli/pull/27793

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
