### PR TITLE
{AKS} Set another VM size for automatic cluster to use

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_consts.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_consts.py
@@ -43,6 +43,7 @@ CONST_AVAILABILITY_SET = "AvailabilitySet"
 
 # vm size
 CONST_DEFAULT_NODE_VM_SIZE = "Standard_DS2_v2"
+CONST_DEFAULT_AUTOMATIC_SKU_NODE_VM_SIZE = "Standard_DS4_v2"
 CONST_DEFAULT_WINDOWS_NODE_VM_SIZE = "Standard_D2s_v3"
 
 # gpu instance

--- a/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
@@ -14,6 +14,7 @@ from azure.cli.command_modules.acs._consts import (
     CONST_DEFAULT_NODE_OS_TYPE,
     CONST_DEFAULT_NODE_VM_SIZE,
     CONST_DEFAULT_WINDOWS_NODE_VM_SIZE,
+    CONST_DEFAULT_AUTOMATIC_SKU_NODE_VM_SIZE,
     CONST_NODEPOOL_MODE_SYSTEM,
     CONST_NODEPOOL_MODE_USER,
     CONST_SCALE_DOWN_MODE_DELETE,
@@ -467,6 +468,10 @@ class AKSAgentPoolContext(BaseAKSContext):
                 node_vm_size = CONST_DEFAULT_WINDOWS_NODE_VM_SIZE
             else:
                 node_vm_size = CONST_DEFAULT_NODE_VM_SIZE
+                sku = self.raw_param.get("sku")
+                # if --node-vm-size is not specified, but --sku automatic is explicitly specified
+                if sku is not None and sku == "automatic":
+                    node_vm_size = CONST_DEFAULT_AUTOMATIC_SKU_NODE_VM_SIZE
 
         # this parameter does not need validation
         return node_vm_size

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_agentpool_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_agentpool_decorator.py
@@ -421,7 +421,7 @@ class AKSAgentPoolContextCommonTestCase(unittest.TestCase):
         # if --node-vm-size is not specified, but --sku automatic is explicitly specified
         ctx_5 = AKSAgentPoolContext(
             self.cmd,
-            AKSAgentPoolParamDict({"sku": "automatic", "os_type": "LINUX"}),
+            AKSAgentPoolParamDict({"sku": "automatic", "os_type": "Linux"}),
             self.models,
             DecoratorMode.CREATE,
             self.agentpool_decorator_mode,

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_agentpool_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_agentpool_decorator.py
@@ -12,6 +12,7 @@ from azure.cli.command_modules.acs._consts import (
     CONST_DEFAULT_NODE_OS_TYPE,
     CONST_DEFAULT_NODE_VM_SIZE,
     CONST_DEFAULT_WINDOWS_NODE_VM_SIZE,
+    CONST_DEFAULT_AUTOMATIC_SKU_NODE_VM_SIZE,
     CONST_NODEPOOL_MODE_SYSTEM,
     CONST_NODEPOOL_MODE_USER,
     CONST_SCALE_DOWN_MODE_DEALLOCATE,
@@ -416,6 +417,16 @@ class AKSAgentPoolContextCommonTestCase(unittest.TestCase):
                 ctx_4.get_node_vm_size()
         else:
             self.assertEqual(ctx_4.get_node_vm_size(), CONST_DEFAULT_WINDOWS_NODE_VM_SIZE)
+        
+        # if --node-vm-size is not specified, but --sku automatic is explicitly specified
+        ctx_5 = AKSAgentPoolContext(
+            self.cmd,
+            AKSAgentPoolParamDict({"sku": "automatic", "os_type": "LINUX"}),
+            self.models,
+            DecoratorMode.CREATE,
+            self.agentpool_decorator_mode,
+        )
+        self.assertEqual(ctx_5.get_node_vm_size(), CONST_DEFAULT_AUTOMATIC_SKU_NODE_VM_SIZE)
 
     def common_get_os_type(self):
         # default


### PR DESCRIPTION
**Related command**
az aks create --sku automatic

**Description**<!--Mandatory-->
When we create an automatic cluster, we need to use node-vm-size to standard_ds4_v2 by default if customer doesn't provide --node-vm-size. Since the automatic cluster enabled the ephemeral OS disk by default, it will throw errors: (Message: The virtual machine size Standard_DS2_v2 has a cache size of 92341796864 bytes and temporary disk size of 15032385536 bytes, but the OS disk requires 137438953472 bytes. Use a VM size with larger cache, larger temp disk, or disable ephemeral OS.)


**Testing Guide**
pytest src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_agentpool_decorator.py

**History Notes**

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
