### PR TITLE
[ARM] Fix #27855: `az bicep generate-params`: Bicep install messages sent to stdout

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -1109,7 +1109,7 @@ def _build_bicepparam_file(cli_ctx, bicepparam_file, template_file, inline_param
 
 
 def _parse_bicepparam_file(cmd, template_file, parameters):
-    ensure_bicep_installation(cmd.cli_ctx)
+    ensure_bicep_installation(cmd.cli_ctx, stdout=False)
 
     minimum_supported_version_bicepparam_compilation = "0.14.85"
     if not bicep_version_greater_than_or_equal_to(minimum_supported_version_bicepparam_compilation):
@@ -4497,7 +4497,7 @@ def build_bicepparam_file(cmd, file, stdout=None, outdir=None, outfile=None, no_
 
 
 def format_bicep_file(cmd, file, stdout=None, outdir=None, outfile=None, newline=None, indent_kind=None, indent_size=None, insert_final_newline=None):
-    ensure_bicep_installation(cmd.cli_ctx)
+    ensure_bicep_installation(cmd.cli_ctx, stdout=False)
 
     minimum_supported_version = "0.12.1"
     if bicep_version_greater_than_or_equal_to(minimum_supported_version):
@@ -4606,7 +4606,7 @@ def list_bicep_cli_versions(cmd):
 
 
 def generate_params_file(cmd, file, no_restore=None, outdir=None, outfile=None, stdout=None, output_format=None, include_params=None):
-    ensure_bicep_installation(cmd.cli_ctx)
+    ensure_bicep_installation(cmd.cli_ctx, stdout=False)
 
     minimum_supported_version = "0.7.4"
     if bicep_version_greater_than_or_equal_to(minimum_supported_version):
@@ -4633,7 +4633,7 @@ def generate_params_file(cmd, file, no_restore=None, outdir=None, outfile=None, 
 
 
 def lint_bicep_file(cmd, file, no_restore=None, diagnostics_format=None):
-    ensure_bicep_installation(cmd.cli_ctx)
+    ensure_bicep_installation(cmd.cli_ctx, stdout=False)
 
     minimum_supported_version = "0.7.4"
     if bicep_version_greater_than_or_equal_to(minimum_supported_version):


### PR DESCRIPTION
**Related command**
az bicep generate-params

**Description**
Remove the sending of Bicep install messages to standard output (stdout) during Bicep auto installation when running `az bicep generate-params`

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[ARM] Fix #27855: `az bicep generate-params`: Bicep install messages sent to stdout

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
