### PR TITLE
{Packaging} Exclude Python test from DEB package

### DIFF
--- a/scripts/release/debian/build.sh
+++ b/scripts/release/debian/build.sh
@@ -42,7 +42,7 @@ wget -qO- https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSI
 echo "Python source code is in $PYTHON_SRC_DIR"
 
 # Build Python
-$PYTHON_SRC_DIR/*/configure --srcdir $PYTHON_SRC_DIR/* --prefix $WORKDIR/python_env
+$PYTHON_SRC_DIR/*/configure --srcdir $PYTHON_SRC_DIR/* --prefix $WORKDIR/python_env --disable-test-modules
 make
 make install
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
close #27961. After this PR, `/opt/az/lib/python3.11/test` folder is removed and it saves 122MB disk space.

Before:
```
❯ apt info azure-cli
Package: azure-cli
Version: 2.55.0-1~jammy
Priority: extra
Section: python
Maintainer: Azure Python CLI Team <azpycli@microsoft.com>
Installed-Size: 802 MB
```
After:
```
❯ apt info './azure-cli_2.55.0-1~jammy_amd64.deb'
Package: azure-cli
Version: 2.55.0-1~jammy
Priority: extra
Section: python
Maintainer: Azure Python CLI Team <azpycli@microsoft.com>
Installed-Size: 684 MB
```
