### PR TITLE
[Core] Redo: Use WAM as the default authentication method on Windows

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -856,8 +856,8 @@ def _create_identity_instance(cli_ctx, *args, **kwargs):
     # EXPERIMENTAL: Use core.use_msal_http_cache=False to turn off MSAL HTTP cache.
     use_msal_http_cache = cli_ctx.config.getboolean('core', 'use_msal_http_cache', fallback=True)
 
-    # PREVIEW: On Windows, use core.enable_broker_on_windows=true to use broker (WAM) for authentication.
-    enable_broker_on_windows = cli_ctx.config.getboolean('core', 'enable_broker_on_windows', fallback=False)
+    # On Windows, use core.enable_broker_on_windows=false to disable broker (WAM) for authentication.
+    enable_broker_on_windows = cli_ctx.config.getboolean('core', 'enable_broker_on_windows', fallback=True)
     from .telemetry import set_broker_info
     set_broker_info(enable_broker_on_windows)
 

--- a/src/azure-cli-core/azure/cli/core/auth/landing_pages/success.html
+++ b/src/azure-cli-core/azure/cli/core/auth/landing_pages/success.html
@@ -21,13 +21,5 @@
 <body>
     <h3>You have logged into Microsoft Azure!</h3>
     <p>You can close this window, or we will redirect you to the <a href="https://docs.microsoft.com/cli/azure/">Azure CLI documentation</a> in 1 minute.</p>
-    <h3>Announcements</h3>
-    <p>[Windows only] Azure CLI is collecting feedback on using the <a href="https://learn.microsoft.com/windows/uwp/security/web-account-manager">Web Account Manager</a> (WAM) broker for the login experience.</p>
-    <p>You may opt-in to use WAM by running the following commands:</p>
-    <code>
-        az config set core.enable_broker_on_windows=true<br>
-        az account clear<br>
-        az login
-    </code>
 </body>
 </html>


### PR DESCRIPTION
Redo #28085

**Related command**
`az login`

**Description**<!--Mandatory-->
After previewing WAM for over a year (https://github.com/Azure/azure-cli/pull/23828), we now use WAM as the default authentication method on Windows.

**Testing Guide**
```sh
az login

# To opt out
az config set core.enable_broker_on_windows=false
az login
```

**History Notes**
[Core] BREAKING CHANGE: `az login`: Use WAM as the default authentication method on Windows. If you encounter any issue and want to revert to the previous browser-based authentication method, run `az account clear`, `az config set core.enable_broker_on_windows=false` and `az login`
