### PR TITLE
[App Service] Fix #28588: `az webapp config access-restriction add`: Check for null before getting values

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_validators.py
@@ -312,13 +312,13 @@ def _validate_service_tag_format(cmd, namespace):
         webapp = _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'get')
         service_tag_full_list = ListServiceTags(cli_ctx=cmd.cli_ctx)(command_args={
             "location": webapp.location
-        })["values"]
+        })
         if service_tag_full_list is None:
             logger.warning('Not able to get full Service Tag list. Cannot validate Service Tag.')
             return
         for tag in input_tags:
             valid_tag = False
-            for tag_full_list in service_tag_full_list:
+            for tag_full_list in service_tag_full_list["values"]:
                 if tag.lower() == tag_full_list["name"].lower():
                     valid_tag = True
                     continue


### PR DESCRIPTION
**Related command**
az webapp config access-restriction add

**Description**<!--Mandatory-->
Fixing an issue where ["values"] was addressed before checking for null. This would cause issues for customers without permissions to read the service tag list (subscription/read)

**Testing Guide**
Add an access restriction without having subscription/read permissions

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
