### PR TITLE
[Keyvault] `az keyvault security-domain upload/restore-blob`: Make `--passwords` required to protect private key files

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/keyvault/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_params.py
@@ -581,10 +581,9 @@ def load_arguments(self, _):
         c.argument('sd_exchange_key', help='The exchange key for security domain.')
         c.argument('sd_wrapping_keys', nargs='*',
                    help='Space-separated file paths to PEM files containing private keys.')
-        c.argument('passwords', nargs='*', required=True,
-                   help='Space-separated password list for --sd-wrapping-keys. '
-                        'CLI will match them in order. Can be omitted if your keys are without '
-                        'password protection.')
+        c.argument('passwords', nargs='*', help='Space-separated password list for --sd-wrapping-keys. '
+                                                'CLI will match them in order. Can be omitted if your keys are without '
+                                                'password protection.')
 
     with self.argument_context('keyvault security-domain restore-blob') as c:
         c.argument('sd_file', help='This file contains security domain encrypted using SD Exchange file downloaded '

--- a/src/azure-cli/azure/cli/command_modules/keyvault/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_params.py
@@ -581,9 +581,10 @@ def load_arguments(self, _):
         c.argument('sd_exchange_key', help='The exchange key for security domain.')
         c.argument('sd_wrapping_keys', nargs='*',
                    help='Space-separated file paths to PEM files containing private keys.')
-        c.argument('passwords', nargs='*', help='Space-separated password list for --sd-wrapping-keys. '
-                                                'CLI will match them in order. Can be omitted if your keys are without '
-                                                'password protection.')
+        c.argument('passwords', nargs='*', required=True,
+                   help='Space-separated password list for --sd-wrapping-keys. '
+                        'CLI will match them in order. Can be omitted if your keys are without '
+                        'password protection.')
 
     with self.argument_context('keyvault security-domain restore-blob') as c:
         c.argument('sd_file', help='This file contains security domain encrypted using SD Exchange file downloaded '
@@ -591,9 +592,10 @@ def load_arguments(self, _):
         c.argument('sd_exchange_key', help='The exchange key for security domain.')
         c.argument('sd_wrapping_keys', nargs='*',
                    help='Space-separated file paths to PEM files containing private keys.')
-        c.argument('passwords', nargs='*', help='Space-separated password list for --sd-wrapping-keys. '
-                                                'CLI will match them in order. Can be omitted if your keys are without '
-                                                'password protection.')
+        c.argument('passwords', nargs='*', required=True,
+                   help='Space-separated password list for --sd-wrapping-keys. '
+                        'CLI will match them in order. Can be omitted if your keys are without '
+                        'password protection.')
         c.argument('sd_file_restore_blob', help='Local file path to store the security domain encrypted with the exchange key.')
 
     with self.argument_context('keyvault security-domain download') as c:

--- a/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
@@ -2375,6 +2375,8 @@ def _security_domain_restore_blob(sd_file, sd_exchange_key, sd_wrapping_keys, pa
         raise CLIError('Unsupported SharedKeys algorithm: {}. Supported: {}'.format(key_algorithm, 'shamir_share'))
 
     if passwords is None:
+        logger.warning("--passwords will be required in the future. "
+                       "Please don't save key files without password protection on local disk.")
         passwords = []
 
     restore_blob_value = _security_domain_make_restore_blob(

--- a/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
@@ -2375,9 +2375,8 @@ def _security_domain_restore_blob(sd_file, sd_exchange_key, sd_wrapping_keys, pa
         raise CLIError('Unsupported SharedKeys algorithm: {}. Supported: {}'.format(key_algorithm, 'shamir_share'))
 
     if passwords is None:
-        logger.warning("--passwords will be required in the future. "
+        raise CLIError("--passwords can't be None. "
                        "Please don't save key files without password protection on local disk.")
-        passwords = []
 
     restore_blob_value = _security_domain_make_restore_blob(
         sd_wrapping_keys=sd_wrapping_keys,


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az keyvault security-domain upload/restore-blob`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix #29278 
It's unsafe to ask customers to store plain text private key files on their local disk for `--sd-wrapping-keys` parameter for `az keyvault security-domain upload/restore-blob`. So we require `--sd-wrapping-keys` together with `--passwords`

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
