### PR TITLE
[RDBMS] `az postgres flexible-server create`: Bug fix for using existing subnet while creating pg flex server

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_virtual_network.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_virtual_network.py
@@ -248,8 +248,9 @@ def _create_subnet_delegation(cmd, nw_subscription, resource_client, delegation_
             "resource_group": resource_group
         })
         logger.warning('Using existing Subnet "%s" in resource group "%s"', subnet_name, resource_group)
-        if subnet_address_pref not in (DEFAULT_SUBNET_ADDRESS_PREFIX, subnet["addressPrefix"]):
-            logger.warning("The prefix of the subnet you provided does not match the --subnet-prefix value %s. Using current prefix %s", subnet_address_pref, subnet["addressPrefix"])
+        subnet_address_prefix = subnet["addressPrefix"] if 'addressPrefix' in subnet else subnet["addressPrefixes"]
+        if subnet_address_pref not in (DEFAULT_SUBNET_ADDRESS_PREFIX, subnet_address_prefix):
+            logger.warning("The prefix of the subnet you provided does not match the --subnet-prefix value %s. Using current prefix %s", subnet_address_pref, subnet_address_prefix)
 
         # Add Delegation if not delegated already
         if not subnet.get("delegations", None):

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_virtual_network.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_virtual_network.py
@@ -224,9 +224,11 @@ def _create_subnet_delegation(cmd, nw_subscription, resource_client, delegation_
             "subscription": nw_subscription,
             "resource_group": resource_group
         })
-        vnet_subnet_prefixes = [subnet["addressPrefix"] for subnet in vnet.get("subnets", [])]
-        if subnet_address_pref in vnet_subnet_prefixes:
-            raise ValidationError(f"The Subnet (default) prefix {subnet_address_pref} is already taken by another Subnet in the Vnet. Please provide a different prefix for --subnet-prefix parameter")
+        subnets = vnet.get("subnets", [])
+        for subnet in subnets:
+            vnet_subnet_prefixes = subnet.get("addressPrefix", "") if 'addressPrefix' in subnet else subnet.get("addressPrefixes", "")
+            if subnet_address_pref in vnet_subnet_prefixes:
+                raise ValidationError(f"The Subnet (default) prefix {subnet_address_pref} is already taken by another Subnet in the Vnet. Please provide a different prefix for --subnet-prefix parameter")
 
         user_confirmation("Do you want to create a new Subnet {0} in resource group {1}".format(subnet_name, resource_group), yes=yes)
         logger.warning('Creating new Subnet "%s" in resource group "%s"', subnet_name, resource_group)


### PR DESCRIPTION
**Related command**
`az postgres flexible-server create`

**Description**<!--Mandatory-->
Fix unexpected error: File "D:\a_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/command_modules/rdbms/flexible_server_virtual_network.py", line 251, in _create_subnet_delegation
KeyError: 'addressPrefix'

Fix #27422 

**Testing Guide**
WARNING: You have supplied a Subnet ID. Verifying its existence...
WARNING: Using existing Vnet "vnet-test-nasc-628" in resource group "nasc-runner"
WARNING: Using existing Subnet "subnet-test-nasc-628-454" in resource group "nasc-runner"
WARNING: Using existing Vnet "vnet-test-nasc-628" in resource group "nasc-runner"
WARNING: Using existing Subnet "subnet-test-nasc-628-454" in resource group "nasc-runner"
WARNING: Using the existing private dns zone nasc-test-dns-628.private.postgres.database.azure.com in resource group "nasc-runner"
WARNING: Creating PostgreSQL Server 'nasc-net-cli1257' in group 'nasc-runner'...
{
  "connectionString": "x",
  "databaseName": null,
  "host": "nasc-net-cli1257.postgres.database.azure.com",
  "id": "/subscriptions/x/resourceGroups/x/providers/Microsoft.DBforPostgreSQL/flexibleServers/nasc-net-cli1257",
  "location": "Korea Central",
  "password": "",
  "resourceGroup": "x",
  "skuname": "Standard_D2s_v3",
  **"subnetId": "/subscriptions/x/resourceGroups/x/providers/Microsoft.Network/virtualNetworks/vnet-test-nasc-628/subnets/subnet-test-nasc-628-454",**
  "version": "13"
}

**History Notes**
`az postgres flexible-server create`: Bug fix for creating a PostgreSQL flexible server using existing network resources


