### PR TITLE
[AKS] `az aks create/update`: Support in place param updates for managed prom

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/azuremonitorprofile.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/azuremonitorprofile.py
@@ -89,17 +89,20 @@ def ensure_azure_monitor_profile_prerequisites(
             cluster_name
         )
     else:
+        is_prometheus_enabled = False
         # Check if already onboarded
         if create_flow is False:
-            check_azuremonitormetrics_profile(cmd, cluster_subscription, cluster_resource_group_name, cluster_name)
-        # Do RP registrations if required
-        rp_registrations(cmd, cluster_subscription, raw_parameters)
-        link_azure_monitor_profile_artifacts(
-            cmd,
-            cluster_subscription,
-            cluster_resource_group_name,
-            cluster_name,
-            cluster_region,
-            raw_parameters,
-            create_flow
-        )
+            is_prometheus_enabled = check_azuremonitormetrics_profile(cmd, cluster_subscription, cluster_resource_group_name, cluster_name)
+        # Do RP registrations and artifact creation (DC*, rules, grafana link etc.) if not enabled already
+        # Otherwise move forward so that the addon can be enabled with new KSM parameters
+        if is_prometheus_enabled == False:
+            rp_registrations(cmd, cluster_subscription, raw_parameters)
+            link_azure_monitor_profile_artifacts(
+                cmd,
+                cluster_subscription,
+                cluster_resource_group_name,
+                cluster_name,
+                cluster_region,
+                raw_parameters,
+                create_flow
+            )

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/azuremonitorprofile.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/azuremonitorprofile.py
@@ -93,9 +93,11 @@ def ensure_azure_monitor_profile_prerequisites(
         # Check if already onboarded
         if create_flow is False:
             is_prometheus_enabled = check_azuremonitormetrics_profile(cmd, cluster_subscription, cluster_resource_group_name, cluster_name)
+        if is_prometheus_enabled:
+            print("Azure Prometheus is already enabled : This command will only allow updates to the KSM parameters. All other parameters will be ignored")
         # Do RP registrations and artifact creation (DC*, rules, grafana link etc.) if not enabled already
         # Otherwise move forward so that the addon can be enabled with new KSM parameters
-        if is_prometheus_enabled == False:
+        if is_prometheus_enabled is False:
             rp_registrations(cmd, cluster_subscription, raw_parameters)
             link_azure_monitor_profile_artifacts(
                 cmd,

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/helper.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/helper.py
@@ -112,4 +112,5 @@ def check_azuremonitormetrics_profile(cmd, cluster_subscription, cluster_resourc
     if "azureMonitorProfile" in values_array:
         if "metrics" in values_array["azureMonitorProfile"]:
             if values_array["azureMonitorProfile"]["metrics"]["enabled"] is True:
-                raise CLIError(f"Azure Monitor Metrics is already enabled for this cluster. Please use `az aks update --disable-azure-monitor-metrics -g {cluster_resource_group_name} -n {cluster_name}` and then try enabling.")
+                return True
+    return False


### PR DESCRIPTION
**Related command**


```az aks update -n kaveeshcli22 -g kaveeshcli --enable-azure-monitor-metrics --ksm-metric-labels-allow-list "namespaces=[k8s-label-1,k8s-label-n]" --ksm-metric-annotations-allow-list "pods=[k8s-annotation-1,k8s-annotation-n]"```

**Description**
Updating the behavior of the az aks update command for managed prom to accept KSM parameter updates even when the addon is enabled on the cluster and stopping the error we throw saying that you have to disable the addon first before updating.

**Testing Guide**

Have the Azure Managed Prometheus enabled on a cluster.

Now run : 
```az aks update -n kaveeshcli22 -g kaveeshcli --enable-azure-monitor-metrics --ksm-metric-labels-allow-list "namespaces=[k8s-label-1,k8s-label-n]" --ksm-metric-annotations-allow-list "pods=[k8s-annotation-1,k8s-annotation-n]"```

The command should give an output which contains the following based on the parameters you passed in: 

"azureMonitorProfile": {
    "metrics": {
      "enabled": true,
      "kubeStateMetrics": {
        "metricAnnotationsAllowList": "pods=[k8s-annotation-1,k8s-annotation-n]",
        "metricLabelsAllowlist": "namespaces=[k8s-label-1,k8s-label-n]"
      }
    }
  },


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
