### PR TITLE
[ARM] `az deployment`: Treat nullable parameters as non-required for Bicep deployment

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/tests/hybrid_2018_03_01/param-validation-template-$ref-indirection.json
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/hybrid_2018_03_01/param-validation-template-$ref-indirection.json
@@ -6,10 +6,10 @@
     "objectType": {
       "type": "object"
     },
-    "object!type~/with~weird name": {
+    "object&type~/with~weird name": {
       "$ref": "#/definitions/object",
       "properties": {
-        "fOo": {
+        "foo": {
           "type": "string"
         }
       }
@@ -17,7 +17,7 @@
   },
   "parameters": {
     "stringParam": {
-      "$ref": "#/dEfInItIoNs/ObJeCt%26tYpE~~1WiTh~0wEiRd%20NaMe/properties/foo"
+      "$ref": "#/definitions/object%26type~~1with~0weird%20name/properties/foo"
     },
     "intParam": {
       "$ref": "#/parameters/tupleParam/prefixItems/0"
@@ -37,7 +37,7 @@
   "outputs": {
     "anOutput": {
       "type": "object",
-      "additionalproperties": {
+      "additionalProperties": {
         "type": "bool"
       }
     }

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/hybrid_2019_03_01/param-validation-template-$ref-indirection.json
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/hybrid_2019_03_01/param-validation-template-$ref-indirection.json
@@ -6,10 +6,10 @@
     "objectType": {
       "type": "object"
     },
-    "object!type~/with~weird name": {
+    "object&type~/with~weird name": {
       "$ref": "#/definitions/object",
       "properties": {
-        "fOo": {
+        "foo": {
           "type": "string"
         }
       }
@@ -17,7 +17,7 @@
   },
   "parameters": {
     "stringParam": {
-      "$ref": "#/dEfInItIoNs/ObJeCt%26tYpE~~1WiTh~0wEiRd%20NaMe/properties/foo"
+      "$ref": "#/definitions/object%26type~~1with~0weird%20name/properties/foo"
     },
     "intParam": {
       "$ref": "#/parameters/tupleParam/prefixItems/0"
@@ -37,7 +37,7 @@
   "outputs": {
     "anOutput": {
       "type": "object",
-      "additionalproperties": {
+      "additionalProperties": {
         "type": "bool"
       }
     }

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/nullable_params_are_not_required/main.bicep
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/nullable_params_are_not_required/main.bicep
@@ -1,0 +1,31 @@
+// sample from https://github.com/Azure/bicep/issues/12538
+targetScope = 'subscription'
+param yourName string?
+
+output greeting string = !empty(yourName)
+  ? 'Hello, ${yourName}. Nice to meet you!'
+  : 'Hey, nice to meet you!'
+
+// verify this also works with nullable custom types
+param optionalCustomType customType?
+type customType = {
+  age: int
+}
+
+param requiredNullableCustomType nullableCustomType
+type nullableCustomType = {
+  age: int
+}?
+
+type customTypeWithRequired = customType!
+
+param optionalRequiredCustomType customTypeWithRequired?
+
+// repro for https://github.com/Azure/bicep/issues/13350
+type nullableArrayOfObjectsType = {
+  property1: string
+}[]?
+
+param param1 nullableArrayOfObjectsType
+
+output output1 nullableArrayOfObjectsType = param1

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/param-validation-template-$ref-indirection.json
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/param-validation-template-$ref-indirection.json
@@ -6,10 +6,10 @@
     "objectType": {
       "type": "object"
     },
-    "object!type~/with~weird name": {
+    "object&type~/with~weird name": {
       "$ref": "#/definitions/object",
       "properties": {
-        "fOo": {
+        "foo": {
           "type": "string"
         }
       }
@@ -17,7 +17,7 @@
   },
   "parameters": {
     "stringParam": {
-      "$ref": "#/dEfInItIoNs/ObJeCt%26tYpE~~1WiTh~0wEiRd%20NaMe/properties/foo"
+      "$ref": "#/definitions/object%26type~~1with~0weird%20name/properties/foo"
     },
     "intParam": {
       "$ref": "#/parameters/tupleParam/prefixItems/0"
@@ -37,7 +37,7 @@
   "outputs": {
     "anOutput": {
       "type": "object",
-      "additionalproperties": {
+      "additionalProperties": {
         "type": "bool"
       }
     }

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
@@ -5528,6 +5528,16 @@ class DeploymentWithBicepScenarioTest(LiveScenarioTest):
             self.check('properties.provisioningState', 'Succeeded')
         ])
 
+    def test_nullable_params_are_not_required(self):
+        curr_dir = os.path.dirname(os.path.realpath(__file__))
+        self.kwargs.update({
+            'tf': os.path.join(curr_dir, 'nullable_params_are_not_required/main.bicep').replace('\\', '\\\\'),
+        })
+
+        self.cmd('deployment sub create --location westus --template-file "{tf}"', checks=[
+            self.check('properties.provisioningState', 'Succeeded')
+        ])
+
     def test_management_group_level_deployment_with_bicep(self):
         curr_dir = os.path.dirname(os.path.realpath(__file__))
         self.kwargs.update({


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az deployment`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Treat nullable parameters as non-required (https://github.com/Azure/bicep/issues/13350)

Closes #28595

**Testing Guide**
```sh
az deployment sub create \ 
  --location westus \
  --template-file main.bicep
```

<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[ARM] `az deployment`: Treat nullable parameters as non-required for Bicep deployment

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
