### PR TITLE
{Misc.} Remove all occurrences of assertNotEquals

### DIFF
--- a/src/azure-cli-core/azure/cli/core/tests/test_application.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_application.py
@@ -32,7 +32,7 @@ class TestApplication(unittest.TestCase):
 
         cli.refresh_request_id()
         self.assertIn('x-ms-client-request-id', cli.data['headers'])
-        self.assertNotEquals(old_id, cli.data['headers']['x-ms-client-request-id'])
+        self.assertNotEqual(old_id, cli.data['headers']['x-ms-client-request-id'])
 
     def test_client_request_id_is_refreshed_after_execution(self):
         def _handler(args):
@@ -53,7 +53,7 @@ class TestApplication(unittest.TestCase):
 
         cli.invoke(['test'])
         self.assertIn('x-ms-client-request-id', cli.data['headers'])
-        self.assertNotEquals(old_id, cli.data['headers']['x-ms-client-request-id'])
+        self.assertNotEqual(old_id, cli.data['headers']['x-ms-client-request-id'])
 
     def test_application_register_and_call_handlers(self):
         handler_called = [False]

--- a/src/azure-cli/azure/cli/command_modules/ams/tests/latest/test_ams_content_key_policy_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/tests/latest/test_ams_content_key_policy_scenarios.py
@@ -395,7 +395,7 @@ class AmsContentKeyPolicyTests(ScenarioTest):
 
         output = self.cmd('az ams content-key-policy show -a {amsname} -n {contentKeyPolicyName} -g {rg} --with-secrets').get_output_in_json()
 
-        self.assertNotEquals(output.get('options')[0].get('restriction').get('primaryVerificationKey').get('rawBody'), None)
+        self.assertNotEqual(output.get('options')[0].get('restriction').get('primaryVerificationKey').get('rawBody'), None)
 
     @ResourceGroupPreparer()
     @StorageAccountPreparer(parameter_name='storage_account_for_delete')

--- a/src/azure-cli/azure/cli/command_modules/ams/tests/latest/test_ams_live_event_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/tests/latest/test_ams_live_event_scenarios.py
@@ -66,8 +66,8 @@ class AmsLiveEventTests(ScenarioTest):
         self.assertIsNotNone(live_event['crossSiteAccessPolicies']['crossDomainPolicy'])
         self.assertIsNotNone(live_event['crossSiteAccessPolicies']['clientAccessPolicy'])
 
-        self.assertNotEquals('Stopping', live_event['resourceState'])
-        self.assertNotEquals('Stopped', live_event['resourceState'])
+        self.assertNotEqual('Stopping', live_event['resourceState'])
+        self.assertNotEqual('Stopped', live_event['resourceState'])
 
         self.cmd('az ams live-event stop -a {amsname} -n {liveEventName} -g {rg}')
 
@@ -106,8 +106,8 @@ class AmsLiveEventTests(ScenarioTest):
             self.check('input.streamingProtocol', 'FragmentedMP4')
         ]).get_output_in_json()
 
-        self.assertNotEquals('Stopping', live_event['resourceState'])
-        self.assertNotEquals('Stopped', live_event['resourceState'])
+        self.assertNotEqual('Stopping', live_event['resourceState'])
+        self.assertNotEqual('Stopped', live_event['resourceState'])
 
     @ResourceGroupPreparer()
     @StorageAccountPreparer(parameter_name='storage_account_for_create')
@@ -144,8 +144,8 @@ class AmsLiveEventTests(ScenarioTest):
             self.check('input.accessToken', '{accessToken}'),
         ]).get_output_in_json()
 
-        self.assertNotEquals('Stopping', live_event['resourceState'])
-        self.assertNotEquals('Stopped', live_event['resourceState'])
+        self.assertNotEqual('Stopping', live_event['resourceState'])
+        self.assertNotEqual('Stopped', live_event['resourceState'])
         self.assertEquals('StandBy', live_event['resourceState'])
 
     @ResourceGroupPreparer()
@@ -174,8 +174,8 @@ class AmsLiveEventTests(ScenarioTest):
             self.check('name', '{liveEventName}')
         ]).get_output_in_json()
 
-        self.assertNotEquals('Starting', live_event['resourceState'])
-        self.assertNotEquals('Running', live_event['resourceState'])
+        self.assertNotEqual('Starting', live_event['resourceState'])
+        self.assertNotEqual('Running', live_event['resourceState'])
 
     @ResourceGroupPreparer()
     @StorageAccountPreparer(parameter_name='storage_account_for_create')
@@ -227,8 +227,8 @@ class AmsLiveEventTests(ScenarioTest):
             self.check('name', '{liveEventName}')
         ]).get_output_in_json()
 
-        self.assertNotEquals('Starting', live_event['resourceState'])
-        self.assertNotEquals('Running', live_event['resourceState'])
+        self.assertNotEqual('Starting', live_event['resourceState'])
+        self.assertNotEqual('Running', live_event['resourceState'])
 
         self.cmd('az ams live-output list -a {amsname} -g {rg} --live-event-name {liveEventName}', checks=[
             self.check('length(@)', 0)
@@ -340,8 +340,8 @@ class AmsLiveEventTests(ScenarioTest):
             self.check('location', 'East US')
         ]).get_output_in_json()
 
-        self.assertNotEquals('Stopping', live_event['resourceState'])
-        self.assertNotEquals('Stopped', live_event['resourceState'])
+        self.assertNotEqual('Stopping', live_event['resourceState'])
+        self.assertNotEqual('Stopped', live_event['resourceState'])
 
     @ResourceGroupPreparer()
     @StorageAccountPreparer(parameter_name='storage_account_for_create')
@@ -378,7 +378,7 @@ class AmsLiveEventTests(ScenarioTest):
 
         self.assertIsNotNone(live_event_updated['crossSiteAccessPolicies']['crossDomainPolicy'])
         self.assertIsNotNone(live_event_updated['crossSiteAccessPolicies']['clientAccessPolicy'])
-    
+
     @ResourceGroupPreparer()
     @StorageAccountPreparer(parameter_name='storage_account_for_create')
     def test_live_event_show(self, storage_account_for_create):

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_commands.py
@@ -676,7 +676,7 @@ class AppConfigImportExportScenarioTest(ScenarioTest):
         exported_file_path = os.path.join(TEST_DIR, 'export.json')
         exported_json_object = os.path.join(TEST_DIR, 'export_changed_json.json')
         exported_json_object_reference = os.path.join(TEST_DIR, 'export_changed_json_ref.json')
- 
+
         self.kwargs.update({
             'import_source': 'file',
             'imported_format': 'json',
@@ -712,17 +712,17 @@ class AppConfigImportExportScenarioTest(ScenarioTest):
                      self.check('key', key_name),
                      self.check('etag', background_color_kv['etag']),
                      ])
-        
+
         self.kwargs.update({
             'imported_file_path': imported_file_path
         })
 
         self.cmd(
             'appconfig kv import -n {config_store_name} -s {import_source} --path "{imported_file_path}" --format {imported_format} --separator {separator} -y --import-mode all')
-        
+
         updated_background_color_kv = self.cmd('appconfig kv show -n {config_store_name} --key {key}').get_output_in_json()
 
-        self.assertNotEquals(background_color_kv['etag'], updated_background_color_kv['etag'])
+        self.assertNotEqual(background_color_kv['etag'], updated_background_color_kv['etag'])
 
         # skip key vault reference while exporting
         self.kwargs.update({
@@ -1101,7 +1101,7 @@ class AppConfigAppServiceImportExportLiveScenarioTest(LiveScenarioTest):
         self.assertEquals(exported_keys['value'], expected_reference)
         self.assertEquals(exported_keys['slotSetting'], False)
 
-        # Assert second reference is of right format    
+        # Assert second reference is of right format
         exported_keys = next(x for x in app_settings if x['name'] == entry_key2)
         self.assertEquals(exported_keys['name'], entry_key2)
         self.assertEquals(exported_keys['value'], expected_reference2)
@@ -2405,7 +2405,7 @@ class AppConfigFeatureScenarioTest(ScenarioTest):
         with self.assertRaisesRegex(CLIError, "Feature name cannot contain the following characters: '%', ':'"):
             self.cmd('appconfig feature set -n {config_store_name} --feature {feature}')
 
-  
+
 class AppConfigFeatureFilterScenarioTest(ScenarioTest):
 
     @AllowLargeResponse()
@@ -2977,8 +2977,8 @@ class AppConfigSnapshotLiveScenarioTest(ScenarioTest):
     def __init__(self, *args, **kwargs):
         kwargs["recording_processors"] = kwargs.get("recording_processors", []) + [CredentialResponseSanitizer()]
         super(AppConfigSnapshotLiveScenarioTest, self).__init__(*args, **kwargs)
-    
-    
+
+
     @ResourceGroupPreparer(parameter_name_for_location='location')
     @AllowLargeResponse()
     def test_azconfig_snapshot_mgmt(self, resource_group, location):
@@ -3011,7 +3011,7 @@ class AppConfigSnapshotLiveScenarioTest(ScenarioTest):
         dev_label = "dev"
         entry_key3 = "LastTestKey"
         entry_value3 = "LastTestValue"
-        
+
         # Create 2 keys with a common prefix and label "dev"
         self.kwargs.update({
             "key": entry_key,
@@ -3046,7 +3046,7 @@ class AppConfigSnapshotLiveScenarioTest(ScenarioTest):
 
         # Create a snapshot of all key-values that begin with the prefix 'Test'
         filter_dict = { "key": "Test*", "label": dev_label }
-        retention_period = 3600 # Set retention period of 1 hour 
+        retention_period = 3600 # Set retention period of 1 hour
         self.kwargs.update({
             'filter': '\'{}\''.format(json.dumps(filter_dict)),
             'retention_period': retention_period
@@ -3057,15 +3057,15 @@ class AppConfigSnapshotLiveScenarioTest(ScenarioTest):
                  checks=[self.check('itemsCount', 2),
                          self.check('status', 'ready')])
 
-        
+
         # Test showing created snapshot
         created_snapshot = self.cmd('appconfig snapshot show --connection-string {connection_string} --snapshot-name {snapshot_name} --fields name status items_count filters').get_output_in_json()
-        
+
         self.assertEqual(created_snapshot['items_count'], 2)
         self.check(created_snapshot['status'], 'ready')
         self.assertDictEqual(created_snapshot['filters'][0], filter_dict)
         self.assertRaises(KeyError, lambda: created_snapshot['created'])
-        
+
         # Test listing snapshots
         created_snapshots = self.cmd('appconfig snapshot list --snapshot-name {snapshot_name} --connection-string {connection_string} --fields name status items_count filters').get_output_in_json()
         self.assertEqual(created_snapshots[0]['items_count'], 2)
@@ -3074,11 +3074,11 @@ class AppConfigSnapshotLiveScenarioTest(ScenarioTest):
 
         # Test snapshot archive
         archived_snapshot = self.cmd('appconfig snapshot archive --connection-string {connection_string} --snapshot-name {snapshot_name}').get_output_in_json()
-        self.assertIsNotNone(archived_snapshot['expires'])        
+        self.assertIsNotNone(archived_snapshot['expires'])
         self.assertEqual(archived_snapshot['status'], 'archived')
         active_snapshots = self.cmd('appconfig snapshot list --connection-string {connection_string} --status ready').get_output_in_json()
         self.assertEqual(len(active_snapshots), 0)
-        
+
         # Test snapshot recovery
         self.cmd('appconfig snapshot recover --connection-string {connection_string} -s {snapshot_name}',
                                      checks=[self.check('itemsCount', 2),

--- a/src/azure-cli/azure/cli/command_modules/search/tests/latest/test_admin_key.py
+++ b/src/azure-cli/azure/cli/command_modules/search/tests/latest/test_admin_key.py
@@ -35,12 +35,12 @@ class AzureSearchAdminKeysTests(ScenarioTest):
 
         self.cmd('az search admin-key renew --service-name {name} -g {rg} --key-kind primary')
         _adminkey_1 = self.cmd('az search admin-key show --service-name {name} -g {rg}').get_output_in_json()
-        self.assertNotEquals(_adminkey['primaryKey'], _adminkey_1['primaryKey'])
+        self.assertNotEqual(_adminkey['primaryKey'], _adminkey_1['primaryKey'])
         self.assertEqual(_adminkey['secondaryKey'], _adminkey_1['secondaryKey'])
 
         self.cmd('az search admin-key renew --service-name {name} -g {rg} --key-kind secondary')
         _adminkey_2 = self.cmd('az search admin-key show --service-name {name} -g {rg}').get_output_in_json()
-        self.assertNotEquals(_adminkey_2['secondaryKey'], _adminkey_1['secondaryKey'])
+        self.assertNotEqual(_adminkey_2['secondaryKey'], _adminkey_1['secondaryKey'])
         self.assertEqual(_adminkey_2['primaryKey'], _adminkey_1['primaryKey'])
 
 


### PR DESCRIPTION

**Description**<!--Mandatory-->
Python 3.12 removes `assertNotEquals`, so we are removing the uses by replacing it by `assertNotEqual`.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
