### PR TITLE
{Profile} Use v2.0 authority to resolve tenant ID

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/profile/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/_validators.py
@@ -12,20 +12,20 @@ logger = get_logger(__name__)
 def validate_tenant(cmd, namespace):
     """
     Make sure tenant is a GUID. If domain name is provided, resolve to GUID.
-    https://docs.microsoft.com/azure/active-directory/develop/v2-protocols-oidc#fetch-the-openid-connect-metadata-document
+    https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols-oidc#find-your-apps-openid-configuration-document-uri
     """
     from azure.cli.core.util import is_guid
     if namespace.tenant is not None and not is_guid(namespace.tenant):
         import requests
         active_directory_endpoint = cmd.cli_ctx.cloud.endpoints.active_directory
-        url = '{}/{}/.well-known/openid-configuration'.format(active_directory_endpoint, namespace.tenant)
+        url = '{}/{}/v2.0/.well-known/openid-configuration'.format(active_directory_endpoint, namespace.tenant)
         response = requests.get(url, verify=not should_disable_connection_verify())
 
         if response.status_code != 200:
             from knack.util import CLIError
             raise CLIError("Failed to resolve tenant '{}'.\n\nError detail: {}".format(namespace.tenant, response.text))
 
-        # Example issuer: https://sts.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47/
+        # Example issuer: https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/v2.0
         tenant_id = response.json()['issuer'].split("/")[3]
         logger.debug('Resolved tenant domain name %s to GUID %s', namespace.tenant, tenant_id)
         namespace.tenant = tenant_id


### PR DESCRIPTION
**Related command**
`az login`

**Description**<!--Mandatory-->
Azure CLI migrated from ADAL to MSAL (https://github.com/Azure/azure-cli/pull/19853) which is powered by AAD v2.0. The tenant resolution logic (added by https://github.com/Azure/azure-cli/pull/10418) should do the same.

https://github.com/Azure/azure-cli/pull/14509 added unit tests `azure.cli.command_modules.profile.tests.latest.test_profile_custom.ProfileCommandTest.test_login_validate_tenant` for `azure.cli.command_modules.profile._validators.validate_tenant`.

**Testing Guide**
`az login --tenant microsoft.onmicrosoft.com`

**Additional information**
Even though MSAL has special logic for handling ADFS:

https://github.com/AzureAD/microsoft-authentication-library-for-python/blob/09d5ff9a71a51c998b83b356047230677825a622/msal/authority.py#L106-L112

```py
            tenant_discovery_endpoint = (
                'https://{}:{}{}{}/.well-known/openid-configuration'.format(
                    self.instance,
                    443 if authority.port is None else authority.port,
                    authority.path,  # In B2C scenario, it is "/tenant/policy"
                    "" if tenant == "adfs" else "/v2.0" # the AAD v2 endpoint
                    ))
```

This not our concern here since on Azure CLI side, `adfs` is part of `active_directory_endpoint` and `tenant` is discarded:

https://github.com/Azure/azure-cli/blob/b00483c1a1cd17053af5c483f62b11c829f4c27d/src/azure-cli-core/azure/cli/core/auth/identity.py#L360-L377

`validate_tenant` shouldn't be hit at all.
