### PR TITLE
[AKS] BREAKING CHANGE: Fix #29379: `az aks create`: Fix option `--cluster-autoscaler-profile` to accept space separated values

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_params.py
@@ -352,7 +352,7 @@ def load_arguments(self, _):
         c.argument('auto_upgrade_channel', arg_type=get_enum_type(auto_upgrade_channels))
         c.argument('node_os_upgrade_channel', arg_type=get_enum_type(node_os_upgrade_channels))
         c.argument('cluster_autoscaler_profile', nargs='+', options_list=["--cluster-autoscaler-profile", "--ca-profile"],
-                   help="Comma-separated list of key=value pairs for configuring cluster autoscaler. Pass an empty string to clear the profile.")
+                   help="Space-separated list of key=value pairs for configuring cluster autoscaler. Pass an empty string to clear the profile.")
         c.argument('tier', arg_type=get_enum_type(sku_tiers), validator=validate_sku_tier)
         c.argument('fqdn_subdomain')
         c.argument('api_server_authorized_ip_ranges', validator=validate_ip_ranges)
@@ -547,7 +547,7 @@ def load_arguments(self, _):
         c.argument('outbound_type', arg_type=get_enum_type(outbound_types))
         c.argument('auto_upgrade_channel', arg_type=get_enum_type(auto_upgrade_channels))
         c.argument('cluster_autoscaler_profile', nargs='+', options_list=["--cluster-autoscaler-profile", "--ca-profile"],
-                   help="Comma-separated list of key=value pairs for configuring cluster autoscaler. Pass an empty string to clear the profile.")
+                   help="Space-separated list of key=value pairs for configuring cluster autoscaler. Pass an empty string to clear the profile.")
         c.argument('tier', arg_type=get_enum_type(sku_tiers), validator=validate_sku_tier)
         c.argument('api_server_authorized_ip_ranges', validator=validate_ip_ranges)
         # advanced networking

--- a/src/azure-cli/azure/cli/command_modules/acs/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_validators.py
@@ -605,7 +605,7 @@ def extract_key_value_pair(
     if raw_string == "":
         return default_value
 
-    result = {} 
+    result = {}
     kv_list = raw_string.split("=")
     if len(kv_list) in [1, 2]:
         key = kv_list[0]

--- a/src/azure-cli/azure/cli/command_modules/acs/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_validators.py
@@ -589,6 +589,44 @@ def extract_comma_separated_string(
     return result
 
 
+def extract_key_value_pair(
+    raw_string,
+    enable_strip=False,
+    allow_empty_value=False,
+    keep_none=False,
+    default_value=None,
+):
+    if raw_string is None:
+        if keep_none:
+            return None
+        return default_value
+    if enable_strip:
+        raw_string = raw_string.strip()
+    if raw_string == "":
+        return default_value
+
+    result = {} 
+    kv_list = raw_string.split("=")
+    if len(kv_list) in [1, 2]:
+        key = kv_list[0]
+        value = ""
+        if len(kv_list) == 2:
+            value = kv_list[1]
+        if not allow_empty_value and (value == "" or value.isspace()):
+            raise InvalidArgumentValueError(
+                f"Empty value not allowed. The value '{value}' of key '{key}' in '{raw_string}' is empty."
+            )
+        if enable_strip:
+            key = key.strip()
+            value = value.strip()
+        result[key] = value
+    else:
+        raise InvalidArgumentValueError(
+            f"The format of '{raw_string}' is incorrect, correct format should be 'Key=Value' or 'Key=Value1,Value2'"
+        )
+    return result
+
+
 def validate_credential_format(namespace):
     if namespace.credential_format and \
         namespace.credential_format.lower() != "azure" and \

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -68,7 +68,7 @@ from azure.cli.command_modules.acs._roleassignments import (
     ensure_cluster_identity_permission_on_kubelet_identity,
     subnet_role_assignment_exists,
 )
-from azure.cli.command_modules.acs._validators import extract_comma_separated_string
+from azure.cli.command_modules.acs._validators import extract_comma_separated_string, extract_key_value_pair
 from azure.cli.command_modules.acs.addonconfiguration import (
     add_ingress_appgw_addon_role_assignment,
     add_monitoring_role_assignment,
@@ -401,9 +401,8 @@ class AKSManagedClusterContext(BaseAKSContext):
                 params_dict = {}
                 for item in cluster_autoscaler_profile:
                     params_dict.update(
-                        extract_comma_separated_string(
+                        extract_key_value_pair(
                             item,
-                            extract_kv=True,
                             allow_empty_value=True,
                             default_value={},
                         )

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_validators.py
@@ -412,6 +412,112 @@ class TestExtractCommaSeparatedString(unittest.TestCase):
         g16 = {"WindowsContainerRuntime": "containerd", "AKSHTTPCustomFeatures": "Microsoft.ContainerService/AKSTestFeaturePreview,Microsoft.ContainerService/AKSExampleFeaturePreview"}
         self.assertEqual(t16, g16)
 
+    def test_extract_key_value_pair(self):
+        tcs = [
+            (
+                {
+                    "raw_string": "abc = def",
+                    "enable_strip": False,
+                    "allow_empty_value": False,
+                    "keep_none": False,
+                    "default_value": None,
+                },
+                {
+                    "result": {"abc ": " def"},
+                    "exception": None
+                }
+            ),
+            (
+                {
+                    "raw_string": "abc = def",
+                    "enable_strip": True,
+                    "allow_empty_value": False,
+                    "keep_none": False,
+                    "default_value": None,
+                },
+                {
+                    "result": {"abc": "def"},
+
+                    "exception": None
+                }
+            ),
+            (
+                {
+                    "raw_string": "abc=",
+                    "enable_strip": False,
+                    "allow_empty_value": False,
+                    "keep_none": False,
+                    "default_value": {},
+                },
+                {
+                    "result": {"abc ": " def"},
+                    "exception": InvalidArgumentValueError("Empty value not allowed. The value '' of key 'abc' in 'abc=' is empty."),
+                }
+            ),
+            (
+                {
+                    "raw_string": "abc=",
+                    "enable_strip": False,
+                    "allow_empty_value": True,
+                    "keep_none": False,
+                    "default_value": {},
+                },
+                {
+                    "result": {"abc": ""},
+                    "exception": None
+                }
+            ),
+            (
+                {
+                    "raw_string": None,
+                    "enable_strip": False,
+                    "allow_empty_value": False,
+                    "keep_none": False,
+                    "default_value": {},
+                },
+                {
+                    "result": {},
+                    "exception": None
+                }
+            ),
+            (
+                {
+                    "raw_string": None,
+                    "enable_strip": False,
+                    "allow_empty_value": False,
+                    "keep_none": True,
+                    "default_value": {},
+                },
+                {
+                    "result": None,
+                    "exception": None
+                }
+            ),
+            (
+                {
+                    "raw_string": None,
+                    "enable_strip": False,
+                    "allow_empty_value": False,
+                    "keep_none": False,
+                    "default_value": "",
+                },
+                {
+                    "result": "",
+                    "exception": None
+                }
+            ),
+        ]
+        for tc in tcs:
+            s = tc[0]
+            g = tc[1]
+            if g["exception"]:
+                with self.assertRaises(type(g["exception"])) as cm:
+                    t = validators.extract_key_value_pair(s["raw_string"], s["enable_strip"], s["allow_empty_value"], s["keep_none"], s["default_value"])
+                self.assertEqual(str(cm.exception), str(g["exception"]))
+            else:
+                t = validators.extract_key_value_pair(s["raw_string"], s["enable_strip"], s["allow_empty_value"], s["keep_none"], s["default_value"])
+                self.assertEqual(t, g["result"])
+
 
 class CredentialFormatNamespace:
     def __init__(self, credential_format):


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

`az aks create`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

[AKS] BREAKING CHANGE: Fix #29379: `az aks create`: Fix option `--cluster-autoscaler-profile` to accept space separated values

Specify multiple values for the same key by separating them with commas. For different key-value pairs, separated by space.
![image](https://github.com/user-attachments/assets/af18e219-a211-4a2c-9980-2b5f8e4777f0)

Announcement #31196


**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
