### PR TITLE
[Synapse] `az synapse spark job submit`: Add ability to pass custom Python files to the job

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/synapse/manual/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/synapse/manual/_params.py
@@ -572,6 +572,8 @@ def load_arguments(self, _):
                    help='Optional arguments to the job (Note: please use storage URIs for file arguments).')
         c.argument('archives', nargs='+', help='The array of archives.')
         c.argument('job_name', arg_type=name_type, help='The Spark job name.')
+        c.argument('python_files', nargs='+', type=split,
+                   help='The array of files used for refenence in the main python definition file.  Examples include custom whl files and custom python files.  May pass multiple files such as "az synapse spark job sumbit <other_args> --python_files abfss://file1 abss://file2')
         c.argument('reference_files', nargs='+',
                    help='Additional files used for reference in the main definition file.')
         c.argument('configuration', type=shell_safe_json_parse, help='The configuration of Spark job.')

--- a/src/azure-cli/azure/cli/command_modules/synapse/manual/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/synapse/manual/_params.py
@@ -572,8 +572,8 @@ def load_arguments(self, _):
                    help='Optional arguments to the job (Note: please use storage URIs for file arguments).')
         c.argument('archives', nargs='+', help='The array of archives.')
         c.argument('job_name', arg_type=name_type, help='The Spark job name.')
-        c.argument('python_files', nargs='+', type=split,
-                   help='The array of files used for refenence in the main python definition file.  Examples include custom whl files and custom python files.  May pass multiple files such as "az synapse spark job sumbit <other_args> --python_files abfss://file1 abss://file2')
+        c.argument('python_files', nargs='+',
+                   help='The array of files used for refenence in the main python definition file.  Examples include custom whl files and custom python files.  May pass multiple files such as "az synapse spark job sumbit <other_args> --python_files abfss://file1 abss://file2"')
         c.argument('reference_files', nargs='+',
                    help='Additional files used for reference in the main definition file.')
         c.argument('configuration', type=shell_safe_json_parse, help='The configuration of Spark job.')

--- a/src/azure-cli/azure/cli/command_modules/synapse/manual/operations/spark.py
+++ b/src/azure-cli/azure/cli/command_modules/synapse/manual/operations/spark.py
@@ -32,7 +32,7 @@ def create_spark_batch_job(cmd, workspace_name, spark_pool_name, job_name, main_
                            executor_size, executors, language=SparkBatchLanguage.Scala, main_class_name=None,
                            command_line_arguments=None,
                            reference_files=None, archives=None, configuration=None,
-                           tags=None):
+                           python_files=None, tags=None):
     # pylint: disable-msg=too-many-locals
     client = cf_synapse_spark_batch(cmd.cli_ctx, workspace_name, spark_pool_name)
     file = main_definition_file
@@ -85,6 +85,7 @@ def create_spark_batch_job(cmd, workspace_name, spark_pool_name, job_name, main_
         jars=jars,
         files=files,
         archives=archives,
+        python_files=python_files,
         configuration=configuration,
         driver_memory=driver_memory,
         driver_cores=driver_cores,


### PR DESCRIPTION
**Related command**
az synapse spark job submit

**Description**<!--Mandatory-->
Synapse allows users to add Python files to Spark jobs in addition to the main job file.  This may include custom .whl files, addition .py files, or anything else that is needed by the main python script.  This PR allows users to specify the additional python files through the az CLI interface.

See [azure-sdk-for-python SparkBatchJobOptions class](https://github.com/Azure/azure-sdk-for-python/blob/632792345c194c82118bbb7062fcc1df7510ef9a/sdk/synapse/azure-synapse/azure/synapse/spark/models/_models.py#L159)

**Testing Guide**
az synapse spark job submit --name MyJobName --workspace MySynapseWorkspace --main-definition-file "abfs://mymainfile" --python-files "abfs://custom_library1.whl" "abfs://custom_library2.whl"

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Synapse] `az synapse spark job submit`: Add optional `--python-files` argument to support job submission

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
