### PR TITLE
{CI} Switch CredScan task

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,23 +66,18 @@ jobs:
   pool:
     name: ${{ variables.windows_pool }}
   steps:
-#  - task: ms-codeanalysis.vss-microsoft-security-code-analysis-devops.build-task-credscan.CredScan@2
-#    displayName: 'Run Credential Scanner'
-#    inputs:
-#      toolMajorVersion: V2
-#      suppressionsFile: './scripts/ci/credscan/CredScanSuppressions.json'
-#      toolVersionV2: '2.1.17'
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@3
+    displayName: 'Run Credential Scanner'
+    inputs:
+      toolVersion: '2.1.17'
+      suppressionsFile: './scripts/ci/credscan/CredScanSuppressions.json'
 
-  - task: ms-codeanalysis.vss-microsoft-security-code-analysis-devops.build-task-postanalysis.PostAnalysis@1
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2
     displayName: 'Post Analysis'
     inputs:
-      AllTools: false
-      BinSkim: false
-      CredScan: true
-      PoliCheck: false
-      RoslynAnalyzers: false
-      TSLint: false
-      ToolLogsNotFoundAction: 'Standard'
+      GdnBreakAllTools: false
+      GdnBreakGdnToolCredScan: true
+      GdnBreakGdnToolCredScanSeverity: Error
 
 - job: PolicyCheck
   displayName: "Policy Check"


### PR DESCRIPTION
Last Saturday, this task `ms-codeanalysis.vss-microsoft-security-code-analysis-devops.build-task-credscan.CredScan@2` began failing unexpectedly with the following error message: 
![image](https://github.com/Azure/azure-cli-extensions/assets/18628534/e6472114-ce9a-4f5d-bb20-5c0a5b3b3ce1)
We have sent an email and created an ICM.
But progress is very slow, and many users' PRs have been blocked by this CI task.
And I found out that these two tasks have been deprecated.
- ms-codeanalysis.vss-microsoft-security-code-analysis-devops.build-task-credscan.CredScan@2
- ms-codeanalysis.vss-microsoft-security-code-analysis-devops.build-task-postanalysis.PostAnalysis@1
![image](https://github.com/Azure/azure-cli-extensions/assets/18628534/b72299c5-2415-452e-b091-107933a4cfbb)
![image](https://github.com/Azure/azure-cli-extensions/assets/18628534/48dc7322-df61-4aad-a2e4-5f1cb8335141)
![image](https://github.com/Azure/azure-cli-extensions/assets/18628534/557ae01c-a60f-4345-9831-c3f52a7cbc9b)

So we decided to switch to the `securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@3` and `securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2`
Test screenshot:
![image](https://github.com/Azure/azure-cli-extensions/assets/18628534/4cda7f0e-dae0-4939-a447-c63e4fffbf63)

Related documents:
[credscan](https://eng.ms/docs/microsoft-security/microsoft-threat-protection-mtp/cloud-and-enterprise-security-cesec/security-integration/guardian-wiki/sdl-azdo-extension/credscan-azure-devops-build-task)
[post analysis](https://eng.ms/docs/microsoft-security/microsoft-threat-protection-mtp/cloud-and-enterprise-security-cesec/security-integration/guardian-wiki/sdl-azdo-extension/post-analysis-build-task)

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
