### PR TITLE
[ARM] `az deployment`: Return better message on incorrect bicepparam file path

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
@@ -170,11 +170,11 @@ def remove_bicep_installation(cli_ctx):
 
 
 def is_bicep_file(file_path):
-    return file_path.lower().endswith(".bicep")
+    return file_path.lower().endswith(".bicep") if file_path else False
 
 
 def is_bicepparam_file(file_path):
-    return file_path.lower().endswith(".bicepparam")
+    return file_path.lower().endswith(".bicepparam") if file_path else False
 
 
 def get_bicep_available_release_tags():

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -1105,6 +1105,18 @@ def _prepare_deployment_properties_unmodified(cmd, deployment_scope, template_fi
                                               mode=None, rollback_on_error=None, no_prompt=False, template_spec=None, query_string=None):
     DeploymentProperties, TemplateLink, OnErrorDeployment = cmd.get_models('DeploymentProperties', 'TemplateLink', 'OnErrorDeployment')
 
+    if template_file:
+        pass
+    elif template_spec:
+        pass
+    elif template_uri:
+        pass
+    elif _is_bicepparam_file_provided(parameters):
+        pass
+    else:
+        raise InvalidArgumentValueError(
+            "Please enter one of the following: template file, template spec, template url, or Bicep parameters file.")
+
     template_link = None
     template_obj = None
     on_error_deployment = None
@@ -1316,7 +1328,7 @@ def _prepare_stacks_templates_and_parameters(cmd, rcf, deployment_scope, deploym
         pass
     else:
         raise InvalidArgumentValueError(
-            "Please enter one of the following: template file, template spec, or template url")
+            "Please enter one of the following: template file, template spec, template url, or Bicep parameters file.")
 
     if t_spec:
         deployment_stack_model.template_link = DeploymentStacksTemplateLink(id=t_spec)

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
@@ -5510,6 +5510,16 @@ class DeploymentWithBicepScenarioTest(LiveScenarioTest):
         with self.assertRaisesRegex(CLIError, "Can not use --parameters argument more than once when using a .bicepparam file"):
             self.cmd('deployment group create --resource-group {rg} --parameters {params1} --parameters {params2}')
 
+    def test_resource_deployment_with_misspelled_bicepparam_file(self):
+        self.kwargs.update({
+            'rg' : "exampleGroup",
+            # this doesn't get recognized as a bicepparam file
+            'params' : "./param.bicepparams",
+        })
+
+        with self.assertRaisesRegex(CLIError, "Please enter one of the following: template file, template spec, template url, or Bicep parameters file."):
+            self.cmd('deployment group create --resource-group {rg} --parameters {params}')
+
     def test_subscription_level_deployment_with_bicep(self):
         curr_dir = os.path.dirname(os.path.realpath(__file__))
         self.kwargs.update({


### PR DESCRIPTION
**Related command**
`az deployment`

**Description**<!--Mandatory-->
Return better message on incorrect bicepparam file path
Closes #27989

**Testing Guide**
```sh
az deployment mg create \
  --management-group-id mymanagementgroup \
  --location westeurope \
  --parameters parameters/notfound.bicepparams
```

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[ARM] `az deployment`: Return better message on incorrect bicepparam file path

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
