### PR TITLE
{Misc.} Add cgmanifest.json

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "version": 1,
+  "registrations": [
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/jmespath/jp",
+          "commitHash": "1331b6f3cbdbea8820b89eea5b8d1a92148f6b32",
+          "tag": "0.2.1"
+        }
+      },
+      "developmentDependency": false
+    }
+  ]
+}


### PR DESCRIPTION
Component Detection can only detect dependencies in `setup.py`.
Add jp to mainifest so that we can generate NOTICE through the Component Governance UI

Ref:
https://docs.opensource.microsoft.com/tools/cg/component-detection/cgmanifest/
https://docs.opensource.microsoft.com/tools/cg/legal/notice/#generate-notice-through-the-component-governance-ui