### PR TITLE
{Network} `az network application-gateway private-link add`: Improve error message for excessive name length

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/application_gateway/private_link/_add.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/application_gateway/private_link/_add.py
@@ -133,7 +133,9 @@ class Add(AAZCommand):
 
     @register_callback
     def pre_operations(self):
-        pass
+        name = self.ctx.args.name
+        if has_value(name) and len(name.to_serialized_data()) > 37:
+            raise ValueError("Name exceeds the maximum character limit of 37.")
 
     @register_callback
     def post_operations(self):


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

`az network application-gateway private-link add`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

This Pull Request addresses the issue of unhelpful error messages when a user inputs a name exceeding 37 characters in the az network application-gateway private-link add command. Currently, the error message for an excessively long name is generic and does not guide the user effectively. This PR aims to implement a more informative error message, clearly stating that the name exceeds the 37-character limit and advising the correct format.

38 characters name test

```console
$ PRIVATELINK_NAME=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKL

$ az network application-gateway private-link add --frontend-ip <your_frontend_ip> --gateway-name <your_appgw_name> --name $PRIVATELINK_NAME --resource-group  <your_resource_group_name> --subnet <your_subnet_name>

This command is in preview and under development. Reference and support levels: https://aka.ms/CLI_refstatus
(ApplicationGatewayPrivateLinkProvisioningError) An error occurred while configuring private link on Application Gateway.
Code: ApplicationGatewayPrivateLinkProvisioningError
Message: An error occurred while configuring private link on Application Gateway.

$ az network application-gateway private-link list --gateway-name  <your_appgw_name> --resource-group <your_resource_group_name>

This command is in preview and under development. Reference and support levels: https://aka.ms/CLI_refstatus
Name                                           ProvisioningState    ResourceGroup
---------------------------------------------  -------------------  --------------------------
abcdefghijklmnopqrstuvwxyzABCDEFGHIJKL  Failed               <your_appgw_name>
```

**Testing Guide**
<!--Example commands with explanations.-->

- 37 characters name test

Expected Result: Successful execution with the provisioning state set to Succeeded.
 
```console
$  PRIVATELINK_NAME=abcdefghijklmnopqrstuvwxyzABCDEFGHIJK
$ env/bin/az network application-gateway private-link add --frontend-ip appGatewayFrontendIP --gateway-name  <your_gateway_name>--name $PRIVATELINK_NAME --resource-group <your_resource_group_name> --subnet <your_subnet_name>
/Users/sakabekodai/src/github.com/koudaiii/azure-cli/env/bin/az:4: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
  __import__('pkg_resources').require('azure-cli==2.56.0')
This command is in preview and under development. Reference and support levels: https://aka.ms/CLI_refstatus
Name                                   ProvisioningState    ResourceGroup
-------------------------------------  -------------------  --------------------------
abcdefghijklmnopqrstuvwxyzABCDEFGHIJK  Succeeded            <your_resourc_group_name>
```

- 38 characters name test

Expected Result: Successful execution with the provisioning state set to Succeeded.

```
$ PRIVATELINK_NAME=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKL
$ env/bin/az network application-gateway private-link add --frontend-ip <your_frontend_ip> --gateway-name <your_gateway_name> --name $PRIVATELINK_NAME --resource-group  <your_resource_group_name> --subnet <your_subnet_name>

/Users/sakabekodai/src/github.com/koudaiii/azure-cli/env/bin/az:4: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
  __import__('pkg_resources').require('azure-cli==2.56.0')
This command is in preview and under development. Reference and support levels: https://aka.ms/CLI_refstatus
38
The command failed with an unexpected error. Here is the traceback:
Name exceeds the maximum character limit of 37.
Traceback (most recent call last):
  File "/Users/sakabekodai/src/github.com/koudaiii/azure-cli/env/lib/python3.11/site-packages/knack/cli.py", line 233, in invoke
    cmd_result = self.invocation.execute(args)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sakabekodai/src/github.com/koudaiii/azure-cli/src/azure-cli-core/azure/cli/core/commands/__init__.py", line 664, in execute
    raise ex
  File "/Users/sakabekodai/src/github.com/koudaiii/azure-cli/src/azure-cli-core/azure/cli/core/commands/__init__.py", line 729, in _run_jobs_serially
    results.append(self._run_job(expanded_arg, cmd_copy))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sakabekodai/src/github.com/koudaiii/azure-cli/src/azure-cli-core/azure/cli/core/commands/__init__.py", line 709, in _run_job
    result = LongRunningOperation(cmd_copy.cli_ctx, 'Starting {}'.format(cmd_copy.name))(result)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sakabekodai/src/github.com/koudaiii/azure-cli/src/azure-cli-core/azure/cli/core/commands/__init__.py", line 1033, in __call__
    result = poller.result()
             ^^^^^^^^^^^^^^^
  File "/Users/sakabekodai/src/github.com/koudaiii/azure-cli/src/azure-cli-core/azure/cli/core/aaz/_poller.py", line 108, in result
    self.wait(timeout)
  File "/Users/sakabekodai/src/github.com/koudaiii/azure-cli/env/lib/python3.11/site-packages/azure/core/tracing/decorator.py", line 76, in wrapper_use_tracer
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sakabekodai/src/github.com/koudaiii/azure-cli/src/azure-cli-core/azure/cli/core/aaz/_poller.py", line 130, in wait
    raise self._exception
  File "/Users/sakabekodai/src/github.com/koudaiii/azure-cli/src/azure-cli-core/azure/cli/core/aaz/_poller.py", line 83, in _start
    for polling_method in self._polling_generator:
  File "/Users/sakabekodai/src/github.com/koudaiii/azure-cli/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/application_gateway/private_link/_add.py", line 126, in _execute_operations
    self.pre_operations()
  File "/Users/sakabekodai/src/github.com/koudaiii/azure-cli/src/azure-cli-core/azure/cli/core/aaz/_command.py", line 289, in wrapper
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sakabekodai/src/github.com/koudaiii/azure-cli/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/application_gateway/private_link/_add.py", line 139, in pre_operations
    raise ValueError("Name exceeds the maximum character limit of 37.")
ValueError: Name exceeds the maximum character limit of 37.
To check existing issues, please visit: https://github.com/Azure/azure-cli/issues
```

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
