### PR TITLE
{RDBMS} Add support for left-shift clusters in westus3

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/config.json
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/config.json
@@ -2,6 +2,7 @@
     "AzureCloud": {
         "southcentralus": ["ossdev", "osshf", "ossmc", "ossrc"],
         "northcentralus": ["ossdev", "osshf", "ossmc", "ossrc"],
+        "westus3": ["ossdev", "osshf", "ossmc", "ossrc"],
         "osshf": {
             "subscriptions": ["4a5d02ab-e0c3-4d39-8031-293ddd4e1875"],
             "privateDnsZoneDomain": "pg.osshf-scus1-a.mscds.com"


### PR DESCRIPTION
Related command
Add support for Left Shift clusters in region westus3. Needed for Geo restore test.

Description
Add support for Left Shift clusters in region westus3. Needed for Geo restore test.

Testing Guide
Verified manually