### PR TITLE
[RDBMS] `az postgres flexible-server firewall-rule create`: Correct firewall rule name and ip range validators

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/validators.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/validators.py
@@ -597,6 +597,8 @@ def virtual_endpoint_name_validator(ns):
 
 
 def firewall_rule_name_validator(ns):
+    if not ns.firewall_rule_name:
+        return
     if not re.search(r'^[a-zA-Z0-9][-_a-zA-Z0-9]{1,126}[_a-zA-Z0-9]$', ns.firewall_rule_name):
         raise ValidationError("The firewall rule name can only contain 0-9, a-z, A-Z, \'-\' and \'_\'. "
                               "Additionally, the name of the firewall rule must be at least 3 characters "

--- a/src/azure-cli/azure/cli/command_modules/rdbms/validators.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/validators.py
@@ -576,14 +576,14 @@ def _validate_ip(ips):
 
 def _validate_ranges_in_ip(ip):
     parsed_ip = ip.split('.')
-    if len(parsed_ip) == 4 and _valid_range(int(parsed_ip[0])) and _valid_range(int(parsed_ip[1])) \
-       and _valid_range(int(parsed_ip[2])) and _valid_range(int(parsed_ip[3])):
+    if len(parsed_ip) == 4 and _valid_range(parsed_ip[0]) and _valid_range(parsed_ip[1]) \
+       and _valid_range(parsed_ip[2]) and _valid_range(parsed_ip[3]):
         return True
     return False
 
 
 def _valid_range(addr_range):
-    if 0 <= addr_range <= 255:
+    if addr_range.isdigit() and 0 <= int(addr_range) <= 255:
         return True
     return False
 


### PR DESCRIPTION
**Related command**
`az postgres flexible-server firewall-rule create`

**Description**<!--Mandatory-->
Help defines that --rule-name is not required argument. If name is omitted, default name will be chosen for firewall name. 
Validator method was return error when arg was not passed. Corrected to only do validation check if rule name arg has value

Addressing bug
#28972 

Bug fix in ip_address_validator to check that only digits are passed in IPV4 format

**Testing Guide**
Manually
Firewall name validator
PS C:\Users\nasc\azureCLI\azure-cli> az postgres flexible-server firewall-rule create --resource-group g --name n --start-ip-address 100.0.00.000
Configuring server firewall rule to accept connections from '100.0.00.000'...
{
  "endIpAddress": "100.0.00.000",
  "id": "/subscriptions/s/resourceGroups/g/providers/Microsoft.DBforPostgreSQL/flexibleServers/n/firewallRules/**FirewallIPAddress_2024-6-21_17-39-47**",
  "name": "**FirewallIPAddress_2024-6-21_17-39-47**",
  "resourceGroup": "g",
  "startIpAddress": "100.0.00.000",
  "systemData": null,
  "type": "Microsoft.DBforPostgreSQL/flexibleServers/firewallRules"
}

IP range validator
az postgres flexible-server firewall-rule create --resource-group g --name n --start-ip-address 10.20.11a1.22                                                       
Incorrect value for ip address. Ip address should be IPv4 format. Example: 12.12.12.12. 


**History Notes**
`az postgres flexible-server firewall-rule create`: Correct default name creation when --rule-name is not passed by user. Fix IP range validation.