### PR TITLE
[AppService] Fix #29041: `az webapp config access-restriction add`: Fix edge case validating service tags

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_validators.py
@@ -348,7 +348,7 @@ def _validate_service_tag_format(cmd, namespace):
         service_tag_full_list = ListServiceTags(cli_ctx=cmd.cli_ctx)(command_args={
             "location": webapp.location
         })
-        if service_tag_full_list is None:
+        if service_tag_full_list is None or "values" not in service_tag_full_list:
             logger.warning('Not able to get full Service Tag list. Cannot validate Service Tag.')
             return
         for tag in input_tags:


### PR DESCRIPTION
**Related command**
az webapp config access-restriction add

**Description**<!--Mandatory-->
Customer reported issue #29041

**Testing Guide**
az webapp config access-restriction add -g <rg> -n <app> --priority 200 --service-tag AzureCloud
Though it requires a specific set of permissions used by this customer. The condition will not impact existing scenarios but catch this specific condition.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
