### PR TITLE
{Core} Fix `random_config_dir` when `AZURE_CONFIG_DIR` is set

### DIFF
--- a/src/azure-cli-core/azure/cli/core/mock.py
+++ b/src/azure-cli-core/azure/cli/core/mock.py
@@ -10,6 +10,7 @@ class DummyCli(AzCli):
     """A dummy CLI instance can be used to facilitate automation"""
     def __init__(self, commands_loader_cls=None, random_config_dir=False, **kwargs):
         import os
+        from unittest.mock import patch
 
         from azure.cli.core import MainCommandsLoader
         from azure.cli.core.commands import AzCliCommandInvoker
@@ -26,9 +27,10 @@ class DummyCli(AzCli):
 
         if random_config_dir:
             config_dir = os.path.join(GLOBAL_CONFIG_DIR, 'dummy_cli_config_dir', random_string())
-            # Knack prioritizes the AZURE_CONFIG_DIR env over the config_dir param, and other function may call
+            # Knack prioritizes the AZURE_CONFIG_DIR env over the config_dir param, and other functions may call
             # get_config_dir directly. We need to set the env to make sure the config_dir is used.
-            os.environ['AZURE_CONFIG_DIR'] = config_dir
+            self.env_patch = patch.dict('os.environ', {'AZURE_CONFIG_DIR': config_dir})
+            self.env_patch.start()
 
             # In recording mode, copy login credentials from global config dir to the dummy config dir
             if os.getenv(ENV_VAR_TEST_LIVE, '').lower() == 'true':

--- a/src/azure-cli-core/azure/cli/core/mock.py
+++ b/src/azure-cli-core/azure/cli/core/mock.py
@@ -43,12 +43,10 @@ class DummyCli(AzCli):
                             shutil.copy(os.path.join(GLOBAL_CONFIG_DIR, file), config_dir)
                         except FileNotFoundError:
                             pass
-        else:
-            config_dir = GLOBAL_CONFIG_DIR
 
         super(DummyCli, self).__init__(
             cli_name='az',
-            config_dir=config_dir,
+            config_dir=GLOBAL_CONFIG_DIR,
             config_env_var_prefix=ENV_VAR_PREFIX,
             commands_loader_cls=commands_loader_cls or MainCommandsLoader,
             parser_cls=AzCliCommandParser,

--- a/src/azure-cli-core/azure/cli/core/mock.py
+++ b/src/azure-cli-core/azure/cli/core/mock.py
@@ -29,7 +29,7 @@ class DummyCli(AzCli):
             config_dir = os.path.join(GLOBAL_CONFIG_DIR, 'dummy_cli_config_dir', random_string())
             # Knack prioritizes the AZURE_CONFIG_DIR env over the config_dir param, and other functions may call
             # get_config_dir directly. We need to set the env to make sure the config_dir is used.
-            self.env_patch = patch.dict('os.environ', {'AZURE_CONFIG_DIR': config_dir})
+            self.env_patch = patch.dict(os.environ, {'AZURE_CONFIG_DIR': config_dir})
             self.env_patch.start()
 
             # In recording mode, copy login credentials from global config dir to the dummy config dir

--- a/src/azure-cli-testsdk/azure/cli/testsdk/base.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/base.py
@@ -142,6 +142,7 @@ class ScenarioTest(ReplayableTest, CheckerMixin, unittest.TestCase):
         if self.random_config_dir:
             from azure.cli.core.util import rmtree_with_retry
             rmtree_with_retry(self.cli_ctx.config.config_dir)
+            self.cli_ctx.env_patch.stop()
         super(ScenarioTest, self).tearDown()
 
     def create_random_name(self, prefix, length):


### PR DESCRIPTION
Resolve #28668

Knack ignores the `config_dir` param when `AZURE_CONFIG_DIR` env is set, and other functions may call `get_config_dir` directly.
So this PR patches `AZURE_CONFIG_DIR` env when `random_config_dir=true` during test