### PR TITLE
[ACR] az acr login: Change warning to info

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/custom.py
@@ -272,7 +272,7 @@ def acr_login(cmd,
             username=username,
             password=password)
 
-        logger.warning("You can perform manual login using the provided access token below, "
+        logger.info("You can perform manual login using the provided access token below, "
                        "for example: 'docker login loginServer -u %s -p accessToken'", EMPTY_GUID)
 
         token_info = {


### PR DESCRIPTION
**Related command**
az acr login

**Description**<!--Mandatory-->
Default message level is WARNING, however this is not really a warning. It should be info level.
WARNING: You can perform manual login using the provided access token below, for example: 'docker login loginServer -u 00000000-0000-0000-0000-000000000000 -p accessToken'

**Testing Guide**
az acr login --name $myACRName  --expose-token

**History Notes**
[az acr login] `az acr login`: Change warning level to info

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
