### PR TITLE
[AKS] `az aks create/update`: Udpate RP registration code to work on azure monitor subscription

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/amw/defaults.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/amw/defaults.py
@@ -15,8 +15,10 @@ def get_default_region(cmd, clusetr_region):
         raise "chinanorth3"
     if cloud_name.lower() == 'azureusgovernment':
         return "usgovvirginia"
-    if cloud_name.lower() == 'ussec' or cloud_name.lower() == 'usnat':
-        return clusetr_region
+    if cloud_name.lower() == 'ussec':
+        return "ussecwest"
+    if cloud_name.lower() == 'usnat':
+        return "usnatwest"
     return "eastus"
 
 

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/amw/defaults.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/amw/defaults.py
@@ -9,12 +9,14 @@ from azure.cli.command_modules.acs.azuremonitormetrics.responseparsers.amwlocati
 from azure.cli.command_modules.acs.azuremonitormetrics.constants import RP_LOCATION_API
 
 
-def get_default_region(cmd):
+def get_default_region(cmd, clusetr_region):
     cloud_name = cmd.cli_ctx.cloud.name
     if cloud_name.lower() == 'azurechinacloud':
         raise "chinanorth3"
     if cloud_name.lower() == 'azureusgovernment':
         return "usgovvirginia"
+    if cloud_name.lower() == 'ussec' or cloud_name.lower() == 'usnat':
+        return clusetr_region
     return "eastus"
 
 
@@ -39,7 +41,7 @@ def get_default_mac_region(cmd, cluster_region, subscription):
     if len(supported_locations) > 0:
         return supported_locations[0]
     # default to public cloud
-    return get_default_region(cmd)
+    return get_default_region(cmd, cluster_region)
 
 
 def get_default_mac_name_and_region(cmd, cluster_region, subscription):

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/amw/defaults.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/amw/defaults.py
@@ -9,7 +9,7 @@ from azure.cli.command_modules.acs.azuremonitormetrics.responseparsers.amwlocati
 from azure.cli.command_modules.acs.azuremonitormetrics.constants import RP_LOCATION_API
 
 
-def get_default_region(cmd, clusetr_region):
+def get_default_region(cmd):
     cloud_name = cmd.cli_ctx.cloud.name
     if cloud_name.lower() == 'azurechinacloud':
         raise "chinanorth3"
@@ -43,7 +43,7 @@ def get_default_mac_region(cmd, cluster_region, subscription):
     if len(supported_locations) > 0:
         return supported_locations[0]
     # default to public cloud
-    return get_default_region(cmd, cluster_region)
+    return get_default_region(cmd)
 
 
 def get_default_mac_name_and_region(cmd, cluster_region, subscription):

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/amw/helper.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/amw/helper.py
@@ -13,6 +13,7 @@ def get_amw_subscription(azure_monitor_workspace_resource_id):
     amw_subscription_id = azure_monitor_workspace_resource_id.split("/")[2]
     return amw_subscription_id
 
+
 def get_amw_region(cmd, azure_monitor_workspace_resource_id):
     # region of MAC can be different from region of RG so find the location of the azure_monitor_workspace_resource_id
     amw_subscription_id = get_amw_subscription(azure_monitor_workspace_resource_id)

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/amw/helper.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/amw/helper.py
@@ -4,19 +4,15 @@
 # --------------------------------------------------------------------------------------------
 from azure.cli.command_modules.acs.azuremonitormetrics.amw.create import create_default_mac
 from azure.cli.command_modules.acs.azuremonitormetrics.constants import MAC_API
-from azure.cli.command_modules.acs.azuremonitormetrics.helper import sanitize_resource_id
+from azure.cli.command_modules.acs.azuremonitormetrics.helper import get_subscription_id_from_resource_id, sanitize_resource_id
 from azure.cli.command_modules.acs._client_factory import get_resources_client
 from azure.core.exceptions import HttpResponseError
 
 
-def get_amw_subscription(azure_monitor_workspace_resource_id):
-    amw_subscription_id = azure_monitor_workspace_resource_id.split("/")[2]
-    return amw_subscription_id
-
 
 def get_amw_region(cmd, azure_monitor_workspace_resource_id):
     # region of MAC can be different from region of RG so find the location of the azure_monitor_workspace_resource_id
-    amw_subscription_id = get_amw_subscription(azure_monitor_workspace_resource_id)
+    amw_subscription_id = get_subscription_id_from_resource_id(azure_monitor_workspace_resource_id)
     resources = get_resources_client(cmd.cli_ctx, amw_subscription_id)
     try:
         resource = resources.get_by_id(

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/amw/helper.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/amw/helper.py
@@ -4,15 +4,15 @@
 # --------------------------------------------------------------------------------------------
 from azure.cli.command_modules.acs.azuremonitormetrics.amw.create import create_default_mac
 from azure.cli.command_modules.acs.azuremonitormetrics.constants import MAC_API
-from azure.cli.command_modules.acs.azuremonitormetrics.helper import get_subscription_id_from_resource_id, sanitize_resource_id
+from azure.cli.command_modules.acs.azuremonitormetrics.helper import sanitize_resource_id
 from azure.cli.command_modules.acs._client_factory import get_resources_client
 from azure.core.exceptions import HttpResponseError
 
 
-
 def get_amw_region(cmd, azure_monitor_workspace_resource_id):
+    from msrestazure.tools import parse_resource_id
     # region of MAC can be different from region of RG so find the location of the azure_monitor_workspace_resource_id
-    amw_subscription_id = get_subscription_id_from_resource_id(azure_monitor_workspace_resource_id)
+    amw_subscription_id = parse_resource_id(azure_monitor_workspace_resource_id)
     resources = get_resources_client(cmd.cli_ctx, amw_subscription_id)
     try:
         resource = resources.get_by_id(

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/amw/helper.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/amw/helper.py
@@ -12,8 +12,8 @@ from azure.core.exceptions import HttpResponseError
 def get_amw_region(cmd, azure_monitor_workspace_resource_id):
     from msrestazure.tools import parse_resource_id
     # region of MAC can be different from region of RG so find the location of the azure_monitor_workspace_resource_id
-    amw_subscription_id = parse_resource_id(azure_monitor_workspace_resource_id)
-    resources = get_resources_client(cmd.cli_ctx, amw_subscription_id)
+    parsed_dict = parse_resource_id(azure_monitor_workspace_resource_id)
+    resources = get_resources_client(cmd.cli_ctx, parsed_dict["subscription"])
     try:
         resource = resources.get_by_id(
             azure_monitor_workspace_resource_id, MAC_API)

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/amw/helper.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/amw/helper.py
@@ -9,9 +9,13 @@ from azure.cli.command_modules.acs._client_factory import get_resources_client
 from azure.core.exceptions import HttpResponseError
 
 
+def get_amw_subscription(azure_monitor_workspace_resource_id):
+    amw_subscription_id = azure_monitor_workspace_resource_id.split("/")[2]
+    return amw_subscription_id
+
 def get_amw_region(cmd, azure_monitor_workspace_resource_id):
     # region of MAC can be different from region of RG so find the location of the azure_monitor_workspace_resource_id
-    amw_subscription_id = azure_monitor_workspace_resource_id.split("/")[2]
+    amw_subscription_id = get_amw_subscription(azure_monitor_workspace_resource_id)
     resources = get_resources_client(cmd.cli_ctx, amw_subscription_id)
     try:
         resource = resources.get_by_id(

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/azuremonitorprofile.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/azuremonitorprofile.py
@@ -88,7 +88,7 @@ def ensure_azure_monitor_profile_prerequisites(
         if create_flow is False:
             check_azuremonitormetrics_profile(cmd, cluster_subscription, cluster_resource_group_name, cluster_name)
         # Do RP registrations if required
-        rp_registrations(cmd, cluster_subscription)
+        rp_registrations(cmd, cluster_subscription, raw_parameters)
         link_azure_monitor_profile_artifacts(
             cmd,
             cluster_subscription,

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/helper.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/helper.py
@@ -13,19 +13,6 @@ from azure.cli.command_modules.acs.azuremonitormetrics.constants import (
 )
 
 
-def get_subscription_id_from_resource_id(resource_id):
-    try:
-        if not isinstance(resource_id, str):
-            raise TypeError("Resource ID must be a string")
-        parts = resource_id.split("/")
-        if len(parts) < 3:
-            raise ValueError("Invalid resource ID format")
-        return parts[2]
-    except (TypeError, ValueError) as e:
-        print(f"Error: {e}")
-        return None
-
-
 def sanitize_resource_id(resource_id):
     resource_id = resource_id.strip()
     if not resource_id.startswith("/"):

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/helper.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/helper.py
@@ -44,7 +44,6 @@ def rp_registrations(cmd, cluster_subscription_id, raw_parameters):
     print("current value of  subscription_id: ", subscription_id)
     if azure_monitor_workspace_resource_id and azure_monitor_workspace_resource_id != "":
         subscription_id = azure_monitor_workspace_resource_id.split("/")[2]
-    print("current value of  subscription_id after workspace param check: ", subscription_id)
     from azure.cli.core.util import send_raw_request
     # Get list of RP's for RP's subscription
     try:

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/helper.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/helper.py
@@ -89,7 +89,8 @@ def rp_registrations(cmd, cluster_subscription_id, raw_parameters):
     subscription_id = cluster_subscription_id
     azure_monitor_workspace_resource_id = raw_parameters.get("azure_monitor_workspace_resource_id")
     if azure_monitor_workspace_resource_id and azure_monitor_workspace_resource_id != "":
-        subscription_id = parse_resource_id(azure_monitor_workspace_resource_id)
+        parsed_dict = parse_resource_id(azure_monitor_workspace_resource_id)
+        subscription_id = parsed_dict["subscription"]
     monitor_workspace_rp_namespaces = {
         "microsoft.insights": False,
         "microsoft.alertsmanagement": False,

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/helper.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/helper.py
@@ -78,6 +78,7 @@ def register_rps(cmd, subscription_id, rp_namespaces, user_agent):
 
 
 def rp_registrations(cmd, cluster_subscription_id, raw_parameters):
+    from msrestazure.tools import parse_resource_id
     cluster_rp_namespaces = {
         "microsoft.insights": False,
         "microsoft.alertsmanagement": False
@@ -88,7 +89,7 @@ def rp_registrations(cmd, cluster_subscription_id, raw_parameters):
     subscription_id = cluster_subscription_id
     azure_monitor_workspace_resource_id = raw_parameters.get("azure_monitor_workspace_resource_id")
     if azure_monitor_workspace_resource_id and azure_monitor_workspace_resource_id != "":
-        subscription_id = get_subscription_id_from_resource_id(azure_monitor_workspace_resource_id)
+        subscription_id = parse_resource_id(azure_monitor_workspace_resource_id)
     monitor_workspace_rp_namespaces = {
         "microsoft.insights": False,
         "microsoft.alertsmanagement": False,

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/helper.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/helper.py
@@ -41,8 +41,10 @@ def post_request(cmd, subscription_id, rp_name, headers):
 def rp_registrations(cmd, cluster_subscription_id, raw_parameters):
     azure_monitor_workspace_resource_id = raw_parameters.get("azure_monitor_workspace_resource_id")
     subscription_id = cluster_subscription_id
+    print("current value of  subscription_id: ", subscription_id)
     if azure_monitor_workspace_resource_id and azure_monitor_workspace_resource_id != "":
         subscription_id = azure_monitor_workspace_resource_id.split("/")[2]
+    print("current value of  subscription_id after workspace param check: ", subscription_id)
     from azure.cli.core.util import send_raw_request
     # Get list of RP's for RP's subscription
     try:
@@ -77,30 +79,29 @@ def rp_registrations(cmd, cluster_subscription_id, raw_parameters):
     if isMoniotrRpRegistered is False:
         headers = ['User-Agent=azuremonitormetrics.register_monitor_rp']
         post_request(cmd, subscription_id, "microsoft.monitor", headers)
-    
+
     grafana_workspace_resource_id = raw_parameters.get("grafana_workspace_resource_id")
     if grafana_workspace_resource_id and grafana_workspace_resource_id != "":
-      grafana_sub_id = grafana_workspace_resource_id.split("/")[2]
-      try:
-          headers = ['User-Agent=azuremonitormetrics.get_grafana_sub_rp_list']
-          armendpoint = cmd.cli_ctx.cloud.endpoints.resource_manager
-          customUrl = "{0}/subscriptions/{1}/providers?api-version={2}&$select=namespace,registrationstate".format(
-              armendpoint,
-              grafana_sub_id,
-              RP_API
-          )
-          r = send_raw_request(cmd.cli_ctx, "GET", customUrl, headers=headers)
-      except CLIError as e:
-          raise CLIError(e)
-  
-      isDashboardRpRegistered = False
-      for value in values_array:
-          if value["namespace"].lower() == "microsoft.dashboard" and value["registrationState"].lower() == "registered":
-              isDashboardRpRegistered = True
-      if isDashboardRpRegistered is False:
-          headers = ['User-Agent=azuremonitormetrics.register_dashboard_rp']
-          post_request(cmd, subscription_id, "microsoft.dashboard", headers)
-    
+        grafana_sub_id = grafana_workspace_resource_id.split("/")[2]
+        try:
+            headers = ['User-Agent=azuremonitormetrics.get_grafana_sub_rp_list']
+            armendpoint = cmd.cli_ctx.cloud.endpoints.resource_manager
+            customUrl = "{0}/subscriptions/{1}/providers?api-version={2}&$select=namespace,registrationstate".format(
+                armendpoint,
+                grafana_sub_id,
+                RP_API
+            )
+            r = send_raw_request(cmd.cli_ctx, "GET", customUrl, headers=headers)
+        except CLIError as e:
+            raise CLIError(e)
+
+        isDashboardRpRegistered = False
+        for value in values_array:
+            if value["namespace"].lower() == "microsoft.dashboard" and value["registrationState"].lower() == "registered":
+                isDashboardRpRegistered = True
+        if isDashboardRpRegistered is False:
+            headers = ['User-Agent=azuremonitormetrics.register_dashboard_rp']
+            post_request(cmd, subscription_id, "microsoft.dashboard", headers)
 
 
 # pylint: disable=line-too-long

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/helper.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/helper.py
@@ -70,8 +70,7 @@ def register_rps(cmd, subscription_id, rp_namespaces, user_agent):
                 rp_namespaces[namespace] = True
 
         for namespace, registered in rp_namespaces.items():
-            # if not registered:
-            if registered:
+            if not registered:
                 headers = ['User-Agent=azuremonitormetrics.register_{}_rp'.format(namespace.split('.')[1].lower())]
                 post_request(cmd, subscription_id, namespace, headers)
     except CLIError as e:

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/test_helper.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/test_helper.py
@@ -1,0 +1,42 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+import unittest
+from unittest.mock import ANY, patch, MagicMock
+
+from azure.cli.command_modules.acs.azuremonitormetrics.helper import (
+    sanitize_resource_id,
+    rp_registrations
+)
+
+class TestHelper(unittest.TestCase):
+
+    def test_sanitize_resource_id(self):
+        # Test case where resource_id is already sanitized
+        self.assertEqual(sanitize_resource_id("/test/resource"), "/test/resource")
+        # Test case where resource_id needs leading slash and trailing slash removed
+        self.assertEqual(sanitize_resource_id("test/resource/"), "/test/resource")
+
+    @patch('msrestazure.tools.parse_resource_id')
+    @patch('azure.cli.command_modules.acs.azuremonitormetrics.helper.register_rps')
+    def test_subscription_id_selection(self, mock_register_rps, mock_parse_resource_id):
+        # Mocking return value of parse_resource_id
+        mock_parse_resource_id.return_value = {"subscription": "mocked_subscription_id"}
+
+        # Define test data
+        cmd = MagicMock()
+        cluster_subscription_id = "cluster_sub_id"
+        raw_parameters_with_azure_monitor_id = {"azure_monitor_workspace_resource_id": "mocked_workspace_id"}
+        raw_parameters_without_azure_monitor_id = {"azure_monitor_workspace_resource_id": ""}
+
+        # Call the function with and without azure_monitor_workspace_resource_id
+        rp_registrations(cmd, cluster_subscription_id, raw_parameters_with_azure_monitor_id)
+        rp_registrations(cmd, cluster_subscription_id, raw_parameters_without_azure_monitor_id)
+
+        # Assert that register_rps was called with the correct subscription_id
+        mock_register_rps.assert_any_call(cmd, "mocked_subscription_id", ANY, ANY)
+        mock_register_rps.assert_any_call(cmd, cluster_subscription_id, ANY, ANY)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Related command**

```az aks create -n kaveeshcli22 -g kaveeshcli --location westeurope --enable-azure-monitor-metrics --azure-monitor-workspace-resource-id "{full_id}" --grafana-resource-id "{full_id}"```

```az aks create -n kaveeshcli22 -g kaveeshcli --disable-azure-monitor-metrics ```

```az aks update -n kaveeshcli22 -g kaveeshcli --enable-azure-monitor-metrics --enable-windows-recording-rules```


**Description**<!--Mandatory-->
I am updating the rp registration logic to register the RP on the azure monitor workspace subscription if its provided as a parameter to the command and if it is not provided then it should work on the clusters subscription.

**Testing Guide**

**Scenario (RP registration)**:
- Use the command with and without the azure-monitor-workspace-resource-id parameter similar to `az aks create -n kaveeshcli22 -g kaveeshcli --location westeurope --enable-azure-monitor-metrics --grafana-resource-id "{full_id}"` and it should result in a success. (Try it on a subscription where the Microsoft.Monitor RP is not registered when not passing in the parameter)

**Scenario (default workspace creation)**:
- Use the command with and without the azure-monitor-workspace-resource-id parameter similar to `az aks create -n kaveeshcli22 -g kaveeshcli --location westeurope --enable-azure-monitor-metrics  --grafana-resource-id "{full_id}"` and it should result in a success.


**History Notes**

[AKS] `az aks create/update`: Udpate RP registration code to work on azure monitor subscription
[AKS] `az aks create/update`: Update to add default region for workspace creation in air gapped cloud

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
