### PR TITLE
[AppService] `az functionapp`: Only show warning but not throw error when checking runtime

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -463,19 +463,20 @@ def check_language_runtime(cmd, resource_group_name, name):
     app = client.web_apps.get(resource_group_name, name)
     is_linux = app.reserved
     if is_functionapp(app):
-        is_flex = is_flex_functionapp(cmd.cli_ctx, resource_group_name, name)
-        runtime_info = _get_functionapp_runtime_info(cmd, resource_group_name, name, None, is_linux)
-        runtime = runtime_info['app_runtime']
-        runtime_version = runtime_info['app_runtime_version']
-        functions_version = runtime_info['functionapp_version']
         try:
-            if not is_flex:
-                runtime_helper = _FunctionAppStackRuntimeHelper(cmd=cmd, linux=is_linux, windows=(not is_linux))
-                runtime_helper.resolve(runtime, runtime_version, functions_version, is_linux)
-            else:
-                location = app.location
-                runtime_helper = _FlexFunctionAppStackRuntimeHelper(cmd, location, runtime, runtime_version)
-                runtime_helper.resolve(runtime, runtime_version)
+            is_flex = is_flex_functionapp(cmd.cli_ctx, resource_group_name, name)
+            runtime_info = _get_functionapp_runtime_info(cmd, resource_group_name, name, None, is_linux)
+            runtime = runtime_info['app_runtime']
+            runtime_version = runtime_info['app_runtime_version']
+            functions_version = runtime_info['functionapp_version']
+            if runtime and runtime_version:
+                if not is_flex:
+                    runtime_helper = _FunctionAppStackRuntimeHelper(cmd=cmd, linux=is_linux, windows=(not is_linux))
+                    runtime_helper.resolve(runtime, runtime_version, functions_version, is_linux)
+                else:
+                    location = app.location
+                    runtime_helper = _FlexFunctionAppStackRuntimeHelper(cmd, location, runtime, runtime_version)
+                    runtime_helper.resolve(runtime, runtime_version)
         except ValidationError as e:
             logger.warning(e.error_msg)
 
@@ -8188,7 +8189,8 @@ def _get_app_runtime_info_helper(cmd, app_runtime, app_runtime_version, is_linux
 def _get_functionapp_runtime_info_helper(cmd, app_runtime, app_runtime_version, functionapp_version, is_linux):
     if is_linux:
         if len(app_runtime.split('|')) < 2:
-            raise ValidationError(f"Runtime {app_runtime} is not supported.")
+            raise ValidationError("Could not detect runtime. To configure linuxFxVersion, "
+                                  "please visit https://aka.ms/linuxFxVersion")
         app_runtime_version = app_runtime.split('|')[1]
         app_runtime = app_runtime.split('|')[0].lower()
 


### PR DESCRIPTION
**Related command**
`az functionapp config appsettings set`
`az functionapp deployment source config-zip`
`az functionapp config set`
`az functionapp config container set`

**Description**<!--Mandatory-->
Resolves #28394
Resolves #28382 
Resolves #28358 

Currently, we throw an error if we are unable to detect the runtime. However, there are many reasons why a linux app might not have a "conventional" runtime and runtime version (e.g. custom apps, centauri apps, apps running a docker image). For that reason, we should not be blocking command execution but should show a warning for how to set linuxFxVersion if we are unable to detect it and should not even show a warning when it is not applicable (e.g. centauri apps, apps running a docker image)

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[AppService] `az functionapp`: Not block execution of command when runtime cannot be detected, and omit showing warning for runtime when not applicable (e.g. centauri apps, apps running a docker image)

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
