### PR TITLE
[Core] `aaz`: Ignore null value when deserialize output

### DIFF
--- a/src/azure-cli-core/azure/cli/core/aaz/_command.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_command.py
@@ -194,7 +194,7 @@ class AAZCommand(CLICommand):
 
         def processor(schema, result):
             """A processor used in AAZBaseValue to serialized data"""
-            if result == AAZUndefined:
+            if result == AAZUndefined or result is None:
                 return result
 
             if isinstance(schema, AAZObjectType):


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Recursively deserialize output will cause `AttributeError` when JSON object contains null value, e.g.,

<img width="594" alt="image" src="https://github.com/Azure/azure-cli/assets/12371639/1218f68a-cd9a-4fbc-aafc-ef2bdb708cc1">

The whole debug log:
```text
cli.azure.cli.core.azclierror: Traceback (most recent call last):
  File "C:\azclivirtualtestenv\azclitestenv\lib\site-packages\knack\cli.py", line 233, in invoke
    cmd_result = self.invocation.execute(args)
  File "c:\users\kalbhatia\source\repos\azclirepos\azure-cli\src\azure-cli-core\azure\cli\core\commands\__init__.py", line 663, in execute
    raise ex
  File "c:\users\kalbhatia\source\repos\azclirepos\azure-cli\src\azure-cli-core\azure\cli\core\commands\__init__.py", line 726, in _run_jobs_serially
    results.append(self._run_job(expanded_arg, cmd_copy))
  File "c:\users\kalbhatia\source\repos\azclirepos\azure-cli\src\azure-cli-core\azure\cli\core\commands\__init__.py", line 710, in _run_job
    result = list(result)
  File "c:\users\kalbhatia\source\repos\azclirepos\azure-cli\src\azure-cli-core\azure\cli\core\aaz\_paging.py", line 87, in __next__
    return next(self._page_iterator)
  File "c:\users\kalbhatia\source\repos\azclirepos\azure-cli\src\azure-cli-core\azure\cli\core\aaz\_paging.py", line 46, in __next__
    curr_page, self._next_link = self._extract_result()
  File "c:\users\kalbhatia\source\repos\azclirepos\azure-cli-extensions\src\iotfirmwaredefense\azext_iotfirmwaredefense\aaz\latest\iotfirmwaredefense\firmware\_crypto_key.py", line 78, in _output
    result = self.deserialize_output(self.ctx.vars.instance.value, client_flatten=True)
  File "c:\users\kalbhatia\source\repos\azclirepos\azure-cli\src\azure-cli-core\azure\cli\core\aaz\_command.py", line 233, in deserialize_output
    return value.to_serialized_data(processor=processor)
  File "c:\users\kalbhatia\source\repos\azclirepos\azure-cli\src\azure-cli-core\azure\cli\core\aaz\_field_value.py", line 433, in to_serialized_data
    v = v.to_serialized_data(
  File "c:\users\kalbhatia\source\repos\azclirepos\azure-cli\src\azure-cli-core\azure\cli\core\aaz\_field_value.py", line 133, in to_serialized_data
    v = self[name].to_serialized_data(processor=processor, **kwargs)
  File "c:\users\kalbhatia\source\repos\azclirepos\azure-cli\src\azure-cli-core\azure\cli\core\aaz\_field_value.py", line 133, in to_serialized_data
    v = self[name].to_serialized_data(processor=processor, **kwargs)
  File "c:\users\kalbhatia\source\repos\azclirepos\azure-cli\src\azure-cli-core\azure\cli\core\aaz\_field_value.py", line 144, in to_serialized_data
    result = processor(self._schema, result)
  File "c:\users\kalbhatia\source\repos\azclirepos\azure-cli\src\azure-cli-core\azure\cli\core\aaz\_command.py", line 204, in processor
    for k, v in result.items():
AttributeError: 'NoneType' object has no attribute 'items'
```


**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
