### PR TITLE
{Storage} `az storage blob show`: Use try catch for `GetPageRange` after `GetBlobProperties` in `blob show`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/operations/blob.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/blob.py
@@ -752,13 +752,16 @@ def show_blob(cmd, client, container_name, blob_name, snapshot=None, lease_id=No
         if_modified_since=if_modified_since, if_unmodified_since=if_unmodified_since, if_match=if_match,
         if_none_match=if_none_match, timeout=timeout)
 
-    page_ranges = None
-    if blob.properties.blob_type == cmd.get_models('blob.models#_BlobTypes').PageBlob:
-        page_ranges = client.get_page_ranges(
-            container_name, blob_name, snapshot=snapshot, lease_id=lease_id, if_modified_since=if_modified_since,
-            if_unmodified_since=if_unmodified_since, if_match=if_match, if_none_match=if_none_match, timeout=timeout)
+    try:
+        page_ranges = None
+        if blob.properties.blob_type == cmd.get_models('blob.models#_BlobTypes').PageBlob:
+            page_ranges = client.get_page_ranges(
+                container_name, blob_name, snapshot=snapshot, lease_id=lease_id, if_modified_since=if_modified_since,
+                if_unmodified_since=if_unmodified_since, if_match=if_match, if_none_match=if_none_match, timeout=timeout)
 
-    blob.properties.page_ranges = page_ranges
+        blob.properties.page_ranges = page_ranges
+    except HttpResponseError as ex:
+        logger.warning(f"GetPageRanges failed with status code:{ex.status_code}, message: {ex.message}")
 
     return blob
 
@@ -943,11 +946,14 @@ def _copy_file_to_blob_container(blob_service, source_file_service, destination_
 def show_blob_v2(cmd, client, **kwargs):
     blob = client.get_blob_properties(**kwargs)
 
-    page_ranges = None
-    if blob.blob_type == cmd.get_models('_models#BlobType', resource_type=ResourceType.DATA_STORAGE_BLOB).PageBlob:
-        page_ranges = client.get_page_ranges(**kwargs)
+    try:
+        page_ranges = None
+        if blob.blob_type == cmd.get_models('_models#BlobType', resource_type=ResourceType.DATA_STORAGE_BLOB).PageBlob:
+            page_ranges = client.get_page_ranges(**kwargs)
 
-    blob.page_ranges = page_ranges
+        blob.page_ranges = page_ranges
+    except HttpResponseError as ex:
+        logger.warning(f"GetPageRanges failed with status code:{ex.status_code}, message: {ex.message}")
 
     return blob
 

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/blob.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/blob.py
@@ -757,11 +757,12 @@ def show_blob(cmd, client, container_name, blob_name, snapshot=None, lease_id=No
         if blob.properties.blob_type == cmd.get_models('blob.models#_BlobTypes').PageBlob:
             page_ranges = client.get_page_ranges(
                 container_name, blob_name, snapshot=snapshot, lease_id=lease_id, if_modified_since=if_modified_since,
-                if_unmodified_since=if_unmodified_since, if_match=if_match, if_none_match=if_none_match, timeout=timeout)
+                if_unmodified_since=if_unmodified_since, if_match=if_match, if_none_match=if_none_match,
+                timeout=timeout)
 
         blob.properties.page_ranges = page_ranges
     except HttpResponseError as ex:
-        logger.warning(f"GetPageRanges failed with status code:{ex.status_code}, message: {ex.message}")
+        logger.warning("GetPageRanges failed with status code: %d, message: %s", ex.status_code, ex.message)
 
     return blob
 
@@ -953,7 +954,7 @@ def show_blob_v2(cmd, client, **kwargs):
 
         blob.page_ranges = page_ranges
     except HttpResponseError as ex:
-        logger.warning(f"GetPageRanges failed with status code:{ex.status_code}, message: {ex.message}")
+        logger.warning("GetPageRanges failed with status code: %d, message: %s", ex.status_code, ex.message)
 
     return blob
 

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/blob_azure_stack.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/blob_azure_stack.py
@@ -494,11 +494,12 @@ def show_blob(cmd, client, container_name, blob_name, snapshot=None, lease_id=No
         if blob.properties.blob_type == cmd.get_models('blob.models#_BlobTypes').PageBlob:
             page_ranges = client.get_page_ranges(
                 container_name, blob_name, snapshot=snapshot, lease_id=lease_id, if_modified_since=if_modified_since,
-                if_unmodified_since=if_unmodified_since, if_match=if_match, if_none_match=if_none_match, timeout=timeout)
+                if_unmodified_since=if_unmodified_since, if_match=if_match, if_none_match=if_none_match,
+                timeout=timeout)
 
         blob.properties.page_ranges = page_ranges
     except HttpResponseError as ex:
-        logger.warning(f"GetPageRanges failed with status code:{ex.status_code}, message: {ex.message}")
+        logger.warning("GetPageRanges failed with status code: %d, message: %s", ex.status_code, ex.message)
 
     return blob
 
@@ -664,7 +665,7 @@ def show_blob_v2(cmd, client, container_name, blob_name, snapshot=None, lease_id
 
         blob.page_ranges = page_ranges
     except HttpResponseError as ex:
-        logger.warning(f"GetPageRanges failed with status code:{ex.status_code}, message: {ex.message}")
+        logger.warning("GetPageRanges failed with status code: %d, message: %s", ex.status_code, ex.message)
 
     return blob
 


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az storage blob show` when `az storage blob copy start` is in progress with a page blob

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
`GetPageRange` call would give 409 error code when there is an in-progress copy with a large page blob across regions. (as same region could finish instantly)
`az storage blob show` should still return with result from `GetBlobProperties`. 
Simply give waring if `GetPageRange` fails
https://learn.microsoft.com/rest/api/storageservices/get-page-ranges?tabs=microsoft-entra-id#remarks
Fix #28727 

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
