### PR TITLE
{Core} Bump MSAL to 1.27.0 and pin `pymsalruntime` to 0.14.0

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -53,7 +53,7 @@ DEPENDENCIES = [
     'jmespath',
     'knack~=0.11.0',
     'msal-extensions~=1.0.0',
-    'msal[broker]==1.26.0',
+    'msal[broker]==1.27.0',
     'msrestazure~=0.6.4',
     'packaging>=20.9',
     'paramiko>=2.0.8,<4.0.0',

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -106,7 +106,7 @@ jsondiff==2.0.0
 knack==0.11.0
 MarkupSafe==2.0.1
 msal-extensions==1.0.0
-msal[broker]==1.26.0
+msal[broker]==1.27.0
 msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -107,7 +107,7 @@ jsondiff==2.0.0
 knack==0.11.0
 MarkupSafe==2.0.1
 msal-extensions==1.0.0
-msal[broker]==1.26.0
+msal[broker]==1.27.0
 msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -106,7 +106,7 @@ jsondiff==2.0.0
 knack==0.11.0
 MarkupSafe==2.0.1
 msal-extensions==1.0.0
-msal[broker]==1.26.0
+msal[broker]==1.27.0
 msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2
@@ -120,6 +120,7 @@ pycomposefile==0.0.30
 pycparser==2.19
 PyGithub==1.55
 PyJWT==2.4.0
+pymsalruntime==0.14.0
 PyNaCl==1.5.0
 pyOpenSSL==23.2.0
 python-dateutil==2.8.0


### PR DESCRIPTION
**Related command**
`az login`

**Description**<!--Mandatory-->
MSAL 1.27.0 (https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/669) contains several improvements.

The most significant one is to tolerate ID token time errors (https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/657) which will solve 2 very common issues:

- RuntimeError: 0. The ID token is not yet valid. (https://github.com/Azure/azure-cli/issues/20388)
- RuntimeError: 9. The ID token already expires. (https://github.com/Azure/azure-cli/issues/23223)
