### PR TITLE
{AppService} `az functionapp config container set`: Check if dapr config is null before updating settings

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -3840,6 +3840,10 @@ def update_dapr_and_workload_config(cmd, resource_group_name, name, enabled=None
                                     http_max_request_size=None, http_read_buffer_size=None, log_level=None,
                                     enable_api_logging=None, workload_profile_name=None, cpu=None, memory=None):
     site = _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'get')
+    DaprConfig = cmd.get_models('DaprConfig')
+    if site.dapr_config is None:
+        site.dapr_config = DaprConfig()
+
     import inspect
     frame = inspect.currentframe()
     bool_flags = ['enabled', 'enable_api_logging']

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands_thru_mock.py
@@ -14,7 +14,8 @@ from azure.cli.command_modules.appservice.custom import (
     add_remote_build_app_settings,
     remove_remote_build_app_settings,
     config_source_control,
-    validate_app_settings_in_scm)
+    validate_app_settings_in_scm,
+    update_container_settings_functionapp)
 from azure.cli.core.profiles import ResourceType
 from azure.cli.core.azclierror import (AzureInternalError, UnclassifiedUserFault)
 
@@ -404,6 +405,35 @@ class TestFunctionappMocked(unittest.TestCase):
 
         # assert
         self.assertFalse(result)
+
+    @mock.patch('azure.cli.command_modules.appservice.custom.is_centauri_functionapp')
+    @mock.patch('azure.cli.command_modules.appservice.custom._generic_site_operation')
+    @mock.patch('azure.cli.command_modules.appservice.custom.update_functionapp_polling', return_value=True)
+    @mock.patch('azure.cli.command_modules.appservice.custom.update_container_settings', autospec=True)
+    def test_update_container_settings_functionapp(self,
+                                                   update_container_settings_mock,
+                                                   update_functionapp_polling_mock,
+                                                   site_op_mock,
+                                                   is_centauri_functionapp_mock):
+        # prepare
+        cmd_mock = _get_test_cmd()
+        cli_ctx_mock = mock.MagicMock()
+        cmd_mock.cli_ctx = cli_ctx_mock
+
+        Site, DaprConfig, ResourceConfig = cmd_mock.get_models('Site', 'DaprConfig', 'ResourceConfig')
+        site = Site(dapr_config=None, location='westus', name='name', resource_config=ResourceConfig())
+        site_op_mock.return_value = site
+        
+        is_centauri_functionapp_mock.return_value = True
+
+        # action
+        update_container_settings_functionapp(cmd_mock, 'rg', 'name', workload_profile_name='d4', cpu=0.5, memory='1Gi')
+
+        # assert
+        updated_site = site
+        updated_site.dapr_config = DaprConfig()
+        update_functionapp_polling_mock.assert_called_with(cmd_mock, 'rg', 'name', updated_site)
+
 
     @mock.patch('azure.cli.command_modules.appservice.custom.validate_app_settings_in_scm', return_value=True)
     @mock.patch('azure.cli.command_modules.appservice.custom.update_app_settings')


### PR DESCRIPTION
**Related command**
`az functionapp config container set`

**Description**<!--Mandatory-->
When customers create Centauri function apps through the Portal, the daprConfig is set to null. If customers then try to update the daprConfig, workload profile name, cpu or memory through the CLI with the command `az functionapp config container set`, they will get an exception because we do not currently check that daprConfig is not null. This PR makes sure that daprConfig is not null. 

**Testing Guide**
1. Create Centauri function app through the Portal
2. Attempt to update the workload profile name, cpu and memory. You will get a failure without the changes in this PR. 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
