### PR TITLE
{AKS} Correct the property `disable_outbound_nat` in `windows_profile` and add UT

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
@@ -1358,9 +1358,9 @@ class AKSAgentPoolContext(BaseAKSContext):
                 self.agentpool and
                 hasattr(self.agentpool, "windows_profile") and
                 self.agentpool.windows_profile and
-                self.agentpool.windows_profile.disable_windows_outbound_nat is not None
+                self.agentpool.windows_profile.disable_outbound_nat is not None
             ):
-                disable_windows_outbound_nat = self.agentpool.windows_profile.disable_windows_outbound_nat
+                disable_windows_outbound_nat = self.agentpool.windows_profile.disable_outbound_nat
 
         # this parameter does not need dynamic completion
         # this parameter does not need validation

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_agentpool_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_agentpool_decorator.py
@@ -1271,6 +1271,32 @@ class AKSAgentPoolContextCommonTestCase(unittest.TestCase):
         with self.assertRaises(InvalidArgumentValueError):
             ctx_3.get_linux_os_config()
 
+    def common_get_agentpool_windows_profile(self):
+        # default
+        ctx_1 = AKSAgentPoolContext(
+            self.cmd,
+            AKSAgentPoolParamDict({
+                "os_type": "windows",
+                "disable_windows_outbound_nat": True,
+            }),
+            self.models,
+            DecoratorMode.CREATE,
+            self.agentpool_decorator_mode,
+        )
+        # check all fields under windows_profile
+        self.assertEqual(ctx_1.get_disable_windows_outbound_nat(), True)
+
+        agentpool_1 = self.create_initialized_agentpool_instance(
+            windows_profile=self.models.AgentPoolWindowsProfile(
+                disable_outbound_nat=False
+            )
+        )
+        ctx_1.attach_agentpool(agentpool_1)
+        self.assertEqual(
+            ctx_1.get_disable_windows_outbound_nat(),
+            False,
+        )
+
     def common_get_aks_custom_headers(self):
         # default
         ctx_1 = AKSAgentPoolContext(
@@ -1510,6 +1536,9 @@ class AKSAgentPoolContextStandaloneModeTestCase(AKSAgentPoolContextCommonTestCas
     def test_get_linux_os_config(self):
         self.common_get_linux_os_config()
 
+    def test_get_agentpool_windows_profile(self):
+        self.common_get_agentpool_windows_profile()
+
     def test_get_aks_custom_headers(self):
         self.common_get_aks_custom_headers()
 
@@ -1669,6 +1698,9 @@ class AKSAgentPoolContextManagedClusterModeTestCase(AKSAgentPoolContextCommonTes
 
     def test_get_linux_os_config(self):
         self.common_get_linux_os_config()
+
+    def test_get_agentpool_windows_profile(self):
+        self.common_get_agentpool_windows_profile()
 
     def test_get_aks_custom_headers(self):
         self.common_get_aks_custom_headers()
@@ -2081,6 +2113,29 @@ class AKSAgentPoolAddDecoratorCommonTestCase(unittest.TestCase):
         )
         self.assertEqual(dec_agentpool_1, ground_truth_agentpool_1)
 
+    def common_set_up_agentpool_windows_profile(self):
+        dec_1 = AKSAgentPoolAddDecorator(
+            self.cmd,
+            self.client,
+            {
+                "os_type": "windows",
+                "disable_windows_outbound_nat": True,
+            },
+            self.resource_type,
+            self.agentpool_decorator_mode,
+        )
+        agentpool_1 = self.create_initialized_agentpool_instance(restore_defaults=False)
+        dec_1.context.attach_agentpool(agentpool_1)
+        dec_agentpool_1 = dec_1.set_up_agentpool_windows_profile(agentpool_1)
+        dec_agentpool_1 = self._restore_defaults_in_agentpool(dec_agentpool_1)
+
+        ground_truth_agentpool_1 = self.create_initialized_agentpool_instance(
+            windows_profile=self.models.AgentPoolWindowsProfile(
+                disable_outbound_nat=True
+            )
+        )
+        self.assertEqual(dec_agentpool_1, ground_truth_agentpool_1)
+
     def common_set_up_gpu_propertes(self):
         dec_1 = AKSAgentPoolAddDecorator(
             self.cmd,
@@ -2145,6 +2200,9 @@ class AKSAgentPoolAddDecoratorStandaloneModeTestCase(AKSAgentPoolAddDecoratorCom
 
     def test_set_up_custom_node_config(self):
         self.common_set_up_custom_node_config()
+
+    def test_set_up_agentpool_windows_profile(self):
+        self.common_set_up_agentpool_windows_profile()
 
     def test_construct_agentpool_profile_default(self):
         import inspect
@@ -2289,6 +2347,9 @@ class AKSAgentPoolAddDecoratorManagedClusterModeTestCase(AKSAgentPoolAddDecorato
 
     def test_set_up_custom_node_config(self):
         self.common_set_up_custom_node_config()
+
+    def test_set_up_agentpool_windows_profile(self):
+        self.common_set_up_agentpool_windows_profile()
 
     def test_construct_agentpool_profile_default(self):
         import inspect


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

```
az aks nodepool add --name npwin --os-type Windows --disable-windows-outbound-nat
```

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Refer to the [cli-extension/aks-preview PR](https://github.com/Azure/azure-cli-extensions/pull/7548)

- Correct the property `disable_outbound_nat` in `windows_profile`. Since customers cannot directly invoke the logic, there is no external impact.
- Why wasn't the error caught earlier? - Because `self.agentpool` is always `None` in customer usage, the code reads from `self.raw_param.get("disable_windows_outbound_nat")` directly, which means the code was not triggered.
- Add UT to validate the `get_disable_windows_outbound_nat` function when the property had been assigned a value.

**Testing Guide**
<!--Example commands with explanations.-->

- azdev test --live test_aks_nodepool_add_with_disable_windows_outbound_nat
- UT `common_get_agentpool_windows_profile` and `common_set_up_agentpool_windows_profile`

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

{AKS} Correct the property `disable_outbound_nat` in `windows_profile` introduced in PR https://github.com/Azure/azure-cli/pull/28806

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
