### PR TITLE
{RDBMS} Add support for ossrc cluster

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/config.json
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/config.json
@@ -1,7 +1,7 @@
 {
     "AzureCloud": {
-        "southcentralus": ["ossdev", "osshf", "ossmc"],
-        "northcentralus": ["ossdev", "osshf", "ossmc"],
+        "southcentralus": ["ossdev", "osshf", "ossmc", "ossrc"],
+        "northcentralus": ["ossdev", "osshf", "ossmc", "ossrc"],
         "osshf": {
             "subscriptions": ["4a5d02ab-e0c3-4d39-8031-293ddd4e1875"],
             "privateDnsZoneDomain": "pg.osshf-scus1-a.mscds.com"
@@ -13,6 +13,10 @@
         "ossmc": {
             "subscriptions": ["d4fbfa87-b94d-4b13-906f-97361388c5e4"],
             "privateDnsZoneDomain": "pg.ossmc-scus1-a.mscds.com"
+        },
+        "ossrc": {
+            "subscriptions": ["39c1cf1f-e76a-40cf-8abb-39073761f513"],
+            "privateDnsZoneDomain": "pg.ossrc-scus1-a.mscds.com"
         }
     },
     "AzureChinaCloud": {


### PR DESCRIPTION
**Related command**
Add support for OSSRC cluster to fetch private DNS zone domain name

**Description**<!--Mandatory-->
Add support for OSSRC cluster to fetch private DNS zone domain name

**Testing Guide**
Verified manually
2024-04-02T17:50:12.7503690Z 2024-04-02 17:50:12 [INFO] Started executing command az postgres flexible-server create -g cli-temp-rg-49b85861f5384246995bb3111c5a8597 -n cli-temp-pg-flex-ha-vnet-756c7321cc1744ff9f3f1c31e1be -l southcentralus --high-availability ZoneRedundant --vnet cli-test-pg-flex-vnet-southcentralus39c1cf1fe76a40cf8 --subnet cli-test-pg-flex-subnet-southcentralus39c1cf1fe76a40c **--private-dns-zone cli-test-pg-flex-dns-southcentralus39c1cf1fe76a40c.pg.ossrc-scus1-a.mscds.com** -y
2024-04-02T18:01:06.0212348Z 2024-04-02 18:01:06 [INFO] Result: 0
2024-04-02T18:01:06.0235566Z 2024-04-02 18:01:06 [INFO] Successfully executed command az postgres flexible-server create -g cli-temp-rg-49b85861f5384246995bb3111c5a8597 -n cli-temp-pg-flex-ha-vnet-756c7321cc1744ff9f3f1c31e1be -l southcentralus --high-availability ZoneRedundant --vnet cli-test-pg-flex-vnet-southcentralus39c1cf1fe76a40cf8 --subnet cli-test-pg-flex-subnet-southcentralus39c1cf1fe76a40c --private-dns-zone cli-test-pg-flex-dns-southcentralus39c1cf1fe76a40c.pg.ossrc-scus1-a.mscds.com -y
2024-04-02T18:01:06.0608403Z 2024-04-02 18:01:06 [INFO] Successfully created flex server cli-temp-pg-flex-ha-vnet-756c7321cc1744ff9f3f1c31e1be in southcentralus region
2024-04-02T18:01:06.0615425Z 2024-04-02 18:01:06 [INFO] Flex server ctreated successfully
2024-04-02T18:01:06.0617071Z 2024-04-02 18:01:06 [INFO] Started executing command az postgres flexible-server show --resource-group cli-temp-rg-49b85861f5384246995bb3111c5a8597 --name cli-temp-pg-flex-ha-vnet-756c7321cc1744ff9f3f1c31e1be
2024-04-02T18:01:08.3821413Z 2024-04-02 18:01:08 [INFO] Result: 0
2024-04-02T18:01:08.3826089Z 2024-04-02 18:01:08 [INFO] Successfully executed command az postgres flexible-server show --resource-group cli-temp-rg-49b85861f5384246995bb3111c5a8597 --name cli-temp-pg-flex-ha-vnet-756c7321cc1744ff9f3f1c31e1be
2024-04-02T18:01:08.3832473Z 2024-04-02 18:01:08 [INFO] Server details: {'administratorLogin': 'measlyibexe5', 'administratorLoginPassword': None, 'authConfig': {'activeDirectoryAuth': 'Disabled', 'passwordAuth': 'Enabled', 'tenantId': None}, 'availabilityZone': '1', 'backup': {'backupRetentionDays': 7, 'earliestRestoreDate': '2024-04-02T17:56:48.601103+00:00', 'geoRedundantBackup': 'Disabled'}, 'createMode': None, 'dataEncryption': {'geoBackupEncryptionKeyStatus': None, 'geoBackupKeyUri': None, 'geoBackupUserAssignedIdentityId': None, 'primaryEncryptionKeyStatus': None, 'primaryKeyUri': None, 'primaryUserAssignedIdentityId': None, 'type': 'SystemManaged'}, 'fullyQualifiedDomainName': 'cli-temp-pg-flex-ha-vnet-756c7321cc1744ff9f3f1c31e1be.ossrc-scus1-a.mscds.com', 'highAvailability': {'mode': 'ZoneRedundant', 'standbyAvailabilityZone': '2', 'state': 'Healthy'}, 'id': '/subscriptions/39c1cf1f-e76a-40cf-8abb-39073761f513/resourceGroups/cli-temp-rg-49b85861f5384246995bb3111c5a8597/providers/Microsoft.DBforPostgreSQL/flexibleServers/cli-temp-pg-flex-ha-vnet-756c7321cc1744ff9f3f1c31e1be', 'identity': None, 'location': 'South Central US', 'maintenanceWindow': {'customWindow': 'Disabled', 'dayOfWeek': 0, 'startHour': 0, 'startMinute': 0}, 'minorVersion': '14', 'name': 'cli-temp-pg-flex-ha-vnet-756c7321cc1744ff9f3f1c31e1be', 'network': {'delegatedSubnetResourceId': '/subscriptions/39c1cf1f-e76a-40cf-8abb-39073761f513/resourceGroups/cli-temp-rg-49b85861f5384246995bb3111c5a8597/providers/Microsoft.Network/virtualNetworks/cli-test-pg-flex-vnet-southcentralus39c1cf1fe76a40cf8/subnets/cli-test-pg-flex-subnet-southcentralus39c1cf1fe76a40c', **'privateDnsZoneArmResourceId': '/subscriptions/39c1cf1f-e76a-40cf-8abb-39073761f513/resourceGroups/cli-temp-rg-49b85861f5384246995bb3111c5a8597/providers/Microsoft.Network/privateDnsZones/cli-test-pg-flex-dns-southcentralus39c1cf1fe76a40c.pg.ossrc-scus1-a.mscds.com**', 'publicNetworkAccess': 'Disabled'}, 'pointInTimeUtc': None, 'privateEndpointConnections': None, 'replica': {'capacity': 5, 'promoteMode': None, 'promoteOption': None, 'replicationState': None, 'role': 'Primary'}, 'replicaCapacity': 5, 'replicationRole': 'Primary', 'resourceGroup': 'cli-temp-rg-49b85861f5384246995bb3111c5a8597', 'sku': {'name': 'Standard_D2s_v3', 'tier': 'GeneralPurpose'}, 'sourceServerResourceId': None, 'state': 'Ready', 'storage': {'autoGrow': 'Disabled', 'iops': 500, 'storageSizeGb': 128, 'throughput': None, 'tier': 'P10', 'type': ''}, 'systemData': {'createdAt': '2024-04-02T17:51:57.031525+00:00', 'createdBy': None, 'createdByType': None, 'lastModifiedAt': None, 'lastModifiedBy': None, 'lastModifiedByType': None}, 'tags': None, 'type': 'Microsoft.DBforPostgreSQL/flexibleServers', 'version': '13'}

**History Notes**

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
