### PR TITLE
{Packaging} Remove Fedora 36 build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -800,12 +800,6 @@ jobs:
           artifact: rpm-ubi9-${{ arch.value }}
           python_package: python3.9
           pool: ${{ arch.pool }}
-        Fedora 36 ${{ arch.name }}:
-          dockerfile: fedora
-          image: fedora:36
-          artifact: rpm-fedora36-${{ arch.value }}
-          python_package: python3
-          pool: ${{ arch.pool }}
   steps:
   - bash: ./scripts/ci/install_docker.sh
     displayName: Install Docker
@@ -852,14 +846,6 @@ jobs:
           python_package: python3.9
           python_cmd: python3.9
           pip_cmd: pip3.9
-          pool: ${{ arch.pool }}
-        Fedora 36 ${{ arch.name }}:
-          artifact: rpm-fedora36-${{ arch.value }}
-          distro: fc36
-          image: fedora:36
-          python_package: python3
-          python_cmd: python3
-          pip_cmd: pip3
           pool: ${{ arch.pool }}
   steps:
   - task: DownloadPipelineArtifact@1


### PR DESCRIPTION
Fedora 36 is EOL and the build task fails like https://github.com/Azure/azure-cli/pull/25969