### PR TITLE
{Core} Bump `msal-extensions` to 1.2.0b1

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -52,7 +52,7 @@ DEPENDENCIES = [
     'humanfriendly~=10.0',
     'jmespath',
     'knack~=0.11.0',
-    'msal-extensions~=1.0.0',
+    'msal-extensions==1.2.0b1',
     'msal[broker]==1.28.0',
     'msrestazure~=0.6.4',
     'packaging>=20.9',

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -105,7 +105,7 @@ jmespath==0.9.5
 jsondiff==2.0.0
 knack==0.11.0
 MarkupSafe==2.0.1
-msal-extensions==1.0.0
+msal-extensions==1.2.0b1
 msal[broker]==1.28.0
 msrest==0.7.1
 msrestazure==0.6.4

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -106,7 +106,7 @@ jmespath==0.9.5
 jsondiff==2.0.0
 knack==0.11.0
 MarkupSafe==2.0.1
-msal-extensions==1.0.0
+msal-extensions==1.2.0b1
 msal[broker]==1.28.0
 msrest==0.7.1
 msrestazure==0.6.4

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -105,7 +105,7 @@ jmespath==0.9.5
 jsondiff==2.0.0
 knack==0.11.0
 MarkupSafe==2.0.1
-msal-extensions==1.0.0
+msal-extensions==1.2.0b1
 msal[broker]==1.28.0
 msrest==0.7.1
 msrestazure==0.6.4


### PR DESCRIPTION
Fix https://github.com/Azure/azure-cli/issues/28737

**Related command**
`az login`
`az account get-access-token`

**Description**<!--Mandatory-->
Bump `msal-extensions` to 1.2.0b1 in order to adopt https://github.com/AzureAD/microsoft-authentication-extensions-for-python/pull/128.

**Testing Guide**
```
$ az login --service-principal
$ az account get-access-token
...
  "expiresOn": "2024-04-15 19:57:04.000000",
  "expires_on": 1713182224,
...
$ az account get-access-token
...
  "expiresOn": "2024-04-15 19:57:04.000000",
  "expires_on": 1713182224,
...
```

Notice executing `az account get-access-token` twice will return the same `expiresOn` and `expires_on`.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Core] Fix #28737: Azure CLI tasks can now run longer than 5 minutes utilizing the token cache