### PR TITLE
{AppService} `az functionapp config appsettings set`: Update example documentation

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -219,7 +219,7 @@ parameters:
 examples:
   - name: Update a function app's settings.
     text: |
-        az functionapp config appsettings set --name MyFunctionApp --resource-group MyResourceGroup --settings "AzureWebJobsStorage=$storageConnectionString"
+        az functionapp config appsettings set --name MyFunctionApp --resource-group MyResourceGroup --settings foo=bar AzureWebJobsStorage=$storageConnectionString
   - name: Set using both key-value pair and a json file with more settings.
     text: >
         az functionapp config appsettings set -g MyResourceGroup -n MyUniqueApp --settings mySetting=value @moreSettings.json


### PR DESCRIPTION
**Related command**
`az functionapp config appsettings set`

**Description**<!--Mandatory-->
Based on the feedback from this GitHub issue, the quotation marks in the documentation might confuse customers: https://github.com/Azure/azure-cli/issues/28071


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
