### PR TITLE
[AKS] `az aks create/update`: Block Azure Managed Grafana for managed prometheus addon in air gapped cloud

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/azuremonitorprofile.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/azuremonitorprofile.py
@@ -74,7 +74,7 @@ def ensure_azure_monitor_profile_prerequisites(
         grafana_resource_id = raw_parameters.get("grafana_resource_id")
         if grafana_resource_id is not None:
             if grafana_resource_id != "":
-                raise InvalidArgumentValueError("The cloud does not support Azure Managed Grarfana yet.")
+                raise InvalidArgumentValueError(f"{cloud_name} does not support Azure Managed Grafana yet.")
             
     if remove_azuremonitormetrics:
         unlink_azure_monitor_profile_artifacts(

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/azuremonitorprofile.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/azuremonitorprofile.py
@@ -18,6 +18,7 @@ from azure.cli.command_modules.acs.azuremonitormetrics.helper import (
 )
 from azure.cli.command_modules.acs.azuremonitormetrics.recordingrules.create import create_rules
 from azure.cli.command_modules.acs.azuremonitormetrics.recordingrules.delete import delete_rules
+from azure.cli.core.azclierror import InvalidArgumentValueError
 
 
 # pylint: disable=line-too-long
@@ -68,6 +69,13 @@ def ensure_azure_monitor_profile_prerequisites(
     remove_azuremonitormetrics,
     create_flow=False
 ):
+    cloud_name = cmd.cli_ctx.cloud.name
+    if cloud_name.lower() == "ussec" or cloud_name.lower() == "usnat" or cloud_name.lower() == "usdod":
+        grafana_resource_id = raw_parameters.get("grafana_resource_id")
+        if grafana_resource_id is not None:
+            if grafana_resource_id != "":
+                raise InvalidArgumentValueError("The cloud does not support Azure Managed Grarfana yet.")
+            
     if remove_azuremonitormetrics:
         unlink_azure_monitor_profile_artifacts(
             cmd,

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/azuremonitorprofile.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/azuremonitorprofile.py
@@ -75,7 +75,7 @@ def ensure_azure_monitor_profile_prerequisites(
         if grafana_resource_id is not None:
             if grafana_resource_id != "":
                 raise InvalidArgumentValueError(f"{cloud_name} does not support Azure Managed Grafana yet.")
-            
+
     if remove_azuremonitormetrics:
         unlink_azure_monitor_profile_artifacts(
             cmd,


### PR DESCRIPTION
… 
**Related command**

```az aks create -n kaveeshcli22 -g kaveeshcli --location westeurope --enable-azure-monitor-metrics --azure-monitor-workspace-resource-id "{full_id}" --grafana-resource-id "{full_id}"```

```az aks create -n kaveeshcli22 -g kaveeshcli --disable-azure-monitor-metrics ```

```az aks update -n kaveeshcli22 -g kaveeshcli --enable-azure-monitor-metrics --enable-windows-recording-rules```

**Description**<!--Mandatory-->
block Azure Mnaaged Grafana for managed prometheus addon in air gapped cloud as its not available there yet.

**Testing Guide**

**Scenario (managed prometheus support in air gapped cloud)**:
- Set context to one of the air gapped clouds
- Use the command with the grafana-resource-id parameter similar to `az aks create -n kaveeshcli22 -g kaveeshcli --location westeurope --enable-azure-monitor-metrics --azure-monitor-workspace-resource-id "{full_id}" --grafana-resource-id "{full_id}"` and it should result in a error message stating that its not supported

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
