### PR TITLE
[NetAppFiles] Add zones to volume-group, update min for usage-threshold volume create

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/netappfiles/aaz/latest/netappfiles/volume/_create.py
+++ b/src/azure-cli/azure/cli/command_modules/netappfiles/aaz/latest/netappfiles/volume/_create.py
@@ -492,6 +492,7 @@ class Create(AAZCommand):
             options=["--remote-path"],
             arg_group="Replication",
             help="The full path to a volume that is to be migrated into ANF. Required for Migration volumes",
+            is_preview=True,
         )
         _args_schema.remote_volume_region = AAZStrArg(
             options=["--remote-volume-region"],
@@ -518,7 +519,7 @@ class Create(AAZCommand):
         )
         remote_path.server_name = AAZStrArg(
             options=["server-name"],
-            help="The name of a server on the Ontap Host",
+            help="The name of a server on the ONTAP Host",
             required=True,
         )
         remote_path.volume_name = AAZStrArg(

--- a/src/azure-cli/azure/cli/command_modules/netappfiles/aaz/latest/netappfiles/volume/_create.py
+++ b/src/azure-cli/azure/cli/command_modules/netappfiles/aaz/latest/netappfiles/volume/_create.py
@@ -20,7 +20,7 @@ class Create(AAZCommand):
     Create the specified volume within the capacity pool
 
     :example: Create an ANF volume
-        az netappfiles volume create -g group --account-name aname --pool-name pname --volume-name vname -l location --service-level "Premium" --usage-threshold 107374182400 --creation-token "unique-token" --protocol-types NFSv3 --vnet myvnet --subnet-id "/subscriptions/mysubsid/resourceGroups/myrg/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/default" --rules '[{"allowed_clients":"0.0.0.0/0","rule_index":"1","unix_read_only":"true","unix_read_write":"false","cifs":"false","nfsv3":"true","nfsv41":"false"}]'
+        az netappfiles volume create -g group --account-name aname --pool-name pname --volume-name vname -l location --service-level "Premium" --usage-threshold 100 --creation-token "unique-token" --protocol-types NFSv3 --vnet myvnet --subnet-id "/subscriptions/mysubsid/resourceGroups/myrg/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/default" --rules '[{"allowed_clients":"0.0.0.0/0","rule_index":"1","unix_read_only":"true","unix_read_write":"false","cifs":"false","nfsv3":"true","nfsv41":"false"}]'
 
     :example: Create an ANF volume with zones (Availability Zone) specified
         az netappfiles volume create -g mygroup --account-name myaccname --pool-name mypoolname --name myvolname -l westus2 --service-level premium --usage-threshold 100 --file-path "unique-file-path" --vnet myvnet --subnet mysubnet --protocol-types NFSv3 --zones zone1
@@ -444,7 +444,7 @@ class Create(AAZCommand):
             arg_group="Properties",
             help={"short-summary": "Maximum storage quota allowed for a file system in bytes.", "long-summary": "This is a soft quota used for alerting only. Minimum size is 100 GiB. \nUpper limit is 100TiB, 500Tib for LargeVolume."},
             required=True,
-            default=107374182400,
+            default=100,
             fmt=AAZIntArgFormat(
                 maximum=2638827906662400,
                 minimum=107374182400,

--- a/src/azure-cli/azure/cli/command_modules/netappfiles/aaz/latest/netappfiles/volume/_create.py
+++ b/src/azure-cli/azure/cli/command_modules/netappfiles/aaz/latest/netappfiles/volume/_create.py
@@ -442,7 +442,7 @@ class Create(AAZCommand):
         _args_schema.usage_threshold = AAZIntArg(
             options=["--usage-threshold"],
             arg_group="Properties",
-            help={"short-summary": "Maximum storage quota allowed for a file system in bytes.", "long-summary": "This is a soft quota used for alerting only. Minimum size is 100 GiB. \nUpper limit is 100TiB, 500Tib for LargeVolume."},
+            help={"short-summary": "Maximum storage quota allowed for a file system as integer number of GiB", "long-summary": "This is a soft quota used for alerting only. Minimum size is 100 GiB. \nUpper limit is 100TiB, 500Tib for LargeVolume or 2400Tib for LargeVolume on exceptional basis."},
             required=True,
             default=100,
             fmt=AAZIntArgFormat(

--- a/src/azure-cli/azure/cli/command_modules/netappfiles/aaz/latest/netappfiles/volume/_update.py
+++ b/src/azure-cli/azure/cli/command_modules/netappfiles/aaz/latest/netappfiles/volume/_update.py
@@ -415,7 +415,7 @@ class Update(AAZCommand):
         _args_schema.usage_threshold = AAZIntArg(
             options=["--usage-threshold"],
             arg_group="Properties",
-            help={"short-summary": "Maximum storage quota allowed for a file system in bytes.", "long-summary": "This is a soft quota used for alerting only. Minimum size is 100 GiB. \nUpper limit is 100TiB, 500Tib for LargeVolume."},
+            help={"short-summary": "Maximum storage quota allowed for a file system as integer number of GiB", "long-summary": "This is a soft quota used for alerting only. Minimum size is 100 GiB. \nUpper limit is 100TiB, 500Tib for LargeVolume or 2400Tib for LargeVolume on exceptional basis."},
             fmt=AAZIntArgFormat(
                 maximum=2638827906662400,
                 minimum=107374182400,

--- a/src/azure-cli/azure/cli/command_modules/netappfiles/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/netappfiles/custom.py
@@ -912,7 +912,7 @@ class VolumeGroupCreate(_VolumeGroupCreate):
             log_backup_size = None
         kv_private_endpoint_id = args.key_vault_private_endpoint_resource_id.to_serialized_data()
         ppg = args.proximity_placement_group.to_serialized_data()
-        
+
         if has_value(args.zones):
             zones = args.zones.to_serialized_data()
         else:

--- a/src/azure-cli/azure/cli/command_modules/netappfiles/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/netappfiles/custom.py
@@ -311,7 +311,7 @@ class VolumeCreate(_VolumeCreate):
 
         args_schema.usage_threshold._default = 100
         args_schema.usage_threshold._fmt = AAZIntArgFormat(
-            maximum=500,
+            maximum=2400,
             minimum=100
         )
 
@@ -435,7 +435,7 @@ class VolumeUpdate(_VolumeUpdate):
             required=False,
         )
         args_schema.usage_threshold._fmt = AAZIntArgFormat(
-            maximum=500,
+            maximum=2400,
             minimum=100,
         )
 
@@ -594,7 +594,7 @@ class ReplicationResume(_ReplicationResume):
 class VolumeGroupCreate(_VolumeGroupCreate):
     @classmethod
     def _build_arguments_schema(cls, *args, **kwargs):
-        from azure.cli.core.aaz import AAZStrArg, AAZIntArg, AAZDictArg, AAZBoolArg
+        from azure.cli.core.aaz import AAZStrArg, AAZIntArg, AAZDictArg, AAZBoolArg, AAZListArg, AAZStrArgFormat
         args_schema = super()._build_arguments_schema(*args, **kwargs)
         logger.debug("ANF log: ExportPolicyRemove _build_arguments_schema")
 
@@ -606,7 +606,18 @@ class VolumeGroupCreate(_VolumeGroupCreate):
         args_schema.tags.Element = AAZStrArg(
             nullable=True,
         )
-
+        args_schema.zones = AAZListArg(
+            options=["--zones"],
+            arg_group="Body",
+            help="Availability Zone",
+        )
+        zones = cls._args_schema.zones
+        zones.Element = AAZStrArg(
+            fmt=AAZStrArgFormat(
+                max_length=255,
+                min_length=1,
+            ),
+        )
         args_schema.gp_rules = AAZDictArg(
             options=["--gp-rules"],
             arg_group="GroupMetaData",
@@ -901,6 +912,11 @@ class VolumeGroupCreate(_VolumeGroupCreate):
             log_backup_size = None
         kv_private_endpoint_id = args.key_vault_private_endpoint_resource_id.to_serialized_data()
         ppg = args.proximity_placement_group.to_serialized_data()
+        
+        if has_value(args.zones):
+            zones = args.zones.to_serialized_data()
+        else:
+            zones = None
 
         logger.debug("ANF log: VolumeGroupCreate.pre_operations: Pool: %s, Hosts: %s, memory: %s, additional snapshot capacity: {add_snapshot_capacity}", {pool_name}, {number_of_hosts}, {memory})
         if number_of_hosts < 1 or number_of_hosts > 3:
@@ -952,6 +968,7 @@ class VolumeGroupCreate(_VolumeGroupCreate):
         subnet_id = f"/subscriptions/{subscription_id}/resourceGroups/{subnet_rg}/providers/Microsoft.Network/virtualNetworks/{vnet}/subnets/{subnet}"
 
         pool_id = f"/subscriptions/{subscription_id}/resourceGroups/{subnet_rg}/providers/Microsoft.NetApp/netAppAccounts/{account_name}/capacityPools/{pool_name}"
+        logger.debug("ANF LOG: VolumeGroupCreate.pre_operations()  => Received: %s volumes ", len(args.volumes))
         if not has_value(args.volumes) or len(args.volumes) == 0:
             # Create data volume(s)
             data_volumes = []
@@ -960,13 +977,13 @@ class VolumeGroupCreate(_VolumeGroupCreate):
             for i in range(start_host_id, start_host_id + number_of_hosts):
                 data_volumes.append(create_data_volume_properties(subnet_id, application_identifier, pool_id, ppg, memory,
                                                                   add_snapshot_capacity, str(i), data_size, data_throughput,
-                                                                  prefix, data_repl_skd, data_src_id, kv_private_endpoint_id))
+                                                                  prefix, data_repl_skd, data_src_id, kv_private_endpoint_id, zones))
 
             # Create log volume(s)
             log_volumes = []
             for i in range(start_host_id, start_host_id + number_of_hosts):
                 log_volumes.append(create_log_volume_properties(subnet_id, application_identifier, pool_id, ppg, memory, str(i), log_size,
-                                                                log_throughput, prefix, kv_private_endpoint_id))
+                                                                log_throughput, prefix, kv_private_endpoint_id, zones))
             total_data_volume_size = sum(int(vol["usage_threshold"]) for vol in data_volumes)
             total_log_volume_size = sum(int(vol["usage_threshold"]) for vol in log_volumes)
 
@@ -977,22 +994,23 @@ class VolumeGroupCreate(_VolumeGroupCreate):
 
             args.volumes.append(create_shared_volume_properties(subnet_id, application_identifier, pool_id, ppg, memory, shared_size,
                                                                 shared_throughput, number_of_hosts, prefix, shared_repl_skd, shared_src_id, kv_private_endpoint_id, smb_access_based_enumeration,
-                                                                smb_non_browsable))
+                                                                smb_non_browsable, zones))
             args.volumes.append(create_data_backup_volume_properties(subnet_id, application_identifier, pool_id, ppg, memory, data_backup_size,
                                                                      data_backup_throughput, total_data_volume_size,
                                                                      total_log_volume_size, prefix, backup_nfsv3,
                                                                      data_backup_repl_skd, data_backup_src_id, kv_private_endpoint_id,
                                                                      smb_access_based_enumeration,
-                                                                     smb_non_browsable))
+                                                                     smb_non_browsable, zones))
             args.volumes.append(create_log_backup_volume_properties(subnet_id, application_identifier, pool_id, ppg, memory, log_backup_size,
                                                                     log_backup_throughput, prefix, backup_nfsv3, log_backup_repl_skd,
                                                                     log_backup_src_id, kv_private_endpoint_id,
                                                                     smb_access_based_enumeration,
-                                                                    smb_non_browsable))
+                                                                    smb_non_browsable, zones))
 
 
 def create_data_volume_properties(subnet_id, application_identifier, pool_id, ppg, memory, add_snap_capacity, host_id,
-                                  data_size, data_throughput, prefix, data_repl_skd=None, data_src_id=None, kv_private_endpoint_id=None):
+                                  data_size, data_throughput, prefix, data_repl_skd=None, data_src_id=None, kv_private_endpoint_id=None,
+                                  zones=None):
     name = prefix + application_identifier + "-" + VolumeType.DATA.value + "-mnt" + (host_id.rjust(5, '0'))
 
     if data_size is None:
@@ -1022,14 +1040,15 @@ def create_data_volume_properties(subnet_id, application_identifier, pool_id, pp
         "throughput_mibps": throughput,
         "export_policy": create_default_export_policy_for_vg(),
         "data_protection": data_protection,
-        "key_vault_private_endpoint_resource_id": kv_private_endpoint_id
+        "key_vault_private_endpoint_resource_id": kv_private_endpoint_id,
+        "zones": zones
     }
 
     return data_volume
 
 
 def create_log_volume_properties(subnet_id, sap_sid, pool_id, ppg, memory, host_id, log_size,
-                                 log_throughput, prefix, kv_private_endpoint_id=None):
+                                 log_throughput, prefix, kv_private_endpoint_id=None, zones=None):
     name = prefix + sap_sid + "-" + VolumeType.LOG.value + "-mnt" + (host_id.rjust(5, '0'))
 
     if log_size is None:
@@ -1051,7 +1070,8 @@ def create_log_volume_properties(subnet_id, sap_sid, pool_id, ppg, memory, host_
         "usage_threshold": size,
         "throughput_mibps": log_throughput,
         "export_policy": create_default_export_policy_for_vg(),
-        "key_vault_private_endpoint_resource_id": kv_private_endpoint_id
+        "key_vault_private_endpoint_resource_id": kv_private_endpoint_id,
+        "zones": zones
     }
 
     return log_volume
@@ -1060,7 +1080,7 @@ def create_log_volume_properties(subnet_id, sap_sid, pool_id, ppg, memory, host_
 def create_shared_volume_properties(subnet_id, sap_sid, pool_id, ppg, memory, shared_size,
                                     shared_throughput, number_of_hosts, prefix, shared_repl_skd=None,
                                     shared_src_id=None, kv_private_endpoint_id=None, smb_access_based_enumeration=None,
-                                    smb_non_browsable=None):
+                                    smb_non_browsable=None, zones=None):
     name = prefix + sap_sid + "-" + VolumeType.SHARED.value
 
     if has_value(shared_size):
@@ -1091,7 +1111,8 @@ def create_shared_volume_properties(subnet_id, sap_sid, pool_id, ppg, memory, sh
         "data_protection": data_protection,
         "key_vault_private_endpoint_resource_id": kv_private_endpoint_id,
         "smb_access_based_enumeration": smb_access_based_enumeration,
-        "smb_non_browsable": smb_non_browsable
+        "smb_non_browsable": smb_non_browsable,
+        "zones": zones
     }
 
     return shared_volume
@@ -1101,7 +1122,7 @@ def create_data_backup_volume_properties(subnet_id, sap_sid, pool_id, ppg, memor
                                          data_backup_throughput, total_data_volume_size, total_log_volume_size,
                                          prefix, backup_nfsv3, data_backup_repl_skd, data_backup_src_id,
                                          kv_private_endpoint_id=None, smb_access_based_enumeration=None,
-                                         smb_non_browsable=None):
+                                         smb_non_browsable=None, zones=None):
     name = prefix + sap_sid + "-" + VolumeType.DATA_BACKUP.value
 
     logger.debug("ANF LOG: create_data_backup_volume_properties  => data_backup_size: %s * %s ", data_backup_size, gib_scale)
@@ -1134,7 +1155,8 @@ def create_data_backup_volume_properties(subnet_id, sap_sid, pool_id, ppg, memor
         "data_protection": data_protection,
         "key_vault_private_endpoint_resource_id": kv_private_endpoint_id,
         "smb_access_based_enumeration": smb_access_based_enumeration,
-        "smb_non_browsable": smb_non_browsable
+        "smb_non_browsable": smb_non_browsable,
+        "zones": zones
     }
 
     return data_backup_volume
@@ -1143,7 +1165,7 @@ def create_data_backup_volume_properties(subnet_id, sap_sid, pool_id, ppg, memor
 def create_log_backup_volume_properties(subnet_id, sap_sid, pool_id, ppg, memory, log_backup_size,
                                         log_backup_throughput, prefix, backup_nfsv3, log_backup_repl_skd,
                                         log_backup_src_id, kv_private_endpoint_id=None, smb_access_based_enumeration=None,
-                                        smb_non_browsable=None):
+                                        smb_non_browsable=None, zones=None):
     name = prefix + sap_sid + "-" + VolumeType.LOG_BACKUP.value
 
     if log_backup_size is None:
@@ -1174,7 +1196,8 @@ def create_log_backup_volume_properties(subnet_id, sap_sid, pool_id, ppg, memory
         "data_protection": data_protection,
         "key_vault_private_endpoint_resource_id": kv_private_endpoint_id,
         "smb_access_based_enumeration": smb_access_based_enumeration,
-        "smb_non_browsable": smb_non_browsable
+        "smb_non_browsable": smb_non_browsable,
+        "zones": zones
     }
 
     return log_backup


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az netappfiles

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Adds `zones` as a convenience argument to `az netappfiles create volume-group` as users had expressed difficulty passing `zones` in with complex paramter `volumes`

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[NetAppFiles] `az netappfiles volume-group create`: Add `zones` argument to set Availability Zone for volume group volumes
[NetAppFiles] `az netappfiles volume create`: Update maximum value for `--usage-threshold` to support large volumes
[NetAppFiles] `az netappfiles volume update`: Update maximum value for `--usage-threshold` to support large volumes

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
