### PR TITLE
{testsdk} Copy command index to random config dir

### DIFF
--- a/.azure-pipelines/templates/azdev_setup.yml
+++ b/.azure-pipelines/templates/azdev_setup.yml
@@ -31,6 +31,9 @@ steps:
       if [ "${{ parameters.EnableCompactAAZ }}" == 'True' ]; then
         python $CLI_REPO_PATH/scripts/compact_aaz.py
       fi
+
+      # Verify installation and build command index
+      az --version
     displayName: 'azdev setup'
     env:
       CLI_REPO_PATH: ${{ parameters.CLIRepoPath }}

--- a/src/azure-cli-core/azure/cli/core/mock.py
+++ b/src/azure-cli-core/azure/cli/core/mock.py
@@ -32,17 +32,23 @@ class DummyCli(AzCli):
             self.env_patch = patch.dict(os.environ, {'AZURE_CONFIG_DIR': config_dir})
             self.env_patch.start()
 
+            # Always copy command index to avoid initializing it again
+            files_to_copy = ['commandIndex.json']
             # In recording mode, copy login credentials from global config dir to the dummy config dir
             if os.getenv(ENV_VAR_TEST_LIVE, '').lower() == 'true':
-                if os.path.exists(GLOBAL_CONFIG_DIR):
-                    ensure_dir(config_dir)
-                    import shutil
-                    for file in ['azureProfile.json', 'msal_token_cache.bin', 'clouds.config', 'msal_token_cache.json',
-                                 'service_principal_entries.json']:
-                        try:
-                            shutil.copy(os.path.join(GLOBAL_CONFIG_DIR, file), config_dir)
-                        except FileNotFoundError:
-                            pass
+                files_to_copy.extend([
+                    'azureProfile.json', 'clouds.config',
+                    'msal_token_cache.bin', 'msal_token_cache.json',
+                    'service_principal_entries.bin', 'service_principal_entries.json'
+                ])
+
+            ensure_dir(config_dir)
+            import shutil
+            for file in files_to_copy:
+                try:
+                    shutil.copy(os.path.join(GLOBAL_CONFIG_DIR, file), config_dir)
+                except FileNotFoundError:
+                    pass
 
         super(DummyCli, self).__init__(
             cli_name='az',


### PR DESCRIPTION
Temporally bypass https://github.com/Azure/azure-cli/issues/28848
Final fix should be done by https://github.com/Azure/azure-cli/pull/28849

**Description**<!--Mandatory-->
Running `test_containerapp_manualjob_withsecret_crudoperations_e2e` and `test_hdinsight_application` sequentially fails with 

```
$ azdev test test_containerapp_manualjob_withsecret_crudoperations_e2e test_hdinsight_application --series -a -rP
...
self = <azure.cli.core._session.Session object at 0x7f15c1b06410>

    def save(self):
        if self.filename:
>           with open(self.filename, 'w', encoding=self._encoding) as f:
E           FileNotFoundError: [Errno 2] No such file or directory: '/home/user2/.azure/dummy_cli_config_dir/mvDaOhlAGfu4OvI6/commandIndex.json'

src/azure-cli-core/azure/cli/core/_session.py:54: FileNotFoundError
```

As explained in https://github.com/Azure/azure-cli/issues/28848#issuecomment-2081967874, even after `test_containerapp_manualjob_withsecret_crudoperations_e2e` finishes and deletes the random config dir, `test_hdinsight_application` still tries to initialize command index in the same random config dir, because of the polluted env var `AZURE_CONFIG_DIR` (https://github.com/Azure/azure-cli/pull/28849#issue-2267820600).

This PR copies command index to random config dir first so that it can be loaded during `azure.cli.core.AzCli.__init__`:

https://github.com/Azure/azure-cli/blob/f98ba8062f08bf5b7460260c56916bd3074bf9e5/src/azure-cli-core/azure/cli/core/__init__.py#L82

which is called during `azure.cli.testsdk.base.ScenarioTest.__init__`:

https://github.com/Azure/azure-cli/blob/2750c65ea77638ecf699243555a5f2f7a1314ed4/src/azure-cli-testsdk/azure/cli/testsdk/base.py#L86

Then command index will not be initialized again by test methods.

**Testing Guide**

```
azdev test test_containerapp_manualjob_withsecret_crudoperations_e2e test_hdinsight_application --series -a -rP
```
