### PR TITLE
[RDBMS] `az postgres flexible-server create`: Bug fix for using existing subnet while creating pg flex server

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_virtual_network.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_virtual_network.py
@@ -248,7 +248,7 @@ def _create_subnet_delegation(cmd, nw_subscription, resource_client, delegation_
             "resource_group": resource_group
         })
         logger.warning('Using existing Subnet "%s" in resource group "%s"', subnet_name, resource_group)
-        if subnet_address_pref not in (DEFAULT_SUBNET_ADDRESS_PREFIX, subnet["addressPrefix"]):
+        if subnet_address_pref not in (DEFAULT_SUBNET_ADDRESS_PREFIX, subnet["addressPrefixes"]):
             logger.warning("The prefix of the subnet you provided does not match the --subnet-prefix value %s. Using current prefix %s", subnet_address_pref, subnet["addressPrefix"])
 
         # Add Delegation if not delegated already


### PR DESCRIPTION
**Related command**
`az postgres flexible-server create`

**Description**<!--Mandatory-->
Fix unexpected error:  File "D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/command_modules/rdbms/flexible_server_virtual_network.py", line 251, in _create_subnet_delegation
KeyError: 'addressPrefix'

**Testing Guide**
Manually, was able to get successful deployment
WARNING: You have supplied a Subnet ID. Verifying its existence...
WARNING: Using existing Vnet "vnet-test-nasc-628" in resource group "nasc-runner"
WARNING: Using existing Subnet "subnet-test-nasc-628-454" in resource group "nasc-runner"
WARNING: Adding "Microsoft.DBforPostgreSQL/flexibleServers" delegation to the existing subnet subnet-test-nasc-628-454.
WARNING: Using the existing private dns zone nasc-test-dns-628.private.postgres.database.azure.com in resource group "nasc-runner"
WARNING: Creating PostgreSQL Server 'nasc-pg-net628-458' in group 'nasc-runner'...
WARNING: Your server 'nasc-pg-net628-458' is using sku 'Standard_D2s_v3' (Paid Tier). Please refer to https://aka.ms/postgres-pricing for pricing details
WARNING: Creating PostgreSQL database 'flexibleserverdb'...
WARNING: Try using 'az postgres flexible-server connect' command to test out connection.
{
  "connectionString": "postgresql:",
  "databaseName": null,
  "host": "nasc-pg-net628-458.postgres.database.azure.com",
  "id": "/id/nasc-pg-net628-458",
  "location": "Korea Central",
  "password": "",
  "resourceGroup": "nasc-runner",
  "skuname": "Standard_D2s_v3",
  "subnetId": "/subscriptions/Microsoft.Network/virtualNetworks/vnet-test-nasc-628/subnets/subnet-test-nasc-628-454",
  "username": "",
  "version": "16"
}

**History Notes**
`az postgres flexible-server create`: Bug fix for creating a PostgreSQL flexible server using existing network resources

