### PR TITLE
[Profile] ```az account get-access-token```: Add ```--show-claims``` argument

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/profile/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/__init__.py
@@ -77,6 +77,6 @@ class ProfileCommandsLoader(AzCommandsLoader):
             c.argument('resource', options_list=['--resource'], help='Azure resource endpoints in AAD v1.0.')
             c.argument('scopes', options_list=['--scope'], nargs='*', help='Space-separated AAD scopes in AAD v2.0. Default to Azure Resource Manager.')
             c.argument('tenant', options_list=['--tenant', '-t'], help='Tenant ID for which the token is acquired. Only available for user and service principal account, not for MSI or Cloud Shell account')
-
+            c.argument('show_claims', help='Show the decoded claims of the token.')
 
 COMMAND_LOADER_CLS = ProfileCommandsLoader

--- a/src/azure-cli/azure/cli/command_modules/profile/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/_help.py
@@ -88,6 +88,9 @@ examples:
     - name: Get an access token to use with MS Graph API
       text: >
         az account get-access-token --resource-type ms-graph
+    - name: Show the decoded claims of the token
+      text: >
+        az account get-access-token --show-claims
 """
 
 helps['self-test'] = """

--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -53,7 +53,7 @@ def show_subscription(cmd, subscription=None):
     return profile.get_subscription(subscription)
 
 
-def get_access_token(cmd, subscription=None, resource=None, scopes=None, resource_type=None, tenant=None):
+def get_access_token(cmd, subscription=None, resource=None, scopes=None, resource_type=None, tenant=None, show_claims=False):
     """
     get AAD token to access to a specified resource.
     Use 'az cloud show' command for other Azure resources
@@ -73,8 +73,14 @@ def get_access_token(cmd, subscription=None, resource=None, scopes=None, resourc
         'expiresOn': creds[2]['expiresOn'],
         'tenant': tenant
     }
+
     if subscription:
         result['subscription'] = subscription
+
+    if show_claims:
+        import jwt
+        decoded = jwt.decode(creds[1], algorithms=['RS256'], options={'verify_signature': False})
+        result['claims'] = decoded
 
     return result
 

--- a/src/azure-cli/azure/cli/command_modules/profile/tests/latest/test_profile_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/tests/latest/test_profile_custom.py
@@ -87,6 +87,22 @@ class ProfileCommandTest(unittest.TestCase):
         self.assertEqual(result, expected_result)
         get_raw_token_mock.assert_called_with(mock.ANY, None, None, None, tenant_id)
 
+        # test get token with decoded claims
+        test_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJodHRwczovL2dyYXBoLm1pY3Jvc29mdC5jb20vIiwibmFtZSI6IlRlc3QgVG9rZW4ifQ.redacted"
+        get_raw_token_mock.return_value = (('bearer', test_token, token_entry), None, 'tenant123')
+        result = get_access_token(cmd, show_claims=True)
+        expected_result = {
+            'tokenType': 'bearer',
+            'accessToken': test_token,
+            'expires_on': timestamp,
+            'expiresOn': datetime_local,
+            'tenant': 'tenant123',
+            'claims': {'aud': 'https://graph.microsoft.com/', 'name': 'Test Token'}
+        }
+
+        self.assertEqual(result, expected_result)
+        get_raw_token_mock.assert_called_with(mock.ANY, None, None, None, None)
+
     @mock.patch('azure.cli.command_modules.profile.custom.Profile', autospec=True)
     def test_get_login(self, profile_mock):
         invoked = []


### PR DESCRIPTION
**Related command**
```az account get-access-token```

**Description**<!--Mandatory-->
This PR introduces a new argument ```--show-claims``` to the ```az account get-access-token``` command. When users include this argument, the command will now display the decoded token along with the token information. This will allow for inspecting and verifying token claims without the need for external decoding tools when using the Azure CLI.

**Testing Guide**
1. Run ```az login``` to authenticate with Azure.
2. Execute ```az account get-access-token --show-claims```.
3. Ensure that the command returns the access token information, including decoded token claims.
4. Verify that the decoded token claims accurately represent the token's details.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
