### PR TITLE
{Profile} Login experience v2

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -24,10 +24,17 @@ logger = get_logger(__name__)
 _IS_DEFAULT_SUBSCRIPTION = 'isDefault'
 _SUBSCRIPTION_ID = 'id'
 _SUBSCRIPTION_NAME = 'name'
+
 # Tenant of the token which is used to list the subscription
 _TENANT_ID = 'tenantId'
-# Home tenant of the subscription, which maps to tenantId in 'Subscriptions - List REST API'
-# https://docs.microsoft.com/en-us/rest/api/resources/subscriptions/list
+
+# More information on the token tenant. Maps to properties in 'Tenants - List' REST API
+# https://learn.microsoft.com/en-us/rest/api/resources/tenants/list
+_TENANT_DEFAULT_DOMAIN = 'tenantDefaultDomain'  # defaultDomain
+_TENANT_DISPLAY_NAME = 'tenantDisplayName'  # displayName
+
+# Home tenant of the subscription. Maps to tenantId in 'Subscriptions - List' REST API
+# https://learn.microsoft.com/en-us/rest/api/resources/subscriptions/list
 _HOME_TENANT_ID = 'homeTenantId'
 _MANAGED_BY_TENANTS = 'managedByTenants'
 _USER_ENTITY = 'user'
@@ -91,17 +98,27 @@ def _get_cloud_console_token_endpoint():
     return os.environ.get('MSI_ENDPOINT')
 
 
-def _attach_token_tenant(subscription, tenant):
-    """Attach the token tenant ID to the subscription as tenant_id, so that CLI knows which token should be used
+def _attach_token_tenant(subscription, tenant, tenant_id_description=None):
+    """Attach the token tenant information to the subscription. CLI uses tenant_id to know which token should be used
     to access the subscription.
 
     This function supports multiple APIs:
-      - v2016_06_01's Subscription doesn't have tenant_id
-      - v2019_11_01's Subscription has tenant_id representing the home tenant ID. It will mapped to home_tenant_id
+      - v2016_06_01: Subscription doesn't have tenant_id
+      - v2022_12_01:
+        - Subscription has tenant_id representing the home tenant ID, mapped to home_tenant_id
+        - TenantIdDescription has default_domain, mapped to tenant_default_domain
+        - TenantIdDescription has display_name, mapped to tenant_display_name
     """
     if hasattr(subscription, "tenant_id"):
         setattr(subscription, 'home_tenant_id', subscription.tenant_id)
     setattr(subscription, 'tenant_id', tenant)
+
+    # Attach tenant_default_domain, if available
+    if tenant_id_description and hasattr(tenant_id_description, "default_domain"):
+        setattr(subscription, 'tenant_default_domain', tenant_id_description.default_domain)
+    # Attach display_name, if available
+    if tenant_id_description and hasattr(tenant_id_description, "display_name"):
+        setattr(subscription, 'tenant_display_name', tenant_id_description.display_name)
 
 
 # pylint: disable=too-many-lines,too-many-instance-attributes,unused-argument
@@ -133,6 +150,7 @@ class Profile:
               use_device_code=False,
               allow_no_subscriptions=False,
               use_cert_sn_issuer=None,
+              show_progress=False,
               **kwargs):
         """
         For service principal, `password` is a dict returned by ServicePrincipalAuth.build_credential
@@ -159,6 +177,11 @@ class Profile:
                 identity.login_with_service_principal(username, password, scopes=scopes)
 
         # We have finished login. Let's find all subscriptions.
+        if show_progress:
+            message = ('Retrieving subscriptions for the selection...' if tenant else
+                       'Retrieving tenants and subscriptions for the selection...')
+            print(f"\n{message}")
+
         if user_identity:
             username = user_identity['username']
 
@@ -735,6 +758,7 @@ class SubscriptionFinder:
         mfa_tenants = []
 
         client = self._create_subscription_client(credential)
+        # https://learn.microsoft.com/en-us/rest/api/resources/tenants/list
         tenants = client.tenants.list()
 
         for t in tenants:
@@ -756,7 +780,9 @@ class SubscriptionFinder:
             specific_tenant_credential = identity.get_user_credential(username)
 
             try:
-                subscriptions = self.find_using_specific_tenant(tenant_id, specific_tenant_credential)
+
+                subscriptions = self.find_using_specific_tenant(tenant_id, specific_tenant_credential,
+                                                                tenant_id_description=t)
             except AuthenticationError as ex:
                 # because user creds went through the 'common' tenant, the error here must be
                 # tenant specific, like the account was disabled. For such errors, we will continue
@@ -802,12 +828,17 @@ class SubscriptionFinder:
                 logger.warning("%s", t.tenant_id_name)
         return all_subscriptions
 
-    def find_using_specific_tenant(self, tenant, credential):
+    def find_using_specific_tenant(self, tenant, credential, tenant_id_description=None):
+        """List subscriptions that can be accessed from a specific tenant.
+        If called from find_using_common_tenant, tenant_id_description is TenantIdDescription retrieved from
+        'Tenants - List' REST API. If directly called, tenant_id_description is None.
+        """
         client = self._create_subscription_client(credential)
+        # https://learn.microsoft.com/en-us/rest/api/resources/subscriptions/list
         subscriptions = client.subscriptions.list()
         all_subscriptions = []
         for s in subscriptions:
-            _attach_token_tenant(s, tenant)
+            _attach_token_tenant(s, tenant, tenant_id_description=tenant_id_description)
             all_subscriptions.append(s)
         self.tenants.append(tenant)
         return all_subscriptions
@@ -840,6 +871,11 @@ def _transform_subscription_for_multiapi(s, s_dict):
     """
     if hasattr(s, 'home_tenant_id'):
         s_dict[_HOME_TENANT_ID] = s.home_tenant_id
+    if hasattr(s, 'tenant_default_domain'):
+        s_dict[_TENANT_DEFAULT_DOMAIN] = s.tenant_default_domain
+    if hasattr(s, 'tenant_display_name'):
+        s_dict[_TENANT_DISPLAY_NAME] = s.tenant_display_name
+
     if hasattr(s, 'managed_by_tenants'):
         if s.managed_by_tenants is None:
             s_dict[_MANAGED_BY_TENANTS] = None

--- a/src/azure-cli-core/azure/cli/core/style.py
+++ b/src/azure-cli-core/azure/cli/core/style.py
@@ -30,6 +30,7 @@ logger = get_logger(__name__)
 class Style(str, Enum):
     PRIMARY = "primary"
     SECONDARY = "secondary"
+    HIGHLIGHT = "highlight"
     IMPORTANT = "important"
     ACTION = "action"  # name TBD
     HYPERLINK = "hyperlink"
@@ -65,6 +66,7 @@ THEME_NONE = None
 THEME_DARK = {
     Style.PRIMARY: DEFAULT,
     Style.SECONDARY: '\x1b[90m',  # Bright Foreground Black
+    Style.HIGHLIGHT: '\x1b[96m',  # Bright Foreground Cyan
     Style.IMPORTANT: '\x1b[95m',  # Bright Foreground Magenta
     Style.ACTION: '\x1b[94m',  # Bright Foreground Blue
     Style.HYPERLINK: '\x1b[96m',  # Bright Foreground Cyan
@@ -77,6 +79,7 @@ THEME_DARK = {
 THEME_LIGHT = {
     Style.PRIMARY: DEFAULT,
     Style.SECONDARY: '\x1b[90m',  # Bright Foreground Black
+    Style.HIGHLIGHT: '\x1b[36m',  # Foreground Cyan
     Style.IMPORTANT: '\x1b[35m',  # Foreground Magenta
     Style.ACTION: '\x1b[34m',  # Foreground Blue
     Style.HYPERLINK: '\x1b[36m',  # Foreground Cyan
@@ -90,6 +93,7 @@ THEME_LIGHT = {
 THEME_CLOUD_SHELL = {
     Style.PRIMARY: _rgb_hex('#ffffff'),
     Style.SECONDARY: _rgb_hex('#bcbcbc'),
+    Style.HIGHLIGHT: _rgb_hex('#72d7d8'),  # Same as Style.HYPERLINK, for now
     Style.IMPORTANT: _rgb_hex('#f887ff'),
     Style.ACTION: _rgb_hex('#6cb0ff'),
     Style.HYPERLINK: _rgb_hex('#72d7d8'),

--- a/src/azure-cli-core/azure/cli/core/telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry.py
@@ -70,11 +70,13 @@ class TelemetrySession:  # pylint: disable=too-many-instance-attributes
         self.suppress_new_event = False
         self.poll_start_time = None
         self.poll_end_time = None
-        self.enable_broker_on_windows = None
-        self.msal_telemetry = None
         self.secrets_detected = None
         self.secret_keys = None
         self.user_agent = None
+        # authentication-related
+        self.enable_broker_on_windows = None
+        self.msal_telemetry = None
+        self.login_experience_v2 = None
 
     def add_event(self, name, properties):
         for key in self.instrumentation_key:
@@ -222,11 +224,13 @@ class TelemetrySession:  # pylint: disable=too-many-instance-attributes
         set_custom_properties(result, 'ShowSurveyMessage', str(self.show_survey_message))
         set_custom_properties(result, 'RegionInput', self.region_input)
         set_custom_properties(result, 'RegionIdentified', self.region_identified)
-        set_custom_properties(result, 'EnableBrokerOnWindows', str(self.enable_broker_on_windows))
-        set_custom_properties(result, 'MsalTelemetry', self.msal_telemetry)
         set_custom_properties(result, 'SecretsWarning', _get_secrets_warning_config())
         set_custom_properties(result, 'SecretsDetected', str(self.secrets_detected))
         set_custom_properties(result, 'SecretKeys', ','.join(self.secret_keys or []))
+        # authentication-related
+        set_custom_properties(result, 'EnableBrokerOnWindows', str(self.enable_broker_on_windows))
+        set_custom_properties(result, 'MsalTelemetry', self.msal_telemetry)
+        set_custom_properties(result, 'LoginExperienceV2', str(self.login_experience_v2))
 
         return result
 
@@ -473,6 +477,11 @@ def set_broker_info(enable_broker_on_windows):
 def set_msal_telemetry(msal_telemetry):
     if not _session.msal_telemetry:
         _session.msal_telemetry = msal_telemetry
+
+
+@decorators.suppress_all_exceptions()
+def set_login_experience_v2(login_experience_v2):
+    _session.login_experience_v2 = login_experience_v2
 
 
 @decorators.suppress_all_exceptions()

--- a/src/azure-cli/azure/cli/command_modules/profile/_subscription_selector.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/_subscription_selector.py
@@ -1,0 +1,101 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from azure.cli.core._profile import (_SUBSCRIPTION_NAME, _SUBSCRIPTION_ID, _TENANT_DISPLAY_NAME, _TENANT_ID,
+                                     _IS_DEFAULT_SUBSCRIPTION)
+from knack.log import get_logger
+
+logger = get_logger(__name__)
+
+
+class SubscriptionSelector:  # pylint: disable=too-few-public-methods
+    DEFAULT_ROW_MARKER = '*'
+
+    def __init__(self, subscriptions):
+        self._subscriptions = subscriptions
+        self._active_one = None
+        self._format_subscription_table()
+
+    def _format_subscription_table(self):
+        from azure.cli.core.style import format_styled_text, Style
+        index_to_subscription_map = {}
+        table_data = []
+        subscription_name_length_limit = 36
+
+        # Sort by subscription name
+        subscriptions_sorted = sorted(self._subscriptions, key=lambda s: s[_SUBSCRIPTION_NAME].lower())
+
+        def highlight_text(text, row_is_default):
+            return format_styled_text((Style.HIGHLIGHT, text)) if row_is_default else text
+
+        for index, sub in enumerate(subscriptions_sorted, start=1):
+            # There is no need to use int, as int requires parsing. str match is sufficient.
+            index_str = str(index)  # '1', '2', ...
+            index_to_subscription_map[index_str] = sub
+
+            is_default = sub[_IS_DEFAULT_SUBSCRIPTION]
+            if is_default:
+                self._active_one = sub
+
+            # Trim subscription name if it is too long
+            subscription_name = sub[_SUBSCRIPTION_NAME]
+            if len(subscription_name) > subscription_name_length_limit:
+                subscription_name = subscription_name[:subscription_name_length_limit - 3] + '...'
+
+            row = {
+                'No': (highlight_text(f'[{index_str}]', is_default) +
+                       (' ' + self.DEFAULT_ROW_MARKER if is_default else '')),
+                'Subscription name': highlight_text(subscription_name, is_default),
+                'Subscription ID': highlight_text(sub[_SUBSCRIPTION_ID], is_default),
+                'Tenant': highlight_text(self._get_tenant_string(sub), is_default)
+            }
+            table_data.append(row)
+
+        from tabulate import tabulate
+        self._table_str = tabulate(table_data, headers="keys", tablefmt="simple", disable_numparse=True)
+
+        self._index_to_subscription_map = index_to_subscription_map
+
+    def __call__(self):
+        """Select a subscription.
+        NOTE: The original subscription list (isDefault property) is not modified. Call
+        Profile.set_active_subscription to modify it.
+        """
+        from knack.prompting import prompt
+
+        print(f'\n[Tenant and subscription selection]\n\n{self._table_str}\n')
+        tenant_string = self._get_tenant_string(self._active_one)
+        print(f"The default is marked with an {self.DEFAULT_ROW_MARKER}; "
+              f"the default tenant is '{tenant_string}' and subscription is "
+              f"'{self._active_one[_SUBSCRIPTION_NAME]}' ({self._active_one[_SUBSCRIPTION_ID]}).\n")
+
+        selected = self._active_one
+        # Keep prompting until the user inputs a valid index
+        while True:
+            select_index = prompt('Select a subscription and tenant (Type a number or Enter for no changes): ')
+
+            # Nothing is typed, keep current selection
+            if select_index == '':
+                break
+
+            if select_index in self._index_to_subscription_map:
+                selected = self._index_to_subscription_map[select_index]
+                break
+
+            logger.warning("Invalid selection.")
+            # Let retry
+
+        # Echo the selection
+        tenant_string = self._get_tenant_string(selected)
+        print(f"\nTenant: {tenant_string}\n"
+              f"Subscription: {selected[_SUBSCRIPTION_NAME]} ({selected[_SUBSCRIPTION_ID]})\n")
+        return selected
+
+    @staticmethod
+    def _get_tenant_string(subscription):
+        try:
+            return subscription[_TENANT_DISPLAY_NAME]
+        except KeyError:
+            return subscription[_TENANT_ID]

--- a/src/azure-cli/azure/cli/command_modules/profile/tests/latest/test_subscription_selector.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/tests/latest/test_subscription_selector.py
@@ -1,0 +1,126 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import unittest
+from unittest import mock
+from azure.cli.command_modules.profile._subscription_selector import SubscriptionSelector
+
+
+# These dummy subscriptions are used in both unit test and interactive test
+DUMMY_SUBSCRIPTIONS = [
+    # 0: sub 2
+    {
+        "id": "00000000-0000-0000-0000-222222222222",
+        "name": "sub 2",
+        "tenantDefaultDomain": "tenant1.onmicrosoft.com",
+        "tenantDisplayName": "Tenant 1",
+        "tenantId": "00000000-0000-0000-1111-111111111111",
+        "environmentName": "AzureCloud",
+        "isDefault": True
+    },
+    # 1: sub 1
+    {
+        "id": "00000000-0000-0000-0000-111111111111",
+        "name": "SUB 1",
+        "tenantDefaultDomain": "tenant1.onmicrosoft.com",
+        "tenantDisplayName": "Tenant 1",
+        "tenantId": "00000000-0000-0000-1111-111111111111",
+        "environmentName": "AzureCloud",
+        "isDefault": False
+    },
+    # 2: sub 3
+    {
+        "id": "00000000-0000-0000-0000-333333333333",
+        "name": "Sub 3 with long long long long long name",
+        "tenantDefaultDomain": "tenant1.onmicrosoft.com",
+        "tenantDisplayName": "Tenant 1",
+        "tenantId": "00000000-0000-0000-1111-111111111111",
+        "environmentName": "AzureCloud",
+        "isDefault": False
+    },
+    # 3: tenant account
+    {
+        "id": "00000000-0000-0000-1111-222222222222",
+        "name": "N/A(tenant level account)",
+        "tenantDefaultDomain": "tenant2.onmicrosoft.com",
+        "tenantDisplayName": "Tenant 2",
+        "tenantId": "00000000-0000-0000-1111-222222222222",
+        "environmentName": "AzureCloud",
+        "isDefault": False
+    }
+]
+
+EXPECTED_SUBSCRIPTION_TABLE = """\
+No     Subscription name                     Subscription ID                       Tenant
+-----  ------------------------------------  ------------------------------------  --------
+[1]    N/A(tenant level account)             00000000-0000-0000-1111-222222222222  Tenant 2
+[2]    SUB 1                                 00000000-0000-0000-0000-111111111111  Tenant 1
+\x1b[96m[3]\x1b[0m *  \x1b[96msub 2\x1b[0m                                 \x1b[96m00000000-0000-0000-0000-222222222222\x1b[0m  \x1b[96mTenant 1\x1b[0m
+[4]    Sub 3 with long long long long lo...  00000000-0000-0000-0000-333333333333  Tenant 1"""
+
+DUMMY_SUBSCRIPTIONS_NO_TENANT_INFO = [
+    {
+        "id": "00000000-0000-0000-0000-222222222222",
+        "name": "sub 2",
+        "tenantId": "00000000-0000-0000-1111-111111111111",
+        "environmentName": "AzureCloud",
+        "isDefault": True
+    },
+    {
+        "id": "00000000-0000-0000-0000-111111111111",
+        "name": "sub 1",
+        "tenantId": "00000000-0000-0000-1111-111111111111",
+        "environmentName": "AzureCloud",
+        "isDefault": False
+    }
+]
+
+EXPECTED_DUMMY_SUBSCRIPTION_TABLE = """\
+No     Subscription name    Subscription ID                       Tenant
+-----  -------------------  ------------------------------------  ------------------------------------
+[1]    sub 1                00000000-0000-0000-0000-111111111111  00000000-0000-0000-1111-111111111111
+\x1b[96m[2]\x1b[0m *  \x1b[96msub 2\x1b[0m                \x1b[96m00000000-0000-0000-0000-222222222222\x1b[0m  \x1b[96m00000000-0000-0000-1111-111111111111\x1b[0m"""
+
+
+class TestSubscriptionSelection(unittest.TestCase):
+
+    def setUp(self):
+        super().setUp()
+
+    def test_format_subscription_table(self):
+        sub = DUMMY_SUBSCRIPTIONS
+        from azure.cli.core.style import format_styled_text
+
+        # We have to force format_styled_text to use 'dark' theme, otherwise other tests in the same process
+        # may change format_styled_text.theme to 'none' and format_styled_text will not print color, leading to
+        # unmatched result. For example, this command fails:
+        #   azdev test test_account_show test_format_subscription_table
+        # create=True is required as running this test alone won't set format_styled_text.theme. patch.object
+        # will fail because of the missing theme attribute. For example, this command fails:
+        #   azdev test test_format_subscription_table
+        with mock.patch.object(format_styled_text, 'theme', 'dark', create=True):
+            selector = SubscriptionSelector(sub)
+            assert (selector._index_to_subscription_map == {
+                '1': sub[3],
+                '2': sub[1],
+                '3': sub[0],
+                '4': sub[2]})
+            assert selector._table_str == EXPECTED_SUBSCRIPTION_TABLE
+
+            selector = SubscriptionSelector(DUMMY_SUBSCRIPTIONS_NO_TENANT_INFO)
+            assert selector._table_str == EXPECTED_DUMMY_SUBSCRIPTION_TABLE
+
+
+def invoke_subscription_selector():
+    """This method provides a way of directly testing subscription selection, without running an actual `az login`.
+    Invoke this method with:
+    python -m azure.cli.command_modules.profile.tests.latest.test_subscription_selector
+    """
+    result = SubscriptionSelector(DUMMY_SUBSCRIPTIONS)()
+    print("Result:", result)
+
+
+if __name__ == '__main__':
+    invoke_subscription_selector()

--- a/src/azure-cli/azure/cli/command_modules/util/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/util/custom.py
@@ -267,6 +267,7 @@ def demo_style(cmd, theme=None):  # pylint: disable=unused-argument
     styled_text = [
         (Style.PRIMARY, placeholder.format("White", "Primary text color")),
         (Style.SECONDARY, placeholder.format("Grey", "Secondary text color")),
+        (Style.HIGHLIGHT, placeholder.format("Cyan", "Highlight text color")),
         (Style.IMPORTANT, placeholder.format("Magenta", "Important text color")),
         (Style.ACTION, placeholder.format(
             "Blue", "Commands, parameters, and system inputs (White in legacy powershell terminal)")),

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -146,6 +146,9 @@ DEPENDENCIES = [
     'semver==2.13.0',
     'six>=1.10.0',  # six is still used by countless extensions
     'sshtunnel~=0.1.4',
+    # Even though knack already depends on tabulate, profile module directly uses it for interactive subscription
+    # selection
+    'tabulate',
     'urllib3',
     'websocket-client~=1.3.1',
     'xmltodict~=0.12'


### PR DESCRIPTION
**Related command**
`az login`

**Description**<!--Mandatory-->
Interactive commands now prompt the user to interactively select the default subscription and tenant:
- `az login`: Auth code flow/WAM
- `az login --use-device-code`: Device code flow

Automation commands are not affected:
- `az login --username --password`: Username password flow
- `az login --service-principal`: Service principal authentication
- `az login --identity`: managed identity authentication

**Testing Guide**
`az login`
`az login --use-device-code`

Turn off:
```
az config set core.login_experience_v2=off
az login
```

**Additional Information**
Require #28660

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
