### PR TITLE
[RDBMS] Add support for major version upgrade to PG16

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
@@ -422,7 +422,7 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
         )
 
         pg_version_upgrade_arg_type = CLIArgumentType(
-            arg_type=get_enum_type(['12', '13', '14', '15']),
+            arg_type=get_enum_type(['12', '13', '14', '15', '16']),
             options_list=['--version', '-v'],
             help='Server major version.'
         )


### PR DESCRIPTION
**Related command**
`az postgres flexible-server upgrade -g testgroup -n testsvr -v 16`

**Description**<!--Mandatory-->
To GA major version upgrade (MVU) to PG16, allowing passing in 16 to upgrade command argument.

**Testing Guide**
Manually tested
PS C:\Users\nasc\azureCLI\azure-cli>  C:; cd 'C:\Users\nasc\azureCLI\azure-cli'; & 'c:\Users\nasc\azureCLI\azure-cli\env\Scripts\python.exe' 'c:\Users\nasc\.vscode\extensions\ms-python.python-2024.4.0\python_files\lib\python\debugpy\adapter/../..\debugpy\launcher' '65045' '--' 'C:\Users\nasc\azureCLI\azure-cli/src/azure-cli/azure/cli/__main__.py' 'postgres' 'flexible-server' 'upgrade' '--name' 'nasc-canary13' '-g' 'nasc-testfree' '-v' '16' 
Updating major version in server nasc-canary13 is irreversible. The action you're about to take can't be undone. Going further will initiate major version upgrade to the selected version on this server. (y/n): y
{
  "administratorLogin": "arcadmin",
  "administratorLoginPassword": null,
  "authConfig": {
    "activeDirectoryAuth": "Disabled",
    "passwordAuth": "Enabled",
    "tenantId": null
  },
  ...
  **"version": "16"**
}
![image](https://github.com/Azure/azure-cli/assets/69922333/49c870db-3ee2-4960-a4dc-207e89bfab3d)
![image](https://github.com/Azure/azure-cli/assets/69922333/360bb6e7-15bb-4e6c-878e-4d66073f9eb7)



**History Notes**
[RDBMS] `az postgres flexible-server upgrade`: Add capability to perform major version upgrade to PG16. 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
