### PR TITLE
{ACR} Change: az acr login support for resource group and skip resource validation for non acr source registry in az acr import

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
@@ -324,7 +324,8 @@ def _get_credentials(cmd,  # pylint: disable=too-many-statements
                      repository=None,
                      artifact_repository=None,
                      permission=None,
-                     is_login_context=False):
+                     is_login_context=False,
+                     resource_group_name=None):
     """Try to get AAD authorization tokens or admin user credentials.
     :param str registry_name: The name of container registry
     :param str tenant_suffix: The registry login server tenant suffix
@@ -342,7 +343,7 @@ def _get_credentials(cmd,  # pylint: disable=too-many-statements
     cli_ctx = cmd.cli_ctx
     resource_not_found, registry = None, None
     try:
-        registry, resource_group_name = get_registry_by_name(cli_ctx, registry_name)
+        registry, resource_group_name = get_registry_by_name(cli_ctx, registry_name, resource_group_name)
         login_server = registry.login_server
         if tenant_suffix:
             logger.warning(
@@ -455,7 +456,8 @@ def get_login_credentials(cmd,
                           registry_name,
                           tenant_suffix=None,
                           username=None,
-                          password=None):
+                          password=None,
+                          resource_group_name=None):
     """Try to get AAD authorization tokens or admin user credentials to log into a registry.
     :param str registry_name: The name of container registry
     :param str username: The username used to log into the container registry
@@ -467,7 +469,8 @@ def get_login_credentials(cmd,
                             username,
                             password,
                             only_refresh_token=True,
-                            is_login_context=True)
+                            is_login_context=True,
+                            resource_group_name=resource_group_name)
 
 
 def get_access_credentials(cmd,
@@ -477,7 +480,8 @@ def get_access_credentials(cmd,
                            password=None,
                            repository=None,
                            artifact_repository=None,
-                           permission=None):
+                           permission=None,
+                           resource_group_name=None):
     """Try to get AAD authorization tokens or admin user credentials to access a registry.
     :param str registry_name: The name of container registry
     :param str username: The username used to log into the container registry
@@ -494,7 +498,8 @@ def get_access_credentials(cmd,
                             only_refresh_token=False,
                             repository=repository,
                             artifact_repository=artifact_repository,
-                            permission=permission)
+                            permission=permission,
+                            resource_group_name=resource_group_name)
 
 
 def log_registry_response(response):

--- a/src/azure-cli/azure/cli/command_modules/acr/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_params.py
@@ -160,7 +160,6 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
         c.argument('days', type=int, help='The number of days to retain a soft-deleted manifest or tag after which it gets purged (Range: 1 to 90). Default is 7.')
 
     with self.argument_context('acr login') as c:
-        c.argument('resource_group_name', deprecate_info=c.deprecate(hide=True))
         c.argument('expose_token', options_list=['--expose-token', '-t'], help='Expose access token instead of automatically logging in through Docker CLI', action='store_true')
 
     with self.argument_context('acr repository') as c:

--- a/src/azure-cli/azure/cli/command_modules/acr/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/custom.py
@@ -256,7 +256,7 @@ def acr_show_endpoints(cmd,
 
 def acr_login(cmd,
               registry_name,
-              resource_group_name=None,  # pylint: disable=unused-argument
+              resource_group_name=None,
               tenant_suffix=None,
               username=None,
               password=None,
@@ -270,7 +270,8 @@ def acr_login(cmd,
             registry_name=registry_name,
             tenant_suffix=tenant_suffix,
             username=username,
-            password=password)
+            password=password,
+            resource_group_name=resource_group_name)
 
         logger.warning("You can perform manual login using the provided access token below, "
                        "for example: 'docker login loginServer -u %s -p accessToken'", EMPTY_GUID)
@@ -301,7 +302,8 @@ def acr_login(cmd,
         registry_name=registry_name,
         tenant_suffix=tenant_suffix,
         username=username,
-        password=password)
+        password=password,
+        resource_group_name=resource_group_name)
 
     # warn casing difference caused by ACR normalizing to lower on login_server
     parts = login_server.split('.')

--- a/src/azure-cli/azure/cli/command_modules/acr/import.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/import.py
@@ -77,7 +77,8 @@ def acr_import(cmd,  # pylint: disable=too-many-locals
                                   credentials=ImportSourceCredentials(password=source_registry_password,
                                                                       username=source_registry_username))
         else:
-            registry = get_registry_from_name_or_login_server(cmd.cli_ctx, registry_uri)
+            if registry_uri.endswith('azurecr.io') or registry_uri.endswith('.azurecr-test.io'):
+                registry = get_registry_from_name_or_login_server(cmd.cli_ctx, registry_uri)
             if registry:
                 # For Azure container registry
                 source = ImportSource(resource_id=registry.id, source_image=source_image)

--- a/src/azure-cli/azure/cli/command_modules/acr/import.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/import.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+from azure.cli.command_modules.acr._docker_utils import get_login_server_suffix
 from knack.util import CLIError
 from knack.log import get_logger
 from msrestazure.tools import is_valid_resource_id, parse_resource_id
@@ -77,7 +78,9 @@ def acr_import(cmd,  # pylint: disable=too-many-locals
                                   credentials=ImportSourceCredentials(password=source_registry_password,
                                                                       username=source_registry_username))
         else:
-            if registry_uri.endswith('azurecr.io') or registry_uri.endswith('.azurecr-test.io'):
+             # Try to get the pre-defined login server suffix.
+            login_server_suffix = get_login_server_suffix(cmd.cli_ctx)
+            if not login_server_suffix or registry_uri.endswith(login_server_suffix):
                 registry = get_registry_from_name_or_login_server(cmd.cli_ctx, registry_uri)
             if registry:
                 # For Azure container registry

--- a/src/azure-cli/azure/cli/command_modules/acr/import.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/import.py
@@ -3,10 +3,10 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from azure.cli.command_modules.acr._docker_utils import get_login_server_suffix
 from knack.util import CLIError
 from knack.log import get_logger
 from msrestazure.tools import is_valid_resource_id, parse_resource_id
+from azure.cli.command_modules.acr._docker_utils import get_login_server_suffix
 from azure.cli.core.commands import LongRunningOperation
 from azure.cli.core.util import sdk_no_wait
 
@@ -78,7 +78,7 @@ def acr_import(cmd,  # pylint: disable=too-many-locals
                                   credentials=ImportSourceCredentials(password=source_registry_password,
                                                                       username=source_registry_username))
         else:
-             # Try to get the pre-defined login server suffix.
+            # Try to get the pre-defined login server suffix.
             login_server_suffix = get_login_server_suffix(cmd.cli_ctx)
             if not login_server_suffix or registry_uri.endswith(login_server_suffix):
                 registry = get_registry_from_name_or_login_server(cmd.cli_ctx, registry_uri)


### PR DESCRIPTION
**Related command**
`az acr login` and `az acr import`

**Description**
`az acr login`
added optional resource group argument to skip subscription level resource scan which fans out to all region and can cause failure if any of arm region have outage.

`az acr import`
added a check to avoid subscription scan if source registry is not an ACR registry. no observable changes for customer.

**Testing Guide** 
az acr login -n registry name -g resoucegroup
az acr login -n registryname
az acr import -n myregistry --source sourceregistry.azurecr.io/sourcerepository:sourcetag
az acr import -n myregistry --source docker.io/library/hello-world:latest

**History Notes**
[ACR] `az acr login`: Support optional resource group argument to skip subscription resource scan

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
