### PR TITLE
[ARO] Update permissions validation to correctly handle not_actions roles

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/aro/_dynamic_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/aro/_dynamic_validators.py
@@ -30,18 +30,29 @@ log_entry_type = {'warn': 'Warning', 'error': 'Error'}
 
 def can_do_action(perms, action):
     for perm in perms:
-        for not_action in perm.not_actions:
-            match = re.escape(not_action)
-            match = re.match("(?i)^" + match.replace(r"\*", ".*") + "$", action)
-            if match:
-                return f"{action} permission is disabled"
+        matched = False
+
         for perm_action in perm.actions:
             match = re.escape(perm_action)
             match = re.match("(?i)^" + match.replace(r"\*", ".*") + "$", action)
             if match:
-                return None
+                matched = True
+                break
 
-    return f"{action} permission is missing"
+        if not matched:
+            continue
+
+        for not_action in perm.not_actions:
+            match = re.escape(not_action)
+            match = re.match("(?i)^" + match.replace(r"\*", ".*") + "$", action)
+            if match:
+                matched = False
+                break
+
+        if matched:
+            return True
+
+    return False
 
 
 def validate_resource(client, key, resource, actions):
@@ -54,9 +65,8 @@ def validate_resource(client, key, resource, actions):
     for action in actions:
         perms, perms_copy = tee(perms)
         perms_list = list(perms_copy)
-        error = can_do_action(perms_list, action)
-        if error is not None:
-            row = [key, resource['name'], log_entry_type["error"], error]
+        if not can_do_action(perms_list, action):
+            row = [key, resource['name'], log_entry_type["error"], f"{action} permission is missing"]
             errors.append(row)
 
     return errors


### PR DESCRIPTION
**Related command**
`az aro`

**Description**

The `az aro create` command performs pre-flight validation of user permissions in order to ensure cluster creation is successful. This validation can also be explicitly performed via `az aro validate`. 

This permissions validation has a bug in its handling, which incorrectly flags the presence of a matching `not_action` in any role to apply to all roles, rather than the specific role it is defined on. 

Fixes #28197 

**Testing Guide**

Given a user with multiple role assignments, one of which denies the required privilege via not_actions while another grants it:
```
{"actions": ["Microsoft.Network/virtualNetworks/*"], "not_actions": ["Microsoft.Network/virtualNetworks/write"]}
{"actions": ["Microsoft.Network/virtualNetworks/write"], "not_actions": []}
```
The functionality within `az aro validate` should allow this configuration, whereas the previous implementation would block the request, as seen in #28197.  


**History Notes**

[ARO] `az aro create/validate`: Fix bug in permissions validation that was preventing cluster creation in cases where the invoking user had the necessary permissions. 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
