### PR TITLE
[Profile] `az login`: Add post-output hint

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -683,7 +683,8 @@ class AzCliCommandInvoker(CommandInvoker):
         return CommandResultItem(
             event_data['result'],
             table_transformer=self.commands_loader.command_table[parsed_args.command].table_transformer,
-            is_query_active=self.data['query_active'])
+            is_query_active=self.data['query_active'],
+            raw_result=results)
 
     @staticmethod
     def _extract_parameter_names(args):


### PR DESCRIPTION
**Related command**
`az login`

**Description**
This PR is a simplified version of https://github.com/Azure/azure-cli/pull/16242:

1. The hinter is only registered on `az login`. No extra command module `hint` is introduced.
2. The different logic for handling subscription and tenant accounts is removed. All accounts are treated as subscriptions, differentiated by `N/A(tenant level account)`. This is because the "dummy subscription representing a tenant" is already a bad design, so I don't want to spend too much effort explaining the intricacy. (See below for additional information.)
3. Subscription ID is always shown.
4. The `TRY` part is omitted.

Explanations:

1. The hint is printed to `stderr`, so it won't corrupt the JSON printed to `stdout`.
2. The default subscription hint may become invalid if https://github.com/Azure/azure-cli/issues/27915 is implemented.

**Testing Guide**
With subscription access:

```
> az login --service-principal --username a7003d8c-e50f-4371-91a6-ef37bba4ab23 --password xxx --tenant 54826b22-38d6-4fb2-bad9-b7b93a3e9c5a --allow-no-subscriptions
[
  {
    "cloudName": "AzureCloud",
    "homeTenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
    "id": "0b1f6471-1bf0-4dda-aec3-cb9272f09590",
    "isDefault": true,
    "managedByTenants": [],
    "name": "AzureSDKTest",
    "state": "Enabled",
    "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
    "user": {
      "name": "a7003d8c-e50f-4371-91a6-ef37bba4ab23",
      "type": "servicePrincipal"
    }
  }
]
[HINT]
The default subscription is 0b1f6471-1bf0-4dda-aec3-cb9272f09590 (AzureSDKTest)
To change the default subscription, run `az account set --subscription {id or name}`
```

Without subscription access:

```
> az login --service-principal --username 92375e31-0eae-4019-8207-0698ce16d144 --password xxx --tenant 54826b22-38d6-4fb2-bad9-b7b93a3e9c5a --allow-no-subscriptions
[
  {
    "cloudName": "AzureCloud",
    "id": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
    "isDefault": true,
    "name": "N/A(tenant level account)",
    "state": "Enabled",
    "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
    "user": {
      "name": "92375e31-0eae-4019-8207-0698ce16d144",
      "type": "servicePrincipal"
    }
  }
]
[HINT]
The default subscription is 54826b22-38d6-4fb2-bad9-b7b93a3e9c5a (N/A(tenant level account))
To change the default subscription, run `az account set --subscription {id or name}`
```

**Additional information**

There is no concept of tenant account at all. There is only "dummy subscription representing a tenant". The help message of `az account set` shows the same:

```
> az account set -h

Command
    az account set : Set a subscription to be the current active subscription.

Arguments
    --name --subscription -n -s [Required] : Name or ID of subscription.
```

Related discussions:

- https://github.com/Azure/azure-cli/issues/13285
- https://github.com/Azure/azure-cli/issues/15585
