### PR TITLE
{RDBMS} Add support for left-shift clusters in new regions

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/config.json
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/config.json
@@ -1,7 +1,9 @@
 {
     "AzureCloud": {
+        "eastus2": ["ossdev", "osshf", "ossmc", "ossrc"],
         "southcentralus": ["ossdev", "osshf", "ossmc", "ossrc"],
         "northcentralus": ["ossdev", "osshf", "ossmc", "ossrc"],
+        "westus2": ["ossdev", "osshf", "ossmc", "ossrc"],
         "westus3": ["ossdev", "osshf", "ossmc", "ossrc"],
         "osshf": {
             "subscriptions": ["4a5d02ab-e0c3-4d39-8031-293ddd4e1875"],


### PR DESCRIPTION
Related command
Add support for Left Shift clusters in regions westus2 and eastus2. Needed for capacity.

Description
Add support for Left Shift clusters in regions westus2 and eastus2. Needed for capacity.

Testing Guide
Verified manually