### PR TITLE
{Network} `az network dns zone export`: Fix KeyError

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -2631,7 +2631,7 @@ def export_zone(cmd, resource_group_name, zone_name, file_name=None):  # pylint:
             if record_type not in zone_obj[record_set_name]:
                 zone_obj[record_set_name][record_type] = []
             # Checking for alias record
-            if (record_type == 'a' or record_type == 'aaaa' or record_type == 'cname') and record_set["target_resource"]["id"]:
+            if (record_type == 'a' or record_type == 'aaaa' or record_type == 'cname') and record_set["target_resource"].get("id", ""):
                 target_resource_id = record_set["target_resource"]["id"]
                 record_obj.update({'target-resource-id': record_type.upper() + " " + target_resource_id})
                 record_type = 'alias'


### PR DESCRIPTION
Don't assume that "id" always exists and check for the value with a default

Command:
az network dns zone export --resource-group <resource_group> --name <dns zone>

**Description**
The command crashes for my zone with KeyError: 'id' on line 2638, for 2.61.0. With the proposed patch the key is not assumed to exist and the check falls through to the other if/else branches.

**Testing Guide**
az network dns zone export --resource-group <resource_group> --name <dns zone>

**History Notes**
This is a bug fix, not likely to cause breaking changes
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
