### PR TITLE
{Core} Remove duplicate credential warning

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -821,7 +821,7 @@ class AzCliCommandInvoker(CommandInvoker):
         if not cmd.cli_ctx.config.getboolean('clients', 'show_secrets_warning', False):
             return
 
-        from constants import CREDENTIAL_WARNING_EXCLUSIVE_COMMANDS
+        from .constants import CREDENTIAL_WARNING_EXCLUSIVE_COMMANDS
         if cmd.name in CREDENTIAL_WARNING_EXCLUSIVE_COMMANDS:
             return
 

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -821,6 +821,10 @@ class AzCliCommandInvoker(CommandInvoker):
         if not cmd.cli_ctx.config.getboolean('clients', 'show_secrets_warning', False):
             return
 
+        from constants import CREDENTIAL_WARNING_EXCLUSIVE_COMMANDS
+        if cmd.name in CREDENTIAL_WARNING_EXCLUSIVE_COMMANDS:
+            return
+
         from ..credential_helper import sensitive_data_detailed_warning_message, sensitive_data_warning_message
         sensitive_info = cmd.sensitive_info if hasattr(cmd, 'sensitive_info') else None
         if sensitive_info:

--- a/src/azure-cli-core/azure/cli/core/commands/constants.py
+++ b/src/azure-cli-core/azure/cli/core/commands/constants.py
@@ -30,3 +30,5 @@ CONFIRM_PARAM_NAME = 'yes'
 DEFAULT_QUERY_TIME_RANGE = 3600000
 
 BLOCKED_MODS = ['context', 'shell', 'documentdb', 'component']
+
+CREDENTIAL_WARNING_EXCLUSIVE_COMMANDS = ['ad sp create-for-rbac']

--- a/src/azure-cli-core/azure/cli/core/commands/constants.py
+++ b/src/azure-cli-core/azure/cli/core/commands/constants.py
@@ -31,4 +31,4 @@ DEFAULT_QUERY_TIME_RANGE = 3600000
 
 BLOCKED_MODS = ['context', 'shell', 'documentdb', 'component']
 
-CREDENTIAL_WARNING_EXCLUSIVE_COMMANDS = ['ad sp create-for-rbac']
+CREDENTIAL_WARNING_EXCLUSIVE_COMMANDS = ['ad sp create-for-rbac', 'ad app credential reset', 'ad sp credential reset']


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az ad sp create-for-rbac`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
After adding global credential warning in cli core (#27929), `az ad sp create-for rbac` will show duplicate warning messages. It's better to keep the command specific warning and suppress generic warning.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
