### PR TITLE
{Packaging} Use deb822 format in DEB installation script

### DIFF
--- a/scripts/release/debian/deb_install.sh
+++ b/scripts/release/debian/deb_install.sh
@@ -42,14 +42,15 @@ setup() {
     set -v
     export DEBIAN_FRONTEND=noninteractive
     apt-get update
-    apt-get install --assume-yes --no-install-recommends apt-transport-https ca-certificates curl gnupg2 lsb-release
+    apt-get install --assume-yes --no-install-recommends apt-transport-https ca-certificates curl gnupg lsb-release
     set +v
 
     assert_consent "Add Microsoft as a trusted package signer?" ${global_consent}
     set -v
     mkdir -p /etc/apt/keyrings
-    curl -fsSL https://packages.microsoft.com/keys/microsoft.asc |\
+    curl -sLS https://packages.microsoft.com/keys/microsoft.asc |
       gpg --dearmor -o /etc/apt/keyrings/microsoft.gpg
+    chmod go+r /etc/apt/keyrings/microsoft.gpg
     set +v
 
     assert_consent "Add the Azure CLI Repository to your apt sources?" ${global_consent}
@@ -58,8 +59,8 @@ setup() {
     if [[ -z $DIST_CODE ]]; then
         CLI_REPO=$(lsb_release -cs)
         shopt -s nocasematch
-        ERROR_MSG="Unable to find a package for your system. Please check if an existing package in https://packages.microsoft.com/repos/azure-cli/dists/ can be used in your system and install with the dist name: 'curl -fsSL https://aka.ms/InstallAzureCLIDeb | sudo DIST_CODE=<dist_code_name> bash'"
-        if [[ ! $(curl -fsSL https://packages.microsoft.com/repos/azure-cli/dists/) =~ $CLI_REPO ]]; then
+        ERROR_MSG="Unable to find a package for your system. Please check if an existing package in https://packages.microsoft.com/repos/azure-cli/dists/ can be used in your system and install with the dist name: 'curl -sL https://aka.ms/InstallAzureCLIDeb | sudo DIST_CODE=<dist_code_name> bash'"
+        if [[ ! $(curl -sL https://packages.microsoft.com/repos/azure-cli/dists/) =~ $CLI_REPO ]]; then
             DIST=$(lsb_release -is)
             if [[ $DIST =~ "Ubuntu" ]]; then
                 CLI_REPO="jammy"
@@ -78,7 +79,7 @@ setup() {
         fi
     else
         CLI_REPO=$DIST_CODE
-        if [[ ! $(curl -fsSL https://packages.microsoft.com/repos/azure-cli/dists/) =~ $CLI_REPO ]]; then
+        if [[ ! $(curl -sL https://packages.microsoft.com/repos/azure-cli/dists/) =~ $CLI_REPO ]]; then
             echo "Unable to find an azure-cli package with DIST_CODE=$CLI_REPO in https://packages.microsoft.com/repos/azure-cli/dists/."
             exit 1
         fi

--- a/scripts/release/debian/deb_install.sh
+++ b/scripts/release/debian/deb_install.sh
@@ -88,7 +88,7 @@ URIs: https://packages.microsoft.com/repos/azure-cli/
 Suites: ${CLI_REPO}
 Components: main
 Architectures: $(dpkg --print-architecture)
-Signed-by: /etc/apt/keyrings/microsoft.gpg" | sudo tee /etc/apt/sources.list.d/azure-cli.sources
+Signed-by: /etc/apt/keyrings/microsoft.gpg" | tee /etc/apt/sources.list.d/azure-cli.sources
     apt-get update
     set +v
 

--- a/scripts/release/debian/deb_install.sh
+++ b/scripts/release/debian/deb_install.sh
@@ -83,6 +83,11 @@ setup() {
             exit 1
         fi
     fi
+
+    if [ -f /etc/apt/sources.list.d/azure-cli.sources ]; then
+        rm /etc/apt/sources.list.d/azure-cli.sources
+    fi
+
     echo "Types: deb
 URIs: https://packages.microsoft.com/repos/azure-cli/
 Suites: ${CLI_REPO}

--- a/scripts/release/debian/deb_install.sh
+++ b/scripts/release/debian/deb_install.sh
@@ -58,8 +58,8 @@ setup() {
     if [[ -z $DIST_CODE ]]; then
         CLI_REPO=$(lsb_release -cs)
         shopt -s nocasematch
-        ERROR_MSG="Unable to find a package for your system. Please check if an existing package in https://packages.microsoft.com/repos/azure-cli/dists/ can be used in your system and install with the dist name: 'curl -sL https://aka.ms/InstallAzureCLIDeb | sudo DIST_CODE=<dist_code_name> bash'"
-        if [[ ! $(curl -sL https://packages.microsoft.com/repos/azure-cli/dists/) =~ $CLI_REPO ]]; then
+        ERROR_MSG="Unable to find a package for your system. Please check if an existing package in https://packages.microsoft.com/repos/azure-cli/dists/ can be used in your system and install with the dist name: 'curl -fsSL https://aka.ms/InstallAzureCLIDeb | sudo DIST_CODE=<dist_code_name> bash'"
+        if [[ ! $(curl -fsSL https://packages.microsoft.com/repos/azure-cli/dists/) =~ $CLI_REPO ]]; then
             DIST=$(lsb_release -is)
             if [[ $DIST =~ "Ubuntu" ]]; then
                 CLI_REPO="jammy"
@@ -78,7 +78,7 @@ setup() {
         fi
     else
         CLI_REPO=$DIST_CODE
-        if [[ ! $(curl -sL https://packages.microsoft.com/repos/azure-cli/dists/) =~ $CLI_REPO ]]; then
+        if [[ ! $(curl -fsSL https://packages.microsoft.com/repos/azure-cli/dists/) =~ $CLI_REPO ]]; then
             echo "Unable to find an azure-cli package with DIST_CODE=$CLI_REPO in https://packages.microsoft.com/repos/azure-cli/dists/."
             exit 1
         fi

--- a/scripts/release/debian/deb_install.sh
+++ b/scripts/release/debian/deb_install.sh
@@ -47,7 +47,8 @@ setup() {
 
     assert_consent "Add Microsoft as a trusted package signer?" ${global_consent}
     set -v
-    curl -fssL https://packages.microsoft.com/keys/microsoft.asc |\
+    sudo mkdir -p /etc/apt/keyrings
+    curl -fsSL https://packages.microsoft.com/keys/microsoft.asc |\
       gpg --dearmor -o /etc/apt/keyrings/microsoft.gpg
     set +v
 

--- a/scripts/release/debian/deb_install.sh
+++ b/scripts/release/debian/deb_install.sh
@@ -47,7 +47,7 @@ setup() {
 
     assert_consent "Add Microsoft as a trusted package signer?" ${global_consent}
     set -v
-    sudo mkdir -p /etc/apt/keyrings
+    mkdir -p /etc/apt/keyrings
     curl -fsSL https://packages.microsoft.com/keys/microsoft.asc |\
       gpg --dearmor -o /etc/apt/keyrings/microsoft.gpg
     set +v

--- a/scripts/release/debian/deb_install.sh
+++ b/scripts/release/debian/deb_install.sh
@@ -13,7 +13,7 @@
 # well-known publishers.                                                                                              #
 #######################################################################################################################
 
-set -e -o pipefail
+set -e
 
 if [[ $# -ge 1 && $1 == "-y" ]]; then
     global_consent=0
@@ -27,7 +27,7 @@ function assert_consent {
     fi
 
     echo -n "$1 [Y/n] "
-    read -r consent
+    read consent
     if [[ ! "${consent}" == "y" && ! "${consent}" == "Y" && ! "${consent}" == "" ]]; then
         echo "'${consent}'"
         exit 1
@@ -85,8 +85,8 @@ setup() {
         fi
     fi
 
-    if [ -f /etc/apt/sources.list.d/azure-cli.sources ]; then
-        rm /etc/apt/sources.list.d/azure-cli.sources
+    if [ -f /etc/apt/sources.list.d/azure-cli.list ]; then
+      rm /etc/apt/sources.list.d/azure-cli.list
     fi
 
     echo "Types: deb

--- a/scripts/release/debian/deb_install.sh
+++ b/scripts/release/debian/deb_install.sh
@@ -13,7 +13,7 @@
 # well-known publishers.                                                                                              #
 #######################################################################################################################
 
-set -e
+set -e -o pipefail
 
 if [[ $# -ge 1 && $1 == "-y" ]]; then
     global_consent=0
@@ -27,7 +27,7 @@ function assert_consent {
     fi
 
     echo -n "$1 [Y/n] "
-    read consent
+    read -r consent
     if [[ ! "${consent}" == "y" && ! "${consent}" == "Y" && ! "${consent}" == "" ]]; then
         echo "'${consent}'"
         exit 1
@@ -42,12 +42,13 @@ setup() {
     set -v
     export DEBIAN_FRONTEND=noninteractive
     apt-get update
-    apt-get install -y apt-transport-https lsb-release gnupg curl
+    apt-get install --assume-yes --no-install-recommends apt-transport-https ca-certificates curl gnupg2 lsb-release
     set +v
 
     assert_consent "Add Microsoft as a trusted package signer?" ${global_consent}
     set -v
-    curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.gpg
+    curl -fssL https://packages.microsoft.com/keys/microsoft.asc |\
+      gpg --dearmor -o /etc/apt/keyrings/microsoft.gpg
     set +v
 
     assert_consent "Add the Azure CLI Repository to your apt sources?" ${global_consent}
@@ -64,13 +65,13 @@ setup() {
             elif [[ $DIST =~ "Debian" ]]; then
                 CLI_REPO="bookworm"
             elif [[ $DIST =~ "LinuxMint" ]]; then
-                CLI_REPO=$(cat /etc/os-release | grep -Po 'UBUNTU_CODENAME=\K.*') || true
+                CLI_REPO=$(grep -Po 'UBUNTU_CODENAME=\K.*' /etc/os-release) || true
                 if [[ -z $CLI_REPO ]]; then
-                    echo $ERROR_MSG
+                    echo "$ERROR_MSG"
                     exit 1
                 fi
             else
-                echo $ERROR_MSG
+                echo "$ERROR_MSG"
                 exit 1
             fi
         fi
@@ -81,13 +82,17 @@ setup() {
             exit 1
         fi
     fi
-    echo "deb [arch=$(dpkg --print-architecture)] https://packages.microsoft.com/repos/azure-cli/ ${CLI_REPO} main" \
-        > /etc/apt/sources.list.d/azure-cli.list
+    echo "Types: deb
+URIs: https://packages.microsoft.com/repos/azure-cli/
+Suites: ${CLI_REPO}
+Components: main
+Architectures: $(dpkg --print-architecture)
+Signed-by: /etc/apt/keyrings/microsoft.gpg" | sudo tee /etc/apt/sources.list.d/azure-cli.sources
     apt-get update
     set +v
 
     assert_consent "Install the Azure CLI?" ${global_consent}
-    apt-get install -y azure-cli
+    apt-get install --assume-yes azure-cli
 
 }
 


### PR DESCRIPTION

**Description**

This PR:
- replaces the One-Line-Style format with the deb822 format, which will be the default in Ubuntu 24.04. See eg https://discourse.ubuntu.com/t/spec-apt-deb822-sources-by-default/29333 and https://repolib.readthedocs.io/en/latest/deb822-format.html
- performs basic shell linting
- is related to, and aligns with, https://github.com/MicrosoftDocs/azure-docs-cli/pull/4106

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
