### PR TITLE
[ARM] Deprecate command arguments for `az bicep format` and `az bicep publish`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_help.py
@@ -2836,9 +2836,9 @@ examples:
   - name: Publish a bicep file overwriting an existing tag.
     text: az bicep publish --file {bicep_file} --target "br:{registry}/{module_path}:{tag} --force"
   - name: Publish a bicep file with documentation uri.
-    text: az bicep publish --file {bicep_file} --target "br:{registry}/{module_path}:{tag}" --documentationUri {documentationUri}
+    text: az bicep publish --file {bicep_file} --target "br:{registry}/{module_path}:{tag}" --documentation-uri {documentation_uri}
   - name: Publish a bicep file with documentation uri and include source code
-    text: az bicep publish --file {bicep_file} --target "br:{registry}/{module_path}:{tag}" --documentationUri {documentationUri} --with-source
+    text: az bicep publish --file {bicep_file} --target "br:{registry}/{module_path}:{tag}" --documentation-uri {documentation_uri} --with-source
 """
 
 helps['bicep restore'] = """

--- a/src/azure-cli/azure/cli/command_modules/resource/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_params.py
@@ -827,7 +827,7 @@ def load_arguments(self, _):
         c.argument('file', arg_type=bicep_file_type, help="The path to the Bicep module file to publish in the file system.")
         c.argument('target', arg_type=CLIArgumentType(options_list=['--target', '-t'], help="The target location where the Bicep module will be published."))
         c.argument('documentationUri', arg_type=CLIArgumentType(options_list=['--documentationUri'], help="The documentation uri of the Bicep module."), deprecate_info=c.deprecate(target='--documentationUri', redirect='--documentation-uri'))
-        c.argument('documentation-uri', arg_type=CLIArgumentType(options_list=['--documentation-uri', '-d'], help="The documentation uri of the Bicep module."))
+        c.argument('documentation_uri', arg_type=CLIArgumentType(options_list=['--documentation-uri', '-d'], help="The documentation uri of the Bicep module."))
         c.argument('with_source', options_list=['--with-source'], action='store_true', help="Publish source code with the module.", is_preview=True)
         c.argument('force', arg_type=bicep_force_type, help="Allow overwriting an existing Bicep module version.")
 

--- a/src/azure-cli/azure/cli/command_modules/resource/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_params.py
@@ -118,10 +118,11 @@ def load_arguments(self, _):
     bicep_outdir_type = CLIArgumentType(options_list=['--outdir'], completer=DirectoriesCompleter(), help="When set, saves the output at the specified directory.")
     bicep_outfile_type = CLIArgumentType(options_list=['--outfile'], completer=FilesCompleter(), help="When set, saves the output as the specified file path.")
     bicep_stdout_type = CLIArgumentType(options_list=['--stdout'], action='store_true', help="When set, prints all output to stdout instead of corresponding files.")
-    bicep_indentkind_type = CLIArgumentType(options_list=['--indent-kind'], help="Set indentation kind. Valid values are ( Space | Tab ).")
-    bicep_indentsize_type = CLIArgumentType(options_list=['--indent-size'], help="Number of spaces to indent with (Only valid with --indent-kind set to Space).")
-    bicep_insertfinalnewline_type = CLIArgumentType(options_list=['--insert-final-newline'], action='store_true', help="Insert a final newline.")
+    bicep_indent_kind_type = CLIArgumentType(options_list=['--indent-kind'], arg_type=get_enum_type(["Space", "Tab"]), help="Set indentation kind.")
+    bicep_indent_size_type = CLIArgumentType(options_list=['--indent-size'], help="Number of spaces to indent with (Only valid with --indent-kind set to Space).")
+    bicep_insert_final_newline_type = CLIArgumentType(options_list=['--insert-final-newline'], action='store_true', help="Insert a final newline.")
     bicep_newline_type = CLIArgumentType(options_list=['--newline'], help="Set newline char. Valid values are ( Auto | LF | CRLF | CR ).")
+    bicep_newline_kind_type = CLIArgumentType(options_list=['--newline-kind'], arg_type=get_enum_type(["LF", "CRLF", "CR"]), help="Set line ending characters.")
     bicep_target_platform_type = CLIArgumentType(options_list=['--target-platform', '-t'],
                                                  arg_type=get_enum_type(
                                                      ["win-x64", "linux-musl-x64", "linux-x64", "osx-x64", "linux-arm64", "osx-arm64"]),
@@ -800,10 +801,11 @@ def load_arguments(self, _):
         c.argument('outdir', arg_type=bicep_outdir_type)
         c.argument('outfile', arg_type=bicep_outfile_type)
         c.argument('stdout', arg_type=bicep_stdout_type)
-        c.argument('indent_kind', arg_type=bicep_indentkind_type)
-        c.argument('indent_size', arg_type=bicep_indentsize_type)
-        c.argument('insert_final_newline', arg_type=bicep_insertfinalnewline_type)
-        c.argument('newline', arg_type=bicep_newline_type)
+        c.argument('indent_kind', arg_type=bicep_indent_kind_type)
+        c.argument('indent_size', arg_type=bicep_indent_size_type)
+        c.argument('insert_final_newline', arg_type=bicep_insert_final_newline_type)
+        c.argument('newline', arg_type=bicep_newline_type, deprecate_info=c.deprecate(target='--newline', redirect='--newline-kind'))
+        c.argument('newline_kind', arg_type=bicep_newline_kind_type)
 
     with self.argument_context('bicep decompile') as c:
         c.argument('file', arg_type=bicep_file_type, help="The path to the ARM template to decompile in the file system.")
@@ -823,10 +825,9 @@ def load_arguments(self, _):
 
     with self.argument_context('bicep publish') as c:
         c.argument('file', arg_type=bicep_file_type, help="The path to the Bicep module file to publish in the file system.")
-        c.argument('target', arg_type=CLIArgumentType(options_list=['--target', '-t'],
-                                                      help="The target location where the Bicep module will be published."))
-        c.argument('documentationUri', arg_type=CLIArgumentType(options_list=['--documentationUri', '-d'],
-                                                                help="The documentation uri of the Bicep module."))
+        c.argument('target', arg_type=CLIArgumentType(options_list=['--target', '-t'], help="The target location where the Bicep module will be published."))
+        c.argument('documentationUri', arg_type=CLIArgumentType(options_list=['--documentationUri'], help="The documentation uri of the Bicep module."), deprecate_info=c.deprecate(target='--documentationUri', redirect='--documentation-uri'))
+        c.argument('documentation-uri', arg_type=CLIArgumentType(options_list=['--documentation-uri', '-d'], help="The documentation uri of the Bicep module."))
         c.argument('with_source', options_list=['--with-source'], action='store_true', help="Publish source code with the module.", is_preview=True)
         c.argument('force', arg_type=bicep_force_type, help="Allow overwriting an existing Bicep module version.")
 

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -4458,26 +4458,35 @@ def build_bicepparam_file(cmd, file, stdout=None, outdir=None, outfile=None, no_
         print(output)
 
 
-def format_bicep_file(cmd, file, stdout=None, outdir=None, outfile=None, newline=None, indent_kind=None, indent_size=None, insert_final_newline=None):
+def format_bicep_file(cmd, file, stdout=None, outdir=None, outfile=None, newline=None, newline_kind=None, indent_kind=None, indent_size=None, insert_final_newline=None):
     ensure_bicep_installation(cmd.cli_ctx, stdout=False)
 
     minimum_supported_version = "0.12.1"
+    kebab_case_params_supported_version = "0.26.54"
+
     if bicep_version_greater_than_or_equal_to(minimum_supported_version):
         args = ["format", file]
+        use_kebab_case_params = bicep_version_greater_than_or_equal_to(kebab_case_params_supported_version)
+        newline_kind = newline_kind or newline
+
+        # Auto is no longer supported by Bicep formatter v2. Use LF as default.
+        if use_kebab_case_params and newline_kind == "Auto":
+            newline_kind = "LF"
+
         if outdir:
             args += ["--outdir", outdir]
         if outfile:
             args += ["--outfile", outfile]
         if stdout:
             args += ["--stdout"]
-        if newline:
-            args += ["--newline", newline]
+        if newline_kind:
+            args += ["--newline-kind" if use_kebab_case_params else "newline", newline_kind]
         if indent_kind:
-            args += ["--indentKind", indent_kind]
+            args += ["--indent-kind" if use_kebab_case_params else "indentKind", indent_kind]
         if indent_size:
-            args += ["--indentSize", indent_size]
+            args += ["--indent-size" if use_kebab_case_params else "indentSize", indent_size]
         if insert_final_newline:
-            args += ["--insertFinalNewline"]
+            args += ["--insert-final-newline" if use_kebab_case_params else "--insertFinalNewline"]
 
         output = run_bicep_command(cmd.cli_ctx, args)
 
@@ -4487,16 +4496,21 @@ def format_bicep_file(cmd, file, stdout=None, outdir=None, outfile=None, newline
         logger.error("az bicep format could not be executed with the current version of Bicep CLI. Please upgrade Bicep CLI to v%s or later.", minimum_supported_version)
 
 
-def publish_bicep_file(cmd, file, target, documentationUri=None, with_source=None, force=None):
+def publish_bicep_file(cmd, file, target, documentationUri=None, documentation_uri=None, with_source=None, force=None):
     ensure_bicep_installation(cmd.cli_ctx)
 
     minimum_supported_version = "0.4.1008"
+    kebab_case_param_supported_version = "0.26.54"
+
     if bicep_version_greater_than_or_equal_to(minimum_supported_version):
         args = ["publish", file, "--target", target]
-        if documentationUri:
+        use_kebab_case_params = bicep_version_greater_than_or_equal_to(kebab_case_param_supported_version)
+        documentation_uri = documentation_uri or documentationUri
+
+        if documentation_uri:
             minimum_supported_version_for_documentationUri_parameter = "0.14.46"
             if bicep_version_greater_than_or_equal_to(minimum_supported_version_for_documentationUri_parameter):
-                args += ["--documentationUri", documentationUri]
+                args += ["--documentation-uri" if use_kebab_case_params else "--documentationUri", documentation_uri]
             else:
                 logger.error("az bicep publish with --documentationUri/-d parameter could not be executed with the current version of Bicep CLI. Please upgrade Bicep CLI to v%s or later.", minimum_supported_version_for_documentationUri_parameter)
         if with_source:
@@ -4511,6 +4525,7 @@ def publish_bicep_file(cmd, file, target, documentationUri=None, with_source=Non
                 args += ["--force"]
             else:
                 logger.error("az bicep publish with --force parameter could not be executed with the current version of Bicep CLI. Please upgrade Bicep CLI to v%s or later.", minimum_supported_version_for_publish_force)
+
         run_bicep_command(cmd.cli_ctx, args)
     else:
         logger.error("az bicep publish could not be executed with the current version of Bicep CLI. Please upgrade Bicep CLI to v%s or later.", minimum_supported_version)

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_custom.py
@@ -672,7 +672,11 @@ class TestFormatBicepFile(unittest.TestCase):
         format_bicep_file(cmd, file_path, stdout=stdout)
 
         # Assert.
-        mock_bicep_version_greater_than_or_equal_to.assert_called_once_with("0.12.1")
+        mock_bicep_version_greater_than_or_equal_to.assert_has_calls([
+            mock.call("0.12.1"),
+            mock.call("0.26.54"),
+        ])
+        mock_bicep_version_greater_than_or_equal_to.assert_called_once_with("")
         mock_run_bicep_command.assert_called_once_with(cmd.cli_ctx, ["format", file_path, "--stdout"])
 
 class TestPublishWithSource(unittest.TestCase):
@@ -705,6 +709,7 @@ class TestPublishWithSource(unittest.TestCase):
         # Assert.
         mock_bicep_version_greater_than_or_equal_to.assert_has_calls([
             mock.call("0.4.1008"), # Min version for 'bicep publish'
+            mock.call('0.26.54'),
             mock.call("0.23.1") # Min version for 'bicep publish --with-source'
         ])
         mock_run_bicep_command.assert_called_once_with(cmd.cli_ctx, ['publish', file_path, '--target', 'br:contoso.azurecr.io/bicep/mymodule:v1', '--with-source'])

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_custom.py
@@ -676,7 +676,6 @@ class TestFormatBicepFile(unittest.TestCase):
             mock.call("0.12.1"),
             mock.call("0.26.54"),
         ])
-        mock_bicep_version_greater_than_or_equal_to.assert_called_once_with("")
         mock_run_bicep_command.assert_called_once_with(cmd.cli_ctx, ["format", file_path, "--stdout"])
 
 class TestPublishWithSource(unittest.TestCase):


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
- `az bicep format`
- `az bicep publish`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Some of the Bicep CLI and `az bicep format | publish` command arguments use camel case, which violates the convention to use kebab case. The PR deprecates the camel case arguments.

**Testing Guide**
<!--Example commands with explanations.-->
- `az bicep format -f main.bicep --newline LF`
- `az bicep publish -f main.bicep --documentationUri {documentationUri}`

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[ARM] `az bicep format`: Replace `--newline` with `--newline-kind`
[ARM] `az bicep publish`: Replace `--documentationUri` with `--documentation-uri`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
