### PR TITLE
{Misc.} Remove all occurrences of assertDictContainsSubset

### DIFF
--- a/src/azure-cli-core/azure/cli/core/tests/test_command_registration.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_command_registration.py
@@ -93,8 +93,8 @@ class TestCommandRegistration(unittest.TestCase):
         }
         for probe in some_expected_arguments:
             existing = next(arg for arg in command_metadata.arguments if arg == probe)
-            self.assertDictContainsSubset(some_expected_arguments[existing].settings,
-                                          command_metadata.arguments[existing].options)
+            self.assertLessEqual(some_expected_arguments[existing].settings.items(),
+                                 command_metadata.arguments[existing].options.items())
         self.assertEqual(command_metadata.arguments['vm_name'].options_list, ('--wonky-name', '-n'))
 
     def test_register_command(self):
@@ -137,8 +137,8 @@ class TestCommandRegistration(unittest.TestCase):
 
         for probe in some_expected_arguments:
             existing = next(arg for arg in command_metadata.arguments if arg == probe)
-            self.assertDictContainsSubset(some_expected_arguments[existing].settings,
-                                          command_metadata.arguments[existing].options)
+            self.assertLessEqual(some_expected_arguments[existing].settings.items(),
+                                 command_metadata.arguments[existing].options.items())
         self.assertEqual(command_metadata.arguments['resource_group_name'].options_list,
                          ['--resource-group-name'])
 
@@ -518,8 +518,8 @@ class TestCommandRegistration(unittest.TestCase):
 
         for probe in some_expected_arguments:
             existing = next(arg for arg in command_metadata.arguments if arg == probe)
-            self.assertDictContainsSubset(some_expected_arguments[existing].settings,
-                                          command_metadata.arguments[existing].options)
+            self.assertLessEqual(some_expected_arguments[existing].settings.items(),
+                                 command_metadata.arguments[existing].options.items())
 
     def test_command_build_argument_help_text(self):
 
@@ -562,8 +562,8 @@ class TestCommandRegistration(unittest.TestCase):
 
         for probe in some_expected_arguments:
             existing = next(arg for arg in command_metadata.arguments if arg == probe)
-            self.assertDictContainsSubset(some_expected_arguments[existing].settings,
-                                          command_metadata.arguments[existing].options)
+            self.assertLessEqual(some_expected_arguments[existing].settings.items(),
+                                 command_metadata.arguments[existing].options.items())
 
     def test_override_existing_option_string(self):
         arg = CLIArgumentType(options_list=('--funky', '-f'))


### PR DESCRIPTION

**Description**<!--Mandatory-->
Python 3.12 removed `assertDictContainsSubset`, so we are removing all usages by replacing it with subset assertion.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
