### PR TITLE
{CI} Remove continueOnError

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -945,7 +945,6 @@ jobs:
     displayName: 'Test Rpm Package'
 
 - job: BuildDebPackages
-  continueOnError: true
   displayName: Build Deb Packages
   condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual', 'Schedule'))
   pool:
@@ -1016,7 +1015,6 @@ jobs:
       ArtifactName: $(deb_system)-$(distro)-$(arch)
 
 - job: TestDebPackages
-  continueOnError: true
   timeoutInMinutes: 120
   displayName: Test Deb Packages
   dependsOn:


### PR DESCRIPTION
We can't re-run failed task in ADO after enabling `continueOnError`.
Remove it so that we can retry DEB build.

![image](https://github.com/Azure/azure-cli/assets/2227874/4e040ee4-97a1-4a1d-b912-d0ac1abca8de)
![image](https://github.com/Azure/azure-cli/assets/2227874/a037a2c2-34e5-4b43-93db-7669c20f73e6)
