### PR TITLE
{Sqlvm} `az sql vm validate-azure-ad-auth`: Change validation for sqlvm Entra authentication

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/sqlvm/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/sqlvm/_validators.py
@@ -218,10 +218,6 @@ def validate_azure_ad_authentication(cmd, namespace):
     if cmd.cli_ctx.cloud.name != AZURE_PUBLIC_CLOUD.name:
         raise InvalidArgumentValueError("Azure AD authentication is not supported in {}".format(cmd.ctx_cli.cloud.name))
 
-    # validate the SQL VM supports Azure AD authentication, i.e. it is on Windows platform and is SQL 2022 or later
-    _validate_azure_ad_authentication_supported_on_sqlvm(cmd.cli_ctx, namespace)
-    logger.debug("Validate Azure AD authentication: the SQL VM itself is suitable for Azure AD authentication.")
-
     # validate the MSI is valid on the Azure virtual machine
     principal_id = _validate_msi_valid_on_vm(cmd.cli_ctx, namespace)
     logger.debug("Validate Azure AD authentication: the managed identity is valid with a principalId %s.", principal_id)
@@ -229,55 +225,6 @@ def validate_azure_ad_authentication(cmd, namespace):
     # validate the MSI has appropriate permission to query Microsoft Graph API
     _validate_msi_with_enough_permission(cmd.cli_ctx, principal_id)
     logger.debug("Validate Azure AD authentication: the managed identity has required Graph API permission.")
-
-
-def _validate_azure_ad_authentication_supported_on_sqlvm(cli_ctx, namespace):
-    """ Validate this SQL VM instance supports Azure AD authentication, i.e. it is on Windows platform and is SQL 2022 or later
-
-        :param cli_ctx: The CLI context.
-        :type cli_ctx: AzCli.
-        :param namespace: The argparse namespace represents the arguments.
-        :type namespace: argpase.Namespace.
-    """
-    logger.debug("Validate Azure AD authentication against SQL VM instance.")
-
-    # retrieve SQL VM client
-    from ._util import get_sqlvirtualmachine_management_client
-    sqlvm_ops = get_sqlvirtualmachine_management_client(cli_ctx).sql_virtual_machines
-
-    # Retrieve the sqlvm instance, This is a rest call to the server and deserialization afterwards
-    # therefore there is a greater chance to encouter an exception. Instead of poping the exception
-    # to the caller directly, we will throw our own InvalidArgumentValueError with more context
-    # information.
-    try:
-        sqlvm = sqlvm_ops.get(namespace.resource_group_name, namespace.sql_virtual_machine_name)
-    except Exception as ex:
-        raise InvalidArgumentValueError("Unable to validate Azure AD authentication due to retrieving SQL VM instance encountering an error: {}.".format(ex)) from ex
-
-    # Construct error message for unsupported SQL server version or OS platform.
-    unsupported_error = "Azure AD authentication requires SQL Server 2022 on Windows platform, but the SQL Image Offer of this SQL VM is {}".format(sqlvm.sql_image_offer)
-
-    logger.debug("The SQL VM sql_image_offer is %s.", sqlvm.sql_image_offer)
-    if sqlvm.sql_image_offer is None:
-        raise InvalidArgumentValueError(unsupported_error)
-
-    # An example sqlImageOffer is SQL2022-WS2022.
-    version_platform = sqlvm.sql_image_offer.split('-')
-    if len(version_platform) < 2:
-        raise InvalidArgumentValueError(unsupported_error)
-
-    version = version_platform[0]
-    platform = version_platform[1]
-
-    try:
-        int_version = int(version[3:])
-    except ValueError:
-        raise InvalidArgumentValueError(unsupported_error)
-
-    if int_version < 2022 or not platform.startswith("WS"):
-        az_error = InvalidArgumentValueError(unsupported_error)
-        az_error.set_recommendation("Upgrade SQL server to SQL server 2022 or later.")
-        raise az_error
 
 
 def _validate_msi_valid_on_vm(cli_ctx, namespace):

--- a/src/azure-cli/azure/cli/command_modules/sqlvm/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/sqlvm/_validators.py
@@ -218,6 +218,10 @@ def validate_azure_ad_authentication(cmd, namespace):
     if cmd.cli_ctx.cloud.name != AZURE_PUBLIC_CLOUD.name:
         raise InvalidArgumentValueError("Azure AD authentication is not supported in {}".format(cmd.ctx_cli.cloud.name))
 
+    # validate the SQL VM supports Azure AD authentication, i.e. it is on Windows platform and is SQL 2022 or later
+    _validate_azure_ad_authentication_supported_on_sqlvm(cmd.cli_ctx, namespace)
+    logger.debug("Validate Azure AD authentication: the SQL VM itself is suitable for Azure AD authentication.")
+
     # validate the MSI is valid on the Azure virtual machine
     principal_id = _validate_msi_valid_on_vm(cmd.cli_ctx, namespace)
     logger.debug("Validate Azure AD authentication: the managed identity is valid with a principalId %s.", principal_id)
@@ -225,6 +229,55 @@ def validate_azure_ad_authentication(cmd, namespace):
     # validate the MSI has appropriate permission to query Microsoft Graph API
     _validate_msi_with_enough_permission(cmd.cli_ctx, principal_id)
     logger.debug("Validate Azure AD authentication: the managed identity has required Graph API permission.")
+
+
+def _validate_azure_ad_authentication_supported_on_sqlvm(cli_ctx, namespace):
+    """ Validate this SQL VM instance supports Azure AD authentication, i.e. it is on Windows platform and is SQL 2022 or later
+
+        :param cli_ctx: The CLI context.
+        :type cli_ctx: AzCli.
+        :param namespace: The argparse namespace represents the arguments.
+        :type namespace: argpase.Namespace.
+    """
+    logger.debug("Validate Azure AD authentication against SQL VM instance.")
+
+    # retrieve SQL VM client
+    from ._util import get_sqlvirtualmachine_management_client
+    sqlvm_ops = get_sqlvirtualmachine_management_client(cli_ctx).sql_virtual_machines
+
+    # Retrieve the sqlvm instance, This is a rest call to the server and deserialization afterwards
+    # therefore there is a greater chance to encouter an exception. Instead of poping the exception
+    # to the caller directly, we will throw our own InvalidArgumentValueError with more context
+    # information.
+    try:
+        sqlvm = sqlvm_ops.get(namespace.resource_group_name, namespace.sql_virtual_machine_name)
+    except Exception as ex:
+        raise InvalidArgumentValueError("Unable to validate Azure AD authentication due to retrieving SQL VM instance encountering an error: {}.".format(ex)) from ex
+
+    # Construct error message for unsupported SQL server version or OS platform.
+    unsupported_error = "Azure AD authentication requires SQL Server 2022 on Windows platform, but the SQL Image Offer of this SQL VM is {}".format(sqlvm.sql_image_offer)
+
+    logger.debug("The SQL VM sql_image_offer is %s.", sqlvm.sql_image_offer)
+    if sqlvm.sql_image_offer is None:
+        raise InvalidArgumentValueError(unsupported_error)
+
+    # An example sqlImageOffer is SQL2022-WS2022.
+    version_platform = sqlvm.sql_image_offer.split('-')
+    if len(version_platform) < 2:
+        raise InvalidArgumentValueError(unsupported_error)
+
+    version = version_platform[0]
+    platform = version_platform[1]
+
+    try:
+        int_version = int(version[3:])
+    except ValueError:
+        raise InvalidArgumentValueError(unsupported_error)
+
+    if int_version < 2022 or not platform.startswith("WS"):
+        az_error = InvalidArgumentValueError(unsupported_error)
+        az_error.set_recommendation("Upgrade SQL server to SQL server 2022 or later.")
+        raise az_error
 
 
 def _validate_msi_valid_on_vm(cli_ctx, namespace):

--- a/src/azure-cli/azure/cli/command_modules/sqlvm/tests/latest/test_sqlvm_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/sqlvm/tests/latest/test_sqlvm_commands.py
@@ -766,8 +766,8 @@ class SqlVmAndGroupScenarioTest(ScenarioTest):
             validate_sql2019 = 'sql vm {} -n {} -g {}'.format(command, sqlvm2019, resource_group)
 
             # Assert customer cannot enable Azure AD authentication on SQL Server 2019
-            with self.assertRaisesRegex(InvalidArgumentValueError, "Azure AD authentication requires SQL Server 2022 on Windows platform"):
-                self.cmd(validate_sql2019)
+            #with self.assertRaisesRegex(InvalidArgumentValueError, "Azure AD authentication requires SQL Server 2022 on Windows platform"):
+            #    self.cmd(validate_sql2019)
 
             validate_system_msi = 'sql vm {} -n {} -g {}'.format(command, sqlvm2022, resource_group)
             validate_attached_msi = 'sql vm {} -n {} -g {} --msi-client-id {}'.format(command, sqlvm2022, resource_group, attached_identity['clientId'])

--- a/src/azure-cli/azure/cli/command_modules/sqlvm/tests/latest/test_sqlvm_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/sqlvm/tests/latest/test_sqlvm_commands.py
@@ -766,8 +766,8 @@ class SqlVmAndGroupScenarioTest(ScenarioTest):
             validate_sql2019 = 'sql vm {} -n {} -g {}'.format(command, sqlvm2019, resource_group)
 
             # Assert customer cannot enable Azure AD authentication on SQL Server 2019
-            #with self.assertRaisesRegex(InvalidArgumentValueError, "Azure AD authentication requires SQL Server 2022 on Windows platform"):
-            #    self.cmd(validate_sql2019)
+            with self.assertRaisesRegex(InvalidArgumentValueError, "Azure AD authentication requires SQL Server 2022 on Windows platform"):
+                self.cmd(validate_sql2019)
 
             validate_system_msi = 'sql vm {} -n {} -g {}'.format(command, sqlvm2022, resource_group)
             validate_attached_msi = 'sql vm {} -n {} -g {} --msi-client-id {}'.format(command, sqlvm2022, resource_group, attached_identity['clientId'])

--- a/src/azure-cli/azure/cli/command_modules/sqlvm/tests/latest/test_sqlvm_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/sqlvm/tests/latest/test_sqlvm_commands.py
@@ -766,8 +766,9 @@ class SqlVmAndGroupScenarioTest(ScenarioTest):
             validate_sql2019 = 'sql vm {} -n {} -g {}'.format(command, sqlvm2019, resource_group)
 
             # Assert customer cannot enable Azure AD authentication on SQL Server 2019
-            with self.assertRaisesRegex(InvalidArgumentValueError, "Azure AD authentication requires SQL Server 2022 on Windows platform"):
-                self.cmd(validate_sql2019)
+            # with self.assertRaisesRegex(InvalidArgumentValueError, "Azure AD authentication requires SQL Server 2022 on Windows platform"):
+            #    self.cmd(validate_sql2019)
+            # this validation will happen in RP call, so skipping this check.
 
             validate_system_msi = 'sql vm {} -n {} -g {}'.format(command, sqlvm2022, resource_group)
             validate_attached_msi = 'sql vm {} -n {} -g {} --msi-client-id {}'.format(command, sqlvm2022, resource_group, attached_identity['clientId'])


### PR DESCRIPTION
**Related command**
az sql vm validate-azure-ad-auth
az sql vm enable-azure-ad-auth

**Description**<!--Mandatory-->
Entra authentication can only be enabled for SQL2022
CLI validates entra auth requests by getting SQL version from SqlImageOffer and checks if the version is SQL2022. But SqlImageOffer is set only once during registration and is not updated when SQL version is changed. As a result, any customer who had previous SQL version and upgraded to SQL2022 will still not be able to configure entra auth.
To avoid this, removing the validation SQL version and rely on the server-side (RP) validation that always happens.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
{Sqlvm} az sql vm validate-azure-ad-auth: Change validation for sqlvm Entra authentication
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
