### PR TITLE
[RDBMS] Fix #27713: `az postgres flexible-server list-skus -o table`: Fix table output from list-skus command

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/_transformers.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_transformers.py
@@ -47,12 +47,12 @@ def table_transform_output_list_servers(result):
 
 def postgres_table_transform_output_list_skus(result):
     table_result = []
-    if len(result) > 1:
-        skus_tiers = result[0]["supportedFlexibleServerEditions"]
+    if len(result) > 0:
+        skus_tiers = result[0]["supportedServerEditions"]
         for skus in skus_tiers:
             tier_name = skus["name"]
             try:
-                keys = skus["supportedServerVersions"][0]["supportedVcores"]
+                keys = skus["supportedServerSkus"]
                 for key in keys:
                     new_entry = OrderedDict()
                     new_entry['SKU'] = key['name']


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az postgres flexible-server list-skus

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
The `list-skus` sub-command with table output has been giving empty result (reported in #27713). This PR fixes this problem and list the available SKUs for a region.

**Testing Guide**
<!--Example commands with explanations.-->
az postgres flexible-server list-skus --location eastus -o table
az postgres flexible-server list-skus --location norwayeast -o table

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
