### PR TITLE
[Service Connector] `az aks connection list/show`: Add kubernetes resource name

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/_transformers.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/_transformers.py
@@ -21,10 +21,31 @@ def transform_support_types(result):
     ])
 
 
+def transform_linkers_properties(result):
+    from azure.core.polling import LROPoller
+    from ._utils import (
+        is_aks_linker_by_id,
+        get_aks_resource_name
+    )
+
+    if isinstance(result, LROPoller):
+        result = result.result()
+
+    linkers = [todict(res) for res in result]
+    for linker in linkers:
+        resource_id = linker.get('id')
+        if is_aks_linker_by_id(resource_id):
+            linker['kubernetesResourceName'] = get_aks_resource_name(linker)
+
+    return linkers
+
+
 def transform_linker_properties(result):
     from azure.core.polling import LROPoller
     from ._utils import (
-        run_cli_cmd
+        run_cli_cmd,
+        is_aks_linker_by_id,
+        get_aks_resource_name
     )
 
     # manually polling if result is a poller
@@ -33,6 +54,8 @@ def transform_linker_properties(result):
 
     result = todict(result)
     resource_id = result.get('id')
+    if is_aks_linker_by_id(resource_id):
+        result['kubernetesResourceName'] = get_aks_resource_name(result)
     try:
         output = run_cli_cmd('az webapp connection list-configuration --id {} -o json'.format(resource_id))
         result['configurations'] = output.get('configurations')

--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/_utils.py
@@ -563,8 +563,8 @@ def get_aks_resource_name(linker):
             not (linker["targetService"]["resourceProperties"] is not None and
                  linker["targetService"]["resourceProperties"].get("connectAsKubernetesCsiDriver")):
         service_account_name = f'sc-account-{linker["authInfo"].get("clientId")}'
-        return f'{secret_name} / {service_account_name}'
-    return secret_name
+        return [secret_name, service_account_name]
+    return [secret_name]
 
 
 def get_aks_resource_secret_name(connection_name):

--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/_validators.py
@@ -315,7 +315,7 @@ def intelligent_experience(cmd, namespace, missing_args):
         }
         logger.warning('Auth info is not specified, use default one: --system-identity')
         if opt_out_auth(namespace):
-            logger.warning('Auth info is only used to generate configurations. ' + \
+            logger.warning('Auth info is only used to generate configurations. %s',
                            'Skip enabling identity and role assignments.')
     elif 'user_account_auth_info' in missing_args:
         cmd_arg_values['user_account_auth_info'] = {

--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/_validators.py
@@ -303,11 +303,6 @@ def intelligent_experience(cmd, namespace, missing_args):
         if getattr(namespace, arg, None) is not None:
             cmd_arg_values[arg] = getattr(namespace, arg)
 
-    opt_out_auth_message = ''
-    if opt_out_auth(namespace):
-        opt_out_auth_message += '. Auth info is only used to generate configurations. ' + \
-            'Skip enabling identity and role assignments.'
-
     # for auth info without additional parameters
     if 'secret_auth_info_auto' in missing_args:
         cmd_arg_values['secret_auth_info_auto'] = {
@@ -318,7 +313,10 @@ def intelligent_experience(cmd, namespace, missing_args):
         cmd_arg_values['system_identity_auth_info'] = {
             'auth_type': 'systemAssignedIdentity'
         }
-        logger.warning('Auth info is not specified, use default one: --system-identity%s', opt_out_auth_message)
+        logger.warning('Auth info is not specified, use default one: --system-identity')
+        if opt_out_auth(namespace):
+            logger.warning('Auth info is only used to generate configurations. ' + \
+                           'Skip enabling identity and role assignments.')
     elif 'user_account_auth_info' in missing_args:
         cmd_arg_values['user_account_auth_info'] = {
             'auth_type': 'userAccount'

--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/commands.py
@@ -7,6 +7,7 @@ from azure.cli.core.commands import CliCommandType
 from knack.log import get_logger
 from ._transformers import (
     transform_support_types,
+    transform_linkers_properties,
     transform_linker_properties,
     transform_validation_result,
     transform_local_linker_properties
@@ -45,7 +46,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-statements
 
             with self.command_group('{} connection'.format(source.value), connection_type,
                                     client_factory=cf_linker, is_preview=is_preview_source) as og:
-                og.custom_command('list', 'connection_list')
+                og.custom_command('list', 'connection_list', transform=transform_linkers_properties)
                 og.custom_show_command('show', 'connection_show', transform=transform_linker_properties)
                 og.custom_command('delete', 'connection_delete', confirmation=True, supports_no_wait=True)
                 og.custom_command('list-configuration', 'connection_list_configuration')

--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/custom.py
@@ -57,7 +57,8 @@ def connection_list(client,
                     source_id=None,
                     cluster=None,
                     site=None, slot=None,
-                    spring=None, app=None, deployment=None):
+                    spring=None, app=None, deployment=None,
+                    opt_out_list=None):
     if not source_id:
         raise RequiredArgumentMissingError(err_msg.format('--source-id'))
     return auto_register(client.list, resource_uri=source_id)
@@ -111,7 +112,8 @@ def connection_show(client,
                     indentifier=None,
                     cluster=None,
                     site=None, slot=None,
-                    spring=None, app=None, deployment=None):
+                    spring=None, app=None, deployment=None,
+                    opt_out_list=None):
     if not source_id or not connection_name:
         raise RequiredArgumentMissingError(
             err_msg.format('--source-id, --connection'))
@@ -142,7 +144,8 @@ def connection_delete(client,
                       cluster=None,
                       site=None, slot=None,
                       spring=None, app=None, deployment=None,
-                      no_wait=False):
+                      no_wait=False,
+                      opt_out_list=None):
     if not source_id or not connection_name:
         raise RequiredArgumentMissingError(err_msg.format('--source-id, --connection'))
 
@@ -177,7 +180,8 @@ def connection_list_configuration(client,
                                   indentifier=None,
                                   cluster=None,
                                   site=None, slot=None,
-                                  spring=None, app=None, deployment=None):
+                                  spring=None, app=None, deployment=None,
+                                  opt_out_list=None):
     if not source_id or not connection_name:
         raise RequiredArgumentMissingError(err_msg.format('--source-id, --connection'))
     configurations = auto_register(client.list_configurations,
@@ -253,7 +257,8 @@ def connection_validate(cmd, client,
                         indentifier=None,
                         cluster=None,
                         site=None, slot=None,
-                        spring=None, app=None, deployment=None):
+                        spring=None, app=None, deployment=None,
+                        opt_out_list=None):
     if not source_id or not connection_name:
         raise RequiredArgumentMissingError(err_msg.format('--source-id, --connection'))
 

--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/custom.py
@@ -57,8 +57,7 @@ def connection_list(client,
                     source_id=None,
                     cluster=None,
                     site=None, slot=None,
-                    spring=None, app=None, deployment=None,
-                    opt_out_list=None):
+                    spring=None, app=None, deployment=None):
     if not source_id:
         raise RequiredArgumentMissingError(err_msg.format('--source-id'))
     return auto_register(client.list, resource_uri=source_id)
@@ -112,8 +111,7 @@ def connection_show(client,
                     indentifier=None,
                     cluster=None,
                     site=None, slot=None,
-                    spring=None, app=None, deployment=None,
-                    opt_out_list=None):
+                    spring=None, app=None, deployment=None):
     if not source_id or not connection_name:
         raise RequiredArgumentMissingError(
             err_msg.format('--source-id, --connection'))
@@ -144,8 +142,7 @@ def connection_delete(client,
                       cluster=None,
                       site=None, slot=None,
                       spring=None, app=None, deployment=None,
-                      no_wait=False,
-                      opt_out_list=None):
+                      no_wait=False):
     if not source_id or not connection_name:
         raise RequiredArgumentMissingError(err_msg.format('--source-id, --connection'))
 
@@ -180,8 +177,7 @@ def connection_list_configuration(client,
                                   indentifier=None,
                                   cluster=None,
                                   site=None, slot=None,
-                                  spring=None, app=None, deployment=None,
-                                  opt_out_list=None):
+                                  spring=None, app=None, deployment=None):
     if not source_id or not connection_name:
         raise RequiredArgumentMissingError(err_msg.format('--source-id, --connection'))
     configurations = auto_register(client.list_configurations,
@@ -257,8 +253,7 @@ def connection_validate(cmd, client,
                         indentifier=None,
                         cluster=None,
                         site=None, slot=None,
-                        spring=None, app=None, deployment=None,
-                        opt_out_list=None):
+                        spring=None, app=None, deployment=None):
     if not source_id or not connection_name:
         raise RequiredArgumentMissingError(err_msg.format('--source-id, --connection'))
 


### PR DESCRIPTION
**Related command**
az aks connection list
az aks connection show

**Description**<!--Mandatory-->
This PR adds kubernetes resource name to align with Portal behavior. Customers can use `kubernetesResourceName` as key to query in a linker result. 

**Testing Guide**
az aks connection list --source-id {aks-cluster-id}
az aks connection show --id {linker-id}

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Service Connector] `az aks connection list/show': Add kubernetes resource name

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
