### PR TITLE
{Packaging} Bump PyWin32 to 306

### DIFF
--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -120,7 +120,7 @@ pymsalruntime==0.16.2
 PyNaCl==1.5.0
 pyOpenSSL==24.0.0
 python-dateutil==2.8.0
-pywin32==305
+pywin32==306
 requests-oauthlib==1.2.0
 requests[socks]==2.32.3
 scp==0.13.2


### PR DESCRIPTION
**Description**<!--Mandatory-->
PyWin32 305 can't be installed on Python 3.12:
```
> pip install pywin32==305
ERROR: Could not find a version that satisfies the requirement pywin32==305 (from versions: 306)
ERROR: No matching distribution found for pywin32==305
```

Bump PyWin32 to 306 to accomplish https://github.com/Azure/azure-cli/issues/27673.
