### PR TITLE
[Network] `az network virtual-appliance`: Add `--internet-ingress-ips` and `--network-profile`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/virtual_appliance/_create.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/virtual_appliance/_create.py
@@ -23,9 +23,9 @@ class Create(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2023-05-01",
+        "version": "2023-11-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/networkvirtualappliances/{}", "2023-05-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/networkvirtualappliances/{}", "2023-11-01"],
         ]
     }
 
@@ -124,6 +124,16 @@ class Create(AAZCommand):
             arg_group="Properties",
             help="The delegation for the Virtual Appliance",
         )
+        _args_schema.internet_ingress_public_ips = AAZListArg(
+            options=["--internet-ingress-public-ips"],
+            arg_group="Properties",
+            help="List of Resource Uri of Public IPs for Internet Ingress Scenario.",
+        )
+        _args_schema.network_profile = AAZObjectArg(
+            options=["--network-profile"],
+            arg_group="Properties",
+            help="Network Profile containing configurations for Public and Private NIC.",
+        )
         _args_schema.asn = AAZIntArg(
             options=["--asn"],
             arg_group="Properties",
@@ -157,6 +167,46 @@ class Create(AAZCommand):
         delegation.service_name = AAZStrArg(
             options=["service-name"],
             help="The service name to which the NVA is delegated.",
+        )
+
+        internet_ingress_public_ips = cls._args_schema.internet_ingress_public_ips
+        internet_ingress_public_ips.Element = AAZObjectArg()
+
+        _element = cls._args_schema.internet_ingress_public_ips.Element
+        _element.id = AAZResourceIdArg(
+            options=["id"],
+            help="Resource Uri of Public Ip",
+        )
+
+        network_profile = cls._args_schema.network_profile
+        network_profile.network_interface_configurations = AAZListArg(
+            options=["network-interface-configurations"],
+        )
+
+        network_interface_configurations = cls._args_schema.network_profile.network_interface_configurations
+        network_interface_configurations.Element = AAZObjectArg()
+
+        _element = cls._args_schema.network_profile.network_interface_configurations.Element
+        _element.ip_configurations = AAZListArg(
+            options=["ip-configurations"],
+        )
+        _element.type = AAZStrArg(
+            options=["type"],
+            help="NIC type. This should be either PublicNic or PrivateNic.",
+            enum={"PrivateNic": "PrivateNic", "PublicNic": "PublicNic"},
+        )
+
+        ip_configurations = cls._args_schema.network_profile.network_interface_configurations.Element.ip_configurations
+        ip_configurations.Element = AAZObjectArg()
+
+        _element = cls._args_schema.network_profile.network_interface_configurations.Element.ip_configurations.Element
+        _element.name = AAZStrArg(
+            options=["name"],
+            help="Name of the IP configuration.",
+        )
+        _element.primary = AAZBoolArg(
+            options=["primary"],
+            help="Whether or not this is primary IP configuration of the NIC.",
         )
 
         # define Arg Group "Sku"
@@ -269,7 +319,7 @@ class Create(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2023-05-01",
+                    "api-version", "2023-11-01",
                     required=True,
                 ),
             }
@@ -315,6 +365,8 @@ class Create(AAZCommand):
                 properties.set_prop("cloudInitConfiguration", AAZStrType, ".cloud_init_config")
                 properties.set_prop("cloudInitConfigurationBlobs", AAZListType, ".cloud_init_config_blobs")
                 properties.set_prop("delegation", AAZObjectType, ".delegation")
+                properties.set_prop("internetIngressPublicIps", AAZListType, ".internet_ingress_public_ips")
+                properties.set_prop("networkProfile", AAZObjectType, ".network_profile")
                 properties.set_prop("nvaSku", AAZObjectType)
                 properties.set_prop("virtualApplianceAsn", AAZIntType, ".asn")
                 properties.set_prop("virtualHub", AAZObjectType)
@@ -339,6 +391,44 @@ class Create(AAZCommand):
             delegation = _builder.get(".properties.delegation")
             if delegation is not None:
                 delegation.set_prop("serviceName", AAZStrType, ".service_name")
+
+            internet_ingress_public_ips = _builder.get(".properties.internetIngressPublicIps")
+            if internet_ingress_public_ips is not None:
+                internet_ingress_public_ips.set_elements(AAZObjectType, ".")
+
+            _elements = _builder.get(".properties.internetIngressPublicIps[]")
+            if _elements is not None:
+                _elements.set_prop("id", AAZStrType, ".id")
+
+            network_profile = _builder.get(".properties.networkProfile")
+            if network_profile is not None:
+                network_profile.set_prop("networkInterfaceConfigurations", AAZListType, ".network_interface_configurations")
+
+            network_interface_configurations = _builder.get(".properties.networkProfile.networkInterfaceConfigurations")
+            if network_interface_configurations is not None:
+                network_interface_configurations.set_elements(AAZObjectType, ".")
+
+            _elements = _builder.get(".properties.networkProfile.networkInterfaceConfigurations[]")
+            if _elements is not None:
+                _elements.set_prop("properties", AAZObjectType)
+                _elements.set_prop("type", AAZStrType, ".type")
+
+            properties = _builder.get(".properties.networkProfile.networkInterfaceConfigurations[].properties")
+            if properties is not None:
+                properties.set_prop("ipConfigurations", AAZListType, ".ip_configurations")
+
+            ip_configurations = _builder.get(".properties.networkProfile.networkInterfaceConfigurations[].properties.ipConfigurations")
+            if ip_configurations is not None:
+                ip_configurations.set_elements(AAZObjectType, ".")
+
+            _elements = _builder.get(".properties.networkProfile.networkInterfaceConfigurations[].properties.ipConfigurations[]")
+            if _elements is not None:
+                _elements.set_prop("name", AAZStrType, ".name")
+                _elements.set_prop("properties", AAZObjectType)
+
+            properties = _builder.get(".properties.networkProfile.networkInterfaceConfigurations[].properties.ipConfigurations[].properties")
+            if properties is not None:
+                properties.set_prop("primary", AAZBoolType, ".primary")
 
             nva_sku = _builder.get(".properties.nvaSku")
             if nva_sku is not None:
@@ -444,6 +534,12 @@ class Create(AAZCommand):
                 serialized_name="inboundSecurityRules",
                 flags={"read_only": True},
             )
+            properties.internet_ingress_public_ips = AAZListType(
+                serialized_name="internetIngressPublicIps",
+            )
+            properties.network_profile = AAZObjectType(
+                serialized_name="networkProfile",
+            )
             properties.nva_sku = AAZObjectType(
                 serialized_name="nvaSku",
             )
@@ -505,6 +601,39 @@ class Create(AAZCommand):
             inbound_security_rules.Element = AAZObjectType()
             _CreateHelper._build_schema_sub_resource_read(inbound_security_rules.Element)
 
+            internet_ingress_public_ips = cls._schema_on_200_201.properties.internet_ingress_public_ips
+            internet_ingress_public_ips.Element = AAZObjectType()
+
+            _element = cls._schema_on_200_201.properties.internet_ingress_public_ips.Element
+            _element.id = AAZStrType()
+
+            network_profile = cls._schema_on_200_201.properties.network_profile
+            network_profile.network_interface_configurations = AAZListType(
+                serialized_name="networkInterfaceConfigurations",
+            )
+
+            network_interface_configurations = cls._schema_on_200_201.properties.network_profile.network_interface_configurations
+            network_interface_configurations.Element = AAZObjectType()
+
+            _element = cls._schema_on_200_201.properties.network_profile.network_interface_configurations.Element
+            _element.properties = AAZObjectType()
+            _element.type = AAZStrType()
+
+            properties = cls._schema_on_200_201.properties.network_profile.network_interface_configurations.Element.properties
+            properties.ip_configurations = AAZListType(
+                serialized_name="ipConfigurations",
+            )
+
+            ip_configurations = cls._schema_on_200_201.properties.network_profile.network_interface_configurations.Element.properties.ip_configurations
+            ip_configurations.Element = AAZObjectType()
+
+            _element = cls._schema_on_200_201.properties.network_profile.network_interface_configurations.Element.properties.ip_configurations.Element
+            _element.name = AAZStrType()
+            _element.properties = AAZObjectType()
+
+            properties = cls._schema_on_200_201.properties.network_profile.network_interface_configurations.Element.properties.ip_configurations.Element.properties
+            properties.primary = AAZBoolType()
+
             nva_sku = cls._schema_on_200_201.properties.nva_sku
             nva_sku.bundled_scale_unit = AAZStrType(
                 serialized_name="bundledScaleUnit",
@@ -540,6 +669,10 @@ class Create(AAZCommand):
                 flags={"read_only": True},
             )
             _element.name = AAZStrType(
+                flags={"read_only": True},
+            )
+            _element.nic_type = AAZStrType(
+                serialized_name="nicType",
                 flags={"read_only": True},
             )
             _element.private_ip_address = AAZStrType(

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/virtual_appliance/_create.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/virtual_appliance/_create.py
@@ -124,8 +124,11 @@ class Create(AAZCommand):
             arg_group="Properties",
             help="The delegation for the Virtual Appliance",
         )
+
+        #Manually changed --internet-ingress-public-ips to --internet-ingress-ips to make it lint compliant.
+        #Will fix in Swagger in next release.
         _args_schema.internet_ingress_public_ips = AAZListArg(
-            options=["--internet-ingress-public-ips"],
+            options=["--internet-ingress-ips"],
             arg_group="Properties",
             help="List of Resource Uri of Public IPs for Internet Ingress Scenario.",
         )

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/virtual_appliance/_delete.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/virtual_appliance/_delete.py
@@ -24,9 +24,9 @@ class Delete(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2023-05-01",
+        "version": "2023-11-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/networkvirtualappliances/{}", "2023-05-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/networkvirtualappliances/{}", "2023-11-01"],
         ]
     }
 
@@ -144,7 +144,7 @@ class Delete(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2023-05-01",
+                    "api-version", "2023-11-01",
                     required=True,
                 ),
             }

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/virtual_appliance/_list.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/virtual_appliance/_list.py
@@ -23,10 +23,10 @@ class List(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2023-05-01",
+        "version": "2023-11-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/providers/microsoft.network/networkvirtualappliances", "2023-05-01"],
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/networkvirtualappliances", "2023-05-01"],
+            ["mgmt-plane", "/subscriptions/{}/providers/microsoft.network/networkvirtualappliances", "2023-11-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/networkvirtualappliances", "2023-11-01"],
         ]
     }
 
@@ -117,7 +117,7 @@ class List(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2023-05-01",
+                    "api-version", "2023-11-01",
                     required=True,
                 ),
             }
@@ -229,6 +229,12 @@ class List(AAZCommand):
                 serialized_name="inboundSecurityRules",
                 flags={"read_only": True},
             )
+            properties.internet_ingress_public_ips = AAZListType(
+                serialized_name="internetIngressPublicIps",
+            )
+            properties.network_profile = AAZObjectType(
+                serialized_name="networkProfile",
+            )
             properties.nva_sku = AAZObjectType(
                 serialized_name="nvaSku",
             )
@@ -290,6 +296,39 @@ class List(AAZCommand):
             inbound_security_rules.Element = AAZObjectType()
             _ListHelper._build_schema_sub_resource_read(inbound_security_rules.Element)
 
+            internet_ingress_public_ips = cls._schema_on_200.value.Element.properties.internet_ingress_public_ips
+            internet_ingress_public_ips.Element = AAZObjectType()
+
+            _element = cls._schema_on_200.value.Element.properties.internet_ingress_public_ips.Element
+            _element.id = AAZStrType()
+
+            network_profile = cls._schema_on_200.value.Element.properties.network_profile
+            network_profile.network_interface_configurations = AAZListType(
+                serialized_name="networkInterfaceConfigurations",
+            )
+
+            network_interface_configurations = cls._schema_on_200.value.Element.properties.network_profile.network_interface_configurations
+            network_interface_configurations.Element = AAZObjectType()
+
+            _element = cls._schema_on_200.value.Element.properties.network_profile.network_interface_configurations.Element
+            _element.properties = AAZObjectType()
+            _element.type = AAZStrType()
+
+            properties = cls._schema_on_200.value.Element.properties.network_profile.network_interface_configurations.Element.properties
+            properties.ip_configurations = AAZListType(
+                serialized_name="ipConfigurations",
+            )
+
+            ip_configurations = cls._schema_on_200.value.Element.properties.network_profile.network_interface_configurations.Element.properties.ip_configurations
+            ip_configurations.Element = AAZObjectType()
+
+            _element = cls._schema_on_200.value.Element.properties.network_profile.network_interface_configurations.Element.properties.ip_configurations.Element
+            _element.name = AAZStrType()
+            _element.properties = AAZObjectType()
+
+            properties = cls._schema_on_200.value.Element.properties.network_profile.network_interface_configurations.Element.properties.ip_configurations.Element.properties
+            properties.primary = AAZBoolType()
+
             nva_sku = cls._schema_on_200.value.Element.properties.nva_sku
             nva_sku.bundled_scale_unit = AAZStrType(
                 serialized_name="bundledScaleUnit",
@@ -325,6 +364,10 @@ class List(AAZCommand):
                 flags={"read_only": True},
             )
             _element.name = AAZStrType(
+                flags={"read_only": True},
+            )
+            _element.nic_type = AAZStrType(
+                serialized_name="nicType",
                 flags={"read_only": True},
             )
             _element.private_ip_address = AAZStrType(
@@ -385,7 +428,7 @@ class List(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2023-05-01",
+                    "api-version", "2023-11-01",
                     required=True,
                 ),
             }
@@ -497,6 +540,12 @@ class List(AAZCommand):
                 serialized_name="inboundSecurityRules",
                 flags={"read_only": True},
             )
+            properties.internet_ingress_public_ips = AAZListType(
+                serialized_name="internetIngressPublicIps",
+            )
+            properties.network_profile = AAZObjectType(
+                serialized_name="networkProfile",
+            )
             properties.nva_sku = AAZObjectType(
                 serialized_name="nvaSku",
             )
@@ -558,6 +607,39 @@ class List(AAZCommand):
             inbound_security_rules.Element = AAZObjectType()
             _ListHelper._build_schema_sub_resource_read(inbound_security_rules.Element)
 
+            internet_ingress_public_ips = cls._schema_on_200.value.Element.properties.internet_ingress_public_ips
+            internet_ingress_public_ips.Element = AAZObjectType()
+
+            _element = cls._schema_on_200.value.Element.properties.internet_ingress_public_ips.Element
+            _element.id = AAZStrType()
+
+            network_profile = cls._schema_on_200.value.Element.properties.network_profile
+            network_profile.network_interface_configurations = AAZListType(
+                serialized_name="networkInterfaceConfigurations",
+            )
+
+            network_interface_configurations = cls._schema_on_200.value.Element.properties.network_profile.network_interface_configurations
+            network_interface_configurations.Element = AAZObjectType()
+
+            _element = cls._schema_on_200.value.Element.properties.network_profile.network_interface_configurations.Element
+            _element.properties = AAZObjectType()
+            _element.type = AAZStrType()
+
+            properties = cls._schema_on_200.value.Element.properties.network_profile.network_interface_configurations.Element.properties
+            properties.ip_configurations = AAZListType(
+                serialized_name="ipConfigurations",
+            )
+
+            ip_configurations = cls._schema_on_200.value.Element.properties.network_profile.network_interface_configurations.Element.properties.ip_configurations
+            ip_configurations.Element = AAZObjectType()
+
+            _element = cls._schema_on_200.value.Element.properties.network_profile.network_interface_configurations.Element.properties.ip_configurations.Element
+            _element.name = AAZStrType()
+            _element.properties = AAZObjectType()
+
+            properties = cls._schema_on_200.value.Element.properties.network_profile.network_interface_configurations.Element.properties.ip_configurations.Element.properties
+            properties.primary = AAZBoolType()
+
             nva_sku = cls._schema_on_200.value.Element.properties.nva_sku
             nva_sku.bundled_scale_unit = AAZStrType(
                 serialized_name="bundledScaleUnit",
@@ -593,6 +675,10 @@ class List(AAZCommand):
                 flags={"read_only": True},
             )
             _element.name = AAZStrType(
+                flags={"read_only": True},
+            )
+            _element.nic_type = AAZStrType(
+                serialized_name="nicType",
                 flags={"read_only": True},
             )
             _element.private_ip_address = AAZStrType(

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/virtual_appliance/_show.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/virtual_appliance/_show.py
@@ -23,9 +23,9 @@ class Show(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2023-05-01",
+        "version": "2023-11-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/networkvirtualappliances/{}", "2023-05-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/networkvirtualappliances/{}", "2023-11-01"],
         ]
     }
 
@@ -128,7 +128,7 @@ class Show(AAZCommand):
                     "$expand", self.ctx.args.expand,
                 ),
                 **self.serialize_query_param(
-                    "api-version", "2023-05-01",
+                    "api-version", "2023-11-01",
                     required=True,
                 ),
             }
@@ -231,6 +231,12 @@ class Show(AAZCommand):
                 serialized_name="inboundSecurityRules",
                 flags={"read_only": True},
             )
+            properties.internet_ingress_public_ips = AAZListType(
+                serialized_name="internetIngressPublicIps",
+            )
+            properties.network_profile = AAZObjectType(
+                serialized_name="networkProfile",
+            )
             properties.nva_sku = AAZObjectType(
                 serialized_name="nvaSku",
             )
@@ -292,6 +298,39 @@ class Show(AAZCommand):
             inbound_security_rules.Element = AAZObjectType()
             _ShowHelper._build_schema_sub_resource_read(inbound_security_rules.Element)
 
+            internet_ingress_public_ips = cls._schema_on_200.properties.internet_ingress_public_ips
+            internet_ingress_public_ips.Element = AAZObjectType()
+
+            _element = cls._schema_on_200.properties.internet_ingress_public_ips.Element
+            _element.id = AAZStrType()
+
+            network_profile = cls._schema_on_200.properties.network_profile
+            network_profile.network_interface_configurations = AAZListType(
+                serialized_name="networkInterfaceConfigurations",
+            )
+
+            network_interface_configurations = cls._schema_on_200.properties.network_profile.network_interface_configurations
+            network_interface_configurations.Element = AAZObjectType()
+
+            _element = cls._schema_on_200.properties.network_profile.network_interface_configurations.Element
+            _element.properties = AAZObjectType()
+            _element.type = AAZStrType()
+
+            properties = cls._schema_on_200.properties.network_profile.network_interface_configurations.Element.properties
+            properties.ip_configurations = AAZListType(
+                serialized_name="ipConfigurations",
+            )
+
+            ip_configurations = cls._schema_on_200.properties.network_profile.network_interface_configurations.Element.properties.ip_configurations
+            ip_configurations.Element = AAZObjectType()
+
+            _element = cls._schema_on_200.properties.network_profile.network_interface_configurations.Element.properties.ip_configurations.Element
+            _element.name = AAZStrType()
+            _element.properties = AAZObjectType()
+
+            properties = cls._schema_on_200.properties.network_profile.network_interface_configurations.Element.properties.ip_configurations.Element.properties
+            properties.primary = AAZBoolType()
+
             nva_sku = cls._schema_on_200.properties.nva_sku
             nva_sku.bundled_scale_unit = AAZStrType(
                 serialized_name="bundledScaleUnit",
@@ -327,6 +366,10 @@ class Show(AAZCommand):
                 flags={"read_only": True},
             )
             _element.name = AAZStrType(
+                flags={"read_only": True},
+            )
+            _element.nic_type = AAZStrType(
+                serialized_name="nicType",
                 flags={"read_only": True},
             )
             _element.private_ip_address = AAZStrType(

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/virtual_appliance/_update.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/virtual_appliance/_update.py
@@ -23,9 +23,9 @@ class Update(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2023-05-01",
+        "version": "2023-11-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/networkvirtualappliances/{}", "2023-05-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/networkvirtualappliances/{}", "2023-11-01"],
         ]
     }
 
@@ -137,6 +137,18 @@ class Update(AAZCommand):
             help="The delegation for the Virtual Appliance",
             nullable=True,
         )
+        _args_schema.internet_ingress_public_ips = AAZListArg(
+            options=["--internet-ingress-public-ips"],
+            arg_group="Properties",
+            help="List of Resource Uri of Public IPs for Internet Ingress Scenario.",
+            nullable=True,
+        )
+        _args_schema.network_profile = AAZObjectArg(
+            options=["--network-profile"],
+            arg_group="Properties",
+            help="Network Profile containing configurations for Public and Private NIC.",
+            nullable=True,
+        )
         _args_schema.asn = AAZIntArg(
             options=["--asn"],
             arg_group="Properties",
@@ -179,6 +191,58 @@ class Update(AAZCommand):
         delegation.service_name = AAZStrArg(
             options=["service-name"],
             help="The service name to which the NVA is delegated.",
+            nullable=True,
+        )
+
+        internet_ingress_public_ips = cls._args_schema.internet_ingress_public_ips
+        internet_ingress_public_ips.Element = AAZObjectArg(
+            nullable=True,
+        )
+
+        _element = cls._args_schema.internet_ingress_public_ips.Element
+        _element.id = AAZResourceIdArg(
+            options=["id"],
+            help="Resource Uri of Public Ip",
+            nullable=True,
+        )
+
+        network_profile = cls._args_schema.network_profile
+        network_profile.network_interface_configurations = AAZListArg(
+            options=["network-interface-configurations"],
+            nullable=True,
+        )
+
+        network_interface_configurations = cls._args_schema.network_profile.network_interface_configurations
+        network_interface_configurations.Element = AAZObjectArg(
+            nullable=True,
+        )
+
+        _element = cls._args_schema.network_profile.network_interface_configurations.Element
+        _element.ip_configurations = AAZListArg(
+            options=["ip-configurations"],
+            nullable=True,
+        )
+        _element.type = AAZStrArg(
+            options=["type"],
+            help="NIC type. This should be either PublicNic or PrivateNic.",
+            nullable=True,
+            enum={"PrivateNic": "PrivateNic", "PublicNic": "PublicNic"},
+        )
+
+        ip_configurations = cls._args_schema.network_profile.network_interface_configurations.Element.ip_configurations
+        ip_configurations.Element = AAZObjectArg(
+            nullable=True,
+        )
+
+        _element = cls._args_schema.network_profile.network_interface_configurations.Element.ip_configurations.Element
+        _element.name = AAZStrArg(
+            options=["name"],
+            help="Name of the IP configuration.",
+            nullable=True,
+        )
+        _element.primary = AAZBoolArg(
+            options=["primary"],
+            help="Whether or not this is primary IP configuration of the NIC.",
             nullable=True,
         )
 
@@ -293,7 +357,7 @@ class Update(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2023-05-01",
+                    "api-version", "2023-11-01",
                     required=True,
                 ),
             }
@@ -392,7 +456,7 @@ class Update(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2023-05-01",
+                    "api-version", "2023-11-01",
                     required=True,
                 ),
             }
@@ -471,6 +535,8 @@ class Update(AAZCommand):
                 properties.set_prop("cloudInitConfiguration", AAZStrType, ".cloud_init_config")
                 properties.set_prop("cloudInitConfigurationBlobs", AAZListType, ".cloud_init_config_blobs")
                 properties.set_prop("delegation", AAZObjectType, ".delegation")
+                properties.set_prop("internetIngressPublicIps", AAZListType, ".internet_ingress_public_ips")
+                properties.set_prop("networkProfile", AAZObjectType, ".network_profile")
                 properties.set_prop("nvaSku", AAZObjectType)
                 properties.set_prop("virtualApplianceAsn", AAZIntType, ".asn")
                 properties.set_prop("virtualHub", AAZObjectType)
@@ -495,6 +561,44 @@ class Update(AAZCommand):
             delegation = _builder.get(".properties.delegation")
             if delegation is not None:
                 delegation.set_prop("serviceName", AAZStrType, ".service_name")
+
+            internet_ingress_public_ips = _builder.get(".properties.internetIngressPublicIps")
+            if internet_ingress_public_ips is not None:
+                internet_ingress_public_ips.set_elements(AAZObjectType, ".")
+
+            _elements = _builder.get(".properties.internetIngressPublicIps[]")
+            if _elements is not None:
+                _elements.set_prop("id", AAZStrType, ".id")
+
+            network_profile = _builder.get(".properties.networkProfile")
+            if network_profile is not None:
+                network_profile.set_prop("networkInterfaceConfigurations", AAZListType, ".network_interface_configurations")
+
+            network_interface_configurations = _builder.get(".properties.networkProfile.networkInterfaceConfigurations")
+            if network_interface_configurations is not None:
+                network_interface_configurations.set_elements(AAZObjectType, ".")
+
+            _elements = _builder.get(".properties.networkProfile.networkInterfaceConfigurations[]")
+            if _elements is not None:
+                _elements.set_prop("properties", AAZObjectType)
+                _elements.set_prop("type", AAZStrType, ".type")
+
+            properties = _builder.get(".properties.networkProfile.networkInterfaceConfigurations[].properties")
+            if properties is not None:
+                properties.set_prop("ipConfigurations", AAZListType, ".ip_configurations")
+
+            ip_configurations = _builder.get(".properties.networkProfile.networkInterfaceConfigurations[].properties.ipConfigurations")
+            if ip_configurations is not None:
+                ip_configurations.set_elements(AAZObjectType, ".")
+
+            _elements = _builder.get(".properties.networkProfile.networkInterfaceConfigurations[].properties.ipConfigurations[]")
+            if _elements is not None:
+                _elements.set_prop("name", AAZStrType, ".name")
+                _elements.set_prop("properties", AAZObjectType)
+
+            properties = _builder.get(".properties.networkProfile.networkInterfaceConfigurations[].properties.ipConfigurations[].properties")
+            if properties is not None:
+                properties.set_prop("primary", AAZBoolType, ".primary")
 
             nva_sku = _builder.get(".properties.nvaSku")
             if nva_sku is not None:
@@ -612,6 +716,12 @@ class _UpdateHelper:
             serialized_name="inboundSecurityRules",
             flags={"read_only": True},
         )
+        properties.internet_ingress_public_ips = AAZListType(
+            serialized_name="internetIngressPublicIps",
+        )
+        properties.network_profile = AAZObjectType(
+            serialized_name="networkProfile",
+        )
         properties.nva_sku = AAZObjectType(
             serialized_name="nvaSku",
         )
@@ -673,6 +783,39 @@ class _UpdateHelper:
         inbound_security_rules.Element = AAZObjectType()
         cls._build_schema_sub_resource_read(inbound_security_rules.Element)
 
+        internet_ingress_public_ips = _schema_network_virtual_appliance_read.properties.internet_ingress_public_ips
+        internet_ingress_public_ips.Element = AAZObjectType()
+
+        _element = _schema_network_virtual_appliance_read.properties.internet_ingress_public_ips.Element
+        _element.id = AAZStrType()
+
+        network_profile = _schema_network_virtual_appliance_read.properties.network_profile
+        network_profile.network_interface_configurations = AAZListType(
+            serialized_name="networkInterfaceConfigurations",
+        )
+
+        network_interface_configurations = _schema_network_virtual_appliance_read.properties.network_profile.network_interface_configurations
+        network_interface_configurations.Element = AAZObjectType()
+
+        _element = _schema_network_virtual_appliance_read.properties.network_profile.network_interface_configurations.Element
+        _element.properties = AAZObjectType()
+        _element.type = AAZStrType()
+
+        properties = _schema_network_virtual_appliance_read.properties.network_profile.network_interface_configurations.Element.properties
+        properties.ip_configurations = AAZListType(
+            serialized_name="ipConfigurations",
+        )
+
+        ip_configurations = _schema_network_virtual_appliance_read.properties.network_profile.network_interface_configurations.Element.properties.ip_configurations
+        ip_configurations.Element = AAZObjectType()
+
+        _element = _schema_network_virtual_appliance_read.properties.network_profile.network_interface_configurations.Element.properties.ip_configurations.Element
+        _element.name = AAZStrType()
+        _element.properties = AAZObjectType()
+
+        properties = _schema_network_virtual_appliance_read.properties.network_profile.network_interface_configurations.Element.properties.ip_configurations.Element.properties
+        properties.primary = AAZBoolType()
+
         nva_sku = _schema_network_virtual_appliance_read.properties.nva_sku
         nva_sku.bundled_scale_unit = AAZStrType(
             serialized_name="bundledScaleUnit",
@@ -708,6 +851,10 @@ class _UpdateHelper:
             flags={"read_only": True},
         )
         _element.name = AAZStrType(
+            flags={"read_only": True},
+        )
+        _element.nic_type = AAZStrType(
+            serialized_name="nicType",
             flags={"read_only": True},
         )
         _element.private_ip_address = AAZStrType(

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/virtual_appliance/_update.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/virtual_appliance/_update.py
@@ -137,8 +137,11 @@ class Update(AAZCommand):
             help="The delegation for the Virtual Appliance",
             nullable=True,
         )
+
+        #Manually changed --internet-ingress-public-ips to --internet-ingress-ips to make it lint compliant.
+        #Will fix in Swagger in next release.
         _args_schema.internet_ingress_public_ips = AAZListArg(
-            options=["--internet-ingress-public-ips"],
+            options=["--internet-ingress-ips"],
             arg_group="Properties",
             help="List of Resource Uri of Public IPs for Internet Ingress Scenario.",
             nullable=True,

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/virtual_appliance/_wait.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/virtual_appliance/_wait.py
@@ -20,7 +20,7 @@ class Wait(AAZWaitCommand):
 
     _aaz_info = {
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/networkvirtualappliances/{}", "2023-05-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/networkvirtualappliances/{}", "2023-11-01"],
         ]
     }
 
@@ -123,7 +123,7 @@ class Wait(AAZWaitCommand):
                     "$expand", self.ctx.args.expand,
                 ),
                 **self.serialize_query_param(
-                    "api-version", "2023-05-01",
+                    "api-version", "2023-11-01",
                     required=True,
                 ),
             }
@@ -226,6 +226,12 @@ class Wait(AAZWaitCommand):
                 serialized_name="inboundSecurityRules",
                 flags={"read_only": True},
             )
+            properties.internet_ingress_public_ips = AAZListType(
+                serialized_name="internetIngressPublicIps",
+            )
+            properties.network_profile = AAZObjectType(
+                serialized_name="networkProfile",
+            )
             properties.nva_sku = AAZObjectType(
                 serialized_name="nvaSku",
             )
@@ -287,6 +293,39 @@ class Wait(AAZWaitCommand):
             inbound_security_rules.Element = AAZObjectType()
             _WaitHelper._build_schema_sub_resource_read(inbound_security_rules.Element)
 
+            internet_ingress_public_ips = cls._schema_on_200.properties.internet_ingress_public_ips
+            internet_ingress_public_ips.Element = AAZObjectType()
+
+            _element = cls._schema_on_200.properties.internet_ingress_public_ips.Element
+            _element.id = AAZStrType()
+
+            network_profile = cls._schema_on_200.properties.network_profile
+            network_profile.network_interface_configurations = AAZListType(
+                serialized_name="networkInterfaceConfigurations",
+            )
+
+            network_interface_configurations = cls._schema_on_200.properties.network_profile.network_interface_configurations
+            network_interface_configurations.Element = AAZObjectType()
+
+            _element = cls._schema_on_200.properties.network_profile.network_interface_configurations.Element
+            _element.properties = AAZObjectType()
+            _element.type = AAZStrType()
+
+            properties = cls._schema_on_200.properties.network_profile.network_interface_configurations.Element.properties
+            properties.ip_configurations = AAZListType(
+                serialized_name="ipConfigurations",
+            )
+
+            ip_configurations = cls._schema_on_200.properties.network_profile.network_interface_configurations.Element.properties.ip_configurations
+            ip_configurations.Element = AAZObjectType()
+
+            _element = cls._schema_on_200.properties.network_profile.network_interface_configurations.Element.properties.ip_configurations.Element
+            _element.name = AAZStrType()
+            _element.properties = AAZObjectType()
+
+            properties = cls._schema_on_200.properties.network_profile.network_interface_configurations.Element.properties.ip_configurations.Element.properties
+            properties.primary = AAZBoolType()
+
             nva_sku = cls._schema_on_200.properties.nva_sku
             nva_sku.bundled_scale_unit = AAZStrType(
                 serialized_name="bundledScaleUnit",
@@ -322,6 +361,10 @@ class Wait(AAZWaitCommand):
                 flags={"read_only": True},
             )
             _element.name = AAZStrType(
+                flags={"read_only": True},
+            )
+            _element.nic_type = AAZStrType(
+                serialized_name="nicType",
                 flags={"read_only": True},
             )
             _element.private_ip_address = AAZStrType(


### PR DESCRIPTION
**Related command**
Network

**Description**<!--Mandatory-->
Added support for network-profile and internet-ingress-ips in virtual-appliance create, update, show, list

**Testing Guide**
//Create Command
```shell
python C:/azure-cli/src/azure-cli/azure/cli/__main__.py network virtual-appliance create -g vimalcha-2-mnva-erbvt -n vimalcha-2-cli-testing-from-cli-with-np-slb  --vhub "/subscriptions/1feaed13-01fa-4f52-9c74-3b5305513c89/resourceGroups/vimalcha-2-mnva-erbvt/providers/Microsoft.Network/virtualHubs/vimalcha-2-erbvt-vhub" --vendor "fortinet" --scale-unit 2 -v latest --asn 64512 --init-config "echo $hello"  --network-profile "{network_interface_configurations:[{type:PublicNic,ip_configurations:[{name:publicnicipconfig,primary:true},{name:publicnicipconfig-vimalcha2,primary:false}]},{type:PrivateNic,ip_configurations:[{name:privatenicipconfig,primary:true},{name:privatenicipconfig-vimalcha2,primary:false},{name:privatenicipconfig-vimalcha3,primary:false}]}]}" --internet-ingress-ips "[{id:/subscriptions/1feaed13-01fa-4f52-9c74-3b5305513c89/resourceGroups/vimalcha-2-mnva-erbvt/providers/Microsoft.Network/publicIPAddresses/slb-1}]" 
``` 
New Arguments
```shell
 --internet-ingress-ips
``` 
List containing resource ids of public IP.

```shell
 --network-profile
``` 
Object containing network profile for NVA, the JSON structure as follows
```rich-text-format
        "networkProfile": {
            "networkInterfaceConfigurations": [
                {
                    "type": "PublicNic",
                    "properties" : {
                        "ipConfigurations": [
                            {
                                "name": "publicnicipconfig",
                                "properties" : {
                                    "primary": true
                                } 
                            }
                        ]
                    }
                },
                {
                    "type": "PrivateNic",
                    "properties" : {
                        "ipConfigurations": [
                            {
                                "name": "privatenicipconfig",
                                "properties" : {
                                    "primary": true
                                } 
                            }
                        ]
                    }
                }
            ]
        },
``` 
We are using shorthand syntax for both the parameters. See https://github.com/Azure/azure-cli/tree/dev/doc/shorthand_syntax.md for more about
shorthand syntax.

**Testing Done**
Tested show, list, create, update with both the new parameters.
Tested delete
Testing doc link - https://microsoftapc-my.sharepoint.com/:w:/g/personal/vimalcha_microsoft_com/EUz9dtgq8xxAteuIvQuoX-IBDdbuumprTdhbKQovQ-sIqw?e=sz6PeW

**History Notes**

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
