### PR TITLE
[AKS] `az aks create/update`: Prompt warning during disablement about CR deletion

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/azuremonitorprofile.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/azuremonitorprofile.py
@@ -51,7 +51,7 @@ def link_azure_monitor_profile_artifacts(
 
 # pylint: disable=line-too-long
 def unlink_azure_monitor_profile_artifacts(cmd, cluster_subscription, cluster_resource_group_name, cluster_name):
-    msg = 'Executing this action will result in the removal of all custom custom resources for the `azmonitoring.coreos.com` custom resource defintion. Are you certain that you wish to proceed with this operation?'
+    msg = 'Executing this action will result in the removal of all custom resources for the `azmonitoring.coreos.com` custom resource defintion. Are you certain that you wish to proceed with this operation?'
     if not prompt_y_n(msg, default="n"):
         raise ClientError("Operation cancelled by user")
     # Remove DC* if prometheus is enabled

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/azuremonitorprofile.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/azuremonitorprofile.py
@@ -51,9 +51,7 @@ def link_azure_monitor_profile_artifacts(
 
 # pylint: disable=line-too-long
 def unlink_azure_monitor_profile_artifacts(cmd, cluster_subscription, cluster_resource_group_name, cluster_name):
-    msg = 'Executing this action will result in the removal of all custom CRDs (Custom Resource Definitions) created by you.\
- It is important to note that the custom resource azmonitoring.coreos.com will also be deleted in the process.\
- Are you certain that you wish to proceed with this operation?'
+    msg = 'Executing this action will result in the removal of all custom custom resources for the `azmonitoring.coreos.com` custom resource defintion. Are you certain that you wish to proceed with this operation?'
     if not prompt_y_n(msg, default="n"):
         raise ClientError("Operation cancelled by user")
     # Remove DC* if prometheus is enabled

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/azuremonitorprofile.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/azuremonitorprofile.py
@@ -51,9 +51,7 @@ def link_azure_monitor_profile_artifacts(
 
 # pylint: disable=line-too-long
 def unlink_azure_monitor_profile_artifacts(cmd, cluster_subscription, cluster_resource_group_name, cluster_name):
-    msg = "Executing this action will result in the removal of all custom resources for the `azmonitoring.coreos.com` custom resource defintion. Are you certain that you wish to proceed with this operation?"
-    if not prompt_y_n(msg, default="n"):
-        raise ClientError("Operation cancelled by user")
+    print("Executing this action will result in the removal of all custom resources for the `azmonitoring.coreos.com` custom resource defintion. Are you certain that you wish to proceed with this operation?")
     # Remove DC* if prometheus is enabled
     dc_objects_list = get_dc_objects_list(cmd, cluster_subscription, cluster_resource_group_name, cluster_name)
     delete_dc_objects_if_prometheus_enabled(cmd, dc_objects_list, cluster_subscription, cluster_resource_group_name, cluster_name)

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/azuremonitorprofile.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/azuremonitorprofile.py
@@ -19,7 +19,6 @@ from azure.cli.command_modules.acs.azuremonitormetrics.helper import (
 from azure.cli.command_modules.acs.azuremonitormetrics.recordingrules.create import create_rules
 from azure.cli.command_modules.acs.azuremonitormetrics.recordingrules.delete import delete_rules
 from azure.cli.core.azclierror import ClientError, InvalidArgumentValueError
-from knack.prompting import prompt_y_n
 
 
 # pylint: disable=line-too-long

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/azuremonitorprofile.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/azuremonitorprofile.py
@@ -19,6 +19,10 @@ from azure.cli.command_modules.acs.azuremonitormetrics.helper import (
 from azure.cli.command_modules.acs.azuremonitormetrics.recordingrules.create import create_rules
 from azure.cli.command_modules.acs.azuremonitormetrics.recordingrules.delete import delete_rules
 from azure.cli.core.azclierror import InvalidArgumentValueError
+from knack.log import get_logger
+
+
+logger = get_logger(__name__)
 
 
 # pylint: disable=line-too-long
@@ -50,7 +54,7 @@ def link_azure_monitor_profile_artifacts(
 
 # pylint: disable=line-too-long
 def unlink_azure_monitor_profile_artifacts(cmd, cluster_subscription, cluster_resource_group_name, cluster_name):
-    print("Executing this action will result in the removal of all custom resources for the `azmonitoring.coreos.com` custom resource defintion. Are you certain that you wish to proceed with this operation?")
+    logger.warning("Deleting all custom resources for the `azmonitoring.coreos.com` custom resource defintion created by the Managed Prometheus addon")
     # Remove DC* if prometheus is enabled
     dc_objects_list = get_dc_objects_list(cmd, cluster_subscription, cluster_resource_group_name, cluster_name)
     delete_dc_objects_if_prometheus_enabled(cmd, dc_objects_list, cluster_subscription, cluster_resource_group_name, cluster_name)

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/azuremonitorprofile.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/azuremonitorprofile.py
@@ -18,7 +18,8 @@ from azure.cli.command_modules.acs.azuremonitormetrics.helper import (
 )
 from azure.cli.command_modules.acs.azuremonitormetrics.recordingrules.create import create_rules
 from azure.cli.command_modules.acs.azuremonitormetrics.recordingrules.delete import delete_rules
-from azure.cli.core.azclierror import InvalidArgumentValueError
+from azure.cli.core.azclierror import ClientError, InvalidArgumentValueError
+from knack.prompting import prompt_y_n
 
 
 # pylint: disable=line-too-long
@@ -50,6 +51,9 @@ def link_azure_monitor_profile_artifacts(
 
 # pylint: disable=line-too-long
 def unlink_azure_monitor_profile_artifacts(cmd, cluster_subscription, cluster_resource_group_name, cluster_name):
+    msg = 'This will delete all custom CRDs created by you as the custom resource `azmonitoring.coreos.com` will also be deleted. Are you sure you want to disable?'
+    if not prompt_y_n(msg, default="n"):
+        raise ClientError("Operation cancelled by user")
     # Remove DC* if prometheus is enabled
     dc_objects_list = get_dc_objects_list(cmd, cluster_subscription, cluster_resource_group_name, cluster_name)
     delete_dc_objects_if_prometheus_enabled(cmd, dc_objects_list, cluster_subscription, cluster_resource_group_name, cluster_name)

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/azuremonitorprofile.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/azuremonitorprofile.py
@@ -51,7 +51,7 @@ def link_azure_monitor_profile_artifacts(
 
 # pylint: disable=line-too-long
 def unlink_azure_monitor_profile_artifacts(cmd, cluster_subscription, cluster_resource_group_name, cluster_name):
-    msg = 'Executing this action will result in the removal of all custom resources for the `azmonitoring.coreos.com` custom resource defintion. Are you certain that you wish to proceed with this operation?'
+    msg = "Executing this action will result in the removal of all custom resources for the `azmonitoring.coreos.com` custom resource defintion. Are you certain that you wish to proceed with this operation?"
     if not prompt_y_n(msg, default="n"):
         raise ClientError("Operation cancelled by user")
     # Remove DC* if prometheus is enabled

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/azuremonitorprofile.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/azuremonitorprofile.py
@@ -51,7 +51,9 @@ def link_azure_monitor_profile_artifacts(
 
 # pylint: disable=line-too-long
 def unlink_azure_monitor_profile_artifacts(cmd, cluster_subscription, cluster_resource_group_name, cluster_name):
-    msg = 'This will delete all custom CRDs created by you as the custom resource `azmonitoring.coreos.com` will also be deleted. Are you sure you want to disable?'
+    msg = 'Executing this action will result in the removal of all custom CRDs (Custom Resource Definitions) created by you.\
+ It is important to note that the custom resource azmonitoring.coreos.com will also be deleted in the process.\
+ Are you certain that you wish to proceed with this operation?'
     if not prompt_y_n(msg, default="n"):
         raise ClientError("Operation cancelled by user")
     # Remove DC* if prometheus is enabled

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/azuremonitorprofile.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/azuremonitorprofile.py
@@ -18,7 +18,7 @@ from azure.cli.command_modules.acs.azuremonitormetrics.helper import (
 )
 from azure.cli.command_modules.acs.azuremonitormetrics.recordingrules.create import create_rules
 from azure.cli.command_modules.acs.azuremonitormetrics.recordingrules.delete import delete_rules
-from azure.cli.core.azclierror import ClientError, InvalidArgumentValueError
+from azure.cli.core.azclierror import InvalidArgumentValueError
 
 
 # pylint: disable=line-too-long


### PR DESCRIPTION
**Related command**

```az aks create -n kaveeshcli22 -g kaveeshcli --disable-azure-monitor-metrics ```

**Description**<!--Mandatory-->
Add a warning message to tell the customer that disabling the addon will also delete any custom resource 

**Testing Guide**

**Scenario**:
- Use the command listed above to disable the addon
- It should result in a prompt warning and should continue with the disablement on a yes and raise an exception if cancelled.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
