### PR TITLE
[RDBMS] BREAKING CHANGE: Update default value of PG version to be 16 for `postgres flexible-server create`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
@@ -566,7 +566,7 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
                 c.argument('tier', default='GeneralPurpose', arg_type=tier_arg_type)
                 c.argument('sku_name', default='Standard_D2s_v3', arg_type=sku_name_arg_type)
                 c.argument('storage_gb', default='128', arg_type=storage_gb_arg_type)
-                c.argument('version', default='13', arg_type=version_arg_type)
+                c.argument('version', default='16', arg_type=version_arg_type)
                 c.argument('backup_retention', default=7, arg_type=pg_backup_retention_arg_type)
                 c.argument('active_directory_auth', default='Disabled', arg_type=active_directory_auth_arg_type)
                 c.argument('password_auth', default='Enabled', arg_type=password_auth_arg_type)

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
@@ -59,9 +59,6 @@ def flexible_server_create(cmd, client,
                            active_directory_auth=None, password_auth=None, auto_grow=None, performance_tier=None,
                            storage_type=None, iops=None, throughput=None, create_default_db='Enabled', yes=False):
 
-    # Warning for upcoming breaking change to default value of pg version
-    logger.warning('In the next release, the default value for the PostgreSQL server major version will be updated to 16')
-
     # Generate missing parameters
     location, resource_group_name, server_name = generate_missing_parameters(cmd, location, resource_group_name,
                                                                              server_name, 'postgres')


### PR DESCRIPTION
**Related command**
`postgres flexible-server create`

**Description**<!--Mandatory-->
Default version is 13 which is very old. Want users to move to 16 when provisioning server.
Removed warning label that this change was to come for August 2024 release.
This was agreed upon by CLI team and PostgreSQL Flex PM

**Testing Guide**
Manually
PS C:\Users\nasc\azureCLI\azure-cli> az postgres flexible-server create -n nasc-pg16-722
Checking the existence of the resource group ...
Your server 'nasc-pg16-722' is using sku 'Standard_D2s_v3' (Paid Tier). Please refer to https://aka.ms/postgres-pricing for pricing details
Creating PostgreSQL database 'flexibleserverdb'...
{
...
  "skuname": "Standard_D2s_v3",
  **"version": "16"**
}

**History Notes**
BREAKING CHANGE: `az postgres flexible-server create`: Default version changing from 13 to 16.


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
