### PR TITLE
{Core} Remove deprecated usages of distutils to support Python 3.12

### DIFF
--- a/src/azure-cli-core/azure/cli/core/extension/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/extension/__init__.py
@@ -8,7 +8,7 @@ import os
 import traceback
 import json
 import re
-from distutils.sysconfig import get_python_lib  # pylint: disable=deprecated-module
+from sysconfig import get_path
 
 import pkginfo
 from knack.config import CLIConfig
@@ -22,7 +22,7 @@ _CUSTOM_EXT_SYS_DIR = az_config.get('extension', 'sys_dir', None)
 EXTENSIONS_DIR = os.path.expanduser(_CUSTOM_EXT_DIR) if _CUSTOM_EXT_DIR else os.path.join(GLOBAL_CONFIG_DIR,
                                                                                           'cliextensions')
 DEV_EXTENSION_SOURCES = _DEV_EXTENSION_SOURCES.split(',') if _DEV_EXTENSION_SOURCES else []
-EXTENSIONS_SYS_DIR = os.path.expanduser(_CUSTOM_EXT_SYS_DIR) if _CUSTOM_EXT_SYS_DIR else os.path.join(get_python_lib(), 'azure-cli-extensions')
+EXTENSIONS_SYS_DIR = os.path.expanduser(_CUSTOM_EXT_SYS_DIR) if _CUSTOM_EXT_SYS_DIR else os.path.join(get_path("purelib"), 'azure-cli-extensions')
 
 EXTENSIONS_MOD_PREFIX = 'azext_'
 

--- a/src/azure-cli/azure/cli/command_modules/acs/_loadbalancer.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_loadbalancer.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from distutils.version import StrictVersion  # pylint: disable=deprecated-module
+from packaging.version import Version
 from types import SimpleNamespace
 from knack.log import get_logger
 
@@ -13,7 +13,7 @@ logger = get_logger(__name__)
 def set_load_balancer_sku(sku, kubernetes_version):
     if sku:
         return sku
-    if kubernetes_version and StrictVersion(kubernetes_version) < StrictVersion("1.13.0"):
+    if kubernetes_version and Version(kubernetes_version) < Version("1.13.0"):
         logger.warning('Setting load_balancer_sku to basic as it is not specified and kubernetes'
                        'version(%s) less than 1.13.0 only supports basic load balancer SKU\n',
                        kubernetes_version)

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -25,7 +25,7 @@ import time
 import uuid
 import webbrowser
 import zipfile
-from distutils.version import StrictVersion  # pylint: disable=deprecated-module
+from packaging.version import Version
 from urllib.error import URLError
 from urllib.request import urlopen
 from azure.cli.command_modules.acs.maintenanceconfiguration import aks_maintenanceconfiguration_update_internal
@@ -159,7 +159,7 @@ def _aks_browse(
 
     return_msg = None
     # open portal view if addon is not enabled or k8s version >= 1.19.0
-    if StrictVersion(instance.kubernetes_version) >= StrictVersion('1.19.0') or (not addon_profile.enabled):
+    if Version(instance.kubernetes_version) >= Version('1.19.0') or (not addon_profile.enabled):
         subscription_id = get_subscription_id(cmd.cli_ctx)
         dashboardURL = (
             # Azure Portal URL (https://portal.azure.com for public cloud)

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -12,9 +12,9 @@ import sys
 try:
     from azure_cli_bdist_wheel import cmdclass
 except ImportError:
-    from distutils import log as logger
+    import logging
 
-    logger.warn("Wheel is not available, disabling bdist_wheel hook")
+    logging.warning("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
 VERSION = "2.59.0"


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az --help`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Remove `distutils` to support Python 3.12
This is related to #27673.

`from distutils.sysconfig import get_python_lib` is slow. This PR also saves about 0.2s for each CLI command on Windows.

**Testing Guide**
<!--Example commands with explanations.-->
On Python 3.12, do `az --help`. If it works, this is fixed.



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
