### PR TITLE
{testsdk} Stop patching `AZURE_CONFIG_DIR` immediately after calling `AzCli.__init__`

### DIFF
--- a/src/azure-cli-core/azure/cli/core/mock.py
+++ b/src/azure-cli-core/azure/cli/core/mock.py
@@ -25,12 +25,14 @@ class DummyCli(AzCli):
         from knack.completion import ARGCOMPLETE_ENV_NAME
         from knack.util import ensure_dir
 
+        env_patch = None
+
         if random_config_dir:
             config_dir = os.path.join(GLOBAL_CONFIG_DIR, 'dummy_cli_config_dir', random_string())
             # Knack prioritizes the AZURE_CONFIG_DIR env over the config_dir param, and other functions may call
             # get_config_dir directly. We need to set the env to make sure the config_dir is used.
-            self.env_patch = patch.dict(os.environ, {'AZURE_CONFIG_DIR': config_dir})
-            self.env_patch.start()
+            env_patch = patch.dict(os.environ, {'AZURE_CONFIG_DIR': config_dir})
+            env_patch.start()
 
             # Always copy command index to avoid initializing it again
             files_to_copy = ['commandIndex.json']
@@ -60,6 +62,9 @@ class DummyCli(AzCli):
             output_cls=AzOutputProducer,
             help_cls=AzCliHelp,
             invocation_cls=AzCliCommandInvoker)
+
+        if random_config_dir:
+            env_patch.stop()
 
         self.data['headers'] = {}  # the x-ms-client-request-id is generated before a command is to execute
         self.data['command'] = 'unknown'

--- a/src/azure-cli-testsdk/azure/cli/testsdk/base.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/base.py
@@ -142,7 +142,6 @@ class ScenarioTest(ReplayableTest, CheckerMixin, unittest.TestCase):
         if self.random_config_dir:
             from azure.cli.core.util import rmtree_with_retry
             rmtree_with_retry(self.cli_ctx.config.config_dir)
-            self.cli_ctx.env_patch.stop()
         super(ScenarioTest, self).tearDown()
 
     def create_random_name(self, prefix, length):


### PR DESCRIPTION
**Description**<!--Mandatory-->
This PR fixes `patch.dict` pollution: `azure.cli.testsdk.base.ScenarioTest.__init__` of each test class is run at pytest's collecting staging, in the same process, but `tearDown` is executed after test methods have been finished. As no test method has been run yet, `patch.dict(os.environ, {'AZURE_CONFIG_DIR': config_dir})` is not stopped, thus polluting other test classes' `__init__` methods at collecting stage and other test methods at running stage.

Consider

```
azdev test test_containerapp_manualjob_withsecret_crudoperations_e2e test_hdinsight_application --live --series -a -rP
```

Even though https://github.com/Azure/azure-cli/pull/28853 bypasses the command index initialization and makes playback test work, during live test, after `test_containerapp_manualjob_withsecret_crudoperations_e2e` finishes, the random config dir is deleted. Because of the `patch.dict` pollution, `test_hdinsight_application` uses the same random config dir, but can't find `msal_token_cache.json` and fails:

```
        if not accounts:
>           raise CLIError("User '{}' does not exist in MSAL token cache. Run `az login`.".format(username))
E           knack.util.CLIError: User 'xxx@microsoft.com' does not exist in MSAL token cache. Run `az login`.

src/azure-cli-core/azure/cli/core/auth/msal_authentication.py:58: CLIError
```

This PR doesn't make things worse than #28673 as currently the `AZURE_CONFIG_DIR` env var is already polluted when running test methods. For example:

```
Collecting:
Class A -> patch AZURE_CONFIG_DIR=random_config_dir_A
Class B -> patch AZURE_CONFIG_DIR=random_config_dir_B

Running:
test_method_A -> see AZURE_CONFIG_DIR=random_config_dir_B
```

When running `test_method_A`, `AZURE_CONFIG_DIR` is `random_config_dir_B`.

**Testing Guide**
```
azdev test test_containerapp_manualjob_withsecret_crudoperations_e2e test_hdinsight_application --live --series -a -rP
```
