### PR TITLE
[App Config] `appconfig kv import`: Update the help message for ignore-match

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appconfig/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/_params.py
@@ -187,7 +187,7 @@ def load_arguments(self, _):
         c.argument('yes', help="Do not prompt for preview.")
         c.argument('skip_features', help="Import only key values and exclude all feature flags. By default, all feature flags will be imported from file or appconfig. Not applicable for appservice.", arg_type=get_three_state_flag())
         c.argument('content_type', help='Content type of all imported items.')
-        c.argument('import_mode', arg_type=get_enum_type([ImportMode.ALL, ImportMode.IGNORE_MATCH]), help='If import mode is "ignore-match", source key-values that already exist at the destination will not be overwritten. Import mode "all" writes all key-values to the destination regardless of whether they exist or not.')
+        c.argument('import_mode', arg_type=get_enum_type([ImportMode.ALL, ImportMode.IGNORE_MATCH]), help='If import mode is "ignore-match", only key-values that do not already exist or whose key, label, value, content-type or tags are different from what is in the destination will be written. Import mode "all" writes all key-values to the destination regardless of whether they exist or not.')
 
     with self.argument_context('appconfig kv import', arg_group='File') as c:
         c.argument('path', help='Local configuration file path. Required for file arguments.')

--- a/src/azure-cli/azure/cli/command_modules/appconfig/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/_params.py
@@ -187,7 +187,7 @@ def load_arguments(self, _):
         c.argument('yes', help="Do not prompt for preview.")
         c.argument('skip_features', help="Import only key values and exclude all feature flags. By default, all feature flags will be imported from file or appconfig. Not applicable for appservice.", arg_type=get_three_state_flag())
         c.argument('content_type', help='Content type of all imported items.')
-        c.argument('import_mode', arg_type=get_enum_type([ImportMode.ALL, ImportMode.IGNORE_MATCH]), help='If import mode is "ignore-match", only key-values that do not already exist or whose key, label, value, content-type or tags are different from what is in the destination will be written. Import mode "all" writes all key-values to the destination regardless of whether they exist or not.')
+        c.argument('import_mode', arg_type=get_enum_type([ImportMode.ALL, ImportMode.IGNORE_MATCH]), help='If import mode is "ignore-match", only source key-values that do not already exist or whose value, content-type or tags are different from that of an existing key-value with the same key and label, will be written. Import mode "all" writes all key-values to the destination regardless of whether they exist or not.')
 
     with self.argument_context('appconfig kv import', arg_group='File') as c:
         c.argument('path', help='Local configuration file path. Required for file arguments.')


### PR DESCRIPTION
**Related command**
 **--import-mode** command under az appconfig kv import

**Description**<!--Mandatory-->
This PR updates the help text for **--import-mode** command under az appconfig kv import

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
This change was discussed in this PR https://github.com/Azure/AppConfiguration/issues/919 to update the help text for import mode ignore-match

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
