### PR TITLE
[Keyvault] `az keyvault key`: sign and verify

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
@@ -1187,10 +1187,11 @@ def decrypt_key(cmd, client, algorithm, value, iv=None, tag=None, aad=None,
 
 
 def sign_key(cmd, client, algorithm, digest, name=None, version=None):
+    import base64
     SignatureAlgorithm = cmd.loader.get_sdk('SignatureAlgorithm', mod='crypto._enums',
                                             resource_type=ResourceType.DATA_KEYVAULT_KEYS)
     crypto_client = client.get_cryptography_client(name, key_version=version)
-    return crypto_client.sign(SignatureAlgorithm(algorithm), digest.encode('utf-8'))
+    return crypto_client.sign(SignatureAlgorithm(algorithm), base64.b64decode(digest))
 
 
 def verify_key(cmd, client, algorithm, digest, signature, name=None, version=None):
@@ -1199,7 +1200,7 @@ def verify_key(cmd, client, algorithm, digest, signature, name=None, version=Non
                                             resource_type=ResourceType.DATA_KEYVAULT_KEYS)
     crypto_client = client.get_cryptography_client(name, key_version=version)
     return crypto_client.verify(SignatureAlgorithm(algorithm),
-                                digest.encode('utf-8'),
+                                base64.b64decode(digest),
                                 base64.b64decode(signature.encode('utf-8')))
 
 


### PR DESCRIPTION
It's not possible to provide data to az keyvault key sign and verify as found in https://github.com/Azure/azure-cli/issues/27631, https://github.com/Azure/azure-cli/issues/28027

We now allow for valid base64 data to be given as digest.

```
$ az keyvault key sign -a RS256 --digest @<(openssl dgst -binary -sha256 bar | base64) --id https://kvfrigo.vault.azure.net/keys/rsaex/0f322aba7573435a96acfba86b521c35
Algorithm    KeyId                                                                          Signature
-----------  -----------------------------------------------------------------------------  --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
RS256        https://kvfrigo.vault.azure.net/keys/rsaex/0f322aba7573435a96acfba86b521c35  e7Wi7PCouEo8ZNlY1dL3IgDm8E63bc8ZE9VW0GQHglHPJjKGHpi9D0MfRFHZXCOHrRAas6JBz0iO5yJBuH+cczMpl+9+lFWNSi7I1efIrPS2NOlrtdhOCI5qLT/nWh++CvRh1+R2iCpVD1uxCkL9sjDwi6k5B+7ySkk9ikUGHG463TFq8/Oftk+mSlNBCd5j3wsva1BOTT1h9qY9eyHZCY319oVRM0jD92jtF2DNu0HF92uhUC8PT/6gjPd6vQtAWxF1LR7KLMx2zCxN9e7aV3bQXtKA4/KMYekE143IY2nMft+XNZ+DT7OIi0TT1ufwdNNjpUk/9LovN+XwYz1p+A==

$ az keyvault key verify -a RS256 --digest @<(openssl dgst -binary -sha256 bar | base64) --id https://kvfrigo.vault.azure.net/keys/rsaex/0f322aba7573435a96acfba86b521c35 --signature e7Wi7PCouEo8ZNlY1dL3IgDm8E63bc8ZE
9VW0GQHglHPJjKGHpi9D0MfRFHZXCOHrRAas6JBz0iO5yJBuH+cczMpl+9+lFWNSi7I1efIrPS2NOlrtdhOCI5qLT/nWh++CvRh1+R2iCpVD1uxCkL9sjDwi6k5B+7ySkk9ikUGHG463TFq8/Oftk+mSlNBCd5j3wsva1BOTT1h9qY9eyHZCY319oVRM0jD92jtF2DNu0HF92uhUC8PT/6gjPd6vQtAWxF1LR7KLMx2zCxN9e7aV3bQXtKA4/KMYekE143IY2nMft+XNZ+DT7OIi0TT1ufwdNNjpUk/9LovN+XwYz1p+A==
Algorithm    IsValid    KeyId
-----------  ---------  -----------------------------------------------------------------------------
RS256        True       https://kvfrigo.vault.azure.net/keys/rsaex/0f322aba7573435a96acfba86b521c35

$ az keyvault key download --id https://kvfrigo.vault.azure.net/keys/rsaex/0f322aba7573435a96acfba86b521c35  -f rsa.pub
$ openssl dgst -verify rsa.pub -sha256 -signature <(echo e7Wi7PCouEo8ZNlY1dL3IgDm8E63bc8ZE9VW0GQHglHPJjKGHpi9D0MfRFHZXCOHrRAas6JBz0iO5yJBuH+cczMpl+9+lFWNSi7I1efIrPS2NOlrtdhOCI5qLT/nWh++CvRh1+R2iCpVD1uxCkL9sjDwi6k5B+7ySkk9ikUGHG463TFq8/Oftk+mSlNBCd5j3wsva1BOTT1h9qY9eyHZCY319oVRM0jD92jtF2DNu0HF92uhUC8PT/6gjPd6vQtAWxF1LR7KLMx2zCxN9e7aV3bQXtKA4/KMYekE143IY2nMft+XNZ+DT7OIi0TT1ufwdNNjpUk/9LovN+XwYz1p+A== | base64 -d) ./bar
Verified OK
```

This also works for EC keys, however openssl is not able to verify these keys so there is some other bug.
```
$ az keyvault key sign -a ES256 --digest @<(openssl dgst -binary -sha256 bar | base64) --id https://kvfrigo.vault.azure.net/keys/ecex/68ab9b9141524362bf10fb96e0158414
Algorithm    KeyId                                                                         Signature
-----------  ----------------------------------------------------------------------------  ----------------------------------------------------------------------------------------
ES256        https://kvfrigo.vault.azure.net/keys/ecex/68ab9b9141524362bf10fb96e0158414  pj9a96b0En6/NbHSeRupa0cz26NicpgiUYRCQYXYikU5bPmaloJhDddkjFqxXUI9DaBLCZRI954UP1i9fGN8kA==
$ az keyvault key verify -a ES256 --digest @<(openssl dgst -binary -sha256 bar | base64) --id https://kvfrigo.vault.azure.net/keys/ecex/68ab9b9141524362bf10fb96e0158414 --signature pj9a96b0En6/NbHSeRupa0cz26NicpgiUYRCQYXYikU5bPmaloJhDddkjFqxXUI9DaBLCZRI954UP1i9fGN8kA==
Algorithm    IsValid    KeyId
-----------  ---------  ----------------------------------------------------------------------------
ES256        True       https://kvfrigo.vault.azure.net/keys/ecex/68ab9b9141524362bf10fb96e0158414

$ az keyvault key download --id https://kvfrigo.vault.azure.net/keys/ecex/68ab9b9141524362bf10fb96e0158414 -f ec.pub
$ openssl ec -pubin -in ec.pub  -text -noout
read EC key
Public-Key: (256 bit)
pub:
    04:83:8f:93:9a:74:c3:0a:39:9d:f4:e5:27:f9:19:
    cd:42:71:1a:5e:c4:87:76:8b:6a:06:19:d3:60:73:
    9f:66:8c:28:1c:ea:d1:1e:f4:c2:c9:90:48:79:85:
    a7:27:c6:ff:46:df:36:01:ce:3b:2e:db:1a:c1:a2:
    68:3e:5e:d8:c5
ASN1 OID: prime256v1
NIST CURVE: P-256
$ openssl dgst -verify ec.pub -sha256 -signature <(echo pj9a96b0En6/NbHSeRupa0cz26NicpgiUYRCQYXYikU5bPmaloJhDddkjFqxXUI9DaBLCZRI954UP1i9fGN8kA== | base64 -d) ./bar
Error verifying data

```

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az keyvault key sign, verify}

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
az keyvault key sign, verify, are unusable today as described in multiple bugs

**Testing Guide**
<!--Example commands with explanations.-->
see commit message

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
