### PR TITLE
{Packaging} Use latest setuptools in Alpine docker image

### DIFF
--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -36,7 +36,7 @@ ARG JP_VERSION="0.2.1"
 
 RUN --mount=type=bind,target=/azure-cli,source=./,rw apk add --no-cache ca-certificates bash bash-completion libintl icu-libs libc6-compat jq openssh-keygen \
     && apk add --no-cache --virtual .build-deps gcc musl-dev linux-headers libffi-dev curl \
-    && update-ca-certificates && cd /azure-cli && ./scripts/install_full.sh && python ./scripts/trim_sdk.py \
+    && update-ca-certificates && pip install --upgrade pip setuptools && cd /azure-cli && ./scripts/install_full.sh && python ./scripts/trim_sdk.py \
     && cat /azure-cli/az.completion > ~/.bashrc \
     && dos2unix /root/.bashrc /usr/local/bin/az \
     && arch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) && curl -L https://github.com/jmespath/jp/releases/download/${JP_VERSION}/jp-linux-$arch -o /usr/local/bin/jp \


### PR DESCRIPTION
We always use latest `setuptools` in packages, see https://github.com/Azure/azure-cli/pull/27196.
This PR updates the `setuptools` and `pip` in Alpine docker image.

For Python<3.12, the docker images uses pinned `setuptools`. In 3.12, it uses the latest version by default.
> ENV PYTHON_SETUPTOOLS_VERSION 65.5.1    --https://github.com/docker-library/python/blob/ec14acd6a0830012b4330429bc173247a375857e/3.11/alpine3.20/Dockerfile#L136

For now, the docker-library team does not want to bump the `setuptools` version because of the compatibility concern: https://github.com/docker-library/python/issues/942

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Core] Resolve CVE-2024-6345