### PR TITLE
{AppService} `az functionapp create`: Update hardcoded list of flex supported regions

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -5353,9 +5353,6 @@ def list_flexconsumption_locations(cmd):
             "name": "eastasia"
         },
         {
-            "name": "centralus"
-        },
-        {
             "name": "uksouth"
         },
         {

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands.py
@@ -724,7 +724,7 @@ class FunctionappDapr(LiveScenarioTest):
 class FunctionAppFlex(LiveScenarioTest):
     def test_functionapp_list_flexconsumption_locations(self):
         locations = self.cmd('functionapp list-flexconsumption-locations').get_output_in_json()
-        self.assertTrue(len(locations) == 13)
+        self.assertTrue(len(locations) == 12)
 
     def test_functionapp_list_flexconsumption_runtimes(self):
         runtimes = self.cmd('functionapp list-flexconsumption-runtimes').get_output_in_json()


### PR DESCRIPTION
**Related command**
`az functionapp create`
`az functionapp list-flexconsumption-locations`

**Description**<!--Mandatory-->
For Flex Public Preview, we will not be supporting centralus so we need to remove it from the list. 

**Testing Guide**
`az functionapp list-flexconsumption-locations` should not list centralus

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
