### PR TITLE
{Packaging} Bump argcomplete to 3.3.0

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -43,7 +43,7 @@ CLASSIFIERS = [
 ]
 
 DEPENDENCIES = [
-    'argcomplete~=3.1.1',
+    'argcomplete~=3.3.0',
     'azure-cli-telemetry==1.1.0.*',
     'azure-mgmt-core>=1.2.0,<2',
     'cryptography',

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -1,6 +1,6 @@
 antlr4-python3-runtime==4.13.1
 applicationinsights==0.11.9
-argcomplete==3.1.1
+argcomplete==3.3.0
 asn1crypto==0.24.0
 azure-appconfiguration==1.1.1
 azure-batch==14.2.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -1,6 +1,6 @@
 antlr4-python3-runtime==4.13.1
 applicationinsights==0.11.9
-argcomplete==3.1.1
+argcomplete==3.3.0
 asn1crypto==0.24.0
 azure-appconfiguration==1.1.1
 azure-batch==14.2.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -1,6 +1,6 @@
 antlr4-python3-runtime==4.13.1
 applicationinsights==0.11.9
-argcomplete==3.1.1
+argcomplete==3.3.0
 asn1crypto==0.24.0
 azure-appconfiguration==1.1.1
 azure-batch==14.2.0


### PR DESCRIPTION
Resolve #28760.

> Changes for v3.3.0 (2024-04-14)
Preserve compatibility with argparse option tuples of length 4. This update is required to use argcomplete on Python 3.11.9+ or 3.12.3+.    --https://github.com/kislyuk/argcomplete/blob/develop/Changes.rst