### PR TITLE
[RDBMS] Bug Fix Pass in MigrationRuntimeResourceId to Migration Parameters when provided as argument

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
@@ -1432,7 +1432,8 @@ def _create_migration(logging_name, client, subscription_id, resource_group_name
         overwrite_dbs_in_target=get_enum_value_true_false(get_case_insensitive_key_value("OverwriteDbsInTarget", parameter_keys, parameters), "OverwriteDbsInTarget"),
         source_type=source_type,
         migration_option=migration_option,
-        ssl_mode=ssl_mode)
+        ssl_mode=ssl_mode,
+        migration_instance_resource_id=migrationInstanceResourceId)
 
     return client.create(subscription_id, resource_group_name, target_db_server_name, migration_name, migration_parameters)
 


### PR DESCRIPTION
**Related command**
`az postgres flexible-server migration create --subscription sub --resource-group testGroup --name testserver --migration-name testmigration --properties "migrationConfig.json" --migrationRuntimeResourceId /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/testGroup/providers/Microsoft.DBforPostgreSQL/flexibleServers/testsourcemigration`

**Description**<!--Mandatory-->
BUG FIX. The migration runtime resource id was not being passed in as a parameter when creating the migration. 

**Testing Guide**
Manually
PS C:\Users\nasc\azureCLI\azure-cli>  & 'c:\Users\nasc\azureCLI\azure-cli\env\Scripts\python.exe' 'c:\Users\nasc\.vscode\extensions\ms-python.debugpy-2024.6.0-win32-x64\bundled\libs\debugpy\adapter/../..\debugpy\launcher' '51390' '--' 'C:\Users\nasc\azureCLI\azure-cli/src/azure-cli/azure/cli/__main__.py' 'postgres' 'flexible-server' 'migration' 'create' '--subscription' 'xxxx' '--resource-group' 'xxxx'' '--name' 'pe-cli-flexible' '--migration-name' 'nasc_test2' '--migrationRuntimeResourceId' '/xxxx'/providers/Microsoft.DBforPostgreSQL/flexibleServers/vnet-flex-test-cli' '--properties' 'C:\Users\nasc\migration_test2.json' '--migration-mode' 'offline' 
WARNING: Checking the existence of the resource group 'xxxx''...
WARNING: Resource group 'xxxx'' exists ? : True 
WARNING: Creating PostgreSQL Migration for server 'pe-cli-flexible' in group 'xxxx'' and subscription 'xxxx''...
{
  "cancel": null,
  "currentStatus": {
    "currentSubStateDetails": null,
    "error": null,
    "state": "InProgress"
  },
  "dbsToCancelMigrationOn": null,
  "dbsToMigrate": [
    "postgres"
  ],
  "dbsToTriggerCutoverOn": null,
  "id": "xxxx'/flexibleServers/pe-cli-flexible/migrations/nasc_test2",    
  "location": "eastus",
  "migrateRoles": null,
  "migrationId": "xxxx'",
  "**migrationInstanceResourceId**": "xxxx'/providers/Microsoft.DBforPostgreSQL/flexibleServers/vnet-flex-test-cli",

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 2] `az postgres flexible-server migration create`: Allow private endpoint migrations by providing migration runtime resource ID as command line argument

---
