### PR TITLE
[Core] `aaz`: Add argument completer support

### DIFF
--- a/src/azure-cli-core/azure/cli/core/aaz/_arg.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_arg.py
@@ -505,7 +505,8 @@ class AAZResourceGroupNameArg(AAZStrArg):
         from azure.cli.core.commands.parameters import get_resource_group_completion_list
         from azure.cli.core.local_context import LocalContextAttribute, LocalContextAction, ALL
         arg = super().to_cmd_arg(name, **kwargs)
-        arg.completer = get_resource_group_completion_list
+        if not arg.completer:
+            arg.completer = get_resource_group_completion_list
         arg.local_context_attribute = LocalContextAttribute(
             name='resource_group_name',
             actions=[LocalContextAction.SET, LocalContextAction.GET],
@@ -546,7 +547,8 @@ class AAZResourceLocationArg(AAZStrArg):
             short_summary += "When not specified, the location of the resource group will be used."
             arg.help = short_summary
 
-        arg.completer = get_location_completion_list
+        if not arg.completer:
+            arg.completer = get_location_completion_list
         arg.local_context_attribute = LocalContextAttribute(
             name='location',
             actions=[LocalContextAction.SET, LocalContextAction.GET],
@@ -580,7 +582,8 @@ class AAZSubscriptionIdArg(AAZStrArg):
     def to_cmd_arg(self, name, **kwargs):
         from azure.cli.core._completers import get_subscription_id_list
         arg = super().to_cmd_arg(name, **kwargs)
-        arg.completer = get_subscription_id_list
+        if not arg.completer:
+            arg.completer = get_subscription_id_list
         return arg
 
 

--- a/src/azure-cli-core/azure/cli/core/aaz/_arg.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_arg.py
@@ -96,7 +96,7 @@ class AAZBaseArg(AAZBaseType):
 
     def __init__(self, options=None, required=False, help=None, arg_group=None, is_preview=False, is_experimental=False,
                  id_part=None, default=AAZUndefined, blank=AAZUndefined, nullable=False, fmt=None, registered=True,
-                 configured_default=None):
+                 configured_default=None, completer=None):
         """
 
         :param options: argument optional names.
@@ -113,6 +113,7 @@ class AAZBaseArg(AAZBaseType):
         :param fmt: argument format
         :param registered: control whether register argument into command display
         :param configured_default: the key to retrieve the default value from cli configuration
+        :param completer: tab completion if completion is active
         """
         super().__init__(options=options, nullable=nullable)
         self._help = {}  # the key in self._help can be 'name', 'short-summary', 'long-summary', 'populator-commands'
@@ -134,6 +135,7 @@ class AAZBaseArg(AAZBaseType):
         self._fmt = fmt
         self._registered = registered
         self._configured_default = configured_default
+        self._completer = completer
 
     def to_cmd_arg(self, name, **kwargs):
         """ convert AAZArg to CLICommandArgument """
@@ -201,6 +203,11 @@ class AAZBaseArg(AAZBaseType):
 
         if self._configured_default:
             arg.configured_default = self._configured_default
+
+        if self._completer:
+            from azure.cli.core.decorators import Completer
+            assert isinstance(self._completer, Completer)
+            arg.completer = self._completer
 
         action = self._build_cmd_action()   # call sub class's implementation to build CLICommandArgument action
         if action:

--- a/src/azure-cli-core/azure/cli/core/aaz/_arg.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_arg.py
@@ -492,21 +492,22 @@ class AAZResourceGroupNameArg(AAZStrArg):
             help="Name of resource group. "
                  "You can configure the default group using `az configure --defaults group=<name>`",
             configured_default='group',
+            completer=None,
             **kwargs):
+        from azure.cli.core.commands.parameters import get_resource_group_completion_list
+        completer = completer or get_resource_group_completion_list
         super().__init__(
             options=options,
             id_part=id_part,
             help=help,
             configured_default=configured_default,
+            completer=completer
             **kwargs
         )
 
     def to_cmd_arg(self, name, **kwargs):
-        from azure.cli.core.commands.parameters import get_resource_group_completion_list
         from azure.cli.core.local_context import LocalContextAttribute, LocalContextAction, ALL
         arg = super().to_cmd_arg(name, **kwargs)
-        if not arg.completer:
-            arg.completer = get_resource_group_completion_list
         arg.local_context_attribute = LocalContextAttribute(
             name='resource_group_name',
             actions=[LocalContextAction.SET, LocalContextAction.GET],
@@ -523,18 +524,22 @@ class AAZResourceLocationArg(AAZStrArg):
                  "You can configure the default location using `az configure --defaults location=<location>`.",
             fmt=None,
             configured_default='location',
+            completer=None,
             **kwargs):
+        from azure.cli.core.commands.parameters import get_location_completion_list
+
         fmt = fmt or AAZResourceLocationArgFormat()
+        completer = completer or get_location_completion_list
         super().__init__(
             options=options,
             help=help,
             fmt=fmt,
             configured_default=configured_default,
+            completer=completer,
             **kwargs
         )
 
     def to_cmd_arg(self, name, **kwargs):
-        from azure.cli.core.commands.parameters import get_location_completion_list
         from azure.cli.core.local_context import LocalContextAttribute, LocalContextAction, ALL
         arg = super().to_cmd_arg(name, **kwargs)
         if self._required and \
@@ -547,8 +552,6 @@ class AAZResourceLocationArg(AAZStrArg):
             short_summary += "When not specified, the location of the resource group will be used."
             arg.help = short_summary
 
-        if not arg.completer:
-            arg.completer = get_location_completion_list
         arg.local_context_attribute = LocalContextAttribute(
             name='location',
             actions=[LocalContextAction.SET, LocalContextAction.GET],
@@ -571,19 +574,20 @@ class AAZSubscriptionIdArg(AAZStrArg):
             self, help="Name or ID of subscription. You can configure the default subscription "
                        "using `az account set -s NAME_OR_ID`",
             fmt=None,
+            completer=None,
             **kwargs):
+        from azure.cli.core._completers import get_subscription_id_list
         fmt = fmt or AAZSubscriptionIdArgFormat()
+        completer = completer or get_subscription_id_list
         super().__init__(
             help=help,
             fmt=fmt,
+            completer=completer,
             **kwargs
         )
 
     def to_cmd_arg(self, name, **kwargs):
-        from azure.cli.core._completers import get_subscription_id_list
         arg = super().to_cmd_arg(name, **kwargs)
-        if not arg.completer:
-            arg.completer = get_subscription_id_list
         return arg
 
 

--- a/src/azure-cli-core/azure/cli/core/aaz/_arg.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_arg.py
@@ -501,7 +501,7 @@ class AAZResourceGroupNameArg(AAZStrArg):
             id_part=id_part,
             help=help,
             configured_default=configured_default,
-            completer=completer
+            completer=completer,
             **kwargs
         )
 
@@ -585,10 +585,6 @@ class AAZSubscriptionIdArg(AAZStrArg):
             completer=completer,
             **kwargs
         )
-
-    def to_cmd_arg(self, name, **kwargs):
-        arg = super().to_cmd_arg(name, **kwargs)
-        return arg
 
 
 class AAZFileArg(AAZStrArg):

--- a/src/azure-cli-core/azure/cli/core/tests/test_aaz_arg.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_aaz_arg.py
@@ -1613,3 +1613,61 @@ class TestAAZArgUtils(unittest.TestCase):
         v.items = assign_aaz_dict_arg(v.items, v.names, element_transformer=lambda _, name: {"name": name})
         self.assertTrue(v.items._is_patch)
         self.assertEqual(v.items, {'a': {"name": '1'}, 'b': {"name": '2'}, 'c': {"name": "3"}})
+
+
+class TestAazArgCompleter(unittest.TestCase):
+    from azure.cli.core.decorators import Completer
+
+    @staticmethod
+    @Completer
+    def custom_completer(cmd, prefix, namespace):
+        return ['a', 'b']
+
+    def test_custom_completer(self):
+        from azure.cli.core.aaz._arg import AAZStrArg, AAZArgumentsSchema, AAZUnregisteredArg
+
+        schema = AAZArgumentsSchema()
+        v = schema()
+
+        schema.foo = AAZStrArg(
+            options=['foo'],
+            nullable=True,
+            completer=self.custom_completer
+        )
+        args = {}
+        for name, field in schema._fields.items():
+            # generate command arguments from argument schema.
+            try:
+                args[name] = field.to_cmd_arg(name)
+            except AAZUnregisteredArg:
+                continue
+        self.assertEqual(args['foo'].completer, schema.foo._completer)
+        self.assertEqual(args['foo'].completer, self.custom_completer)
+
+    def test_completer_override(self):
+        from azure.cli.core.aaz._arg import AAZResourceLocationArg, AAZArgumentsSchema, AAZUnregisteredArg
+        from azure.cli.core.commands.parameters import get_location_completion_list
+
+        schema = AAZArgumentsSchema()
+        v = schema()
+
+        schema.foo = AAZResourceLocationArg(
+            options=['foo'],
+            completer=self.custom_completer
+        )
+        schema.bar = AAZResourceLocationArg(
+            options=['bar']
+        )
+
+        args = {}
+        for name, field in schema._fields.items():
+            # generate command arguments from argument schema.
+            try:
+                args[name] = field.to_cmd_arg(name)
+            except AAZUnregisteredArg:
+                continue
+        self.assertEqual(args['foo'].completer, self.custom_completer)
+        self.assertEqual(args['bar'].completer, get_location_completion_list)
+        schema.bar._completer = self.custom_completer
+        new_arg = schema.bar.to_cmd_arg('bar')
+        self.assertEqual(new_arg.completer, self.custom_completer)

--- a/src/azure-cli-core/azure/cli/core/tests/test_aaz_arg.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_aaz_arg.py
@@ -1658,6 +1658,8 @@ class TestAazArgCompleter(unittest.TestCase):
         schema.bar = AAZResourceLocationArg(
             options=['bar']
         )
+        self.assertEqual(schema.foo._completer, self.custom_completer)
+        self.assertEqual(schema.bar._completer, get_location_completion_list)
 
         args = {}
         for name, field in schema._fields.items():

--- a/src/azure-cli-core/azure/cli/core/tests/test_aaz_arg.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_aaz_arg.py
@@ -1645,8 +1645,10 @@ class TestAazArgCompleter(unittest.TestCase):
         self.assertEqual(args['foo'].completer, self.custom_completer)
 
     def test_completer_override(self):
-        from azure.cli.core.aaz._arg import AAZResourceLocationArg, AAZArgumentsSchema, AAZUnregisteredArg
+        from azure.cli.core.aaz._arg import (AAZResourceLocationArg, AAZArgumentsSchema, AAZUnregisteredArg,
+                                             AAZSubscriptionIdArg)
         from azure.cli.core.commands.parameters import get_location_completion_list
+        from azure.cli.core._completers import get_subscription_id_list
 
         schema = AAZArgumentsSchema()
         v = schema()
@@ -1658,8 +1660,14 @@ class TestAazArgCompleter(unittest.TestCase):
         schema.bar = AAZResourceLocationArg(
             options=['bar']
         )
+        schema.sub = AAZSubscriptionIdArg(
+            options=["--subscription-id"],
+            help="subscription id",
+            required=True,
+            id_part="subscription")
         self.assertEqual(schema.foo._completer, self.custom_completer)
         self.assertEqual(schema.bar._completer, get_location_completion_list)
+        self.assertEqual(schema.sub._completer, get_subscription_id_list)
 
         args = {}
         for name, field in schema._fields.items():
@@ -1670,6 +1678,7 @@ class TestAazArgCompleter(unittest.TestCase):
                 continue
         self.assertEqual(args['foo'].completer, self.custom_completer)
         self.assertEqual(args['bar'].completer, get_location_completion_list)
+        self.assertEqual(args['sub'].completer, get_subscription_id_list)
         schema.bar._completer = self.custom_completer
         new_arg = schema.bar.to_cmd_arg('bar')
         self.assertEqual(new_arg.completer, self.custom_completer)


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Add completer support in aaz core.

Customer could use custom completer:

```Python
from azure.cli.core.decorators import Completer

@Completer
def _get_supported_languages(cmd, prefix, namespace):
    return ["en-us", "es-es", "fr-fr", "de-de"]

class FooCreate(_CreateFoo):

    @classmethod
    def _build_arguments_schema(cls, *args, **kwargs):
        if cls._args_schema is not None:
            return cls._args_schema
        cls._args_schema = super()._build_arguments_schema(*args, **kwargs)

        _args_schema = cls._args_schema
        _args_schema.bar._completer = _get_supported_languages

        return cls._args_schema
```

![image](https://github.com/Azure/azure-cli/assets/32201005/b481fc7c-9dc9-4c7d-bd61-ec08ff3ecab1)

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
