### PR TITLE
[Containerapp] `az containerapp revision copy`: Fix `--from-revision` bug for inheriting a specific revision (Azure/azure-cli-extensions#5435)

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/containerapp/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/containerapp/custom.py
@@ -592,7 +592,7 @@ def update_containerapp_logic(cmd,
         scale_def["maxReplicas"] = max_replicas
     # so we don't overwrite rules
     if safe_get(new_containerapp, "properties", "template", "scale", "rules"):
-        new_containerapp["properties"]["template"]["scale"].pop(["rules"])
+        new_containerapp["properties"]["template"]["scale"].pop("rules")
     if scale_rule_name:
         if not scale_rule_type:
             scale_rule_type = "http"


### PR DESCRIPTION
**Related command**
`az containerapp revision copy --from-revision`

**Description**
Fix Azure/azure-cli-extensions#5435

**Testing Guide**
Without this PR, `az containerapp revision copy --from-revision` will be failed always.

**History Notes**
[Containerapp] `az containerapp revision copy`: Fix Azure/azure-cli-extensions#5435:`--from-revision` crash on specific revision inheritance

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
