### PR TITLE
{CI} Disable Credential Scanner

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,12 +66,12 @@ jobs:
   pool:
     name: ${{ variables.windows_pool }}
   steps:
-  - task: ms-codeanalysis.vss-microsoft-security-code-analysis-devops.build-task-credscan.CredScan@2
-    displayName: 'Run Credential Scanner'
-    inputs:
-      toolMajorVersion: V2
-      suppressionsFile: './scripts/ci/credscan/CredScanSuppressions.json'
-      toolVersionV2: '2.1.17'
+#  - task: ms-codeanalysis.vss-microsoft-security-code-analysis-devops.build-task-credscan.CredScan@2
+#    displayName: 'Run Credential Scanner'
+#    inputs:
+#      toolMajorVersion: V2
+#      suppressionsFile: './scripts/ci/credscan/CredScanSuppressions.json'
+#      toolVersionV2: '2.1.17'
 
   - task: ms-codeanalysis.vss-microsoft-security-code-analysis-devops.build-task-postanalysis.PostAnalysis@1
     displayName: 'Post Analysis'


### PR DESCRIPTION
Temporarily disable Credential Scanner
https://dev.azure.com/azclitools/public/_build/results?buildId=133760&view=logs&j=9a50307c-53e6-51fa-ddad-d8767a4a0ece&t=854f603a-ce91-59a3-a3f0-bfbaa050f0db
```
Attempting to gather dependency information for package 'Microsoft.Security.CredScan.2.1.17' with respect to project 'D:\a\_work\_sdt', targeting 'Any,Version=v0.0'
MSBuild auto-detection: using msbuild version '16.11.2.50704' from 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\bin'.
Using credentials from config. UserName: VssSessionToken
WARNING: The plugin credential provider could not acquire credentials. Authentication may require manual action. Consider re-running the command with --interactive for `dotnet`, /p:NuGetInteractive="true" for MSBuild or removing the -NonInteractive switch for `NuGet`
Unable to load the service index for source https://pkgs.dev.azure.com/secdevtools/_packaging/SecDevTools/nuget/v3/index.json.
  Response status code does not indicate success: 401 (Unauthorized).
##[error]Failed to install Microsoft.Security.CredScan from https://pkgs.dev.azure.com/secdevtools/_packaging/SecDevTools/nuget/v3/index.json
##[error]Please contact mscahelp@microsoft.com for support if the issue persists.
##[warning]Package install failed. Attempts left = 0

```