### PR TITLE
[NetAppFiles] Coolnessperiod minimum fix

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/netappfiles/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/netappfiles/custom.py
@@ -443,7 +443,7 @@ class VolumeUpdate(_VolumeUpdate):
             maximum=2400,
             minimum=100,
         )
-        
+
         args_schema.coolness_period._fmt = AAZIntArgFormat(
             maximum=183,
             minimum=2,

--- a/src/azure-cli/azure/cli/command_modules/netappfiles/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/netappfiles/custom.py
@@ -315,6 +315,11 @@ class VolumeCreate(_VolumeCreate):
             minimum=100
         )
 
+        args_schema.coolness_period._fmt = AAZIntArgFormat(
+            maximum=183,
+            minimum=2,
+        )
+
         # The API does only support setting Basic and Standard
         args_schema.network_features.enum = AAZArgEnum({"Basic": "Basic", "Standard": "Standard"}, case_sensitive=False)
 
@@ -437,6 +442,11 @@ class VolumeUpdate(_VolumeUpdate):
         args_schema.usage_threshold._fmt = AAZIntArgFormat(
             maximum=2400,
             minimum=100,
+        )
+        
+        args_schema.coolness_period._fmt = AAZIntArgFormat(
+            maximum=183,
+            minimum=2,
         )
 
         return args_schema


### PR DESCRIPTION
**Related command**
The minimum supported coolness-period value in `az netappfiles volume create` and `az netappfiles volume update`  was changed from 7 to 2.
This change makes it less constraining and is correcting the definition to accurately match the service behavior. The root issue is due to incorrect swagger spec that is being corrected in a separate action. 
Since that takes time we would like to make this change in customization to get this fix out asap to Azure CLI.

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
