### PR TITLE
[App Service] `az functionapp scale config always-ready`: Set alwaysReady property to empty array if it is null

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -1936,6 +1936,9 @@ def update_runtime_config(cmd, resource_group_name, name, runtime_version):
 def update_always_ready_settings(cmd, resource_group_name, name, settings):
     functionapp = get_raw_functionapp(cmd, resource_group_name, name)
 
+    if functionapp["properties"]["functionAppConfig"]["scaleAndConcurrency"].get("alwaysReady") is None:
+        functionapp["properties"]["functionAppConfig"]["scaleAndConcurrency"]["alwaysReady"] = []
+
     always_ready_config = functionapp["properties"]["functionAppConfig"]["scaleAndConcurrency"].get("alwaysReady", [])
 
     updated_always_ready_dict = _parse_key_value_pairs(settings)


### PR DESCRIPTION
**Related command**
- az functionapp scale config always-ready

**Description**<!--Mandatory-->
For Flex Function App, it sets alwaysReady property to empty array when it is null. It is to avoid the exception which is thrown if the mentioned property is not iterable. 

**Testing Guide**

Create a function app
`az functionapp create -g <resource-group> -n <function-app-name> -s flexeastorage --functions-version 4 --debug --runtime python --runtime-version 3.11 --flexconsumption-location '"eastasia"' --debug --deployment-storage-auth-type storageAccountConnectionString`

Update the scale config of the function app
`az functionapp scale config always-ready set -g <resource-group> -n <function-app-name> --settings http=1 functionfunction1=1`

