### PR TITLE
{Packaging} Bump cffi to 1.16.0

### DIFF
--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -89,7 +89,7 @@ azure-synapse-managedprivateendpoints==0.4.0
 azure-synapse-spark==0.2.0
 bcrypt==3.2.0
 certifi==2024.7.4
-cffi==1.15.1
+cffi==1.16.0
 chardet==5.2.0
 colorama==0.4.6
 cryptography==42.0.5

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -89,7 +89,7 @@ azure-synapse-managedprivateendpoints==0.4.0
 azure-synapse-spark==0.2.0
 bcrypt==3.2.0
 certifi==2024.7.4
-cffi==1.15.1
+cffi==1.16.0
 chardet==5.2.0
 colorama==0.4.6
 cryptography==42.0.5

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -89,7 +89,7 @@ azure-synapse-managedprivateendpoints==0.4.0
 azure-synapse-spark==0.2.0
 bcrypt==3.2.0
 certifi==2024.7.4
-cffi==1.15.1
+cffi==1.16.0
 chardet==5.2.0
 colorama==0.4.6
 cryptography==42.0.5


### PR DESCRIPTION
1.15.1 does not provide wheel for Python 3.12. Bump it. Error log: https://github.com/Azure/azure-cli/issues/29467

Not sure if 1.14.6 is compatible with 3.12. It is stated that cffi 1.16 add 3.12 support: https://cffi.readthedocs.io/en/latest/whatsnew.html

https://github.com/Azure/azure-cli/blob/5f52c83e218f3ddc4d933bd99a88dab9e1864d81/scripts/release/rpm/azure-cli.spec#L55
