### PR TITLE
{Core} Bump MSAL to 1.26.0

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -53,7 +53,7 @@ DEPENDENCIES = [
     'jmespath',
     'knack~=0.11.0',
     'msal-extensions~=1.0.0',
-    'msal[broker]==1.24.0b2',
+    'msal[broker]==1.26.0',
     'msrestazure~=0.6.4',
     'packaging>=20.9',
     'paramiko>=2.0.8,<4.0.0',

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -106,7 +106,7 @@ jsondiff==2.0.0
 knack==0.11.0
 MarkupSafe==2.0.1
 msal-extensions==1.0.0
-msal[broker]==1.24.0b2
+msal[broker]==1.26.0
 msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -107,7 +107,7 @@ jsondiff==2.0.0
 knack==0.11.0
 MarkupSafe==2.0.1
 msal-extensions==1.0.0
-msal[broker]==1.24.0b2
+msal[broker]==1.26.0
 msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -106,7 +106,7 @@ jsondiff==2.0.0
 knack==0.11.0
 MarkupSafe==2.0.1
 msal-extensions==1.0.0
-msal[broker]==1.24.0b2
+msal[broker]==1.26.0
 msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2


### PR DESCRIPTION
**Related command**
`az login`

**Description**<!--Mandatory-->
As https://github.com/Azure/azure-cli/pull/27726 is under debate, we will put `allow_broker`'s renaming on hold and first bump MSAL to the latest version. This will pick up https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/569, so that making WAM the default authentication method in the future (https://github.com/Azure/azure-cli/pull/28085) won't be a breaking change. See https://github.com/Azure/azure-cli/pull/28085#issuecomment-1870093562 for detailed explanation.
