### PR TITLE
[AppService] `az functionapp create`: Refactor consumption function app creation experience

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/utils.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/utils.py
@@ -96,6 +96,8 @@ def get_sku_tier(name):  # pylint: disable=too-many-return-statements
         return 'IsolatedV2'
     if name in ['WS1', 'WS2', 'WS3']:
         return 'WorkflowStandard'
+    if name in ['Y1']:
+        return 'Dynamic'
     raise ValidationError("Invalid sku(pricing tier), please refer to command help for valid values")
 
 


### PR DESCRIPTION
**Related command**
`az functionapp create`
`az functionapp plan create`

**Description**<!--Mandatory-->
1. Allow consumption plans to be created using the Az CLI
2. Allow customers to pass an existing consumption plan when creating a new function app (currently we create the consumption plan for them)
3. If customers do not provide an existing consumption plan, create one for them in the CLI instead of depending on the backend for the plan creation, and follow the same plan naming convention as the Portal. 

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
