### PR TITLE
{AppService} `az functionapp create`: Update runtimes and add MSI support

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_constants.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_constants.py
@@ -152,15 +152,19 @@ FLEX_RUNTIMES = [
     },
     {
         'runtime': 'node',
+        'version': '20'
+    },
+    {
+        'runtime': 'node',
         'version': '18'
     },
     {
         'runtime': 'python',
-        'version': '3.10'
+        'version': '3.11'
     },
     {
         'runtime': 'python',
-        'version': '3.11'
+        'version': '3.10'
     },
     {
         'runtime': 'powershell',
@@ -174,6 +178,6 @@ DEFAULT_INSTANCE_SIZE = 2048
 
 DEFAULT_MAXIMUM_INSTANCE_COUNT = 100
 
-DEPLOYMENT_STORAGE_AUTH_TYPES = ['StorageAccountConnectionString']
+DEPLOYMENT_STORAGE_AUTH_TYPES = ['SystemAssignedIdentity', 'UserAssignedIdentity', 'StorageAccountConnectionString']
 
 STORAGE_BLOB_DATA_CONTRIBUTOR_ROLE_ID = 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'


### PR DESCRIPTION
**Related command**
`az functionapp create`

**Description**<!--Mandatory-->
1. Add Node 20 support
2. Update default runtimes to be Node 20 and Python 3.11
3. Add MSI support for deployment auth

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**

[AppService] `az functionapp create`: Add support for Node 20 for Flex function apps 
[AppService] `az functionapp create`: Make Node 20 the default for node flex function apps and Python 3.11 the default for python flex function apps
[AppService] `az functionapp create`: Add support for SystemAssignedIdentity and UserAssignedIdentity as the deployment storage authentication type

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
