### PR TITLE
{Core} Migrate from `pyOpenSSL` to `cryptography`

### DIFF
--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -249,20 +249,26 @@ class ServicePrincipalAuth:
         self.__dict__.update(entry)
 
         if _CERTIFICATE in entry:
-            from OpenSSL.crypto import load_certificate, FILETYPE_PEM, Error
+            from cryptography.x509 import load_pem_x509_certificate
+            from cryptography.hazmat.primitives import hashes
+
             self.public_certificate = None
             try:
                 with open(self.certificate, 'r') as file_reader:
                     self.certificate_string = file_reader.read()
-                    cert = load_certificate(FILETYPE_PEM, self.certificate_string)
-                    self.thumbprint = cert.digest("sha1").decode().replace(':', '')
+
+                    # Calculate SHA1 thumbprint
+                    # load_pem_x509_certificate may raise ValueError
+                    x509_cert = load_pem_x509_certificate(self.certificate_string.encode('utf-8'))
+                    self.thumbprint = x509_cert.fingerprint(hashes.SHA1()).hex().upper()
+
                     if entry.get(_USE_CERT_SN_ISSUER):
                         # low-tech but safe parsing based on
                         # https://github.com/libressl-portable/openbsd/blob/master/src/lib/libcrypto/pem/pem.h
                         match = re.search(r'-----BEGIN CERTIFICATE-----(?P<cert_value>[^-]+)-----END CERTIFICATE-----',
                                           self.certificate_string, re.I)
                         self.public_certificate = match.group()
-            except (UnicodeDecodeError, Error) as ex:
+            except (UnicodeDecodeError, ValueError) as ex:
                 raise CLIError('Invalid certificate, please use a valid PEM file. Error detail: {}'.format(ex))
 
     @classmethod


### PR DESCRIPTION
**Related command**
`az login`

**Description**<!--Mandatory-->
https://pypi.org/project/pyOpenSSL/

> Note: The Python Cryptographic Authority **strongly suggests** the use of [pyca/cryptography](https://github.com/pyca/cryptography) where possible. If you are using pyOpenSSL for anything other than making a TLS connection **you should move to cryptography and drop your pyOpenSSL dependency**.

**Testing Guide**
```
az login --service-principal --username xxx --password C:\Users\xxx\tmpxxx.pem  --tenant xxx
```
