### PR TITLE
{CI} When the test report length exceeds 65535, guide the user to get error details in the pipeline log.

### DIFF
--- a/scripts/ci/automation_full_test.py
+++ b/scripts/ci/automation_full_test.py
@@ -463,6 +463,10 @@ def get_pipeline_result(test_result_fp, pipeline_result):
                 for i in pipeline_result[unique_job_name]['Details'][0]['Details'][0]['Details'][0]['Details']:
                     if i['Module'] == module:
                         i['Status'] = 'Failed'
+                        # GitHub has a comment length limit of 65535, we must ensure that the length is less than 65535.
+                        # The calculation based on 90% is because the azure cli bot will also add some html characters, so 10% needs to be reserved
+                        if len(pipeline_result) + len(message) > 65535 * 0.9:
+                            message = 'The error message is too long, please check the pipeline log for details.'
                         i['Content'] = build_markdown_content(state, test_case, message, line, i['Content'])
                         break
             else:

--- a/scripts/ci/automation_full_test.py
+++ b/scripts/ci/automation_full_test.py
@@ -464,8 +464,10 @@ def get_pipeline_result(test_result_fp, pipeline_result):
                     if i['Module'] == module:
                         i['Status'] = 'Failed'
                         # GitHub has a comment length limit of 65535, we must ensure that the length is less than 65535.
-                        # The calculation based on 90% is because the azure cli bot will also add some html characters, so 10% needs to be reserved
-                        if len(json.dumps(pipeline_result)) + len(message) > 65535 * 0.9:
+                        # The azure cli bot will also add extra html characters.
+                        # So the number of characters cannot be accurately calculated.
+                        # Using indent=4 is just a rough estimate.
+                        if len(json.dumps(pipeline_result, indent=4)) + len(message) > 65535:
                             message = 'The error message is too long, please check the pipeline log for details.'
                         i['Content'] = build_markdown_content(state, test_case, message, line, i['Content'])
                         break

--- a/scripts/ci/automation_full_test.py
+++ b/scripts/ci/automation_full_test.py
@@ -465,7 +465,7 @@ def get_pipeline_result(test_result_fp, pipeline_result):
                         i['Status'] = 'Failed'
                         # GitHub has a comment length limit of 65535, we must ensure that the length is less than 65535.
                         # The calculation based on 90% is because the azure cli bot will also add some html characters, so 10% needs to be reserved
-                        if len(pipeline_result) + len(message) > 65535 * 0.9:
+                        if len(json.dumps(pipeline_result)) + len(message) > 65535 * 0.9:
                             message = 'The error message is too long, please check the pipeline log for details.'
                         i['Content'] = build_markdown_content(state, test_case, message, line, i['Content'])
                         break


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

GitHub does not allow comments longer than 65535 characters,
When the test report length exceeds 65535, guide the user to get error details in the pipeline log. 
![image](https://github.com/Azure/azure-cli/assets/18628534/6eea6c45-9905-4d02-84e2-23193fe26058)

The logic is too complex if calculated through the final result and removed extra characters:
```
<!-- Azure CLI Extensions Breaking Change Test --><details>
<summary>️✔️Azure CLI Extensions Breaking Change Test</summary>
 
><details>
> <summary>️✔️Non Breaking Changes</summary>
>
>
></details>
</details>
```

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
