### PR TITLE
{Auth} Enable PII log for WAM

### DIFF
--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -112,7 +112,9 @@ class Identity:  # pylint: disable=too-many-instance-attributes
     def _msal_public_app_kwargs(self):
         """kwargs for creating PublicClientApplication."""
         # enable_broker_on_windows can only be used on PublicClientApplication.
-        return {**self._msal_app_kwargs, "enable_broker_on_windows": self._enable_broker_on_windows}
+        return {**self._msal_app_kwargs,
+                "enable_broker_on_windows": self._enable_broker_on_windows,
+                "enable_pii_log": True}
 
     @property
     def _msal_app(self):


### PR DESCRIPTION
**Related command**
`az login`

**Description**<!--Mandatory-->
MSAL  hides the original `AADSTS` error when WAM is used (https://github.com/AzureAD/microsoft-authentication-library-for-python/issues/698).

This PR uses `enable_pii_log` from https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/590 to print the original `AADSTS` error.

~We should carefully inspect that no PII is sent to the telemetry before merging this PR.~

As confirmed by MSAL (https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/590#issuecomment-2113956923), `enable_pii_log` only affects logs, not telemetry. In other words, the telemetry will not contain PII even when `enable_pii_log` is set to `True`.

**Testing Guide**
Before:

```
> az login --scope https://graph.microsoft.com/User.ReadWrite
...
(pii). Status: Response_Status.Status_IncorrectConfiguration, Error code: 3399614466, Tag: 557973643
```

After:

```
> az login --scope https://graph.microsoft.com/User.ReadWrite
...
V2Error: invalid_request AADSTS65002: Consent between first party application '04b07795-8ddb-461a-bbee-02f9e1bf7b46' 
and first party resource '00000003-0000-0000-c000-000000000000' must be configured via preauthorization - 
applications owned and operated by Microsoft must get approval from the API owner before requesting tokens for that 
API. Trace ID: 75dc241c-0678-496c-ab6a-101595e34000 Correlation ID: 33a31850-1124-47d8-ab9c-085c4a0b9db8 Timestamp: 
2024-05-13 12:31:04Z. Status: Response_Status.Status_IncorrectConfiguration, Error code: 3399614466, Tag: 557973643
```
