### PR TITLE
{Profile} Handle None tenantDisplayName

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/profile/_subscription_selector.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/_subscription_selector.py
@@ -95,7 +95,7 @@ class SubscriptionSelector:  # pylint: disable=too-few-public-methods
 
     @staticmethod
     def _get_tenant_string(subscription):
-        try:
+        if subscription.get(_TENANT_DISPLAY_NAME):
             return subscription[_TENANT_DISPLAY_NAME]
-        except KeyError:
-            return subscription[_TENANT_ID]
+        # If _TENANT_DISPLAY_NAME doesn't exist or is None, return _TENANT_ID
+        return subscription[_TENANT_ID]


### PR DESCRIPTION
**Related command**
`az login`

**Description**<!--Mandatory-->
Fix https://github.com/Azure/azure-cli/issues/29030

HTTP traces in https://github.com/Azure/azure-cli/issues/29030 show that `https://management.azure.com/tenants?api-version=2022-12-01` API sometimes don't return `displayName` property. This contradicts the ARM public document https://learn.microsoft.com/en-us/rest/api/resources/tenants/list?view=rest-resources-2022-12-01

As `displayName` is defined in the swagger, SDK returns `displayName` as `None`, leading to `str` + `None` concatenation error in Azure CLI.

This PR handles `None` `tenantDisplayName` by falling back to `tenantId`.

**Testing Guide**
Change 

https://github.com/Azure/azure-cli/blob/235c3554b7d79d33544c70dee12d66154abe74a9/src/azure-cli-core/azure/cli/core/_profile.py#L874

to 

```py
        s_dict[_TENANT_DISPLAY_NAME] = None
```

Run `az login`.
