### PR TITLE
[ARM] `az bicep restore`: Fix typos in help messages

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_help.py
@@ -2845,9 +2845,9 @@ helps['bicep restore'] = """
 type: command
 short-summary: Restore external modules for a bicep file.
 examples:
-  - name: Retore external modules.
+  - name: Restore external modules.
     text: az bicep restore --file {bicep_file}
-  - name: Retore external modules and overwrite cached external modules.
+  - name: Restore external modules and overwrite cached external modules.
     text: az bicep restore --file {bicep_file} --force
 """
 


### PR DESCRIPTION
**Related command**
`az bicep restore --help`

**Description**<!--Mandatory-->
The help contents of the command mentioned above contains a (very minor) typo which occurs twice.

**Testing Guide**
N/A

[Bicep restore] `az bicep restore`: Fix typos in documentation

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
