### PR TITLE
{Packaging} Bump embedded Python version to 3.11.7

### DIFF
--- a/build_scripts/windows/scripts/build.cmd
+++ b/build_scripts/windows/scripts/build.cmd
@@ -25,7 +25,7 @@ if "%ARCH%"=="x86" (
     echo Please set ARCH to "x86" or "x64"
     goto ERROR
 )
-set PYTHON_VERSION=3.11.5
+set PYTHON_VERSION=3.11.7
 
 set WIX_DOWNLOAD_URL="https://azurecliprod.blob.core.windows.net/msi/wix310-binaries-mirror.zip"
 set PYTHON_DOWNLOAD_URL="https://www.python.org/ftp/python/%PYTHON_VERSION%/python-%PYTHON_VERSION%-embed-%PYTHON_ARCH%.zip"

--- a/scripts/release/debian/build.sh
+++ b/scripts/release/debian/build.sh
@@ -15,7 +15,7 @@ set -exv
 ls -Rl /mnt/artifacts
 
 WORKDIR=`cd $(dirname $0); cd ../../../; pwd`
-PYTHON_VERSION="3.11.5"
+PYTHON_VERSION="3.11.7"
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Update APT packages


### PR DESCRIPTION
CVE-2023-4807 is fixed in Python 3.11.7.

Ref: https://github.com/python/cpython/issues/109991