### PR TITLE
{RDBMS} Revert - Add MigrationRuntimeResourceId to properties of creating migration request in CLI

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/_helptext_pg.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_helptext_pg.py
@@ -518,7 +518,7 @@ examples:
             },
             "SourceServerUserName": "testuser@pg-single-1",
             "TargetServerUserName": "fspguser"
-          },
+          }
           "dBsToMigrate": [
             "postgres"
           ],
@@ -543,7 +543,7 @@ examples:
             },
             "SourceServerUserName": "testuser@pg-single-1",
             "TargetServerUserName": "fspguser"
-          },
+          }
           "dBsToMigrate": [
             "postgres"
           ],
@@ -574,7 +574,7 @@ examples:
             },
             "SourceServerUserName": "postgres",
             "TargetServerUserName": "fspguser"
-          },
+          }
           "dBsToMigrate": [
             "ticketdb","timedb","inventorydb"
           ],
@@ -586,30 +586,6 @@ examples:
     text: >
       az postgres flexible-server migration create --subscription xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --resource-group testGroup --name testserver \
         --migration-name testmigration --properties "migrationConfig.json"
-  - name: >
-      Start a private endpoint enabled migration workflow on the target server identified by the parameters. The configurations of the migration should be specified in the migrationConfig.json file.
-      Pass in MigrationRuntimeResourceId to define the migration runtime server that is responsible for migrating data between source and target server. Sample migrationConfig.json will look like this: \n
-      {
-        "properties": {
-          "SourceDBServerResourceId": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/test-single-rg/providers/Microsoft.DBforPostgreSQL/servers/pg-single-1",
-          "MigrationRuntimeResourceId": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/testGroup/providers/Microsoft.DBforPostgreSQL/flexibleServers/testsourcemigration",
-          "SecretParameters": {
-            "AdminCredentials": {
-              "SourceServerPassword": "password",
-              "TargetServerPassword": "password"
-            },
-            "SourceServerUserName": "testuser@pg-single-1",
-            "TargetServerUserName": "fspguser"
-          },
-          "dBsToMigrate": [
-            "postgres"
-          ],
-          "OverwriteDbsInTarget": "true"
-        }
-      }
-    text: >
-      az postgres flexible-server migration create --subscription xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --resource-group testGroup --name testserver --migration-name testmigration
-      --properties "migrationConfig.json"
 """
 
 helps['postgres flexible-server migration list'] = """

--- a/src/azure-cli/azure/cli/command_modules/rdbms/_helptext_pg.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_helptext_pg.py
@@ -518,7 +518,7 @@ examples:
             },
             "SourceServerUserName": "testuser@pg-single-1",
             "TargetServerUserName": "fspguser"
-          }
+          },
           "dBsToMigrate": [
             "postgres"
           ],
@@ -543,7 +543,7 @@ examples:
             },
             "SourceServerUserName": "testuser@pg-single-1",
             "TargetServerUserName": "fspguser"
-          }
+          },
           "dBsToMigrate": [
             "postgres"
           ],
@@ -574,7 +574,7 @@ examples:
             },
             "SourceServerUserName": "postgres",
             "TargetServerUserName": "fspguser"
-          }
+          },
           "dBsToMigrate": [
             "ticketdb","timedb","inventorydb"
           ],

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
@@ -33,7 +33,7 @@ from ._flexible_server_location_capabilities_util import get_postgres_location_c
 from .flexible_server_custom_common import create_firewall_rule
 from .flexible_server_virtual_network import prepare_private_network, prepare_private_dns_zone, prepare_public_network
 from .validators import pg_arguments_validator, validate_server_name, validate_and_format_restore_point_in_time, \
-    validate_postgres_replica, validate_georestore_network, pg_byok_validator, validate_migration_runtime_server
+    validate_postgres_replica, validate_georestore_network, pg_byok_validator
 
 logger = get_logger(__name__)
 DEFAULT_DB_NAME = 'flexibleserverdb'
@@ -1117,7 +1117,7 @@ def migration_create_func(cmd, client, resource_group_name, server_name, propert
         # Use default migration_option as 'ValidateAndMigrate'
         migration_option = "ValidateAndMigrate"
 
-    return _create_migration(cmd, logging_name, client, subscription_id, resource_group_name, server_name, migration_name,
+    return _create_migration(logging_name, client, subscription_id, resource_group_name, server_name, migration_name,
                              migration_mode, migration_option, migration_parameters, tags, location)
 
 
@@ -1394,14 +1394,11 @@ def _get_pg_replica_zone(availabilityZones, sourceServerZone, replicaZone):
     return pg_replica_zone
 
 
-def _create_migration(cmd, logging_name, client, subscription_id, resource_group_name, target_db_server_name,
+def _create_migration(logging_name, client, subscription_id, resource_group_name, target_db_server_name,
                       migration_name, migration_mode, migration_option, parameters, tags, location):
-    parameter_keys = list(parameters.keys())
-    migrationInstanceResourceId = get_case_insensitive_key_value("MigrationRuntimeResourceId", parameter_keys, parameters)
-    if migrationInstanceResourceId is not None:
-        validate_migration_runtime_server(cmd, migrationInstanceResourceId, resource_group_name, target_db_server_name)
-
     logger.warning('Creating %s Migration for server \'%s\' in group \'%s\' and subscription \'%s\'...', logging_name, target_db_server_name, resource_group_name, subscription_id)
+
+    parameter_keys = list(parameters.keys())
     secret_parameter_dictionary = get_case_insensitive_key_value("SecretParameters", parameter_keys, parameters)
     secret_parameter_keys = list(secret_parameter_dictionary.keys())
     admin_credentials_dictionary = get_case_insensitive_key_value("AdminCredentials", secret_parameter_keys, secret_parameter_dictionary)
@@ -1427,8 +1424,7 @@ def _create_migration(cmd, logging_name, client, subscription_id, resource_group
         overwrite_dbs_in_target=get_enum_value_true_false(get_case_insensitive_key_value("OverwriteDbsInTarget", parameter_keys, parameters), "OverwriteDbsInTarget"),
         source_type=source_type,
         migration_option=migration_option,
-        ssl_mode=ssl_mode,
-        migration_instance_resource_id=migrationInstanceResourceId)
+        ssl_mode=ssl_mode)
 
     return client.create(subscription_id, resource_group_name, target_db_server_name, migration_name, migration_parameters)
 

--- a/src/azure-cli/azure/cli/command_modules/rdbms/validators.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/validators.py
@@ -627,19 +627,6 @@ def validate_server_name(db_context, server_name, type_):
         raise ValidationError(result.message)
 
 
-def validate_migration_runtime_server(cmd, migrationInstanceResourceId, target_resource_group_name, target_server_name):
-    id_comps = parse_resource_id(migrationInstanceResourceId)
-    runtime_server_resource_resource_type = id_comps['resource_type'].lower()
-    if "flexibleservers" != runtime_server_resource_resource_type:
-        raise ValidationError("Migration Runtime Resource ID provided should be Flexible server.")
-
-    server_operations_client = cf_postgres_flexible_servers(cmd.cli_ctx, '_')
-    target_server = server_operations_client.get(target_resource_group_name, target_server_name)
-    if target_server.id.lower() == migrationInstanceResourceId.lower():
-        raise ValidationError("Migration Runtime server is same as Target Flexible server. "
-                              "Please change the values accordingly.")
-
-
 def validate_private_dns_zone(db_context, server_name, private_dns_zone, private_dns_zone_suffix):
     cmd = db_context.cmd
     if db_context.command_group == 'postgres':


### PR DESCRIPTION
**Related command**
`az postgres flexible-server migration create --subscription sub --resource-group testGroup --name testserver --migration-name testmigration --properties "migrationConfig.json"`

**Description**<!--Mandatory-->
SDK may not get bumped up in time to include these changes in current milestone.
Revert #28695 



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
