### PR TITLE
{Misc.} Remove deprecated `assertRaisesRegexp`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
@@ -2898,7 +2898,7 @@ class TrackRuntimeStatusTest(ScenarioTest):
             'appservice plan create -g {} -n {} --sku S1 --is-linux'.format(resource_group, plan_name))
         self.cmd(
             'webapp create -g {} -n {} --plan {} -r "NODE|20-LTS"'.format(resource_group, webapp_name, plan_name))
-        with self.assertRaisesRegexp(CLIError, "Deployment failed because the build process failed"):
+        with self.assertRaisesRegex(CLIError, "Deployment failed because the build process failed"):
             self.cmd('webapp deploy -g {} --n {} --src-path "{}" --type zip --async'.format(resource_group, webapp_name, zip_file))
 
     @ResourceGroupPreparer(name_prefix='cli_test_webapp_deploy_runtimestatus', location='eastus')
@@ -2910,7 +2910,7 @@ class TrackRuntimeStatusTest(ScenarioTest):
             'appservice plan create -g {} -n {} --sku S1 --is-linux'.format(resource_group, plan_name))
         self.cmd(
             'webapp create -g {} -n {} --plan {} -r "NODE|20-LTS"'.format(resource_group, webapp_name, plan_name))
-        with self.assertRaisesRegexp(CLIError, "Deployment failed because the site failed to start within 10 mins."):
+        with self.assertRaisesRegex(CLIError, "Deployment failed because the site failed to start within 10 mins."):
             self.cmd('webapp deploy -g {} --n {} --src-path "{}" --type zip --async'.format(resource_group, webapp_name, zip_file))
 
     @ResourceGroupPreparer(name_prefix='cli_test_webapp_deployment_source_configzip_runtimestatus', location='eastus')
@@ -2955,7 +2955,7 @@ class TrackRuntimeStatusTest(ScenarioTest):
             'appservice plan create -g {} -n {} --sku S1 --is-linux'.format(resource_group, plan_name))
         self.cmd(
             'webapp create -g {} -n {} --plan {} -r "NODE|20-LTS"'.format(resource_group, webapp_name, plan_name))
-        with self.assertRaisesRegexp(CLIError, "Deployment failed because the build process failed"):
+        with self.assertRaisesRegex(CLIError, "Deployment failed because the build process failed"):
             self.cmd('webapp deployment source config-zip -g {} --n {} --src "{}"'.format(resource_group, webapp_name, zip_file))
 
     @ResourceGroupPreparer(name_prefix='cli_test_webapp_deployment_source_configzip_runtimestatus', location='eastus')
@@ -2967,7 +2967,7 @@ class TrackRuntimeStatusTest(ScenarioTest):
             'appservice plan create -g {} -n {} --sku S1 --is-linux'.format(resource_group, plan_name))
         self.cmd(
             'webapp create -g {} -n {} --plan {} -r "NODE|20-LTS"'.format(resource_group, webapp_name, plan_name))
-        with self.assertRaisesRegexp(CLIError, "Deployment failed because the site failed to start within 10 mins."):
+        with self.assertRaisesRegex(CLIError, "Deployment failed because the site failed to start within 10 mins."):
             self.cmd('webapp deployment source config-zip -g {} --n {} --src "{}"'.format(resource_group, webapp_name, zip_file))
 
 class DomainScenarioTest(ScenarioTest):

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_up_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_up_commands.py
@@ -1331,7 +1331,7 @@ class WebAppUpE2ETests(ScenarioTest):
         # change the working dir to the dir where the code has been extracted to
         os.chdir(temp_dir)
 
-        with self.assertRaisesRegexp(CLIError, "Deployment failed because the build process failed"):
+        with self.assertRaisesRegex(CLIError, "Deployment failed because the build process failed"):
             self.cmd('webapp up -g {} -n {} --os-type linux -r "NODE|20-LTS"'.format(resource_group, webapp_name))
 
         # cleanup
@@ -1359,7 +1359,7 @@ class WebAppUpE2ETests(ScenarioTest):
         # change the working dir to the dir where the code has been extracted to
         os.chdir(temp_dir)
 
-        with self.assertRaisesRegexp(CLIError, "Deployment failed because the site failed to start within 10 mins."):
+        with self.assertRaisesRegex(CLIError, "Deployment failed because the site failed to start within 10 mins."):
             self.cmd('webapp up -g {} -n {} --os-type linux -r "NODE|20-LTS"'.format(resource_group, webapp_name))
 
         # cleanup

--- a/src/azure-cli/azure/cli/command_modules/cdn/tests/latest/test_afd_secret_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/cdn/tests/latest/test_afd_secret_scenarios.py
@@ -26,7 +26,7 @@ class CdnAfdSecretScenarioTest(CdnAfdScenarioMixin, ScenarioTest):
         secret_source = f"/subscriptions/{self.get_subscription_id()}/resourceGroups/CliDevReservedGroup/providers/Microsoft.KeyVault/vaults/clibyoc-int/secrets/localdev-multi"
         secret_version = "5f652542f6ef46ef9fc4ed8af07c54f1"
 
-        with self.assertRaisesRegexp(HttpResponseError, "The server \\(leaf\\) certificate isn't within the validity period"):
+        with self.assertRaisesRegex(HttpResponseError, "The server \\(leaf\\) certificate isn't within the validity period"):
             self.afd_secret_create_cmd(resource_group,
                                profile_name,
                                secret_name,

--- a/src/azure-cli/azure/cli/command_modules/cdn/tests/latest/test_afd_security_policy_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/cdn/tests/latest/test_afd_security_policy_scenarios.py
@@ -44,7 +44,7 @@ class CdnAfdSecurityPolicyScenarioTest(CdnAfdScenarioMixin, ScenarioTest):
         
         # Create a security policy with non-exisit waf should fail
         waf_policy_id = f'/subscriptions/{self.get_subscription_id()}/resourcegroups/CliDevReservedGroup/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/nonexist'
-        with self.assertRaisesRegexp(HttpResponseError, "Web Application Firewall Policy being attached to AFDX profile does not exist"):
+        with self.assertRaisesRegex(HttpResponseError, "Web Application Firewall Policy being attached to AFDX profile does not exist"):
             self.afd_security_policy_create_cmd(resource_group,
                                                 profile_name,
                                                 security_policy_name,

--- a/src/azure-cli/azure/cli/command_modules/cdn/tests/latest/test_custom_domain_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/cdn/tests/latest/test_custom_domain_scenarios.py
@@ -187,7 +187,7 @@ class CdnCustomDomainScenarioTest(CdnScenarioMixin, ScenarioTest):
 
         # Enable custom HTTPS with a custom certificate
         # With the latest service side change to move the certificate validation to RP layer, the request will be rejected.
-        with self.assertRaisesRegexp(HttpResponseError, "The certificate chain includes an invalid number of certificates. The number of certificates should be greater than 2"):
+        with self.assertRaisesRegex(HttpResponseError, "The certificate chain includes an invalid number of certificates. The number of certificates should be greater than 2"):
             self.custom_domain_enable_https_command(resource_group,
                                                     profile_name,
                                                     endpoint_name,
@@ -234,7 +234,7 @@ class CdnCustomDomainScenarioTest(CdnScenarioMixin, ScenarioTest):
 
         # Enable custom HTTPS with the custom certificate.
         # With the latest service side change to move the certificate validation to RP layer, the request will be rejected.
-        with self.assertRaisesRegexp(HttpResponseError, "The certificate chain includes an invalid number of certificates. The number of certificates should be greater than 2"):
+        with self.assertRaisesRegex(HttpResponseError, "The certificate chain includes an invalid number of certificates. The number of certificates should be greater than 2"):
             self.custom_domain_enable_https_command(resource_group,
                                                     profile_name,
                                                     endpoint_name,

--- a/src/azure-cli/azure/cli/command_modules/iot/tests/latest/test_iot_central_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/tests/latest/test_iot_central_commands.py
@@ -219,8 +219,7 @@ class IoTCentralTest(ScenarioTest):
         # self.cmd('iot central app private-endpoint-connection reject --id {iotc_pec_id}',
         #          checks=[self.check('privateLinkServiceConnectionState.status', 'Rejected')])
 
-        # with self.assertRaisesRegexp(CloudError, 'You cannot approve the connection request after rejection.'):
+        # with self.assertRaisesRegex(CloudError, 'You cannot approve the connection request after rejection.'):
         #     self.cmd('iot central app private-endpoint-connection approve --account-name {app_name} -g {rg} --name {iotc_pec_name}')
 
         self.cmd('iot central app private-endpoint-connection delete --id {iotc_pec_id} -y')
-     

--- a/src/azure-cli/azure/cli/command_modules/security/tests/latest/test_security_securityconnectors_devops.py
+++ b/src/azure-cli/azure/cli/command_modules/security/tests/latest/test_security_securityconnectors_devops.py
@@ -174,7 +174,7 @@ class SecurityConnectorsDevOpsTests(ScenarioTest):
         ])
 
         from azure.core.exceptions import HttpResponseError
-        with self.assertRaisesRegexp(HttpResponseError, expected_regex=".*TokenExchangeFailed.*"):
+        with self.assertRaisesRegex(HttpResponseError, expected_regex=".*TokenExchangeFailed.*"):
             self.cmd("az security security-connector devops create --resource-group {} --security-connector-name {} --auto-discovery Disabled --inventory-list {} --authorization-code {}".format(resource_group, name, org_name, code))
 
         devops = self.cmd("az security security-connector devops show --resource-group {} --security-connector-name {}".format(resource_group, name)).get_output_in_json()
@@ -184,4 +184,3 @@ class SecurityConnectorsDevOpsTests(ScenarioTest):
         assert devops['properties']['provisioningState'] == 'Failed'
 
         self.cmd("az security security-connector devops delete --yes --resource-group {} --security-connector-name {}".format(resource_group, name))
-        

--- a/src/azure-cli/azure/cli/command_modules/sql/tests/latest/test_sql_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/tests/latest/test_sql_commands.py
@@ -1501,11 +1501,11 @@ class AzureActiveDirectoryAdministratorScenarioTest(ScenarioTest):
 
         print('Arguments are updated with login and sid data')
 
-        with self.assertRaisesRegexp(SystemExit, "2"):
+        with self.assertRaisesRegex(SystemExit, "2"):
             self.cmd('sql server ad-admin create -s {sn} -g {rg}')
-        with self.assertRaisesRegexp(SystemExit, "2"):
+        with self.assertRaisesRegex(SystemExit, "2"):
             self.cmd('sql server ad-admin create -s {sn} -g {rg} -u {user}')
-        with self.assertRaisesRegexp(SystemExit, "2"):
+        with self.assertRaisesRegex(SystemExit, "2"):
             self.cmd('sql server ad-admin create -s {sn} -g {rg} -i {oid}')
 
         self.cmd('sql server ad-admin create -s {sn} -g {rg} -i {oid} -u {user}',

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_file_share_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_file_share_scenarios.py
@@ -25,7 +25,7 @@ class StorageShareScenarioTests(StorageScenarioMixin, ScenarioTest):
 
         # Test create with fail-on-exist
         from azure.core.exceptions import ResourceExistsError
-        with self.assertRaisesRegexp(ResourceExistsError, 'The specified share already exists.'):
+        with self.assertRaisesRegex(ResourceExistsError, 'The specified share already exists.'):
             self.cmd(
                 'storage share create -n {} --fail-on-exist --connection-string {} --quota 3'
                 .format(share_name, connection_string))
@@ -66,7 +66,7 @@ class StorageShareScenarioTests(StorageScenarioMixin, ScenarioTest):
         # Test delete with fail-not-exist
         share_not_exist = self.create_random_name('share', 24)
         from azure.core.exceptions import ResourceNotFoundError
-        with self.assertRaisesRegexp(ResourceNotFoundError, 'The specified share does not exist.'):
+        with self.assertRaisesRegex(ResourceNotFoundError, 'The specified share does not exist.'):
             self.storage_cmd('storage share delete -n {} --fail-not-exist', account_info, share_not_exist)
 
         self.storage_cmd('storage share update --name {} --quota 3', account_info, share)

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_queue_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_queue_scenarios.py
@@ -27,7 +27,7 @@ class StorageQueueScenarioTests(StorageScenarioMixin, ScenarioTest):
                  checks=JMESPathCheck('created', True))
         # Test create with fail-on-exist
         from azure.core.exceptions import ResourceExistsError
-        with self.assertRaisesRegexp(ResourceExistsError, 'The specified queue already exists.'):
+        with self.assertRaisesRegex(ResourceExistsError, 'The specified queue already exists.'):
             self.cmd(
                 'storage queue create -n {} --fail-on-exist --connection-string {}'.format(queue, connection_string))
 
@@ -64,7 +64,7 @@ class StorageQueueScenarioTests(StorageScenarioMixin, ScenarioTest):
         # Test delete with fail-not-exist
         queue_not_exist = self.create_random_name('queue', 24)
         from azure.core.exceptions import ResourceNotFoundError
-        with self.assertRaisesRegexp(ResourceNotFoundError, 'The specified queue does not exist.'):
+        with self.assertRaisesRegex(ResourceNotFoundError, 'The specified queue does not exist.'):
             self.cmd('storage queue delete -n {} --fail-not-exist'.format(queue_not_exist))
 
         # check status of the queue


### PR DESCRIPTION
`assertRaisesRegexp` is removed in 3.12. It's replaced by `assertRaisesRegex`

Ref:
- https://docs.python.org/3/whatsnew/3.12.html#id3






















































































