### PR TITLE
{Core} Bump MSAL to 1.30.0

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -53,7 +53,7 @@ DEPENDENCIES = [
     'jmespath',
     'knack~=0.11.0',
     'msal-extensions==1.2.0',
-    'msal[broker]==1.29.0',
+    'msal[broker]==1.30.0',
     'msrestazure~=0.6.4',
     'packaging>=20.9',
     'paramiko>=2.0.8,<4.0.0',

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -105,7 +105,7 @@ jsondiff==2.0.0
 knack==0.11.0
 MarkupSafe==2.0.1
 msal-extensions==1.2.0
-msal[broker]==1.29.0
+msal[broker]==1.30.0
 msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -106,7 +106,7 @@ jsondiff==2.0.0
 knack==0.11.0
 MarkupSafe==2.0.1
 msal-extensions==1.2.0
-msal[broker]==1.29.0
+msal[broker]==1.30.0
 msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -105,7 +105,7 @@ jsondiff==2.0.0
 knack==0.11.0
 MarkupSafe==2.0.1
 msal-extensions==1.2.0
-msal[broker]==1.29.0
+msal[broker]==1.30.0
 msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2


### PR DESCRIPTION
**Related command**
`az ssh`

**Description**<!--Mandatory-->
Fix https://github.com/Azure/azure-cli/issues/29006

MSAL 1.26.0 in Azure CLI 2.58.0 bypasses token cache for SSH cert which is the expected behavior:

```
cli.azure.cli.core.auth.msal_authentication: ServicePrincipalCredential.get_token: scopes=('https://pas.windows.net/CheckMyAccess/Linux/.default',), kwargs={'data': {'token_type': 'ssh-cert', ...
urllib3.connectionpool: Starting new HTTPS connection (1): login.microsoftonline.com:443
```

But MSAL 1.27.0 (bumped by https://github.com/Azure/azure-cli/pull/28556) in Azure CLI 2.59.0 fetches SSH cert from token cache:
 
```
cli.azure.cli.core.auth.msal_authentication: ServicePrincipalCredential.get_token: scopes=('https://pas.windows.net/CheckMyAccess/Linux/.default',), kwargs={'data': {'token_type': 'ssh-cert', ...
msal.application: Cache hit an AT
```

This caused issue https://github.com/Azure/azure-cli/issues/29006. MSAL 1.30.0 fixed the token cache in https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/717, so we should bump MSAL to 1.30.0 to adopt that fix.

See email: _AADLogin failures with recent MSAL.py_

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Compute] Fix #29006: `az ssh`: Fix the `Permissions 0644 for '...' are too open` error
