### PR TITLE
{Key Vault} Update params file to correct default vaule

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/keyvault/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_params.py
@@ -126,7 +126,7 @@ def load_arguments(self, _):
                         'Role Based Access Control (RBAC) for authorization of data actions, and the access policies '
                         'specified in vault properties will be ignored. When false, the key vault will use the access '
                         'policies specified in vault properties, and any policy stored on Azure Resource Manager will '
-                        'be ignored. If null or not specified, the vault is created with the default value of false. '
+                        'be ignored. If null or not specified, the vault is created with the default value of true. '
                         'Note that management actions are always authorized with RBAC.')
         c.argument('enable_purge_protection', arg_type=get_three_state_flag(),
                    help='Property specifying whether protection against purge is enabled for this vault/managed HSM '


### PR DESCRIPTION
The description of the [CLI az keyvault create --enable-rbac-authorization parameter](https://learn.microsoft.com/en-us/cli/azure/keyvault?view=azure-cli-latest#az-keyvault-create-optional-parameters) currently reads:

> --enable-rbac-authorization
> Property that controls how data actions are authorized. When true, the key vault will use Role Based Access Control (RBAC) for authorization of data actions, and the access policies specified in vault properties will be ignored. When false, the key vault will use the access policies specified in vault properties, and any policy stored on Azure Resource Manager will be ignored. If null or not specified, the vault is created **with the default value of false**. Note that management actions are always authorized with RBAC.
> 
> Accepted values: false, true
> Default value: **True**

This PR corrects the param description.

**Related command**

az keyvault create

**Description**

Updated param description to specify that enableRbacAuthorization=True (as of Azure CLI 2.61.0).

**Testing Guide**

az keyvault create -g <resourcegroup>-n <keyvault-name.

Note the absence of "--enable-rbac-authorization". Created key vault will have this property:

`    "enableRbacAuthorization": true,`




