### PR TITLE
[RDBMS] `az postgres flexible-server update`: Correct setting `--maintenance-window` to be disabled

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
@@ -363,13 +363,14 @@ def flexible_server_update_custom_func(cmd, client, instance,
     if backup_retention:
         instance.backup.backup_retention_days = backup_retention
 
-    if maintenance_window and maintenance_window.lower() == "disabled":
-        # if disabled is pass in reset to default values
-        day_of_week = start_hour = start_minute = 0
-        custom_window = "Disabled"
-    elif maintenance_window:
-        day_of_week, start_hour, start_minute = parse_maintenance_window(maintenance_window)
-        custom_window = "Enabled"
+    if maintenance_window:
+        if maintenance_window.lower() == "disabled":
+            # if disabled is pass in reset to default values
+            day_of_week = start_hour = start_minute = 0
+            custom_window = "Disabled"
+        else:
+            day_of_week, start_hour, start_minute = parse_maintenance_window(maintenance_window)
+            custom_window = "Enabled"
 
         # set values - if maintenance_window when is None when created then create a new object
         instance.maintenance_window.day_of_week = day_of_week


### PR DESCRIPTION
**Related command**
`az postgres flexible-server update --maintenance-window`

**Description**<!--Mandatory-->
Bug found, not properly setting parameters to disable maintenance window

**Testing Guide**
Manually

**History Notes**
 `az postgres flexible-server update`: Fix ability to disable maintenance window

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
