### PR TITLE
{Keyvault} `az keyvault create`: Remove explicit cvm type from default cvm policy template

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/keyvault/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_validators.py
@@ -251,10 +251,6 @@ def _fetch_default_cvm_policy(cli_ctx, vault_url):
                     'authority': attest_uri,
                     'allOf': [
                         {
-                            'claim': 'x-ms-attestation-type',
-                            'equals': 'sevsnpvm'
-                        },
-                        {
                             'claim': 'x-ms-compliance-status',
                             'equals': 'azure-compliant-cvm'
                         }


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az keyvault create --default-cvm-policy`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Current default cvm policy used for keyvault creation is
```
        {
            'version': '1.0.0',
            'anyOf': [
                {
                    'authority': attest_uri,
                    'allOf': [
                        {
                            'claim': 'x-ms-attestation-type',
                            'equals': 'sevsnpvm'
                        },
                        {
                            'claim': 'x-ms-compliance-status',
                            'equals': 'azure-compliant-cvm'
                        }
                    ]
                }
            ]
        }
```
As @praenubilus reported:

> We have two type of cvm: sevsnp and tdx, if sevsnp is explicitly in the policy, the tdx(new hardware) cannot work

So this PR aims to remove explicit cvm type from the policy template

**Testing Guide**
<!--Example commands with explanations.-->
`az keyvault create --default-cvm-policy`



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
