### PR TITLE
{Packaging} Bump requests to 2.32.0

### DIFF
--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -130,7 +130,7 @@ semver==2.13.0
 six==1.16.0
 sshtunnel==0.1.5
 tabulate==0.8.9
-urllib3==2.2.1
+urllib3==1.26.18
 wcwidth==0.1.7
 websocket-client==1.3.1
 xmltodict==0.12.0

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -124,13 +124,13 @@ PyNaCl==1.5.0
 pyOpenSSL==24.0.0
 python-dateutil==2.8.0
 requests-oauthlib==1.2.0
-requests[socks]==2.31.0
+requests[socks]==2.32.0
 scp==0.13.2
 semver==2.13.0
 six==1.16.0
 sshtunnel==0.1.5
 tabulate==0.8.9
-urllib3==1.26.18
+urllib3==2.2.1
 wcwidth==0.1.7
 websocket-client==1.3.1
 xmltodict==0.12.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -125,13 +125,13 @@ PyNaCl==1.5.0
 pyOpenSSL==24.0.0
 python-dateutil==2.8.0
 requests-oauthlib==1.2.0
-requests[socks]==2.31.0
+requests[socks]==2.32.0
 scp==0.13.2
 semver==2.13.0
 six==1.16.0
 sshtunnel==0.1.5
 tabulate==0.8.9
-urllib3==1.26.18
+urllib3==2.2.1
 wcwidth==0.1.7
 websocket-client==1.3.1
 xmltodict==0.12.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -131,7 +131,7 @@ semver==2.13.0
 six==1.16.0
 sshtunnel==0.1.5
 tabulate==0.8.9
-urllib3==2.2.1
+urllib3==1.26.18
 wcwidth==0.1.7
 websocket-client==1.3.1
 xmltodict==0.12.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -126,13 +126,13 @@ pyOpenSSL==24.0.0
 python-dateutil==2.8.0
 pywin32==305
 requests-oauthlib==1.2.0
-requests[socks]==2.31.0
+requests[socks]==2.32.0
 scp==0.13.2
 semver==2.13.0
 six==1.16.0
 sshtunnel==0.1.5
 tabulate==0.8.9
-urllib3==1.26.18
+urllib3==2.2.1
 wcwidth==0.1.7
 websocket-client==1.3.1
 xmltodict==0.12.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -132,7 +132,7 @@ semver==2.13.0
 six==1.16.0
 sshtunnel==0.1.5
 tabulate==0.8.9
-urllib3==2.2.1
+urllib3==1.26.18
 wcwidth==0.1.7
 websocket-client==1.3.1
 xmltodict==0.12.0


### PR DESCRIPTION

**Description**<!--Mandatory-->
Bump requests to fix [CVE-2024-35195](https://github.com/advisories/GHSA-9wx4-h78v-vm56)
Also bump urllib3 to latest version

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Core] Resolve CVE-2024-35195