### PR TITLE
{Storage} Fix #27671: `az storage share close-handle`: Fix duplicate kwarg error when closing a handle by id

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/operations/fileshare.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/fileshare.py
@@ -139,6 +139,9 @@ def close_handle(client, **kwargs):
     handle = kwargs.pop("handle", None)
     if kwargs.pop("close_all", None) or handle == '*':
         return client.close_all_handles(**kwargs)
+    # recursive argument not supported when handle is specified
+    if handle and "recursive" in kwargs:
+        kwargs.pop("recursive")
     return client.close_handle(handle=handle, **kwargs)
 
 


### PR DESCRIPTION
**Related command**
`az storage share close-handle`

**Description**
Fix issue #27671. Specifying a handle id with `--handle` fails with a stack trace because the `recursive` argument is sent down in `kwargs` by default, then another `recursive=None` is added because closing a handle cannot be recursive.

**Testing Guide**
Just find a handle on an Azure File share with `az storage share list-handle` and try to close it with `az storage share close-handle --handle ...`.

**History Notes**
N/A

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
