### PR TITLE
{RDBMS} Add support for osshf cluster

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/_config_reader.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_config_reader.py
@@ -1,21 +1,30 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
 import json
 from azure.cli.core.azclierror import BadRequestError
 
 _config = None
+
+
 def get_config_json():
-    global _config
+    global _config  # pylint:disable=global-statement
     if _config is not None:
         return _config
     with open("src\\azure-cli\\azure\\cli\\command_modules\\rdbms\\config.json", "r") as f:
         try:
             _config = json.load(f)
             return _config
-        except ValueError as err:
+        except ValueError as _:
             raise BadRequestError("Invalid json file. Make sure that the json file content is properly formatted.")
+
 
 def get_cloud(cmd):
     config = get_config_json()
     return config[cmd.cli_ctx.cloud.name]
+
 
 def get_cloud_cluster(cmd, location, subscription_id):
     cloud = get_cloud(cmd)
@@ -24,7 +33,4 @@ def get_cloud_cluster(cmd, location, subscription_id):
             if cloud[cluster] is not None:
                 if subscription_id in cloud[cluster]["subscriptions"]:
                     return cloud[cluster]
-    return            
-
-
-
+    return

--- a/src/azure-cli/azure/cli/command_modules/rdbms/_config_reader.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_config_reader.py
@@ -32,7 +32,7 @@ def get_cloud_cluster(cmd, location, subscription_id):
     cloud = get_cloud(cmd)
     try:
         clusters = cloud[location]
-    except Exception:
+    except KeyError:
         clusters = None
     if clusters is not None:
         for cluster in clusters:

--- a/src/azure-cli/azure/cli/command_modules/rdbms/_config_reader.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_config_reader.py
@@ -28,8 +28,12 @@ def get_cloud(cmd):
 
 def get_cloud_cluster(cmd, location, subscription_id):
     cloud = get_cloud(cmd)
-    if cloud[location] is not None:
-        for cluster in cloud[location]:
+    try:
+        clusters = cloud[location]
+    except:
+        clusters = None
+    if clusters is not None:
+        for cluster in clusters:
             if cloud[cluster] is not None:
                 if subscription_id in cloud[cluster]["subscriptions"]:
                     return cloud[cluster]

--- a/src/azure-cli/azure/cli/command_modules/rdbms/_config_reader.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_config_reader.py
@@ -1,0 +1,30 @@
+import json
+from azure.cli.core.azclierror import BadRequestError
+
+_config = None
+def get_config_json():
+    global _config
+    if _config is not None:
+        return _config
+    with open("src\\azure-cli\\azure\\cli\\command_modules\\rdbms\\config.json", "r") as f:
+        try:
+            _config = json.load(f)
+            return _config
+        except ValueError as err:
+            raise BadRequestError("Invalid json file. Make sure that the json file content is properly formatted.")
+
+def get_cloud(cmd):
+    config = get_config_json()
+    return config[cmd.cli_ctx.cloud.name]
+
+def get_cloud_cluster(cmd, location, subscription_id):
+    cloud = get_cloud(cmd)
+    if cloud[location] is not None:
+        for cluster in cloud[location]:
+            if cloud[cluster] is not None:
+                if subscription_id in cloud[cluster]["subscriptions"]:
+                    return cloud[cluster]
+    return            
+
+
+

--- a/src/azure-cli/azure/cli/command_modules/rdbms/_config_reader.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_config_reader.py
@@ -29,8 +29,8 @@ def get_cloud(cmd):
 
 
 def get_cloud_cluster(cmd, location, subscription_id):
-    cloud = get_cloud(cmd)
     try:
+        cloud = get_cloud(cmd)
         clusters = cloud[location]
     except KeyError:
         clusters = None

--- a/src/azure-cli/azure/cli/command_modules/rdbms/_config_reader.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_config_reader.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import json
+import os
 from azure.cli.core.azclierror import BadRequestError
 
 _config = None
@@ -13,11 +14,12 @@ def get_config_json():
     global _config  # pylint:disable=global-statement
     if _config is not None:
         return _config
-    with open("src\\azure-cli\\azure\\cli\\command_modules\\rdbms\\config.json", "r") as f:
+    script_dir = os.path.dirname(os.path.realpath(__file__))
+    with open(os.path.join(script_dir, "config.json"), "r") as f:
         try:
             _config = json.load(f)
             return _config
-        except ValueError as _:
+        except ValueError:
             raise BadRequestError("Invalid json file. Make sure that the json file content is properly formatted.")
 
 
@@ -30,7 +32,7 @@ def get_cloud_cluster(cmd, location, subscription_id):
     cloud = get_cloud(cmd)
     try:
         clusters = cloud[location]
-    except:
+    except Exception:
         clusters = None
     if clusters is not None:
         for cluster in clusters:

--- a/src/azure-cli/azure/cli/command_modules/rdbms/config.json
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/config.json
@@ -1,0 +1,17 @@
+{
+    "AzureCloud": {
+        "southcentralus": ["ossdev", "osshf", "ossmc"],
+        "osshf": {
+            "subscriptions": ["4a5d02ab-e0c3-4d39-8031-293ddd4e1875"],
+            "privateDnsZoneDomain": "pg.osshf-scus1-a.mscds.com"
+        },
+        "ossdev": {
+            "subscriptions": ["4a739919-f590-44f7-9eb8-0b84cde3bac8"],
+            "privateDnsZoneDomain": "pg.ossdev-scus1-a.mscds.com"
+        },
+        "ossmc": {
+            "subscriptions": ["d4fbfa87-b94d-4b13-906f-97361388c5e4"],
+            "privateDnsZoneDomain": "pg.ossmc-scus1-a.mscds.com"
+        }
+    }
+}

--- a/src/azure-cli/azure/cli/command_modules/rdbms/config.json
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/config.json
@@ -14,5 +14,13 @@
             "subscriptions": ["d4fbfa87-b94d-4b13-906f-97361388c5e4"],
             "privateDnsZoneDomain": "pg.ossmc-scus1-a.mscds.com"
         }
+    },
+    "AzureChinaCloud": {
+    },
+    "AzureUSGovernment": {
+    },
+    "AzureGermanCloud": {
+    },
+    "Stage": {
     }
 }

--- a/src/azure-cli/azure/cli/command_modules/rdbms/config.json
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/config.json
@@ -1,6 +1,7 @@
 {
     "AzureCloud": {
         "southcentralus": ["ossdev", "osshf", "ossmc"],
+        "northcentralus": ["ossdev", "osshf", "ossmc"],
         "osshf": {
             "subscriptions": ["4a5d02ab-e0c3-4d39-8031-293ddd4e1875"],
             "privateDnsZoneDomain": "pg.osshf-scus1-a.mscds.com"

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_virtual_network.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_virtual_network.py
@@ -15,6 +15,7 @@ from azure.mgmt.privatedns.models import PrivateZone
 from azure.mgmt.privatedns.models import SubResource
 from azure.mgmt.privatedns.models import VirtualNetworkLink
 from ._client_factory import resource_client_factory, private_dns_client_factory, private_dns_link_client_factory
+from ._config_reader import get_cloud_cluster
 from ._flexible_server_util import get_id_components, check_existence, _is_resource_name, parse_public_access_input, get_user_confirmation, _check_resource_group_existence
 from .validators import validate_private_dns_zone, validate_vnet_location
 
@@ -338,14 +339,6 @@ def prepare_mysql_exist_private_dns_zone(cmd, resource_group, private_dns_zone, 
 
 def prepare_private_dns_zone(db_context, resource_group, server_name, private_dns_zone, subnet_id, location, yes):
     cmd = db_context.cmd
-    dns_suffix_client = db_context.cf_private_dns_zone_suffix(cmd.cli_ctx, '_')
-    private_dns_zone_suffix = dns_suffix_client.execute()
-    if db_context.command_group == 'mysql':
-        private_dns_zone_suffix = private_dns_zone_suffix.private_dns_zone_suffix
-
-    # suffix should start with .
-    if private_dns_zone_suffix[0] != '.':
-        private_dns_zone_suffix = '.' + private_dns_zone_suffix
 
     # Get Vnet Components
     vnet_subscription, vnet_rg, vnet_name, _ = get_id_components(subnet_id)
@@ -359,6 +352,20 @@ def prepare_private_dns_zone(db_context, resource_group, server_name, private_dn
         "subscription": vnet_subscription,
         "resource_group": vnet_rg
     })
+
+    cluster = get_cloud_cluster(cmd, location.replace('/ +/g', '').lower(), vnet_subscription)
+
+    if cluster is not None:
+        private_dns_zone_suffix = cluster["privateDnsZoneDomain"]
+    else:        
+        dns_suffix_client = db_context.cf_private_dns_zone_suffix(cmd.cli_ctx, '_')
+        private_dns_zone_suffix = dns_suffix_client.execute()
+        if db_context.command_group == 'mysql':
+            private_dns_zone_suffix = private_dns_zone_suffix.private_dns_zone_suffix
+
+    # suffix should start with .
+    if private_dns_zone_suffix[0] != '.':
+        private_dns_zone_suffix = '.' + private_dns_zone_suffix
 
     # Process private dns zone (no input or Id input)
     dns_rg = None

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_virtual_network.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_virtual_network.py
@@ -357,7 +357,7 @@ def prepare_private_dns_zone(db_context, resource_group, server_name, private_dn
 
     if cluster is not None:
         private_dns_zone_suffix = cluster["privateDnsZoneDomain"]
-    else:        
+    else:
         dns_suffix_client = db_context.cf_private_dns_zone_suffix(cmd.cli_ctx, '_')
         private_dns_zone_suffix = dns_suffix_client.execute()
         if db_context.command_group == 'mysql':


### PR DESCRIPTION
**Related command**
Add support for OSSHF cluster to fetch private DNS zone domain name

**Description**<!--Mandatory-->
Add support for OSSHF cluster to fetch private DNS zone domain name

**Testing Guide**
Verified manually
az postgres flexible-server create -g cli-test-do-not-delete-rg-southcentralus -n cli-test-server-pg-flex-ha-vnet-southcentralus -l southcentralus --geo-redundant-backup Enabled --high-availability ZoneRedundant --vnet cli-test-osshf-pg-flex-vnet-southcentralus --subnet cli-test-osshf-pg-flex-subnet-southcentralus --private-dns-zone cli-test-osshf-pg-flex-dns-southcentralus.pg.osshf-scus1-a.mscds.com
Checking the existence of the resource group 'cli-test-do-not-delete-rg-southcentralus'...
Resource group 'cli-test-do-not-delete-rg-southcentralus' exists ? : True 
You have supplied a Vnet and Subnet name. Verifying its existence...
Using existing Vnet "cli-test-osshf-pg-flex-vnet-southcentralus" in resource group "cli-test-do-not-delete-rg-southcentralus"
Using existing Subnet "cli-test-osshf-pg-flex-subnet-southcentralus" in resource group "cli-test-do-not-delete-rg-southcentralus"
Do you want to create a new private DNS zone cli-test-osshf-pg-flex-dns-southcentralus.pg.osshf-scus1-a.mscds.com in resource group cli-test-do-not-delete-rg-southcentralus (y/n): y
Creating a private dns zone cli-test-osshf-pg-flex-dns-southcentralus.pg.osshf-scus1-a.mscds.com in resource group "cli-test-do-not-delete-rg-southcentralus"
Creating PostgreSQL Server 'cli-test-server-pg-flex-ha-vnet-southcentralus' in group 'cli-test-do-not-delete-rg-southcentralus'...
Your server 'cli-test-server-pg-flex-ha-vnet-southcentralus' is using sku 'Standard_D2s_v3' (Paid Tier). Please refer to https://aka.ms/postgres-pricing for pricing details
Creating PostgreSQL database 'flexibleserverdb'...
Make a note of your password. If you forget, you would have to reset your password with "az postgres flexible-server update -n cli-test-server-pg-flex-ha-vnet-southcentralus -g cli-test-do-not-delete-rg-southcentralus -p <new-password>".
Try using 'az postgres flexible-server connect' command to test out connection.
{
  "connectionString": "postgresql://giddyox2:JErrwcvummMoZ7Zxz2coyw@cli-test-server-pg-flex-ha-vnet-southcentralus.osshf-scus1-a.mscds.com/flexibleserverdb?sslmode=require",
  "databaseName": "flexibleserverdb",
  "host": "cli-test-server-pg-flex-ha-vnet-southcentralus.osshf-scus1-a.mscds.com",
  "id": "/subscriptions/4a5d02ab-e0c3-4d39-8031-293ddd4e1875/resourceGroups/cli-test-do-not-delete-rg-southcentralus/providers/Microsoft.DBforPostgreSQL/flexibleServers/cli-test-server-pg-flex-ha-vnet-southcentralus",
  "location": "South Central US",
  "password": "JErrwcvummMoZ7Zxz2coyw",
  "resourceGroup": "cli-test-do-not-delete-rg-southcentralus",
  "skuname": "Standard_D2s_v3",
  "subnetId": "/subscriptions/4a5d02ab-e0c3-4d39-8031-293ddd4e1875/resourceGroups/cli-test-do-not-delete-rg-southcentralus/providers/Microsoft.Network/virtualNetworks/cli-test-osshf-pg-flex-vnet-southcentralus/subnets/cli-test-osshf-pg-flex-subnet-southcentralus",
  "username": "giddyox2",
  "version": "13"
}

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
