### PR TITLE
[Role] `az role assignment list`: Add warning for classic administrators retirement

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_help.py
@@ -773,7 +773,15 @@ examples:
 helps['role assignment list'] = """
 type: command
 short-summary: List role assignments.
-long-summary: By default, only assignments scoped to subscription will be displayed. To view assignments scoped by resource or group, use `--all`.
+long-summary: >-
+    By default, only assignments scoped to subscription will be displayed.
+    To view assignments scoped by resource or group, use `--all`.
+
+
+    [WARNING] Azure classic subscription administrators will be retired on August 31, 2024.
+    After August 31, 2024, all classic administrators risk losing access to the subscription.
+    Delete classic administrators who no longer need access or assign an Azure RBAC role for fine-grained access
+    control. Learn more: https://go.microsoft.com/fwlink/?linkid=2238474
 """
 
 helps['role assignment list-changelogs'] = """

--- a/src/azure-cli/azure/cli/command_modules/role/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_params.py
@@ -314,7 +314,9 @@ def load_arguments(self, _):
                    "managed identities. For managed identities use the principal id. For service principals, "
                    "use the object id and not the app id.")
         c.argument('ids', nargs='+', help='space-separated role assignment ids')
-        c.argument('include_classic_administrators', arg_type=get_three_state_flag(), help='list default role assignments for subscription classic administrators, aka co-admins')
+        c.argument('include_classic_administrators', arg_type=get_three_state_flag(),
+                   help='list default role assignments for subscription classic administrators, aka co-admins',
+                   deprecate_info=c.deprecate(target='--include-classic-administrators'))
         c.argument('description', is_preview=True, min_api='2020-04-01-preview', help='Description of role assignment.')
         c.argument('condition', is_preview=True, min_api='2020-04-01-preview', help='Condition under which the user can be granted permission.')
         c.argument('condition_version', is_preview=True, min_api='2020-04-01-preview', help='Version of the condition syntax. If --condition is specified without --condition-version, default to 2.0.')

--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -50,6 +50,12 @@ CREDENTIAL_WARNING = (
     "The output includes credentials that you must protect. Be sure that you do not include these credentials in "
     "your code or check the credentials into your source control. For more information, see https://aka.ms/azadsp-cli")
 
+CLASSIC_ADMINISTRATOR_WARNING = (
+    "Azure classic subscription administrators will be retired on August 31, 2024. "
+    "After August 31, 2024, all classic administrators risk losing access to the subscription. "
+    "Delete classic administrators who no longer need access or assign an Azure RBAC role for fine-grained access "
+    "control. Learn more: https://go.microsoft.com/fwlink/?linkid=2238474")
+
 logger = get_logger(__name__)
 
 # pylint: disable=too-many-lines, protected-access
@@ -213,6 +219,9 @@ def list_role_assignments(cmd, assignee=None, role=None, resource_group_name=Non
     :param include_groups: include extra assignments to the groups of which the user is a
     member(transitively).
     '''
+    if include_classic_administrators:
+        logger.warning(CLASSIC_ADMINISTRATOR_WARNING)
+
     graph_client = _graph_client_factory(cmd.cli_ctx)
     authorization_client = _auth_client_factory(cmd.cli_ctx, scope)
     assignments_client = authorization_client.role_assignments


### PR DESCRIPTION
**Related command**
`az role assignment list`

**Description**<!--Mandatory-->
According to https://azure.microsoft.com/en-us/updates/azure-classic-administrator-roles-are-retiring-on-31-august-2024/, Azure Classic Administrator roles will be retired on 2024-08-31.

Azure CLI should announce this in advance:

> Azure classic subscription administrators will be retired on August 31, 2024. After August 31, 2024, all classic administrators risk losing access to the subscription. Delete classic administrators who no longer need access or assign an Azure RBAC role for fine-grained access control. Learn more: https://go.microsoft.com/fwlink/?linkid=2238474

**Testing Guide**
```
az role assignment list -h
az role assignment list --include-classic-administrators
```
