### PR TITLE
{Storage} `az storage fs directory generate-sas`: Remove ending slash in directory name

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_help.py
@@ -2534,7 +2534,7 @@ examples:
   - name: Generate a sas token for directory and use it to upload files.
     text: |
         end=`date -u -d "30 minutes" '+%Y-%m-%dT%H:%MZ'`
-        az storage fs directory generate-sas --name dir/ --file-system myfilesystem --https-only --permissions dlrw --expiry $end -o tsv
+        az storage fs directory generate-sas --name dir --file-system myfilesystem --https-only --permissions dlrw --expiry $end -o tsv
 """
 
 helps['storage fs file'] = """


### PR DESCRIPTION
**Related command**
az storage fs directory generate-sas

**Description**<!--Mandatory-->
If a slash is specified at the end of the name parameter, the error message is "<Code>AuthenticationFailed</Code><Message>Server failed to authenticate the request. Make sure the value of Authorization header is correctly formed including the signature.

**Testing Guide**
We can reproduce the simple way.

a) az storage fs directory generate-sas --file-system test00 --account-name mystorageadlsgen2 --name **directory00** --expiry 2025-07-11T09:46:44Z --permissions cw
b) az storage fs directory generate-sas --file-system test00 --account-name mystorageadlsgen2 --name **directory00/** --expiry 2025-07-11T09:46:44Z --permissions cw

a) is success upload using the generated SAS like using azcopy. On the other hands, Using SAS from generated by b) is failed upload by AuthenticationError Signature did not match.


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
