### PR TITLE
[AKS] `az aks get-versions`: showing new column for supportPlan

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_format.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_format.py
@@ -105,9 +105,10 @@ def aks_versions_table_format(result):
     parsed = compile_jmes("""[].{
         kubernetesVersion: version,
         isPreview: isPreview,
-        upgrades: upgrades || [`None available`] | sort_versions(@) | join(`, `, @),
-        supportPlan: supportPlan
+        upgrades: upgrades || [`None available`] | join(`, `, @),
+        supportPlan: supportPlan | join(`, `, @)
     }""")
+
     # use ordered dicts so headers are predictable
     results = parsed.search(version_table, Options(
         dict_cls=OrderedDict, custom_functions=_custom_functions({})))

--- a/src/azure-cli/azure/cli/command_modules/acs/_format.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_format.py
@@ -105,7 +105,8 @@ def aks_versions_table_format(result):
     parsed = compile_jmes("""[].{
         kubernetesVersion: version,
         isPreview: isPreview,
-        upgrades: upgrades || [`None available`] | sort_versions(@) | join(`, `, @)
+        upgrades: upgrades || [`None available`] | sort_versions(@) | join(`, `, @),
+        supportPlan: supportPlan
     }""")
     # use ordered dicts so headers are predictable
     results = parsed.search(version_table, Options(
@@ -149,8 +150,9 @@ def flatten_version_table(release_info):
     flattened = []
     for release in release_info:
         isPreview = release.get("isPreview", False)
+        supportPlan = release.get("capabilities", {}).get("supportPlan", {})
         for k, v in release.get("patchVersions", {}).items():
-            item = {"version": k, "upgrades": v.get("upgrades", []), "isPreview": isPreview}
+            item = {"version": k, "upgrades": v.get("upgrades", []), "isPreview": isPreview, "supportPlan": supportPlan}
             flattened.append(item)
     return flattened
 


### PR DESCRIPTION
**Related command**
```az aks get-versions``` when ```-o table``` used

**Description**
showing additional column 'SupportPlan' on list result, diff:

New:
```
KubernetesVersion    Upgrades                 SupportPlan
-------------------  -----------------------  --------------------------------------
1.28.3               None available           KubernetesOfficial
1.28.0               1.28.3                   KubernetesOfficial
1.27.7               1.28.3, 1.28.0           KubernetesOfficial, AKSLongTermSupport
1.27.3               1.28.3, 1.28.0, 1.27.7   KubernetesOfficial, AKSLongTermSupport
1.26.10              1.27.7, 1.27.3           KubernetesOfficial
1.26.6               1.26.10, 1.27.7, 1.27.3  KubernetesOfficial
```
Current:
```
KubernetesVersion    Upgrades
-------------------  -----------------------
1.28.3               None available
1.28.0               1.28.3
1.27.7               1.28.0, 1.28.3
1.27.3               1.27.7, 1.28.0, 1.28.3
1.26.10              1.27.3, 1.27.7
1.26.6               1.26.10, 1.27.3, 1.27.7
```

**Testing Guide**
```az aks get-versions -l westus2 -o table```

**History Notes**

[AKS] `az aks get-versions`: showing extra column on supportPlan

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
