### PR TITLE
[Service Connector] Fix Azure/azure-cli-extension#7235: `az containerapp connection`: Create postgresql-flexible

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/_utils.py
@@ -343,17 +343,17 @@ def is_packaged_installed(package_name):
 
 
 def get_object_id_of_current_user():
-    signed_in_user = run_cli_cmd('az account show').get('user')
+    signed_in_user = run_cli_cmd('az account show -o json').get('user')
     user_type = signed_in_user.get('type')
     try:
         if user_type == 'user':
-            user_info = run_cli_cmd('az ad signed-in-user show')
+            user_info = run_cli_cmd('az ad signed-in-user show -o json')
             user_object_id = user_info.get('objectId') if user_info.get(
                 'objectId') else user_info.get('id')
             return user_object_id
         if user_type == 'servicePrincipal':
             user_info = run_cli_cmd(
-                f'az ad sp show --id {signed_in_user.get("name")}')
+                f'az ad sp show --id {signed_in_user.get("name")} -o json')
             user_object_id = user_info.get('id')
             return user_object_id
     except CLIInternalError as e:


### PR DESCRIPTION
{containerapp} Update CLI commands to explicitly use JSON output format. 

**Related command**
az containerapp connection create postgres-flexible

**Description**<4!--Mandatory-->
Update CLI commands to explicitly use JSON output format. This fixes
    the issue described in Azure/azure-cli-extension#7235 but other
    commands might have similar issues.


**Testing Guide**
Change the default format:
`az config set core.output=table`

Run : 
`az containerapp connection create postgres-flexible ...`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
