### PR TITLE
[Packaging] Drop Ubuntu 18.04 support

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -952,12 +952,6 @@ jobs:
     matrix:
       ${{ each arch in parameters.architectures }}:
         # https://wiki.ubuntu.com/Releases
-        Bionic ${{ arch.name }}:
-          # 18.04
-          deb_system: ubuntu
-          distro: bionic
-          arch: ${{ arch.value }}
-          pool: ${{ arch.pool }}
         Focal ${{ arch.name }}:
           # 20.04
           deb_system: ubuntu

--- a/scripts/release/debian/build.sh
+++ b/scripts/release/debian/build.sh
@@ -21,17 +21,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Update APT packages
 apt-get update
 # uuid-dev is used to build _uuid module: https://github.com/python/cpython/pull/3796
-apt-get install -y libssl-dev libffi-dev python3-dev zlib1g-dev uuid-dev wget
-
-# In Ubuntu 18.04, debhelper 11.1.6 has bug which makes it fail to dpkg-buildpackage. Use backport version instead.
-# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=897569
-if cat /etc/lsb-release | grep 18.04
-then
-  apt-get install -y debhelper -t bionic-backports
-else
-  apt-get install -y debhelper
-fi
-
+apt-get install -y libssl-dev libffi-dev python3-dev zlib1g-dev uuid-dev wget debhelper
 # Git is not strictly necessary, but it would allow building an experimental package
 # with dependency which is currently only available in its git repo feature branch.
 apt-get install -y git


### PR DESCRIPTION
Ubuntu 18.04 reached its EOL in June 2023.
Drop it to reduce the maintenance efforts as we support 24.04 now.

Ref: https://wiki.ubuntu.com/Releases