### PR TITLE
[Core] Use WAM as the default authentication method on Windows

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -856,8 +856,8 @@ def _create_identity_instance(cli_ctx, *args, **kwargs):
     # EXPERIMENTAL: Use core.use_msal_http_cache=False to turn off MSAL HTTP cache.
     use_msal_http_cache = cli_ctx.config.getboolean('core', 'use_msal_http_cache', fallback=True)
 
-    # PREVIEW: On Windows, use core.enable_broker_on_windows=true to use broker (WAM) for authentication.
-    enable_broker_on_windows = cli_ctx.config.getboolean('core', 'enable_broker_on_windows', fallback=False)
+    # On Windows, use core.enable_broker_on_windows=false to disable broker (WAM) for authentication.
+    enable_broker_on_windows = cli_ctx.config.getboolean('core', 'enable_broker_on_windows', fallback=True)
     from .telemetry import set_broker_info
     set_broker_info(enable_broker_on_windows)
 

--- a/src/azure-cli-core/azure/cli/core/auth/landing_pages/success.html
+++ b/src/azure-cli-core/azure/cli/core/auth/landing_pages/success.html
@@ -21,13 +21,5 @@
 <body>
     <h3>You have logged into Microsoft Azure!</h3>
     <p>You can close this window, or we will redirect you to the <a href="https://docs.microsoft.com/cli/azure/">Azure CLI documentation</a> in 1 minute.</p>
-    <h3>Announcements</h3>
-    <p>[Windows only] Azure CLI is collecting feedback on using the <a href="https://learn.microsoft.com/windows/uwp/security/web-account-manager">Web Account Manager</a> (WAM) broker for the login experience.</p>
-    <p>You may opt-in to use WAM by running the following commands:</p>
-    <code>
-        az config set core.enable_broker_on_windows=true<br>
-        az account clear<br>
-        az login
-    </code>
 </body>
 </html>

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -53,7 +53,7 @@ DEPENDENCIES = [
     'jmespath',
     'knack~=0.11.0',
     'msal-extensions~=1.0.0',
-    'msal[broker]==1.26.0',
+    'msal[broker]==1.27.0',
     'msrestazure~=0.6.4',
     'packaging>=20.9',
     'paramiko>=2.0.8,<4.0.0',

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -106,7 +106,7 @@ jsondiff==2.0.0
 knack==0.11.0
 MarkupSafe==2.0.1
 msal-extensions==1.0.0
-msal[broker]==1.26.0
+msal[broker]==1.27.0
 msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -107,7 +107,7 @@ jsondiff==2.0.0
 knack==0.11.0
 MarkupSafe==2.0.1
 msal-extensions==1.0.0
-msal[broker]==1.26.0
+msal[broker]==1.27.0
 msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -106,7 +106,7 @@ jsondiff==2.0.0
 knack==0.11.0
 MarkupSafe==2.0.1
 msal-extensions==1.0.0
-msal[broker]==1.26.0
+msal[broker]==1.27.0
 msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2


### PR DESCRIPTION
**Related command**
`az login`

**Description**<!--Mandatory-->
Fix https://github.com/Azure/azure-cli/issues/26573
Fix https://github.com/Azure/azure-cli/issues/28417
Require https://github.com/Azure/azure-cli/pull/27726

After previewing WAM for over a year (https://github.com/Azure/azure-cli/pull/23828), we now use WAM as the default authentication method on Windows.

This PR bumps MSAL to 1.27.0 (https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/669) which raised the upper bound of `pymsalruntime` (https://github.com/AzureAD/microsoft-authentication-library-for-python/commit/59c3000192e92a49f483045071b97aa79929d19f). This fixes the issues with PIM (https://github.com/Azure/azure-cli/issues/26573) and VM SSH (https://github.com/Azure/azure-cli/issues/28417).

**Testing Guide**
```sh
az login

# To opt out
az config set core.enable_broker_on_windows=false
az login
```

**History Notes**
[Core] BREAKING CHANGE: `az login`: Use WAM as the default authentication method on Windows. If you encounter any issue and want to opt out, run `az config set core.enable_broker_on_windows=false`, `az account clear` and `az login`


