### PR TITLE
{Packaging} Fix DEB install script

### DIFF
--- a/scripts/release/debian/deb_install.sh
+++ b/scripts/release/debian/deb_install.sh
@@ -49,7 +49,7 @@ setup() {
     set -v
     mkdir -p /etc/apt/keyrings
     curl -sLS https://packages.microsoft.com/keys/microsoft.asc |
-      gpg --dearmor -o /etc/apt/keyrings/microsoft.gpg
+      gpg --dearmor > /etc/apt/keyrings/microsoft.gpg
     chmod go+r /etc/apt/keyrings/microsoft.gpg
     set +v
 


### PR DESCRIPTION
Resolve #28984.

There is [no tty in GitHub runner](https://github.com/actions/runner/issues/241). This error is raised when run `gpg --dearmor -o /etc/apt/keyrings/microsoft.gpg`:
`gpg: cannot open '/dev/tty': No such device or address`

The reason is that this file already exists in the agent:
```
ls -la /etc/apt/keyrings/
total 20
drwxr-xr-x 2 root root 4096 May 16 11:42 .
drwxr-xr-x 8 root root 4096 May 16 11:10 ..
-rw-r--r-- 1 root root 2825 May 16 11:31 github_git-lfs-archive-keyring.gpg
-rw-r--r-- 1 root root 1200 May 16 11:42 kubernetes-apt-keyring.gpg
-rw-r--r-- 1 root root  641 May 16 11:20 microsoft.gpg
```

And `gpg` wants to ask: `File '/etc/apt/keyrings/microsoft.gpg' exists. Overwrite? (y/N)`

This PR reverts to the save method from the previous commit, which overwrites the file.

Related PR: #28250

Tested in this workflow: https://github.com/bebound/starter-workflows/actions/runs/9152933588

