### PR TITLE
[RDBMS] `az postgres flexible-server restore`: Bug fix when using resource id as value for source-server argument

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
@@ -203,8 +203,6 @@ def flexible_server_restore(cmd, client,
     else:
         source_server_id = source_server
 
-    instance = client.get(resource_group_name, source_server)
-
     restore_point_in_time = validate_and_format_restore_point_in_time(restore_point_in_time)
 
     try:
@@ -225,6 +223,7 @@ def flexible_server_restore(cmd, client,
 
         pg_byok_validator(byok_identity, byok_key, backup_byok_identity, backup_byok_key, geo_redundant_backup)
 
+        instance = client.get(resource_group_name, id_parts['name'])
         storage = postgresql_flexibleservers.models.Storage(type=storage_type if instance.storage.type != "PremiumV2_LRS" else None)
 
         parameters = postgresql_flexibleservers.models.Server(


### PR DESCRIPTION
**Related command**
`az postgres flexible-server restore`

**Description**<!--Mandatory-->
Regression introduced: #28975 

**Testing Guide**
az postgres flexible-server restore --resource-group nasc-runner --source-server /subscriptions/x/resourceGroups/nasc-runner/providers/Microsoft.DBforPostgreSQL/flexibleServers/nasc-pg16-722 -n nasc-test-restore510
{
...
  "backup": {
    "backupRetentionDays": 7,
    "earliestRestoreDate": "2024-07-24T21:13:14.296422+00:00",
    "geoRedundantBackup": "Disabled"
  },
...
  "id": "/subscriptions/x/resourceGroups/nasc-runner/providers/Microsoft.DBforPostgreSQL/flexibleServers/nasc-test-restore510",
  "name": "nasc-test-restore510",
...
}

**History Notes**
[RDBMS] `az postgres flexible-server restore`: Bug fix when using resource id as value for source-server argument
