### PR TITLE
{RDBMS} `az postgres flexible-server create`: Remove duplicate (y/n) in first prompt from prepare_public_network

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_virtual_network.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_virtual_network.py
@@ -449,10 +449,10 @@ def prepare_public_network(public_access, yes):
         if yes:
             return ip_address, ip_address
 
-        if get_user_confirmation("Do you want to enable access to client {0} (y/n)".format(ip_address), yes=yes):
+        if get_user_confirmation("Do you want to enable access to client {0}".format(ip_address), yes=yes):
             return ip_address, ip_address
 
-        if get_user_confirmation("Do you want to enable access for all IPs ", yes=yes):
+        if get_user_confirmation("Do you want to enable access for all IPs", yes=yes):
             return '0.0.0.0', '255.255.255.255'
         return -1, -1
 


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az postgres flexible-server create

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
To avoid the redundant (y/n) in the prompt in which user is asked to confirm adding client IP address to the firewall, like in:

Do you want to enable access to client 20.82.64.133 (y/n) (y/n)

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
