### PR TITLE
[AppService] `az webapp list`: Add parameter `--show-details` to include detailed site configuration of listed webapps in output

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -173,6 +173,9 @@ subscription than the app service environment, please use the resource ID for --
     with self.argument_context('webapp show') as c:
         c.argument('name', arg_type=webapp_name_arg_type)
 
+    with self.argument_context('webapp list') as c:
+        c.argument('show_details', action='store_true', help='Include detailed site configuration of listed web apps in output')
+
     with self.argument_context('webapp list-instances') as c:
         c.argument('name', arg_type=webapp_name_arg_type, id_part=None)
         c.argument('slot', options_list=['--slot', '-s'], help='Name of the web app slot. Default to the productions slot if not specified.')

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -1098,8 +1098,8 @@ def get_functionapp(cmd, resource_group_name, name, slot=None):
     return function_app
 
 
-def list_webapp(cmd, resource_group_name=None):
-    full_list = _list_app(cmd.cli_ctx, resource_group_name)
+def list_webapp(cmd, resource_group_name=None, show_details=False):
+    full_list = _list_app(cmd.cli_ctx, resource_group_name, show_details=show_details)
     # ignore apps with kind==null & not functions apps
     return list(filter(lambda x: x.kind is not None and "function" not in x.kind.lower(), full_list))
 
@@ -1180,7 +1180,7 @@ def show_app(cmd, resource_group_name, name, slot=None):
     return app
 
 
-def _list_app(cli_ctx, resource_group_name=None):
+def _list_app(cli_ctx, resource_group_name=None, show_details=False):
     client = web_client_factory(cli_ctx)
     if resource_group_name:
         result = list(client.web_apps.list_by_resource_group(resource_group_name))
@@ -1188,6 +1188,9 @@ def _list_app(cli_ctx, resource_group_name=None):
         result = list(client.web_apps.list())
     for webapp in result:
         _rename_server_farm_props(webapp)
+        if show_details:
+            webapp.site_config = _generic_site_operation(
+                cli_ctx, resource_group_name, webapp.name, 'get_configuration')
     return result
 
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_list_show_details.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_list_show_details.yaml
@@ -1,0 +1,861 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - appservice plan create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.59.0 azsdk-python-core/1.28.0 Python/3.9.13 (Windows-10-10.0.22631-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","test":"test_webapp_list_show_details","date":"2024-04-08T22:27:15Z","module":"appservice"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '375'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 08 Apr 2024 22:27:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-msedge-ref:
+      - 'Ref A: 66CAB83CCEAF4A6D9C3DA19731919D05 Ref B: CO6AA3150218029 Ref C: 2024-04-08T22:27:22Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "westeurope", "sku": {"name": "B1", "tier": "BASIC", "capacity":
+      1}, "properties": {"perSiteScaling": false, "isXenon": false, "zoneRedundant":
+      false}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - appservice plan create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '164'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.59.0 azsdk-python-core/1.28.0 Python/3.9.13 (Windows-10-10.0.22631-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/webapp-list-show-details-plan000003?api-version=2023-01-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/webapp-list-show-details-plan000003","name":"webapp-list-show-details-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"westeurope","properties":{"serverFarmId":23475,"name":"webapp-list-show-details-plan000003","sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1},"workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestEuropewebspace","subscription":"759b11c8-e99e-4abc-9b8b-6328e82da570","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":0,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        Europe","perSiteScaling":false,"elasticScaleEnabled":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-739_23475","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"kubeEnvironmentProfile":null,"zoneRedundant":false,"migrateToVMSS":null,"vnetConnectionsUsed":null,"vnetConnectionsMax":null,"createdTime":"2024-04-08T22:27:27.7166667"},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1662'
+      content-type:
+      - application/json
+      date:
+      - Mon, 08 Apr 2024 22:27:31 GMT
+      etag:
+      - '"1DA8A03F0B9E2E0"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+      x-msedge-ref:
+      - 'Ref A: 4BB89B425FC04E4B8411859FDEA148C9 Ref B: CO6AA3150220029 Ref C: 2024-04-08T22:27:23Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --plan --runtime
+      User-Agent:
+      - AZURECLI/2.59.0 azsdk-python-core/1.28.0 Python/3.9.13 (Windows-10-10.0.22631-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/webapp-list-show-details-plan000003?api-version=2023-01-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/webapp-list-show-details-plan000003","name":"webapp-list-show-details-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
+        Europe","properties":{"serverFarmId":23475,"name":"webapp-list-show-details-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestEuropewebspace","subscription":"759b11c8-e99e-4abc-9b8b-6328e82da570","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        Europe","perSiteScaling":false,"elasticScaleEnabled":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-739_23475","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"kubeEnvironmentProfile":null,"zoneRedundant":false,"migrateToVMSS":null,"vnetConnectionsUsed":0,"vnetConnectionsMax":2,"createdTime":"2024-04-08T22:27:27.7166667"},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1584'
+      content-type:
+      - application/json
+      date:
+      - Mon, 08 Apr 2024 22:27:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-msedge-ref:
+      - 'Ref A: F102FBA70CAA4FD9ACDAF1786125CF75 Ref B: CO6AA3150220023 Ref C: 2024-04-08T22:27:32Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "webapp-list-show-details000002", "type": "Site"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '58'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -n --plan --runtime
+      User-Agent:
+      - AZURECLI/2.59.0 azsdk-python-core/1.28.0 Python/3.9.13 (Windows-10-10.0.22631-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/checknameavailability?api-version=2023-01-01
+  response:
+    body:
+      string: '{"nameAvailable":true,"reason":"","message":""}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '47'
+      content-type:
+      - application/json
+      date:
+      - Mon, 08 Apr 2024 22:27:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-msedge-ref:
+      - 'Ref A: 673A5336717146C29D22C8840D2E6E16 Ref B: CO6AA3150217033 Ref C: 2024-04-08T22:27:33Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --plan --runtime
+      User-Agent:
+      - AZURECLI/2.59.0 azsdk-python-core/1.28.0 Python/3.9.13 (Windows-10-10.0.22631-SP0)
+    method: GET
+    uri: https://management.azure.com/providers/Microsoft.Web/webAppStacks?api-version=2023-01-01
+  response:
+    body:
+      string: '{"value":[{"id":null,"name":"dotnet","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":".NET","value":"dotnet","preferredOs":"windows","majorVersions":[{"displayText":".NET
+        8 (LTS)","value":"dotnet8","minorVersions":[{"displayText":".NET 8 (LTS)","value":"8","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v8.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.x"}},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|8.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.x"},"supportedFeatures":{"disableSsh":true}}}}]},{"displayText":".NET
+        7 (STS)","value":"dotnet7","minorVersions":[{"displayText":".NET 7 (STS)","value":"7","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v7.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.x"}},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|7.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.x"},"supportedFeatures":{"disableSsh":true}}}}]},{"displayText":".NET
+        6","value":"dotnet6","minorVersions":[{"displayText":".NET 6 (LTS)","value":"6","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v6.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"6.0.x"}},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|6.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"6.0.x"},"supportedFeatures":{"disableSsh":true}}}}]},{"displayText":".NET
+        5","value":"dotnet5","minorVersions":[{"displayText":".NET 5","value":"5","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v5.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"5.0.x"},"endOfLifeDate":"2022-05-08T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|5.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"5.0.x"},"endOfLifeDate":"2022-05-08T00:00:00Z"}}}]},{"displayText":".NET
+        Core 3","value":"dotnetcore3","minorVersions":[{"displayText":".NET Core 3.1
+        (LTS)","value":"3.1","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"3.1","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.1.301"},"isDeprecated":true,"endOfLifeDate":"2022-12-03T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|3.1","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.1.301"},"isDeprecated":true,"endOfLifeDate":"2022-12-03T00:00:00Z"}}},{"displayText":".NET
+        Core 3.0","value":"3.0","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"3.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.0.103"},"endOfLifeDate":"2020-03-03T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|3.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.0.103"},"endOfLifeDate":"2020-03-03T00:00:00Z"}}}]},{"displayText":".NET
+        Core 2","value":"dotnetcore2","minorVersions":[{"displayText":".NET Core 2.2","value":"2.2","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"2.2","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"2.2.207"},"endOfLifeDate":"2019-12-23T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|2.2","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"2.2.207"},"endOfLifeDate":"2019-12-23T00:00:00Z"}}},{"displayText":".NET
+        Core 2.1 (LTS)","value":"2.1","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"2.1","remoteDebuggingSupported":false,"isDeprecated":true,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"2.1.807"},"endOfLifeDate":"2021-07-21T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|2.1","remoteDebuggingSupported":false,"isDeprecated":true,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"2.1.807"},"endOfLifeDate":"2021-07-21T00:00:00Z"}}},{"displayText":".NET
+        Core 2.0","value":"2.0","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"2.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"2.1.202"},"endOfLifeDate":"2018-10-01T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|2.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"2.1.202"},"endOfLifeDate":"2018-10-01T00:00:00Z"}}}]},{"displayText":".NET
+        Core 1","value":"dotnetcore1","minorVersions":[{"displayText":".NET Core 1.1","value":"1.1","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.1","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"1.1.14"},"endOfLifeDate":"2019-06-27T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|1.1","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"1.1.14"},"endOfLifeDate":"2019-06-27T00:00:00Z"}}},{"displayText":".NET
+        Core 1.0","value":"1.0","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"1.1.14"},"endOfLifeDate":"2019-06-27T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|1.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"1.1.14"},"endOfLifeDate":"2019-06-27T00:00:00Z"}}}]},{"displayText":"ASP.NET
+        V4","value":"aspdotnetv4","minorVersions":[{"displayText":"ASP.NET V4.8","value":"v4.8","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v4.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.1"}}}}]},{"displayText":"ASP.NET
+        V3","value":"aspdotnetv3","minorVersions":[{"displayText":"ASP.NET V3.5","value":"v3.5","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v2.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"2.1"}}}}]}]}},{"id":null,"name":"node","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"Node","value":"node","preferredOs":"linux","majorVersions":[{"displayText":"Node
+        LTS","value":"lts","minorVersions":[{"displayText":"Node LTS","value":"lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|lts","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true}}}}]},{"displayText":"Node
+        20","value":"20","minorVersions":[{"displayText":"Node 20 LTS","value":"20-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|20-lts","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"20.x"},"supportedFeatures":{"disableSsh":true}},"windowsRuntimeSettings":{"runtimeVersion":"~20","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"20.x"}}}}]},{"displayText":"Node
+        18","value":"18","minorVersions":[{"displayText":"Node 18 LTS","value":"18-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|18-lts","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"18.x"},"supportedFeatures":{"disableSsh":true}},"windowsRuntimeSettings":{"runtimeVersion":"~18","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"18.x"}}}}]},{"displayText":"Node
+        16","value":"16","minorVersions":[{"displayText":"Node 16 LTS","value":"16-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|16-lts","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"16.x"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2023-09-11T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"~16","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"16.x"},"endOfLifeDate":"2023-09-11T00:00:00Z"}}}]},{"displayText":"Node
+        14","value":"14","minorVersions":[{"displayText":"Node 14 LTS","value":"14-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|14-lts","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"14.x"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2023-04-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"~14","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"14.x"},"endOfLifeDate":"2023-04-30T00:00:00Z"}}}]},{"displayText":"Node
+        12","value":"12","minorVersions":[{"displayText":"Node 12 LTS","value":"12-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|12-lts","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"12.x"},"endOfLifeDate":"2022-04-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"12.13.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2022-04-01T00:00:00Z"}}},{"displayText":"Node
+        12.9","value":"12.9","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|12.9","isDeprecated":true,"remoteDebuggingSupported":true,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"12.x"},"endOfLifeDate":"2022-04-01T00:00:00Z"}}}]},{"displayText":"Node
+        10","value":"10","minorVersions":[{"displayText":"Node 10 LTS","value":"10-LTS","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|10-lts","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"10.x"},"endOfLifeDate":"2021-04-01T00:00:00Z"}}},{"displayText":"Node
+        10.16","value":"10.16","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|10.16","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"10.x"},"endOfLifeDate":"2021-04-01T00:00:00Z"}}},{"displayText":"Node
+        10.15","value":"10.15","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"10.15.2","isDeprecated":true,"isPreview":true,"isHidden":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"10.x"},"endOfLifeDate":"2021-04-01T00:00:00Z"}}},{"displayText":"Node
+        10.14","value":"10.14","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|10.14","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"10.x"},"endOfLifeDate":"2021-04-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"10.14.1","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"10.x"},"endOfLifeDate":"2021-04-01T00:00:00Z"}}},{"displayText":"Node
+        10.12","value":"10.12","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|10.12","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"10.x"},"endOfLifeDate":"2021-04-01T00:00:00Z"}}},{"displayText":"Node
+        10.10","value":"10.10","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|10.10","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"10.x"},"endOfLifeDate":"2021-04-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"10.0.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"10.x"},"endOfLifeDate":"2021-04-01T00:00:00Z"}}},{"displayText":"Node
+        10.6","value":"10.6","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|10.6","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"10.x"},"endOfLifeDate":"2021-04-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"10.6.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2021-04-01T00:00:00Z"}}},{"displayText":"Node
+        10.1","value":"10.1","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|10.1","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"10.x"},"endOfLifeDate":"2021-04-01T00:00:00Z"}}}]},{"displayText":"Node
+        9","value":"9","minorVersions":[{"displayText":"Node 9.4","value":"9.4","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|9.4","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2019-06-30T00:00:00Z"}}}]},{"displayText":"Node
+        8","value":"8","minorVersions":[{"displayText":"Node 8 LTS","value":"8-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|8-lts","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2019-12-31T00:00:00Z"}}},{"displayText":"Node
+        8.12","value":"8.12","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|8.12","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2019-12-31T00:00:00Z"}}},{"displayText":"Node
+        8.11","value":"8.11","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|8.11","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2019-12-31T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"8.11","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2019-12-31T00:00:00Z"}}},{"displayText":"Node
+        8.10","value":"8.10","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"8.10","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2019-12-31T00:00:00Z"}}},{"displayText":"Node
+        8.9","value":"8.9","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|8.9","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2019-12-31T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"8.9","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2019-12-31T00:00:00Z"}}},{"displayText":"Node
+        8.8","value":"8.8","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|8.8","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2019-12-31T00:00:00Z"}}},{"displayText":"Node
+        8.5","value":"8.5","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"8.5","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2019-12-31T00:00:00Z"}}},{"displayText":"Node
+        8.4","value":"8.4","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"8.4","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2019-12-31T00:00:00Z"}}},{"displayText":"Node
+        8.2","value":"8.2","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|8.2","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2019-12-31T00:00:00Z"}}},{"displayText":"Node
+        8.1","value":"8.1","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|8.1","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2019-12-31T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"8.1.4","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2019-12-31T00:00:00Z"}}},{"displayText":"Node
+        8.0","value":"8.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|8.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2019-12-31T00:00:00Z"}}}]},{"displayText":"Node
+        7","value":"7","minorVersions":[{"displayText":"Node 7.10","value":"7.10","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"7.10.1","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2017-06-30T00:00:00Z"}}}]},{"displayText":"Node
+        6","value":"6","minorVersions":[{"displayText":"Node 6 LTS","value":"6-LTS","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|6-lts","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2019-04-30T00:00:00Z"}}},{"displayText":"Node
+        6.12","value":"6.12","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"6.12","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2019-04-30T00:00:00Z"}}},{"displayText":"Node
+        6.11","value":"6.11","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|6.11","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2019-04-30T00:00:00Z"}}},{"displayText":"Node
+        6.10","value":"6.10","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|6.10","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2019-04-30T00:00:00Z"}}},{"displayText":"Node
+        6.9","value":"6.9","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|6.9","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2019-04-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"6.9.5","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2019-04-30T00:00:00Z"}}},{"displayText":"Node
+        6.6","value":"6.6","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|6.6","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2019-04-30T00:00:00Z"}}},{"displayText":"Node
+        6.5","value":"6.5","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"6.5.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2019-04-30T00:00:00Z"}}},{"displayText":"Node
+        6.2","value":"6.2","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|6.2","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2019-04-30T00:00:00Z"}}}]},{"displayText":"Node
+        4","value":"4","minorVersions":[{"displayText":"Node 4.8","value":"4.8","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|4.8","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2018-04-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"4.8","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2018-04-30T00:00:00Z"}}},{"displayText":"Node
+        4.5","value":"4.5","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|4.5","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2018-04-30T00:00:00Z"}}},{"displayText":"Node
+        4.4","value":"4.4","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|4.4","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2018-04-30T00:00:00Z"}}}]}]}},{"id":null,"name":"python","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"Python","value":"python","preferredOs":"linux","majorVersions":[{"displayText":"Python
+        3","value":"3","minorVersions":[{"displayText":"Python 3.12","value":"3.12","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.12","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.12"},"supportedFeatures":{"disableSsh":true}}}},{"displayText":"Python
+        3.11","value":"3.11","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.11","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.11"},"supportedFeatures":{"disableSsh":true},"isHidden":false}}},{"displayText":"Python
+        3.10","value":"3.10","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.10","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.10"},"supportedFeatures":{"disableSsh":true},"isHidden":false,"isEarlyAccess":false}}},{"displayText":"Python
+        3.9","value":"3.9","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.9","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.9"},"supportedFeatures":{"disableSsh":true},"isHidden":false}}},{"displayText":"Python
+        3.8","value":"3.8","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.8","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.8"},"supportedFeatures":{"disableSsh":true}}}},{"displayText":"Python
+        3.7","value":"3.7","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.7","remoteDebuggingSupported":false,"isDeprecated":true,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.7"},"supportedFeatures":{"disableSsh":true}}}},{"displayText":"Python
+        3.6","value":"3.6","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.6","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.6"}},"windowsRuntimeSettings":{"runtimeVersion":"3.4.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.6"}}}}]},{"displayText":"Python
+        2","value":"2","minorVersions":[{"displayText":"Python 2.7","value":"2.7","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|2.7","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"2.7"},"endOfLifeDate":"2020-02-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"2.7.3","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"2.7"},"endOfLifeDate":"2020-02-01T00:00:00Z"}}}]}]}},{"id":null,"name":"php","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"PHP","value":"php","preferredOs":"linux","majorVersions":[{"displayText":"PHP
+        8","value":"8","minorVersions":[{"displayText":"PHP 8.2","value":"8.2","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|8.2","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.2"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2025-12-08T00:00:00Z"}}},{"displayText":"PHP
+        8.1","value":"8.1","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|8.1","isHidden":false,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.1"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2023-11-26T00:00:00Z"}}},{"displayText":"PHP
+        8.0","value":"8.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|8.0","isHidden":false,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.0"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2023-11-26T00:00:00Z"}}}]},{"displayText":"PHP
+        7","value":"7","minorVersions":[{"displayText":"PHP 7.4","value":"7.4","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"7.4","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.4","notSupportedInCreates":true},"isDeprecated":true,"endOfLifeDate":"2022-11-30T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"PHP|7.4","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.4","notSupportedInCreates":true},"isDeprecated":true,"endOfLifeDate":"2022-11-30T00:00:00Z"}}},{"displayText":"PHP
+        7.3","value":"7.3","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|7.3","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.3","notSupportedInCreates":true},"endOfLifeDate":"2021-12-06T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"7.3","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.3","notSupportedInCreates":true},"endOfLifeDate":"2021-12-06T00:00:00Z"}}},{"displayText":"PHP
+        7.2","value":"7.2","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|7.2","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2020-11-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"7.2","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2020-11-30T00:00:00Z"}}},{"displayText":"PHP
+        7.1","value":"7.1","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"7.1","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2020-02-01T00:00:00Z"}}},{"displayText":"7.0","value":"7.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|7.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2020-02-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"7.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2020-02-01T00:00:00Z"}}}]},{"displayText":"PHP
+        5","value":"5","minorVersions":[{"displayText":"PHP 5.6","value":"5.6","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|5.6","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2021-02-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"5.6","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2021-02-01T00:00:00Z"}}}]}]}},{"id":null,"name":"ruby","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"Ruby","value":"ruby","preferredOs":"linux","majorVersions":[{"displayText":"Ruby
+        2","value":"2","minorVersions":[{"displayText":"Ruby 2.7","value":"2.7","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.7","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2023-03-31T00:00:00Z"}}},{"displayText":"Ruby
+        2.7.3","value":"2.7.3","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.7.3","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"isHidden":true,"endOfLifeDate":"2023-03-31T00:00:00Z"}}},{"displayText":"Ruby
+        2.6","value":"2.6","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.6","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2022-03-31T00:00:00Z"}}},{"displayText":"Ruby
+        2.6.2","value":"2.6.2","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.6.2","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2022-03-31T00:00:00Z"}}},{"displayText":"Ruby
+        2.5","value":"2.5","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.5","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2021-03-31T00:00:00Z"}}},{"displayText":"Ruby
+        2.5.5","value":"2.5.5","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.5.5","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2021-03-31T00:00:00Z"}}},{"displayText":"Ruby
+        2.4","value":"2.4","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.4","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2020-04-01T00:00:00Z"}}},{"displayText":"Ruby
+        2.4.5","value":"2.4.5","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.4.5","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2020-04-01T00:00:00Z"}}},{"displayText":"Ruby
+        2.3","value":"2.3","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.3","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2019-03-31T00:00:00Z"}}},{"displayText":"Ruby
+        2.3.8","value":"2.3.8","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.3.8","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2019-03-31T00:00:00Z"}}},{"displayText":"Ruby
+        2.3.3","value":"2.3.3","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.3.3","remoteDebuggingSupported":false,"isDeprecated":true,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2019-03-31T00:00:00Z"}}}]}]}},{"id":null,"name":"java","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"Java","value":"java","preferredOs":"linux","majorVersions":[{"displayText":"Java
+        21","value":"21","minorVersions":[{"displayText":"Java 21","value":"21.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"21","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"}}},{"displayText":"Java
+        21.0.1","value":"21.0.1","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"21.0.1","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"}}}]},{"displayText":"Java
+        17","value":"17","minorVersions":[{"displayText":"Java 17","value":"17.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        17.0.9","value":"17.0.9","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.9","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        17.0.4","value":"17.0.4","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.4","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        17.0.3","value":"17.0.3","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.3","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        17.0.2","value":"17.0.2","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.2","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        17.0.1","value":"17.0.1","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.1","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}}]},{"displayText":"Java
+        11","value":"11","minorVersions":[{"displayText":"Java 11","value":"11.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.21","value":"11.0.21","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.21","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.16","value":"11.0.16","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.16","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.15","value":"11.0.15","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.15","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.14","value":"11.0.14","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.14","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.13","value":"11.0.13","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.13","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.12","value":"11.0.12","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.12","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.11","value":"11.0.11","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.11","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.9","value":"11.0.9","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.9","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.8","value":"11.0.8","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"11.0.8","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.7","value":"11.0.7","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.7","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.6","value":"11.0.6","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.6","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.5","value":"11.0.5","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.5_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.3","value":"11.0.3","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"11.0.3_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.2","value":"11.0.2","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"11.0.2_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}}]},{"displayText":"Java
+        8","value":"8","minorVersions":[{"displayText":"Java 8","value":"8.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"1.8","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_392","value":"8.0.392","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_392","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_345","value":"8.0.345","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_345","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_332","value":"8.0.332","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_332","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_322","value":"8.0.322","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_322","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_312","value":"8.0.312","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_312","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_302","value":"8.0.302","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_302","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_292","value":"8.0.292","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_292","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_282","value":"8.0.282","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_282","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_275","value":"8.0.275","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_265","value":"8.0.265","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_265","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_252","value":"8.0.252","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_252","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_242","value":"8.0.242","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_242","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_232","value":"8.0.232","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_232_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_212","value":"8.0.212","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_212_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_202","value":"8.0.202","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_202_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_202 (Oracle)","value":"8.0.202 (Oracle)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_202","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"}}}},{"displayText":"Java
+        1.8.0_181","value":"8.0.181","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_181_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_181 (Oracle)","value":"8.0.181 (Oracle)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_181","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"}}}},{"displayText":"Java
+        1.8.0_172","value":"8.0.172","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_172_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_172 (Oracle)","value":"8.0.172 (Oracle)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_172","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"}}}},{"displayText":"Java
+        1.8.0_144","value":"8.0.144","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_144","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_111 (Oracle)","value":"8.0.111 (Oracle)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_111","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"}}}},{"displayText":"Java
+        1.8.0_102","value":"8.0.102","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_102","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_92","value":"8.0.92","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_92","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_73 (Oracle)","value":"8.0.73 (Oracle)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_73","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"}}}},{"displayText":"Java
+        1.8.0_60 (Oracle)","value":"8.0.60 (Oracle)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_60","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"}}}},{"displayText":"Java
+        1.8.0_25 (Oracle)","value":"8.0.25 (Oracle)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_25","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"}}}}]},{"displayText":"Java
+        7","value":"7","minorVersions":[{"displayText":"Java 7","value":"7.0","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.7","isAutoUpdate":true,"isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2023-07-01T00:00:00Z"}}},{"displayText":"Java
+        1.7.0_292","value":"7.0.292","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.7.0_292","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2023-07-01T00:00:00Z"}}},{"displayText":"Java
+        1.7.0_272","value":"7.0.272","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.7.0_272","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2023-07-01T00:00:00Z"}}},{"displayText":"Java
+        1.7.0_262","value":"7.0.262","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.7.0_262","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2023-07-01T00:00:00Z"}}},{"displayText":"Java
+        1.7.0_242","value":"7.0.242","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.7.0_242_ZULU","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2023-07-01T00:00:00Z"}}},{"displayText":"Java
+        1.7.0_222","value":"7.0.222","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.7.0_222_ZULU","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2023-07-01T00:00:00Z"}}},{"displayText":"Java
+        1.7.0_191","value":"7.0.191","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.7.0_191_ZULU","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2023-07-01T00:00:00Z"}}},{"displayText":"Java
+        1.7.0_80 (Oracle)","value":"7.0.80 (Oracle)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.7.0_80","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false}}}},{"displayText":"Java
+        1.7.0_71 (Oracle)","value":"7.0.71 (Oracle)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.7.0_71","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false}}}},{"displayText":"Java
+        1.7.0_51 (Oracle)","value":"7.0.51 (Oracle)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.7.0_51","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false}}}}]}]}},{"id":null,"name":"javacontainers","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"Java
+        Containers","value":"javacontainers","majorVersions":[{"displayText":"Java
+        SE (Embedded Web Server)","value":"javase","minorVersions":[{"displayText":"Java
+        SE (Embedded Web Server)","value":"SE","stackSettings":{"windowsContainerSettings":{"javaContainer":"JAVA","javaContainerVersion":"SE","isAutoUpdate":true},"linuxContainerSettings":{"java21Runtime":"JAVA|21-java21","java17Runtime":"JAVA|17-java17","java11Runtime":"JAVA|11-java11","java8Runtime":"JAVA|8-jre8","isAutoUpdate":true}}},{"displayText":"Java
+        SE 21.0.1","value":"21.0.1","stackSettings":{"linuxContainerSettings":{"java21Runtime":"JAVA|21.0.1"}}},{"displayText":"Java
+        SE 17.0.9","value":"17.0.9","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.9"}}},{"displayText":"Java
+        SE 17.0.4","value":"17.0.4","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.4"}}},{"displayText":"Java
+        SE 17.0.3","value":"17.0.3","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.3"}}},{"displayText":"Java
+        SE 17.0.2","value":"17.0.2","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.2"}}},{"displayText":"Java
+        SE 17.0.1","value":"17.0.1","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.1"}}},{"displayText":"Java
+        SE 11.0.21","value":"11.0.21","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.21"}}},{"displayText":"Java
+        SE 11.0.16","value":"11.0.16","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.16"}}},{"displayText":"Java
+        SE 11.0.15","value":"11.0.15","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.15"}}},{"displayText":"Java
+        SE 11.0.14","value":"11.0.14","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.14"}}},{"displayText":"Java
+        SE 11.0.13","value":"11.0.13","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.13"}}},{"displayText":"Java
+        SE 11.0.12","value":"11.0.12","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.12"}}},{"displayText":"Java
+        SE 11.0.11","value":"11.0.11","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.11"}}},{"displayText":"Java
+        SE 11.0.9","value":"11.0.9","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.9"}}},{"displayText":"Java
+        SE 11.0.7","value":"11.0.7","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.7"}}},{"displayText":"Java
+        SE 11.0.6","value":"11.0.6","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.6"}}},{"displayText":"Java
+        SE 11.0.5","value":"11.0.5","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.5"}}},{"displayText":"Java
+        SE 8u392","value":"1.8.392","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u392"}}},{"displayText":"Java
+        SE 8u345","value":"1.8.345","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u345"}}},{"displayText":"Java
+        SE 8u332","value":"1.8.332","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u332"}}},{"displayText":"Java
+        SE 8u322","value":"1.8.322","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u322"}}},{"displayText":"Java
+        SE 8u312","value":"1.8.312","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u312"}}},{"displayText":"Java
+        SE 8u302","value":"1.8.302","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u302"}}},{"displayText":"Java
+        SE 8u292","value":"1.8.292","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u292"}}},{"displayText":"Java
+        SE 8u275","value":"1.8.275","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u275"}}},{"displayText":"Java
+        SE 8u252","value":"1.8.252","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u252"}}},{"displayText":"Java
+        SE 8u242","value":"1.8.242","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u242"}}},{"displayText":"Java
+        SE 8u232","value":"1.8.232","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u232"}}}]},{"displayText":"Red
+        Hat JBoss EAP 7","value":"jbosseap","minorVersions":[{"displayText":"Red Hat
+        JBoss EAP 7","value":"7","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7-java8","java11Runtime":"JBOSSEAP|7-java11","java17Runtime":"JBOSSEAP|7-java17","isAutoUpdate":true}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.13","value":"7.4.13","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.13-java8","java11Runtime":"JBOSSEAP|7.4.13-java11","java17Runtime":"JBOSSEAP|7.4.13-java17"}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.7","value":"7.4.7","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.7-java8","java11Runtime":"JBOSSEAP|7.4.7-java11","java17Runtime":"JBOSSEAP|7.4.7-java17"}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.5","value":"7.4.5","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.5-java8","java11Runtime":"JBOSSEAP|7.4.5-java11","java17Runtime":"JBOSSEAP|7.4.5-java17"}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.2","value":"7.4.2","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.2-java8","java11Runtime":"JBOSSEAP|7.4.2-java11"}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.1","value":"7.4.1","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.1-java8","java11Runtime":"JBOSSEAP|7.4.1-java11"}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.0","value":"7.4.0","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.0-java8","java11Runtime":"JBOSSEAP|7.4.0-java11"}}},{"displayText":"Red
+        Hat JBoss EAP 7.3.10","value":"7.3.10","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.3.10-java8","java11Runtime":"JBOSSEAP|7.3.10-java11"}}},{"displayText":"Red
+        Hat JBoss EAP 7.3.9","value":"7.3.9","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.3.9-java8","java11Runtime":"JBOSSEAP|7.3.9-java11"}}},{"displayText":"Red
+        Hat JBoss EAP 7.3","value":"7.3","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.3-java8","java11Runtime":"JBOSSEAP|7.3-java11","isAutoUpdate":true,"isHidden":true}}},{"displayText":"Red
+        Hat JBoss EAP 7.4","value":"7.4","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4-java8","java11Runtime":"JBOSSEAP|7.4-java11","isAutoUpdate":true,"isHidden":true}}},{"displayText":"JBoss
+        EAP 7.2","value":"7.2.0","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.2-java8","isDeprecated":true}}}]},{"displayText":"Apache
+        Tomcat 10.1","value":"tomcat10.1","minorVersions":[{"displayText":"Apache
+        Tomcat 10.1","value":"10.1","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1","isAutoUpdate":true},"linuxContainerSettings":{"java21Runtime":"TOMCAT|10.1-java21","java17Runtime":"TOMCAT|10.1-java17","java11Runtime":"TOMCAT|10.1-java11","isAutoUpdate":true}}},{"displayText":"Apache
+        Tomcat 10.1.16","value":"10.1.16","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.16"},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.16-java11","java17Runtime":"TOMCAT|10.1.16-java17","java21Runtime":"TOMCAT|10.1.16-java21"}}}]},{"displayText":"Apache
+        Tomcat 10.0","value":"tomcat10.0","minorVersions":[{"displayText":"Apache
+        Tomcat 10.0","value":"10.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0","isAutoUpdate":true,"endOfLifeDate":"2022-10-31T00:00:00Z"},"linuxContainerSettings":{"java17Runtime":"TOMCAT|10.0-java17","java11Runtime":"TOMCAT|10.0-java11","java8Runtime":"TOMCAT|10.0-jre8","isAutoUpdate":true,"endOfLifeDate":"2022-10-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 10.0.27","value":"10.0.27","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0.27"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|10.0.27-java8","java11Runtime":"TOMCAT|10.0.27-java11","java17Runtime":"TOMCAT|10.0.27-java17","endOfLifeDate":"2022-10-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 10.0.23","value":"10.0.23","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0.23","endOfLifeDate":"2022-10-31T00:00:00Z"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|10.0.23-java8","java11Runtime":"TOMCAT|10.0.23-java11","java17Runtime":"TOMCAT|10.0.23-java17","endOfLifeDate":"2022-10-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 10.0.21","value":"10.0.21","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0.21","endOfLifeDate":"2022-10-31T00:00:00Z"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|10.0.21-java8","java11Runtime":"TOMCAT|10.0.21-java11","java17Runtime":"TOMCAT|10.0.21-java17","endOfLifeDate":"2022-10-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 10.0.20","value":"10.0.20","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0.20","endOfLifeDate":"2022-10-31T00:00:00Z"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|10.0.20-java8","java11Runtime":"TOMCAT|10.0.20-java11","java17Runtime":"TOMCAT|10.0.20-java17","endOfLifeDate":"2022-10-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 10.0.12","value":"10.0.12","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0.12","endOfLifeDate":"2022-10-31T00:00:00Z"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|10.0.12-java8","java11Runtime":"TOMCAT|10.0.12-java11","java17Runtime":"TOMCAT|10.0.12-java17","endOfLifeDate":"2022-10-31T00:00:00Z"}}}]},{"displayText":"Apache
+        Tomcat 9.0","value":"tomcat9.0","minorVersions":[{"displayText":"Apache Tomcat
+        9.0","value":"9.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0","isAutoUpdate":true},"linuxContainerSettings":{"java17Runtime":"TOMCAT|9.0-java17","java11Runtime":"TOMCAT|9.0-java11","java8Runtime":"TOMCAT|9.0-jre8","isAutoUpdate":true}}},{"displayText":"Apache
+        Tomcat 9.0.83","value":"9.0.83","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.83"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.83-java8","java11Runtime":"TOMCAT|9.0.83-java11","java17Runtime":"TOMCAT|9.0.83-java17"}}},{"displayText":"Apache
+        Tomcat 9.0.65","value":"9.0.65","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.65"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.65-java8","java11Runtime":"TOMCAT|9.0.65-java11","java17Runtime":"TOMCAT|9.0.65-java17"}}},{"displayText":"Apache
+        Tomcat 9.0.63","value":"9.0.63","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.63"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.63-java8","java11Runtime":"TOMCAT|9.0.63-java11","java17Runtime":"TOMCAT|9.0.63-java17"}}},{"displayText":"Apache
+        Tomcat 9.0.62","value":"9.0.62","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.62"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.62-java8","java11Runtime":"TOMCAT|9.0.62-java11","java17Runtime":"TOMCAT|9.0.62-java17"}}},{"displayText":"Apache
+        Tomcat 9.0.54","value":"9.0.54","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.54"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.54-java8","java11Runtime":"TOMCAT|9.0.54-java11","java17Runtime":"TOMCAT|9.0.54-java17"}}},{"displayText":"Apache
+        Tomcat 9.0.52","value":"9.0.52","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.52"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.52-java8","java11Runtime":"TOMCAT|9.0.52-java11"}}},{"displayText":"Apache
+        Tomcat 9.0.46","value":"9.0.46","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.46"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.46-java8","java11Runtime":"TOMCAT|9.0.46-java11"}}},{"displayText":"Apache
+        Tomcat 9.0.41","value":"9.0.41","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.41-java8","java11Runtime":"TOMCAT|9.0.41-java11"}}},{"displayText":"Apache
+        Tomcat 9.0.38","value":"9.0.38","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.38"}}},{"displayText":"Apache
+        Tomcat 9.0.37","value":"9.0.37","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.37"},"linuxContainerSettings":{"java11Runtime":"TOMCAT|9.0.37-java11","java8Runtime":"TOMCAT|9.0.37-java8"}}},{"displayText":"Apache
+        Tomcat 9.0.33","value":"9.0.33","stackSettings":{"linuxContainerSettings":{"java11Runtime":"TOMCAT|9.0.33-java11","java8Runtime":"TOMCAT|9.0.33-java8"}}},{"displayText":"Apache
+        Tomcat 9.0.31","value":"9.0.31","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.31"}}},{"displayText":"Apache
+        Tomcat 9.0.27","value":"9.0.27","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.27"}}},{"displayText":"Apache
+        Tomcat 9.0.21","value":"9.0.21","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.21"}}},{"displayText":"Apache
+        Tomcat 9.0.20","value":"9.0.20","stackSettings":{"linuxContainerSettings":{"java11Runtime":"TOMCAT|9.0.20-java11","java8Runtime":"TOMCAT|9.0.20-java8"}}},{"displayText":"Apache
+        Tomcat 9.0.14","value":"9.0.14","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.14"}}},{"displayText":"Apache
+        Tomcat 9.0.12","value":"9.0.12","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.12"}}},{"displayText":"Apache
+        Tomcat 9.0.8","value":"9.0.8","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.8"}}},{"displayText":"Apache
+        Tomcat 9.0.0","value":"9.0.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.0"}}}]},{"displayText":"Apache
+        Tomcat 8.5","value":"tomcat8.5","minorVersions":[{"displayText":"Apache Tomcat
+        8.5","value":"8.5","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5","isAutoUpdate":true,"endOfLifeDate":"2024-03-31T00:00:00Z"},"linuxContainerSettings":{"java11Runtime":"TOMCAT|8.5-java11","java8Runtime":"TOMCAT|8.5-jre8","isAutoUpdate":true,"endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.96","value":"8.5.96","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.96-java8","java11Runtime":"TOMCAT|8.5.96-java11","endOfLifeDate":"2024-03-31T00:00:00Z"},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.96","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.82","value":"8.5.82","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.82-java8","java11Runtime":"TOMCAT|8.5.82-java11","endOfLifeDate":"2024-03-31T00:00:00Z"},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.82","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.79","value":"8.5.79","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.79-java8","java11Runtime":"TOMCAT|8.5.79-java11","endOfLifeDate":"2024-03-31T00:00:00Z"},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.79","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.78","value":"8.5.78","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.78-java8","java11Runtime":"TOMCAT|8.5.78-java11","endOfLifeDate":"2024-03-31T00:00:00Z"},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.78","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.72","value":"8.5.72","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.72-java8","java11Runtime":"TOMCAT|8.5.72-java11","endOfLifeDate":"2024-03-31T00:00:00Z"},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.72","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.69","value":"8.5.69","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.69-java8","java11Runtime":"TOMCAT|8.5.69-java11","endOfLifeDate":"2024-03-31T00:00:00Z"},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.69","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.66","value":"8.5.66","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.66-java8","java11Runtime":"TOMCAT|8.5.66-java11","endOfLifeDate":"2024-03-31T00:00:00Z"},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.66","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.61","value":"8.5.61","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.61-java8","java11Runtime":"TOMCAT|8.5.61-java11","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.58","value":"8.5.58","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.58","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.57","value":"8.5.57","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.57","endOfLifeDate":"2024-03-31T00:00:00Z"},"linuxContainerSettings":{"java11Runtime":"TOMCAT|8.5.57-java11","java8Runtime":"TOMCAT|8.5.57-java8","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.53","value":"8.5.53","stackSettings":{"linuxContainerSettings":{"java11Runtime":"TOMCAT|8.5.53-java11","java8Runtime":"TOMCAT|8.5.53-java8","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.51","value":"8.5.51","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.51","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.47","value":"8.5.47","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.47","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.42","value":"8.5.42","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.42","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.41","value":"8.5.41","stackSettings":{"linuxContainerSettings":{"java11Runtime":"TOMCAT|8.5.41-java11","java8Runtime":"TOMCAT|8.5.41-java8","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.37","value":"8.5.37","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.37","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.34","value":"8.5.34","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.34","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.31","value":"8.5.31","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.31","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.20","value":"8.5.20","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.20","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.6","value":"8.5.6","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.6","endOfLifeDate":"2024-03-31T00:00:00Z"}}}]},{"displayText":"Apache
+        Tomcat 8.0","value":"tomcat8.0","minorVersions":[{"displayText":"Apache Tomcat
+        8.0","value":"8.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.0","isAutoUpdate":true,"isDeprecated":true}}},{"displayText":"Apache
+        Tomcat 8.0.53","value":"8.0.53","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.0.53","isDeprecated":true}}},{"displayText":"Apache
+        Tomcat 8.0.46","value":"8.0.46","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.0.46","isDeprecated":true}}},{"displayText":"Apache
+        Tomcat 8.0.23","value":"8.0.23","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.0.23","isDeprecated":true}}}]},{"displayText":"Apache
+        Tomcat 7.0","value":"tomcat7.0","minorVersions":[{"displayText":"Apache Tomcat
+        7.0","value":"7.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0","isAutoUpdate":true,"isDeprecated":true}}},{"displayText":"Apache
+        Tomcat 7.0.94","value":"7.0.94","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0.94","isDeprecated":true}}},{"displayText":"Apache
+        Tomcat 7.0.81","value":"7.0.81","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0.81","isDeprecated":true}}},{"displayText":"Apache
+        Tomcat 7.0.62","value":"7.0.62","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0.62","isDeprecated":true}}},{"displayText":"Apache
+        Tomcat 7.0.50","value":"7.0.50","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0.50","isDeprecated":true}}}]},{"displayText":"Jetty
+        9.3","value":"jetty9.3","minorVersions":[{"displayText":"Jetty 9.3","value":"9.3","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.3","isAutoUpdate":true,"isDeprecated":true}}},{"displayText":"Jetty
+        9.3.25","value":"9.3.25","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.3.25","isDeprecated":true}}},{"displayText":"Jetty
+        9.3.13","value":"9.3.13","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.3.13","isDeprecated":true}}}]},{"displayText":"Jetty
+        9.1","value":"jetty9.1","minorVersions":[{"displayText":"Jetty 9.1","value":"9.1","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.1","isAutoUpdate":true,"isDeprecated":true}}},{"displayText":"Jetty
+        9.1.0","value":"9.1.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.1.0","isDeprecated":true}}}]},{"displayText":"WildFly
+        14","value":"wildfly14","minorVersions":[{"displayText":"WildFly 14","value":"14","stackSettings":{"linuxContainerSettings":{"java8Runtime":"WILDFLY|14-jre8","isDeprecated":true,"isAutoUpdate":true}}},{"displayText":"WildFly
+        14.0.1","value":"14.0.1","stackSettings":{"linuxContainerSettings":{"isDeprecated":true,"java8Runtime":"WILDFLY|14.0.1-java8"}}}]}]}},{"id":null,"name":"staticsite","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"HTML
+        (Static Content)","value":"staticsite","preferredOs":"linux","majorVersions":[{"displayText":"HTML
+        (Static Content)","value":"1","minorVersions":[{"displayText":"HTML (Static
+        Content)","value":"1.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"STATICSITE|1.0","isHidden":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false}}}}]}]}},{"id":null,"name":"go","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"Go","value":"go","preferredOs":"linux","majorVersions":[{"displayText":"Go
+        1","value":"go1","minorVersions":[{"displayText":"Go 1.19 (Experimental)","value":"go1.19","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"GO|1.19","remoteDebuggingSupported":false,"isDeprecated":true,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true},"supportedFeatures":{"disableSsh":true},"isHidden":false,"isEarlyAccess":false}}},{"displayText":"Go
+        1.18 (Experimental)","value":"go1.18","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"GO|1.18","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"supportedFeatures":{"disableSsh":true},"isHidden":false,"isEarlyAccess":false,"isDeprecated":true}}}]}]}}],"nextLink":null,"id":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '86930'
+      content-type:
+      - application/json
+      date:
+      - Mon, 08 Apr 2024 22:27:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-msedge-ref:
+      - 'Ref A: 7F66BBF83AA3457AB42E96503564DAD1 Ref B: CO6AA3150219009 Ref C: 2024-04-08T22:27:33Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "West Europe", "properties": {"serverFarmId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/webapp-list-show-details-plan000003",
+      "reserved": false, "isXenon": false, "hyperV": false, "siteConfig": {"netFrameworkVersion":
+      "v4.6", "appSettings": [], "javaVersion": "17", "javaContainer": "TOMCAT", "javaContainerVersion":
+      "10.0", "localMySqlEnabled": false, "http20Enabled": true}, "scmSiteAlsoStopped":
+      false, "httpsOnly": false}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '518'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -n --plan --runtime
+      User-Agent:
+      - AZURECLI/2.59.0 azsdk-python-core/1.28.0 Python/3.9.13 (Windows-10-10.0.22631-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/webapp-list-show-details000002?api-version=2023-01-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/webapp-list-show-details000002","name":"webapp-list-show-details000002","type":"Microsoft.Web/sites","kind":"app","location":"West
+        Europe","properties":{"name":"webapp-list-show-details000002","state":"Running","hostNames":["webapp-list-show-details000002.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-739.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/webapp-list-show-details000002","repositorySiteName":"webapp-list-show-details000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"afdEnabled":false,"enabledHostNames":["webapp-list-show-details000002.azurewebsites.net","webapp-list-show-details000002.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-list-show-details000002.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-list-show-details000002.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/webapp-list-show-details-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2024-04-08T22:27:37.3166667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"vnetRouteAllEnabled":false,"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"vnetImagePullEnabled":false,"vnetContentShareEnabled":false,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"","windowsFxVersion":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"elasticWebAppScaleLimit":0,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null},"functionAppConfig":null,"daprConfig":null,"deploymentId":"webapp-list-show-details000002","slotName":null,"trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"ipMode":"IPv4","vnetBackupRestoreEnabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"39FA4F04E017AC10557B8101317AE43119F2B44E31320238F03EBDEF13EAC17E","kind":"app","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"20.105.224.45","possibleInboundIpAddresses":"20.105.224.45","ftpUsername":"webapp-list-show-details000002\\$webapp-list-show-details000002","ftpsHostName":"ftps://waws-prod-am2-739.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"20.8.21.115,20.8.21.131,20.8.21.134,20.8.21.151,20.8.21.194,20.8.21.198,4.175.245.8,4.175.245.194,4.175.246.44,4.175.246.46,20.103.107.42,20.86.240.202,20.8.16.156,20.8.16.255,20.8.17.123,20.8.18.61,20.8.19.226,20.8.19.227,20.105.224.45","possibleOutboundIpAddresses":"20.8.21.115,20.8.21.131,20.8.21.134,20.8.21.151,20.8.21.194,20.8.21.198,4.175.245.8,4.175.245.194,4.175.246.44,4.175.246.46,20.103.107.42,20.86.240.202,20.8.16.156,20.8.16.255,20.8.17.123,20.8.18.61,20.8.19.226,20.8.19.227,20.8.22.31,20.8.22.52,20.8.22.117,20.8.22.167,20.8.23.44,20.103.105.119,20.8.23.96,20.8.23.211,4.175.240.23,4.175.240.41,4.175.240.55,4.175.240.175,4.175.241.30,4.175.241.47,4.175.241.87,4.175.241.185,4.175.242.90,4.175.243.52,4.175.245.8,4.175.245.194,4.175.246.44,4.175.246.46,20.103.107.42,20.86.240.202,20.8.16.156,20.8.16.255,20.8.17.123,20.8.18.61,20.8.19.226,20.8.19.227,20.8.20.18,20.8.20.74,20.8.20.75,20.8.20.127,20.8.20.131,20.8.20.200,20.105.224.45","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-739","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"webapp-list-show-details000002.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"publicNetworkAccess":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs","inFlightFeatures":null,"storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"defaultHostNameScope":"Global","privateLinkIdentifiers":null,"sshEnabled":null}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '7846'
+      content-type:
+      - application/json
+      date:
+      - Mon, 08 Apr 2024 22:27:59 GMT
+      etag:
+      - '"1DA8A03F66EA935"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-msedge-ref:
+      - 'Ref A: 80501C5DA835442FB8D087E76FDE2681 Ref B: CO6AA3150220023 Ref C: 2024-04-08T22:27:34Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n --plan --runtime
+      User-Agent:
+      - AZURECLI/2.59.0 azsdk-python-core/1.28.0 Python/3.9.13 (Windows-10-10.0.22631-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/webapp-list-show-details000002/config/metadata/list?api-version=2023-01-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/webapp-list-show-details000002/config/metadata","name":"metadata","type":"Microsoft.Web/sites/config","location":"West
+        Europe","properties":{}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '264'
+      content-type:
+      - application/json
+      date:
+      - Mon, 08 Apr 2024 22:27:59 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-msedge-ref:
+      - 'Ref A: B3FFD7A0E5B448209408B18872FAA888 Ref B: CO6AA3150217053 Ref C: 2024-04-08T22:27:59Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"CURRENT_STACK": "java"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '41'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -n --plan --runtime
+      User-Agent:
+      - AZURECLI/2.59.0 azsdk-python-core/1.28.0 Python/3.9.13 (Windows-10-10.0.22631-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/webapp-list-show-details000002/config/metadata?api-version=2023-01-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/webapp-list-show-details000002/config/metadata","name":"metadata","type":"Microsoft.Web/sites/config","location":"West
+        Europe","properties":{"CURRENT_STACK":"java"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '286'
+      content-type:
+      - application/json
+      date:
+      - Mon, 08 Apr 2024 22:28:01 GMT
+      etag:
+      - '"1DA8A0403D5586B"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1198'
+      x-msedge-ref:
+      - 'Ref A: B3461EC1BECE4C2AA454EF41AAD61F54 Ref B: CO6AA3150217053 Ref C: 2024-04-08T22:28:00Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"format": "WebDeploy"}'
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -n --plan --runtime
+      User-Agent:
+      - AZURECLI/2.59.0 azsdk-python-core/1.28.0 Python/3.9.13 (Windows-10-10.0.22631-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/webapp-list-show-details000002/publishxml?api-version=2023-01-01
+  response:
+    body:
+      string: <publishData><publishProfile profileName="webapp-list-show-details000002
+        - Web Deploy" publishMethod="MSDeploy" publishUrl="webapp-list-show-details000002.scm.azurewebsites.net:443"
+        msdeploySite="webapp-list-show-details000002" userName="$webapp-list-show-details000002"
+        userPWD="JNomi6wjuYNBx3BnraMuvjhnwzhLoF6i4NQnDLdvmWwQzfWEnhxkytakeSPH" destinationAppUrl="http://webapp-list-show-details000002.azurewebsites.net"
+        SQLServerDBConnectionString="" mySQLDBConnectionString="" hostingProviderForumLink=""
+        controlPanelLink="https://portal.azure.com" webSystem="WebSites"><databases
+        /></publishProfile><publishProfile profileName="webapp-list-show-details000002
+        - FTP" publishMethod="FTP" publishUrl="ftps://waws-prod-am2-739.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="webapp-list-show-details000002\$webapp-list-show-details000002"
+        userPWD="JNomi6wjuYNBx3BnraMuvjhnwzhLoF6i4NQnDLdvmWwQzfWEnhxkytakeSPH" destinationAppUrl="http://webapp-list-show-details000002.azurewebsites.net"
+        SQLServerDBConnectionString="" mySQLDBConnectionString="" hostingProviderForumLink=""
+        controlPanelLink="https://portal.azure.com" webSystem="WebSites"><databases
+        /></publishProfile><publishProfile profileName="webapp-list-show-details000002
+        - Zip Deploy" publishMethod="ZipDeploy" publishUrl="webapp-list-show-details000002.scm.azurewebsites.net:443"
+        userName="$webapp-list-show-details000002" userPWD="JNomi6wjuYNBx3BnraMuvjhnwzhLoF6i4NQnDLdvmWwQzfWEnhxkytakeSPH"
+        destinationAppUrl="http://webapp-list-show-details000002.azurewebsites.net"
+        SQLServerDBConnectionString="" mySQLDBConnectionString="" hostingProviderForumLink=""
+        controlPanelLink="https://portal.azure.com" webSystem="WebSites"><databases
+        /></publishProfile></publishData>
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1746'
+      content-type:
+      - application/xml
+      date:
+      - Mon, 08 Apr 2024 22:28:01 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-msedge-ref:
+      - 'Ref A: 64BB13F965C14A1F89139E29B67F395A Ref B: CO6AA3150218027 Ref C: 2024-04-08T22:28:01Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --show-details
+      User-Agent:
+      - AZURECLI/2.59.0 azsdk-python-core/1.28.0 Python/3.9.13 (Windows-10-10.0.22631-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites?api-version=2023-01-01
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/webapp-list-show-details000002","name":"webapp-list-show-details000002","type":"Microsoft.Web/sites","kind":"app","location":"West
+        Europe","properties":{"name":"webapp-list-show-details000002","state":"Running","hostNames":["webapp-list-show-details000002.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-739.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/webapp-list-show-details000002","repositorySiteName":"webapp-list-show-details000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"afdEnabled":false,"enabledHostNames":["webapp-list-show-details000002.azurewebsites.net","webapp-list-show-details000002.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-list-show-details000002.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-list-show-details000002.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/webapp-list-show-details-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2024-04-08T22:28:00.9666667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"vnetRouteAllEnabled":false,"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"vnetImagePullEnabled":false,"vnetContentShareEnabled":false,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"","windowsFxVersion":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":true,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":null,"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":true,"minTlsVersion":null,"minTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":0,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null},"functionAppConfig":null,"daprConfig":null,"deploymentId":"webapp-list-show-details000002","slotName":null,"trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"ipMode":"IPv4","vnetBackupRestoreEnabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"39FA4F04E017AC10557B8101317AE43119F2B44E31320238F03EBDEF13EAC17E","kind":"app","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"20.105.224.45","possibleInboundIpAddresses":"20.105.224.45","ftpUsername":"webapp-list-show-details000002\\$webapp-list-show-details000002","ftpsHostName":"ftps://waws-prod-am2-739.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"20.8.21.115,20.8.21.131,20.8.21.134,20.8.21.151,20.8.21.194,20.8.21.198,4.175.245.8,4.175.245.194,4.175.246.44,4.175.246.46,20.103.107.42,20.86.240.202,20.8.16.156,20.8.16.255,20.8.17.123,20.8.18.61,20.8.19.226,20.8.19.227,20.105.224.45","possibleOutboundIpAddresses":"20.8.21.115,20.8.21.131,20.8.21.134,20.8.21.151,20.8.21.194,20.8.21.198,4.175.245.8,4.175.245.194,4.175.246.44,4.175.246.46,20.103.107.42,20.86.240.202,20.8.16.156,20.8.16.255,20.8.17.123,20.8.18.61,20.8.19.226,20.8.19.227,20.8.22.31,20.8.22.52,20.8.22.117,20.8.22.167,20.8.23.44,20.103.105.119,20.8.23.96,20.8.23.211,4.175.240.23,4.175.240.41,4.175.240.55,4.175.240.175,4.175.241.30,4.175.241.47,4.175.241.87,4.175.241.185,4.175.242.90,4.175.243.52,4.175.245.8,4.175.245.194,4.175.246.44,4.175.246.46,20.103.107.42,20.86.240.202,20.8.16.156,20.8.16.255,20.8.17.123,20.8.18.61,20.8.19.226,20.8.19.227,20.8.20.18,20.8.20.74,20.8.20.75,20.8.20.127,20.8.20.131,20.8.20.200,20.105.224.45","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-739","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"webapp-list-show-details000002.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"publicNetworkAccess":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs","inFlightFeatures":null,"storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"defaultHostNameScope":"Global","privateLinkIdentifiers":null,"sshEnabled":null}}],"nextLink":null,"id":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '7666'
+      content-type:
+      - application/json
+      date:
+      - Mon, 08 Apr 2024 22:28:02 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-msedge-ref:
+      - 'Ref A: 427A45AD1A8D4BADB75EEA14777640BA Ref B: CO6AA3150218029 Ref C: 2024-04-08T22:28:02Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --show-details
+      User-Agent:
+      - AZURECLI/2.59.0 azsdk-python-core/1.28.0 Python/3.9.13 (Windows-10-10.0.22631-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/webapp-list-show-details000002/config/web?api-version=2023-01-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/webapp-list-show-details000002/config/web","name":"webapp-list-show-details000002","type":"Microsoft.Web/sites/config","location":"West
+        Europe","properties":{"numberOfWorkers":1,"defaultDocuments":["Default.htm","Default.html","Default.asp","index.htm","index.html","iisstart.htm","default.aspx","index.php","hostingstart.html"],"netFrameworkVersion":"v4.0","phpVersion":"5.6","pythonVersion":"","nodeVersion":"","powerShellVersion":"","linuxFxVersion":"","windowsFxVersion":null,"windowsConfiguredStacks":[],"requestTracingEnabled":false,"remoteDebuggingEnabled":false,"remoteDebuggingVersion":null,"httpLoggingEnabled":false,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":35,"detailedErrorLoggingEnabled":false,"publishingUsername":"$webapp-list-show-details000002","publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":"None","use32BitWorkerProcess":true,"webSocketsEnabled":false,"alwaysOn":true,"javaVersion":"17","javaContainer":"TOMCAT","javaContainerVersion":"10.0","appCommandLine":"","managedPipelineMode":"Integrated","virtualApplications":[{"virtualPath":"/","physicalPath":"site\\wwwroot","preloadEnabled":true,"virtualDirectories":null}],"winAuthAdminState":0,"winAuthTenantState":0,"customAppPoolIdentityAdminState":false,"customAppPoolIdentityTenantState":false,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":"LeastRequests","routingRules":[],"experiments":{"rampUpRules":[]},"limits":null,"autoHealEnabled":false,"autoHealRules":null,"tracingOptions":null,"vnetName":"","vnetRouteAllEnabled":false,"vnetPrivatePortsCount":0,"publicNetworkAccess":null,"siteAuthEnabled":false,"siteAuthSettings":{"enabled":null,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"clientSecretSettingName":null,"clientSecretCertificateThumbprint":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"aadClaimsAuthorization":null,"googleClientId":null,"googleClientSecret":null,"googleClientSecretSettingName":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookAppSecretSettingName":null,"facebookOAuthScopes":null,"gitHubClientId":null,"gitHubClientSecret":null,"gitHubClientSecretSettingName":null,"gitHubOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"twitterConsumerSecretSettingName":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountClientSecretSettingName":null,"microsoftAccountOAuthScopes":null,"configVersion":null},"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":false,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":false,"http20Enabled":true,"minTlsVersion":"1.2","minTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmMinTlsVersion":"1.2","ftpsState":"FtpsOnly","preWarmedInstanceCount":0,"functionAppScaleLimit":null,"elasticWebAppScaleLimit":0,"healthCheckPath":null,"fileChangeAuditEnabled":false,"functionsRuntimeScaleMonitoringEnabled":false,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":{},"http20ProxyFlag":0,"sitePort":null,"antivirusScanEnabled":false,"storageType":"StorageVolume","sitePrivateLinkHostEnabled":false}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '4070'
+      content-type:
+      - application/json
+      date:
+      - Mon, 08 Apr 2024 22:28:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-msedge-ref:
+      - 'Ref A: 8365E86779614395ABAD17F5A440566D Ref B: CO6AA3150219027 Ref C: 2024-04-08T22:28:03Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
@@ -2990,6 +2990,25 @@ class WebappSlotTest(ScenarioTest):
             JMESPathCheck(f"siteConfig.azureStorageAccounts.{store_id}.type", store_type),
         ])
 
+class WebappStackTest(ScenarioTest):
+    @AllowLargeResponse(8192)
+    @ResourceGroupPreparer(location=WINDOWS_ASP_LOCATION_WEBAPP)
+    def test_webapp_list_show_details(self, resource_group):
+        webapp_name = self.create_random_name(prefix='webapp-list-show-details', length=40)
+        webapp_plan = self.create_random_name(prefix='webapp-list-show-details-plan', length=40)
+
+        self.cmd('appservice plan create -g {} -n {}'.format(resource_group, webapp_plan))
+        self.cmd('webapp create -g {} -n {} --plan {} --runtime {}'.format(resource_group, webapp_name, webapp_plan, 'java:17:TOMCAT:10.0'),
+            checks=[
+                JMESPathCheck('name', webapp_name),
+        ])
+        self.cmd('webapp list -g {} --show-details'.format(resource_group), checks=[
+            JMESPathCheck('length([])', 1),
+            JMESPathCheck('[0].name', webapp_name),
+            JMESPathCheck('[0].siteConfig.javaVersion', '17'),
+            JMESPathCheck('[0].siteConfig.javaContainer', 'TOMCAT'),
+            JMESPathCheck('[0].siteConfig.javaContainerVersion', '10.0'),
+        ])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Related command**
`az webapp list`

**Description**<!--Mandatory-->
Add new parameter `--show-details` for `az webapp list` to show detailed site configuration in output. For example, after adding this parameter java webapp user can directly query their java related configurations, like java version, java container and java container version when running `az webapp list`

**Testing Guide**
Ran changed command locally and added test for this change

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
