### PR TITLE
[Packaging] Drop Debian 10 support

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -974,12 +974,6 @@ jobs:
           pool: ${{ arch.pool }}
 
         # https://wiki.debian.org/DebianReleases
-        Buster ${{ arch.name }}:
-          # 10
-          deb_system: debian
-          distro: buster
-          arch: ${{ arch.value }}
-          pool: ${{ arch.pool }}
         Bullseye ${{ arch.name }}:
           # 11
           deb_system: debian
@@ -1036,11 +1030,6 @@ jobs:
         Noble ${{ arch.name }}:
           deb_system: ubuntu
           distro: noble
-          arch: ${{ arch.value }}
-          pool: ${{ arch.pool }}
-        Buster ${{ arch.name }}:
-          deb_system: debian
-          distro: buster
           arch: ${{ arch.value }}
           pool: ${{ arch.pool }}
         Bullseye ${{ arch.name }}:


### PR DESCRIPTION
Debian 10 reached its EOL LTS in June 2024.

Ref: https://wiki.debian.org/DebianReleases