### PR TITLE
[RDBMS] `az postgres flexible-server create`: Add argument `--create-default-database` to support disabling default database creation

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
@@ -328,7 +328,7 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
 
         create_default_db_arg_type = CLIArgumentType(
             arg_type=get_enum_type(['Enabled', 'Disabled']),
-            options_list=['--create-default-database'],
+            options_list=['--create-default-database', '-c'],
             help='Enable or disable the creation of default database flexibleserverdb. Default value is Enabled.'
         )
 

--- a/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
@@ -329,7 +329,7 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
         create_default_db_arg_type = CLIArgumentType(
             arg_type=get_enum_type(['Enabled', 'Disabled']),
             options_list=['--create-default-database'],
-            help='Enable or disable the creation of default database flexibleserverdb.. Default value is Enabled.'
+            help='Enable or disable the creation of default database flexibleserverdb. Default value is Enabled.'
         )
 
         auto_grow_arg_type = CLIArgumentType(

--- a/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
@@ -326,6 +326,12 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
                  'This value can only be updated if flexible server is using Premium SSD v2 Disks.'
         )
 
+        create_default_db_arg_type = CLIArgumentType(
+            arg_type=get_enum_type(['Enabled', 'Disabled']),
+            options_list=['--create-default-database'],
+            help='Enable or disable the creation of default database flexibleserverdb.. Default value is Enabled.'
+        )
+
         auto_grow_arg_type = CLIArgumentType(
             arg_type=get_enum_type(['Enabled', 'Disabled']),
             options_list=['--storage-auto-grow'],
@@ -569,6 +575,7 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
                 c.argument('iops', default=None, arg_type=iops_v2_arg_type)
                 c.argument('throughput', default=None, arg_type=throughput_arg_type)
                 c.argument('performance_tier', default=None, arg_type=performance_tier_arg_type)
+                c.argument('create_default_db', default='Enabled', arg_type=create_default_db_arg_type)
             elif command_group == 'mysql':
                 c.argument('tier', default='Burstable', arg_type=tier_arg_type)
                 c.argument('sku_name', default='Standard_B1ms', arg_type=sku_name_arg_type)

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
@@ -57,7 +57,7 @@ def flexible_server_create(cmd, client,
                            high_availability=None, zone=None, standby_availability_zone=None,
                            geo_redundant_backup=None, byok_identity=None, byok_key=None, backup_byok_identity=None, backup_byok_key=None,
                            active_directory_auth=None, password_auth=None, auto_grow=None, performance_tier=None,
-                           storage_type=None, iops=None, throughput=None, yes=False):
+                           storage_type=None, iops=None, throughput=None, create_default_db='Enabled', yes=False):
 
     # Generate missing parameters
     location, resource_group_name, server_name = generate_missing_parameters(cmd, location, resource_group_name,
@@ -152,9 +152,9 @@ def flexible_server_create(cmd, client,
         firewall_id = create_firewall_rule(db_context, cmd, resource_group_name, server_name, start_ip, end_ip)
 
     # Create mysql database if it does not exist
-    if database_name is None:
-        database_name = DEFAULT_DB_NAME
-    _create_database(db_context, cmd, resource_group_name, server_name, database_name)
+    if database_name is not None or (create_default_db and create_default_db.lower() == 'enabled'):
+        db_name = database_name if database_name else DEFAULT_DB_NAME
+        _create_database(db_context, cmd, resource_group_name, server_name, db_name)
 
     user = server_result.administrator_login
     server_id = server_result.id


### PR DESCRIPTION
**Related command**
postgres flexible-server create

**Description**<!--Mandatory-->
Add a new --create-default-database parameter which defaults to true, so that users who don't like this: behavior can change it, without breaking other existing scenarios.

Fix for #20958 

**Testing Guide**
Manually


