### PR TITLE
[RDBMS] `az postgres flexible-server upgrade`: Unblock MVU for Burstable from CLI

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/mysql/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/mysql/custom.py
@@ -287,13 +287,11 @@ def flexible_server_log_list(client, resource_group_name, server_name, filename_
 def flexible_server_version_upgrade(cmd, client, resource_group_name, server_name, version, yes=None):
     if not yes:
         user_confirmation(
-            "Updating major version in server {} is irreversible. The action you're about to take can't be undone. "
+            "Upgrading major version in server {} is irreversible. The action you're about to take can't be undone. "
             "Going further will initiate major version upgrade to the selected version on this server."
             .format(server_name), yes=yes)
 
     instance = client.get(resource_group_name, server_name)
-    if instance.sku.tier == 'Burstable':
-        raise CLIError("Major version update is not supported for the Burstable pricing tier.")
 
     current_version = int(instance.version.split('.')[0])
     if current_version >= int(version):
@@ -322,7 +320,7 @@ def flexible_server_version_upgrade(cmd, client, resource_group_name, server_nam
             resource_group_name=resource_group_name,
             server_name=server_name,
             parameters=parameters),
-        cmd.cli_ctx, 'Updating server {} to major version {}'.format(server_name, version)
+        cmd.cli_ctx, 'Upgrading server {} to major version {}'.format(server_name, version)
     )
 
 

--- a/src/azure-cli/azure/cli/command_modules/mysql/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/mysql/custom.py
@@ -292,6 +292,8 @@ def flexible_server_version_upgrade(cmd, client, resource_group_name, server_nam
             .format(server_name), yes=yes)
 
     instance = client.get(resource_group_name, server_name)
+    if instance.sku.tier == 'Burstable':
+        raise CLIError("Major version update is not supported for the Burstable pricing tier.")
 
     current_version = int(instance.version.split('.')[0])
     if current_version >= int(version):

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_common.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_common.py
@@ -252,13 +252,11 @@ def flexible_server_log_list(client, resource_group_name, server_name, filename_
 def flexible_server_version_upgrade(cmd, client, resource_group_name, server_name, version, yes=None):
     if not yes:
         user_confirmation(
-            "Updating major version in server {} is irreversible. The action you're about to take can't be undone. "
+            "Upgrading major version in server {} is irreversible. The action you're about to take can't be undone. "
             "Going further will initiate major version upgrade to the selected version on this server."
             .format(server_name), yes=yes)
 
     instance = client.get(resource_group_name, server_name)
-    if instance.sku.tier == 'Burstable':
-        raise CLIError("Major version update is not supported for the Burstable pricing tier.")
 
     current_version = int(instance.version.split('.')[0])
     if current_version >= int(version):
@@ -281,5 +279,5 @@ def flexible_server_version_upgrade(cmd, client, resource_group_name, server_nam
             resource_group_name=resource_group_name,
             server_name=server_name,
             parameters=parameters),
-        cmd.cli_ctx, 'Updating server {} to major version {}'.format(server_name, version)
+        cmd.cli_ctx, 'Upgrading server {} to major version {}'.format(server_name, version)
     )


### PR DESCRIPTION
**Related command**
`az postgres flexible-server upgrade --subscription <subscription> --resource-group <resourcegroup> --name <postgresql> --version <version>`

**Description**<!--Mandatory-->
It doesn't make sense that we keep blocking customers to run MVU for Burstable from CLI, when we allow them to run it from REST API and portal UX.

**Testing Guide**
<!--Example commands with explanations.-->



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
