### PR TITLE
{Core} Make the recommendation for `SSLError` more accurate

### DIFF
--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -25,10 +25,9 @@ logger = get_logger(__name__)
 CLI_PACKAGE_NAME = 'azure-cli'
 COMPONENT_PREFIX = 'azure-cli-'
 
-SSLERROR_TEMPLATE = ('Certificate verification failed. This typically happens when using Azure CLI behind a proxy '
-                     'that intercepts traffic with a self-signed certificate. '
-                     # pylint: disable=line-too-long
-                     'Please add this certificate to the trusted CA bundle. More info: https://docs.microsoft.com/cli/azure/use-cli-effectively#work-behind-a-proxy.')
+SSLERROR_TEMPLATE = ('An SSL error occurred. This typically happens when using Azure CLI behind a proxy or firewall. '
+                     'For more information, see: '
+                     'https://learn.microsoft.com/cli/azure/use-cli-effectively#work-behind-a-proxy')
 
 QUERY_REFERENCE = ("To learn more about --query, please visit: "
                    "'https://docs.microsoft.com/cli/azure/query-azure-cli'")


### PR DESCRIPTION
**Description**<!--Mandatory-->
Not all `SSLError`s are caused by untrusted self-signed certificate. For example, when a firewall blocks https://management.azure.com/, an `requests.exceptions.SSLError` will be raised:

```
$ PYTHONPATH="/lib64/az/lib/python3.9/site-packages" python3.9 -c "import requests; print(requests.get('https://management.azure.com/').status_code)"
...
requests.exceptions.SSLError: HTTPSConnectionPool(host='management.azure.com', port=443): Max retries exceeded with url: / (Caused by SSLError(SSLEOFError(8, 'EOF occurred in violation of protocol (_ssl.c:1129)')))
```

This PR refines the recommendation message to make it more accurate.

**Testing Guide**
TBD
