### PR TITLE
{Mysql} Removed preview tag from Advanced Threat Protection for Azure MySQL

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/mysql/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/mysql/commands.py
@@ -90,8 +90,7 @@ def load_command_table(self, _):
     with self.command_group('mysql flexible-server advanced-threat-protection-setting',
                             mysql_advanced_threat_protection_sdk,
                             custom_command_type=mysql_custom,
-                            client_factory=cf_mysql_advanced_threat_protection,
-                            is_preview=True) as g:
+                            client_factory=cf_mysql_advanced_threat_protection) as g:
         g.custom_command('update', 'flexible_server_advanced_threat_protection_update')
         g.custom_show_command('show', 'flexible_server_advanced_threat_protection_show')
 


### PR DESCRIPTION
**Related command**
az mysql flexible-server advanced-threat-protection-setting

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Advanced Threat Protection for Azure MySQL is GA, removed the CLI preview tag.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
