### PR TITLE
{ACR} Fix az acr login command on AzureStackHub

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/policy.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/policy.py
@@ -162,11 +162,12 @@ def acr_config_authentication_as_arm_show(cmd,
     AzureADAuthenticationAsArmPolicy = cmd.get_models('AzureADAuthenticationAsArmPolicy')
     policies = registry.policies
 
-    # On AzureStackHub, the 2019-05-01 API version is still in use, so we need to check if the 'azure_ad_authentication_as_arm_policy' attribute exists before we invoke it
-    aadAuth_policy = policies.azure_ad_authentication_as_arm_policy if policies and hasattr(policies, 'azure_ad_authentication_as_arm_policy') else AzureADAuthenticationAsArmPolicy
-
-    return aadAuth_policy
-
+    # On AzureStackHub, the 2019-05-01 API version is still in use, so we need to check if the
+    # 'azure_ad_authentication_as_arm_policy' attribute exists before we invoke it
+    if policies and hasattr(policies, 'azure_ad_authentication_as_arm_policy'):
+        return policies.azure_ad_authentication_as_arm_policy
+    else:
+        return AzureADAuthenticationAsArmPolicy
 
 def acr_config_authentication_as_arm_update(cmd,
                                             client,

--- a/src/azure-cli/azure/cli/command_modules/acr/policy.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/policy.py
@@ -161,7 +161,7 @@ def acr_config_authentication_as_arm_show(cmd,
 
     AzureADAuthenticationAsArmPolicy = cmd.get_models('AzureADAuthenticationAsArmPolicy')
     policies = registry.policies
-    aadAuth_policy = policies.azure_ad_authentication_as_arm_policy if policies else AzureADAuthenticationAsArmPolicy()
+    aadAuth_policy = policies.azure_ad_authentication_as_arm_policy if policies and hasattr(policies, 'azure_ad_authentication_as_arm_policy') else AzureADAuthenticationAsArmPolicy
 
     return aadAuth_policy
 

--- a/src/azure-cli/azure/cli/command_modules/acr/policy.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/policy.py
@@ -161,6 +161,8 @@ def acr_config_authentication_as_arm_show(cmd,
 
     AzureADAuthenticationAsArmPolicy = cmd.get_models('AzureADAuthenticationAsArmPolicy')
     policies = registry.policies
+
+    # On AzureStackHub, the 2019-05-01 API version is still in use, so we need to check if the 'azure_ad_authentication_as_arm_policy' attribute exists before we invoke it
     aadAuth_policy = policies.azure_ad_authentication_as_arm_policy if policies and hasattr(policies, 'azure_ad_authentication_as_arm_policy') else AzureADAuthenticationAsArmPolicy
 
     return aadAuth_policy

--- a/src/azure-cli/azure/cli/command_modules/acr/policy.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/policy.py
@@ -166,8 +166,9 @@ def acr_config_authentication_as_arm_show(cmd,
     # 'azure_ad_authentication_as_arm_policy' attribute exists before we invoke it
     if policies and hasattr(policies, 'azure_ad_authentication_as_arm_policy'):
         return policies.azure_ad_authentication_as_arm_policy
-    else:
-        return AzureADAuthenticationAsArmPolicy
+
+    return AzureADAuthenticationAsArmPolicy
+
 
 def acr_config_authentication_as_arm_update(cmd,
                                             client,


### PR DESCRIPTION
**Related command**
az acr login

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
On AzureStackHub, ACR is using the API version `2019-05-01` in the latest available hybrid profile which is [2020-09-01-hybrid](https://github.com/Azure/azure-cli/blob/dev/src/azure-cli-core/azure/cli/core/profiles/_shared.py#L315). The `2019-05-01` API version does not have a `azureADAuthenticationAsArmPolicy` object in the registry, and so when that attribute is invoked during an `az acr login` command, this error is thrown:

```
The command failed with an unexpected error. Here is the traceback:
'Policies' object has no attribute 'azure_ad_authentication_as_arm_policy'
Traceback (most recent call last):
  File "D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\knack/cli.py", line 233, in invoke
  File "D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/commands/__init__.py", line 664, in execute
  File "D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/commands/__init__.py", line 731, in _run_jobs_serially
  File "D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/commands/__init__.py", line 701, in _run_job
  File "D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/commands/__init__.py", line 334, in __call__
  File "D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/commands/command_operation.py", line 121, in handler
  File "D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/command_modules/acr/custom.py", line 268, in acr_login
  File "D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/command_modules/acr/_docker_utils.py", line 464, in get_login_credentials
  File "D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/command_modules/acr/_docker_utils.py", line 405, in _get_credentials
  File "D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/command_modules/acr/policy.py", line 164, in acr_config_authentication_as_arm_show
AttributeError: 'Policies' object has no attribute 'azure_ad_authentication_as_arm_policy'
```

Until a newer API version is added for AzureStackHub, the fix in this PR will ensure that the `azure_ad_authentication_as_arm_policy` attribute is only invoked when it exists. This fixes the `az acr login` command on AzureStackHub. 

**Testing Guide**
I first tested my change by ensuring normal use cases are not broken while running these commands which succeeded:

``` bash
az acr login -n <registry>
az acr config authentication-as-arm show -r aksonazs
```

Then I set the profile to `2020-09-01-hybrid` which switches the ACR API version to `2019-05-01` and tested the login command again which also succeeded:

``` bash
az cloud update --profile 2020-09-01-hybrid
az acr login -n <registry>
```

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
