### PR TITLE
[Security] Fix spelling error in docs for `az security assessment`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/security/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/security/_params.py
@@ -75,8 +75,8 @@ workspace_setting_target_workspace_arg_type = CLIArgumentType(options_list=('--t
 # Assessments
 assessment_assessed_resource_id_arg_type = CLIArgumentType(options_list=('--assessed-resource-id'), metavar='ASSESSEDRESOURCEID', help='The target resource for this assessment')
 assessment_additional_data_arg_type = CLIArgumentType(options_list=('--additional-data'), metavar='ADDITIONALDATA', help='Data that is attached to the assessment result for better investigations or status clarity')
-assessment_status_code_arg_type = CLIArgumentType(options_list=('--status-code'), metavar='STATUSCODE', help='Progremmatic code for the result of the assessment. can be "Healthy", "Unhealthy" or "NotApplicable"')
-assessment_status_cause_arg_type = CLIArgumentType(options_list=('--status-cause'), metavar='STATUSCAUSE', help='Progremmatic code for the cause of the assessment result')
+assessment_status_code_arg_type = CLIArgumentType(options_list=('--status-code'), metavar='STATUSCODE', help='Programmatic code for the result of the assessment. can be "Healthy", "Unhealthy" or "NotApplicable"')
+assessment_status_cause_arg_type = CLIArgumentType(options_list=('--status-cause'), metavar='STATUSCAUSE', help='Programmatic code for the cause of the assessment result')
 assessment_status_description_arg_type = CLIArgumentType(options_list=('--status-description'), metavar='STATUSDESCRIPTION', help='Human readable description of the cause of the assessment result')
 
 # Assessment metadata


### PR DESCRIPTION
Correct spelling of "Progremmatic" to "Programmatic".
Fixes #27909 

**Related command**
`az security assessment`

**Description**<!--Mandatory-->
Spelling correction for documentation.

**Testing Guide**
N/A

**History Notes**
N/A

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
