### PR TITLE
[AD] Fix #28520: `az ad app credential reset/az ad sp create-for-rbac`: Each year specified by `--years` now only contains 365 days

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_params.py
@@ -191,7 +191,8 @@ def load_arguments(self, _):
         with self.argument_context(item) as c:
             # general credential arguments
             c.argument('years', type=int, default=None, arg_group='Credential',
-                       help='Number of years for which the credentials will be valid. Default: 1 year')
+                       help='Number of years for which the credentials will be valid. Each year contains 365 days.'
+                            'Leap years are not considered. Default: 1 year')
             c.argument('append', action='store_true', arg_group='Credential',
                        help='Append the new credential instead of overwriting.')
             c.argument('end_date', default=None, arg_group='Credential',

--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -20,7 +20,6 @@ import re
 import uuid
 
 import dateutil.parser
-from dateutil.relativedelta import relativedelta
 from knack.log import get_logger
 from knack.util import CLIError, todict
 from msrestazure.azure_exceptions import CloudError
@@ -1174,7 +1173,7 @@ def create_service_principal_for_rbac(
         existing_sps = list(graph_client.service_principal_list(filter=query_exp))
 
     app_start_date = datetime.datetime.now(datetime.timezone.utc)
-    app_end_date = app_start_date + relativedelta(years=years or 1)
+    app_end_date = app_start_date + datetime.timedelta(days=_years_to_days(years))
 
     use_cert = False
     public_cert_string = None
@@ -1659,7 +1658,7 @@ def _build_key_credentials(key_value=None, key_type=None, key_usage=None,
         start_date = dateutil.parser.parse(start_date)
 
     if not end_date:
-        end_date = start_date + relativedelta(years=1) - relativedelta(hours=24)
+        end_date = start_date + datetime.timedelta(days=_years_to_days(1))
     elif isinstance(end_date, str):
         end_date = dateutil.parser.parse(end_date)
 
@@ -1705,7 +1704,7 @@ def _reset_credential(cmd, graph_object, add_password_func, remove_password_func
         raise CLIError('usage error: --years | --end-date')
     if end_date is None:
         years = years or 1
-        app_end_date = app_start_date + relativedelta(years=years)
+        app_end_date = app_start_date + datetime.timedelta(days=_years_to_days(years))
     else:
         app_end_date = dateutil.parser.parse(end_date)
         if app_end_date.tzinfo is None:
@@ -2001,3 +2000,7 @@ def _get_member_groups(get_member_group_func, identifier, security_enabled_only)
         "securityEnabledOnly": security_enabled_only
     }
     return get_member_group_func(identifier, body)
+
+
+def _years_to_days(years):
+    return years * 365


### PR DESCRIPTION
Fix #28520

**Related command**
`az ad app credential reset`
`az ad sp create-for-rbac`

**Description**<!--Mandatory-->
Each year specified by `--years` now only contains 365 days. Leap years are not considered.

**Testing Guide**
```sh
$ az ad sp create-for-rbac --years 5
$ az ad app show --id xxx
...
  "passwordCredentials": [
    {
      "customKeyIdentifier": null,
      "displayName": "rbac",
      "endDateTime": "2029-03-10T08:23:04Z",
      "hint": "0Is",
      "keyId": "68be536d-66fa-461e-a147-03aa74691646",
      "secretText": null,
      "startDateTime": "2024-03-11T08:23:04Z"
    }
  ],
# notice the 'day' part of endDateTime is 1 day before startDateTime, as 2028-02-29 is not included.

$ az ad app credential reset --id xxx --years 5
$ az ad app show --id xxx
...
  "passwordCredentials": [
    {
      "customKeyIdentifier": null,
      "displayName": null,
      "endDateTime": "2029-03-10T08:25:13Z",
      "hint": "WJn",
      "keyId": "beccfbcc-1245-42dc-8d82-37fec1cc6a4b",
      "secretText": null,
      "startDateTime": "2024-03-11T08:25:13Z"
    }
  ],
# notice the 'day' part of endDateTime is 1 day before startDateTime, as 2028-02-29 is not included.
```