### PR TITLE
Update link for "work-behind-a-proxy" MS doc due to doc change

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Please check [Tips for using Azure CLI effectively](https://learn.microsoft.com/
 - [Generic resource commands - `az resource`](https://learn.microsoft.com/en-us/cli/azure/use-cli-effectively#generic-resource-commands---az-resource)
 - [REST API command - `az rest`](https://learn.microsoft.com/en-us/cli/azure/use-cli-effectively#rest-api-command---az-rest)
 - [Quoting issues](https://learn.microsoft.com/en-us/cli/azure/use-cli-effectively#quoting-issues)
-- [Work behind a proxy](https://learn.microsoft.com/en-us/cli/azure/use-cli-effectively#work-behind-a-proxy)
+- [Proxy blocks connection](https://learn.microsoft.com/en-us/cli/azure/use-azure-cli-successfully-troubleshooting#error-sslerror-bad-handshakecertificate-verify-failed-proxy-blocks-connection)
 - [Concurrent builds](https://learn.microsoft.com/en-us/cli/azure/use-cli-effectively#concurrent-builds)
 
 ### More samples and snippets

--- a/doc/use_cli_in_airgapped_clouds.md
+++ b/doc/use_cli_in_airgapped_clouds.md
@@ -70,7 +70,7 @@ Then CLI will load the available clouds and the corresponding cloud endpoints fr
 If you are working with multiple clouds, you can learn more in [Work with multiple clouds](https://learn.microsoft.com/cli/azure/manage-clouds-azure-cli).
 
 ## Set CA bundle certificate
-Please follow the first solution in [Work behind a proxy](https://learn.microsoft.com/cli/azure/use-cli-effectively#work-behind-a-proxy) to set up the certificate in your airgapped cloud environment. For more details, you can also refer to the steps in the [guide](https://learn.microsoft.com/azure-stack/user/azure-stack-version-profiles-azurecli2) to set up CLI for Azure Stack Hub.
+Please follow the first solution in [Proxy blocks connection](https://learn.microsoft.com/en-us/cli/azure/use-azure-cli-successfully-troubleshooting#error-sslerror-bad-handshakecertificate-verify-failed-proxy-blocks-connection) to set up the certificate in your airgapped cloud environment. For more details, you can also refer to the steps in the [guide](https://learn.microsoft.com/azure-stack/user/azure-stack-version-profiles-azurecli2) to set up CLI for Azure Stack Hub.
 
 ## Login with service principal
 Use the service principal that was granted permission to access a subscription in the airgapped cloud to login.

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -22,7 +22,7 @@ COMPONENT_PREFIX = 'azure-cli-'
 SSLERROR_TEMPLATE = ('Certificate verification failed. This typically happens when using Azure CLI behind a proxy '
                      'that intercepts traffic with a self-signed certificate. '
                      # pylint: disable=line-too-long
-                     'Please add this certificate to the trusted CA bundle. More info: https://learn.microsoft.com/cli/azure/use-cli-effectively#work-behind-a-proxy.')
+                     'Please add this certificate to the trusted CA bundle. More info: https://learn.microsoft.com/en-us/cli/azure/use-azure-cli-successfully-troubleshooting#error-sslerror-bad-handshakecertificate-verify-failed-proxy-blocks-connection.')
 
 QUERY_REFERENCE = ("To learn more about --query, please visit: "
                    "'https://learn.microsoft.com/cli/azure/query-azure-cli'")


### PR DESCRIPTION
**Related command**
None in particular

**Description**<!--Mandatory-->
This current link is dead: https://docs.microsoft.com/cli/azure/use-cli-effectively#work-behind-a-proxy. It redirects to https://learn.microsoft.com/en-us/cli/azure/use-azure-cli-successfully-tips but the `#work-behind-a-proxy` heading is missing
Thanks to this diff in this file: https://github.com/MicrosoftDocs/azure-docs-cli/commit/a13273197419083910e2ccfa970ec4f3dd41b6e9#diff-4e1076161d25f82116cf0ef7a0b33a48b4883bf6c38db8f858cd1cf291655dab, I found that the new location for this content is now https://learn.microsoft.com/en-us/cli/azure/use-azure-cli-successfully-troubleshooting#error-sslerror-bad-handshakecertificate-verify-failed-proxy-blocks-connection so I've updated all references in this repo

**Testing Guide**
I didn't test

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
