### PR TITLE
[BREAKING CHANGE] `az role assignment list`: Drop `--include-classic-administrators` argument

### DIFF
--- a/linter_exclusions.yml
+++ b/linter_exclusions.yml
@@ -3113,11 +3113,6 @@ role assignment create:
     assignee_principal_type:
       rule_exclusions:
       - option_length_too_long
-role assignment list:
-  parameters:
-    include_classic_administrators:
-      rule_exclusions:
-      - option_length_too_long
 security adaptive_network_hardenings show:
   parameters:
     adaptive_network_hardenings_resource_name:

--- a/src/azure-cli-core/azure/cli/core/profiles/_shared.py
+++ b/src/azure-cli-core/azure/cli/core/profiles/_shared.py
@@ -191,7 +191,6 @@ AZURE_API_PROFILES = {
             'managed_hsms': '2024-11-01'
         }),
         ResourceType.MGMT_AUTHORIZATION: SDKProfile('2022-04-01', {
-            'classic_administrators': '2015-06-01',
             'role_definitions': '2022-05-01-preview',
             'provider_operations_metadata': '2018-01-01-preview'
         }),
@@ -292,7 +291,6 @@ AZURE_API_PROFILES = {
         ResourceType.MGMT_RESOURCE_MANAGEDAPPLICATIONS: '2019-07-01',
         ResourceType.MGMT_NETWORK_DNS: '2016-04-01',
         ResourceType.MGMT_AUTHORIZATION: SDKProfile('2015-07-01', {
-            'classic_administrators': '2015-06-01',
             'policy_assignments': '2016-12-01',
             'policy_definitions': '2016-12-01'
         }),
@@ -338,7 +336,6 @@ AZURE_API_PROFILES = {
         ResourceType.MGMT_NETWORK_DNS: '2016-04-01',
         ResourceType.MGMT_KEYVAULT: '2016-10-01',
         ResourceType.MGMT_AUTHORIZATION: SDKProfile('2015-07-01', {
-            'classic_administrators': '2015-06-01',
             'policy_assignments': '2016-12-01',
             'policy_definitions': '2016-12-01'
         }),
@@ -377,9 +374,7 @@ AZURE_API_PROFILES = {
         ResourceType.MGMT_RESOURCE_MANAGEDAPPLICATIONS: '2019-07-01',
         ResourceType.MGMT_NETWORK_DNS: '2016-04-01',
         ResourceType.MGMT_KEYVAULT: '2016-10-01',
-        ResourceType.MGMT_AUTHORIZATION: SDKProfile('2015-07-01', {
-            'classic_administrators': '2015-06-01'
-        }),
+        ResourceType.MGMT_AUTHORIZATION: SDKProfile('2015-07-01'),
         # The order does make things different.
         # Please keep ResourceType.DATA_KEYVAULT_KEYS before ResourceType.DATA_KEYVAULT
         ResourceType.DATA_KEYVAULT_CERTIFICATES: None,
@@ -407,9 +402,7 @@ AZURE_API_PROFILES = {
         ResourceType.MGMT_RESOURCE_MANAGEDAPPLICATIONS: '2019-07-01',
         ResourceType.MGMT_NETWORK_DNS: '2016-04-01',
         ResourceType.MGMT_KEYVAULT: '2016-10-01',
-        ResourceType.MGMT_AUTHORIZATION: SDKProfile('2015-07-01', {
-            'classic_administrators': '2015-06-01'
-        }),
+        ResourceType.MGMT_AUTHORIZATION: SDKProfile('2015-07-01'),
         # The order does make things different.
         # Please keep ResourceType.DATA_KEYVAULT_KEYS before ResourceType.DATA_KEYVAULT
         ResourceType.DATA_KEYVAULT_CERTIFICATES: None,

--- a/src/azure-cli/azure/cli/command_modules/role/_breaking_change.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_breaking_change.py
@@ -1,8 +1,0 @@
-# --------------------------------------------------------------------------------------------
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License. See License.txt in the project root for license information.
-# --------------------------------------------------------------------------------------------
-
-from azure.cli.core.breaking_change import register_argument_deprecate
-
-register_argument_deprecate('role assignment list', '--include-classic-administrators')

--- a/src/azure-cli/azure/cli/command_modules/role/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_help.py
@@ -795,12 +795,6 @@ short-summary: List role assignments.
 long-summary: >-
     By default, only assignments scoped to subscription will be displayed.
     To view assignments scoped by resource or group, use `--all`.
-
-
-    [WARNING] Azure classic subscription administrators will be retired on August 31, 2024.
-    After August 31, 2024, all classic administrators risk losing access to the subscription.
-    Delete classic administrators who no longer need access or assign an Azure RBAC role for fine-grained access
-    control. Learn more: https://go.microsoft.com/fwlink/?linkid=2238474
 examples:
   - name: List role assignments at the subscription scope.
     text: az role assignment list --scope /subscriptions/00000000-0000-0000-0000-000000000000

--- a/src/azure-cli/azure/cli/command_modules/role/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_params.py
@@ -340,8 +340,6 @@ def load_arguments(self, _):
                         "the logged-in account has no permission or the machine has no network access to query "
                         "Microsoft Graph.")
         c.argument('ids', nargs='+', help='space-separated role assignment ids')
-        c.argument('include_classic_administrators', arg_type=get_three_state_flag(),
-                   help='list default role assignments for subscription classic administrators, aka co-admins')
         c.argument('description', is_preview=True, min_api='2020-04-01-preview', help='Description of role assignment.')
         c.argument('condition', is_preview=True, min_api='2020-04-01-preview', help='Condition under which the user can be granted permission.')
         c.argument('condition_version', is_preview=True, min_api='2020-04-01-preview', help='Version of the condition syntax. If --condition is specified without --condition-version, default to 2.0.')

--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -52,12 +52,6 @@ CREDENTIAL_WARNING = (
     "The output includes credentials that you must protect. Be sure that you do not include these credentials in "
     "your code or check the credentials into your source control. For more information, see https://aka.ms/azadsp-cli")
 
-CLASSIC_ADMINISTRATOR_WARNING = (
-    "Azure classic subscription administrators will be retired on August 31, 2024. "
-    "After August 31, 2024, all classic administrators risk losing access to the subscription. "
-    "Delete classic administrators who no longer need access or assign an Azure RBAC role for fine-grained access "
-    "control. Learn more: https://go.microsoft.com/fwlink/?linkid=2238474")
-
 logger = get_logger(__name__)
 
 # pylint: disable=too-many-lines, protected-access
@@ -237,16 +231,10 @@ def list_role_assignments(cmd,  # pylint: disable=too-many-locals, too-many-bran
                           role=None,
                           resource_group_name=None, scope=None,
                           include_inherited=False,
-                          show_all=False, include_groups=False, include_classic_administrators=False,
+                          show_all=False, include_groups=False,
                           fill_role_definition_name=True, fill_principal_name=True):
     if assignee and assignee_object_id:
         raise CLIError('Usage error: Provide only one of --assignee or --assignee-object-id.')
-    if assignee_object_id and include_classic_administrators:
-        raise CLIError('Usage error: --assignee-object-id cannot be used with --include-classic-administrators. '
-                       'Use --assignee instead.')
-
-    if include_classic_administrators:
-        logger.warning(CLASSIC_ADMINISTRATOR_WARNING)
 
     graph_client = _graph_client_factory(cmd.cli_ctx)
     authorization_client = _auth_client_factory(cmd.cli_ctx, scope)
@@ -268,8 +256,6 @@ def list_role_assignments(cmd,  # pylint: disable=too-many-locals, too-many-bran
                                            include_inherited, include_groups)
 
     results = todict(assignments) if assignments else []
-    if include_classic_administrators:
-        results += _backfill_assignments_for_co_admins(cmd.cli_ctx, authorization_client, assignee)
 
     if not results:
         return []
@@ -468,53 +454,6 @@ def list_role_assignment_change_logs(cmd, start_time=None, end_time=None):  # py
                 for e in result:
                     e['principalName'] = principal_dics.get(e['principalId'], None)
 
-    return result
-
-
-def _backfill_assignments_for_co_admins(cli_ctx, auth_client, assignee=None):
-    worker = MultiAPIAdaptor(cli_ctx)
-    co_admins = auth_client.classic_administrators.list()  # known swagger bug on api-version handling
-    co_admins = [x for x in co_admins if x.email_address]
-    graph_client = _graph_client_factory(cli_ctx)
-    if assignee:  # apply assignee filter if applicable
-        if is_guid(assignee):
-            try:
-                result = _get_object_stubs(graph_client, [assignee])
-                if not result:
-                    return []
-                assignee = _get_displayable_name(result[0]).lower()
-            except ValueError:
-                pass
-        co_admins = [x for x in co_admins if assignee == x.email_address.lower()]
-
-    if not co_admins:
-        return []
-
-    result, users = [], []
-    for i in range(0, len(co_admins), 10):  # graph allows up to 10 query filters, so split into chunks here
-        upn_queries = ["userPrincipalName eq '{}'".format(x.email_address)
-                       for x in co_admins[i:i + 10]]
-        temp = list(list_users(graph_client, query_filter=' or '.join(upn_queries)))
-        users += temp
-    upns = {u['userPrincipalName']: u[ID] for u in users}
-    for admin in co_admins:
-        na_text = 'NA(classic admins)'
-        email = admin.email_address
-        result.append({
-            'id': na_text,
-            'name': na_text,
-        })
-        properties = {
-            'principalId': upns.get(email),
-            'principalName': email,
-            'roleDefinitionName': admin.role,
-            'roleDefinitionId': 'NA(classic admin role)',
-            'scope': '/subscriptions/' + auth_client._config.subscription_id
-        }
-        if worker.old_api:
-            result[-1]['properties'] = properties
-        else:
-            result[-1].update(properties)
     return result
 
 

--- a/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role.py
+++ b/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role.py
@@ -820,15 +820,6 @@ class RoleAssignmentLiveScenarioTest(LiveScenarioTest):
         # There are role assignments inherited from subscription, so we can't tell the exact number.
         self.cmd('role assignment list -g {rg} --include-inherited', checks=[self.greater_than("length([])", 0)])
 
-    @ResourceGroupPreparer(name_prefix='cli_test_assignments_for_coadmins')
-    def test_role_assignment_for_co_admins(self, resource_group):
-
-        result = self.cmd('role assignment list --include-classic-administrator').get_output_in_json()
-        self.assertTrue([x for x in result if x['roleDefinitionName'] in ['CoAdministrator', 'AccountAdministrator']])
-
-        result = self.cmd('role assignment list -g {rg} --include-classic-administrator').get_output_in_json()
-        self.assertTrue([x for x in result if x['roleDefinitionName'] in ['CoAdministrator', 'AccountAdministrator']])
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Related command**
`az role assignment list`

**Description**<!--Mandatory-->
Close https://github.com/Azure/azure-cli/issues/27199

https://github.com/Azure/azure-cli/pull/29404 added deprecation message for `--include-classic-administrators`. This PR drops `--include-classic-administrators` argument.

**Testing Guide**
```
az role assignment list -h
az role assignment list --include-classic-administrators
```
