### PR TITLE
[RDBMS] `az postgres flexible-server update`: Add argument to enable or disable public-access

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
@@ -687,6 +687,7 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
             c.argument('byok_identity', arg_type=identity_arg_type)
             c.argument('backup_byok_identity', arg_type=backup_identity_arg_type)
             c.argument('backup_byok_key', arg_type=backup_key_arg_type)
+            c.argument('public_access', arg_type=public_access_update_arg_type)
             if command_group == 'mysql':
                 c.argument('auto_grow', arg_type=auto_grow_arg_type)
                 c.argument('auto_scale_iops', arg_type=auto_scale_iops_arg_type)
@@ -696,7 +697,6 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
                 c.argument('backup_retention', arg_type=mysql_backup_retention_arg_type)
                 c.argument('geo_redundant_backup', arg_type=geo_redundant_backup_arg_type)
                 c.argument('disable_data_encryption', arg_type=disable_data_encryption_arg_type)
-                c.argument('public_access', arg_type=public_access_update_arg_type)
             elif command_group == 'postgres':
                 c.argument('auto_grow', arg_type=auto_grow_arg_type)
                 c.argument('performance_tier', default=None, arg_type=performance_tier_arg_type)

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
@@ -275,6 +275,7 @@ def flexible_server_update_custom_func(cmd, client, instance,
                                        backup_byok_identity=None, backup_byok_key=None,
                                        active_directory_auth=None, password_auth=None,
                                        private_dns_zone_arguments=None,
+                                       public_access=None,
                                        tags=None,
                                        auto_grow=None,
                                        performance_tier=None,
@@ -315,6 +316,9 @@ def flexible_server_update_custom_func(cmd, client, instance,
     server_id_parts = parse_resource_id(instance.id)
     resource_group_name = server_id_parts['resource_group']
     server_name = server_id_parts['name']
+
+    if public_access:
+        instance.network.public_network_access = public_access
 
     if private_dns_zone_arguments:
         private_dns_zone_id = prepare_private_dns_zone(db_context,


### PR DESCRIPTION
**Related command**
az postgres flexible-server update

**Description**<!--Mandatory-->
Allow being able to update public access flag for Azure PostgreSQL Flexible server through the Azure CLI

Fix #28838 

**Testing Guide**
Manually

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

`az postgres flexible-server update`: Enable or disable public access flag be setting argument --public-access

