### PR TITLE
{CI} Disable CodeQL task

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,8 @@ pr:
 
 variables:
 - template: ${{ variables.Pipeline.Workspace }}/.azure-pipelines/templates/variables.yml
-- Codeql.Enabled: false
+- name: Codeql.Enabled
+  value: false
 
 parameters:
 - name: architectures

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,7 @@ pr:
 
 variables:
 - template: ${{ variables.Pipeline.Workspace }}/.azure-pipelines/templates/variables.yml
+- Codeql.Enabled: false
 
 parameters:
 - name: architectures


### PR DESCRIPTION
CodeQL tasks always timeout in these tasks. https://dev.azure.com/azclitools/public/_build/results?buildId=172894&view=logs&jobId=61bf4700-6d0f-55d3-0cc1-f8d3dd51c404
![image](https://github.com/user-attachments/assets/96ded99a-904f-4ea1-9674-602d7566aa97)
![image](https://github.com/user-attachments/assets/99f97b9b-d4cd-4d26-9797-94b6b1cbeb99)

Usually, `Finalize CodeQL (auto-injected)` takes about 30min. I have no idea why they fail in these 6 tasks.

Luckily, they are all in `azure-pipelines.yml`. Even though we disable it here, **the CodeQL task still runs in `azure-pipelines-full-tests.yml`**. We still meet the security requirements.

PS: CodeQL also make some tasks in PowerShell fail: https://github.com/Azure/azure-powershell/pull/25560

Ref:
https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/configuring-codeql3000-ado-pipelines
https://portal.microsofticm.com/imp/v5/incidents/details/520675856/summary