### PR TITLE
{App Service} Clean error messages relating to ASP creation

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_client_factory.py
@@ -13,13 +13,8 @@ def ex_handler_factory(creating_plan=False, no_throw=False):
             detail = json.loads(ex.response.text)['Message']
             if creating_plan:
                 if 'Requested features are not supported in region' in detail:
-                    detail = ("Plan with linux worker is not supported in current region. For " +
-                              "supported regions, please refer to https://docs.microsoft.com/"
-                              "azure/app-service-web/app-service-linux-intro")
-                elif 'Not enough available reserved instance servers to satisfy' in detail:
-                    detail = ("Plan with Linux worker can only be created in a group " +
-                              "which has never contained a Windows worker, and vice versa. " +
-                              "Please use a new resource group. Original error:" + detail)
+                    detail = ("Selected plan is not supported in current region. " +
+                        "Original error: " + detail)
             ex = CLIError(detail)
         except Exception:  # pylint: disable=broad-except
             pass

--- a/src/azure-cli/azure/cli/command_modules/appservice/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_client_factory.py
@@ -14,7 +14,7 @@ def ex_handler_factory(creating_plan=False, no_throw=False):
             if creating_plan:
                 if 'Requested features are not supported in region' in detail:
                     detail = ("Selected plan is not supported in current region. " +
-                        "Original error: " + detail)
+                              "Original error: " + detail)
             ex = CLIError(detail)
         except Exception:  # pylint: disable=broad-except
             pass

--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -86,10 +86,6 @@ def _polish_bad_errors(ex, creating_plan):
                                   "If creating an App Service Plan with --zone-redundant/-z, "
                                   "please see supported regions here: "
                                   "https://docs.microsoft.com/en-us/azure/app-service/how-to-zone-redundancy#requirements")
-                    elif 'Not enough available reserved instance servers to satisfy' in detail:
-                        detail = ("Plan with Linux worker can only be created in a group " +
-                                  "which has never contained a Windows worker, and vice versa. " +
-                                  "Please use a new resource group. Original error:" + detail)
         else:
             detail = json.loads(ex.error_msg.response.text())['Message']
         ex = CLIError(detail)


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

```az
az appservice plan create
```

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Cleans outdated error messages related to App Service Plan creation. We no longer append "Plan with Linux worker can only be created in a group which has never contained a Windows worker, and vise versa." because this is no longer true (and has not been true for 2+ years).

We also make a Linux-specific error more generic in `_client_factory.py`, as nothing guarantees that this is only hit while creating a Linux App Service Plan.

**Testing Guide**
<!--Example commands with explanations.-->

I was able to reproduce the original error message with the following commands:

```az
az group create -n testgroup2 -l westus3
az appservice plan create --name windowstestplan --sku p1v3 -g testgroup2 --zone-redundant --number-of-workers 10
az appservice plan create --name hypervtestplan --sku p1v3 -g testgroup2 --zone-redundant --hyper-v --number-of-workers 20
```

![image](https://github.com/Azure/azure-cli/assets/136374263/a0bf20d4-54df-4d9e-b3ce-652736fe2d62)

Re-running the same commands with the changes from this PR, we instead see the following output:

![image](https://github.com/Azure/azure-cli/assets/136374263/040b4c2e-b9f8-427c-80b1-3d905c1189af)

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
