### PR TITLE
{CI} Add permissions block for `Github Action Permission Changes`

### DIFF
--- a/.github/workflows/AddIssueComment.yml
+++ b/.github/workflows/AddIssueComment.yml
@@ -5,6 +5,8 @@ on:
 jobs:
   thank-user:
     runs-on: ubuntu-20.04
+    permissions:
+      issues: write
     name: Say thanks for the Issue
     steps:
       - name: comment on the issue

--- a/.github/workflows/AddPRComment.yml
+++ b/.github/workflows/AddPRComment.yml
@@ -8,8 +8,6 @@ permissions:
 jobs:
   thank-user:
     runs-on: ubuntu-20.04
-    permissions:
-      pull-requests: write
     name: Say thanks for the PR
     steps:
       - name: get message

--- a/.github/workflows/AddPRComment.yml
+++ b/.github/workflows/AddPRComment.yml
@@ -8,6 +8,8 @@ permissions:
 jobs:
   thank-user:
     runs-on: ubuntu-20.04
+    permissions:
+      pull-requests: write
     name: Say thanks for the PR
     steps:
       - name: get message


### PR DESCRIPTION
Starting February 1, 2024 the default permission for the GITHUB_TOKEN will change from Read/Write to Read-only for all Open Source GitHub orgs. 
Add permissions block to avoid breaking change to our workflows.
Learn more [here](https://docs.opensource.microsoft.com/github/apps/permission-changes/)

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
