### PR TITLE
{Packaging} Bump requests to 2.32.3

### DIFF
--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -123,7 +123,7 @@ PyNaCl==1.5.0
 pyOpenSSL==24.0.0
 python-dateutil==2.8.0
 requests-oauthlib==1.2.0
-requests[socks]==2.32.0
+requests[socks]==2.32.3
 scp==0.13.2
 semver==2.13.0
 six==1.16.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -124,7 +124,7 @@ PyNaCl==1.5.0
 pyOpenSSL==24.0.0
 python-dateutil==2.8.0
 requests-oauthlib==1.2.0
-requests[socks]==2.32.0
+requests[socks]==2.32.3
 scp==0.13.2
 semver==2.13.0
 six==1.16.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -125,7 +125,7 @@ pyOpenSSL==24.0.0
 python-dateutil==2.8.0
 pywin32==305
 requests-oauthlib==1.2.0
-requests[socks]==2.32.0
+requests[socks]==2.32.3
 scp==0.13.2
 semver==2.13.0
 six==1.16.0


### PR DESCRIPTION
2.32.0 is yanked.

![image](https://github.com/user-attachments/assets/f2d3d194-fa9d-44fc-ab22-6b61a1c85567)
Ref: https://pypi.org/project/requests/#history