### PR TITLE
[ACS] `az aks update`: Handle zero value for outbound_ports

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_loadbalancer.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_loadbalancer.py
@@ -110,7 +110,7 @@ def configure_load_balancer_profile(managed_outbound_ip_count, managed_outbound_
                 profile.managed_outbound_i_ps.count_ipv6 = managed_outbound_ipv6_count
         elif profile.managed_outbound_i_ps is not None:
             profile.managed_outbound_i_ps = None
-    if outbound_ports:
+    if outbound_ports != None:
         profile.allocated_outbound_ports = outbound_ports
     if idle_timeout:
         profile.idle_timeout_in_minutes = idle_timeout
@@ -121,6 +121,8 @@ def configure_load_balancer_profile(managed_outbound_ip_count, managed_outbound_
 
 def is_load_balancer_profile_provided(managed_outbound_ip_count, managed_outbound_ipv6_count, outbound_ips, ip_prefixes,
                                       outbound_ports, backend_pool_type, idle_timeout):
+    if isinstance(outbound_ports, int):
+        return True
     return any([managed_outbound_ip_count,
                 managed_outbound_ipv6_count,
                 outbound_ips,

--- a/src/azure-cli/azure/cli/command_modules/acs/_loadbalancer.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_loadbalancer.py
@@ -110,7 +110,7 @@ def configure_load_balancer_profile(managed_outbound_ip_count, managed_outbound_
                 profile.managed_outbound_i_ps.count_ipv6 = managed_outbound_ipv6_count
         elif profile.managed_outbound_i_ps is not None:
             profile.managed_outbound_i_ps = None
-    if outbound_ports != None:
+    if outbound_ports is not None:
         profile.allocated_outbound_ports = outbound_ports
     if idle_timeout:
         profile.idle_timeout_in_minutes = idle_timeout

--- a/src/azure-cli/azure/cli/command_modules/acs/_loadbalancer.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_loadbalancer.py
@@ -121,6 +121,7 @@ def configure_load_balancer_profile(managed_outbound_ip_count, managed_outbound_
 
 def is_load_balancer_profile_provided(managed_outbound_ip_count, managed_outbound_ipv6_count, outbound_ips, ip_prefixes,
                                       outbound_ports, backend_pool_type, idle_timeout):
+    """allow outbound_port to be set to 0"""
     if isinstance(outbound_ports, int):
         return True
     return any([managed_outbound_ip_count,

--- a/src/azure-cli/azure/cli/command_modules/acs/_loadbalancer.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_loadbalancer.py
@@ -121,7 +121,6 @@ def configure_load_balancer_profile(managed_outbound_ip_count, managed_outbound_
 
 def is_load_balancer_profile_provided(managed_outbound_ip_count, managed_outbound_ipv6_count, outbound_ips, ip_prefixes,
                                       outbound_ports, backend_pool_type, idle_timeout):
-    """allow outbound_port to be set to 0"""
     if isinstance(outbound_ports, int):
         return True
     return any([managed_outbound_ip_count,


### PR DESCRIPTION
below command does not work as expected.
the reason is outbound_ports 0 is considered False. I added isinstance and none checking process.

**Related command**
$ az aks update -g rgname -n clustername --load-balancer-outbound-ports 0 --debug 

**Description**
If outbound_ports 0, it is considered False.
Even if outbound_ports is not None.
there need the checking logic for outbound_ports whether None or 0.
Given outbound_ports 0, the update process should work due to it is not None

**Testing Guide**
$ az aks update -g rgname -n clustername --load-balancer-outbound-ports 0 --debug 
$ az aks show -g rgname -n clustername -o yaml | grep allocate
    allocatedOutboundPorts: 0

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
