### PR TITLE
[MySQL] `az mysql flexible-server maintenance`: New command group for managing maintenance of MySQL flexible server

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/mysql/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/mysql/_client_factory.py
@@ -106,6 +106,10 @@ def cf_mysql_advanced_threat_protection(cli_ctx, _):
     return get_mysql_flexible_management_client(cli_ctx).advanced_threat_protection_settings
 
 
+def cf_mysql_flexible_maintenances(cli_ctx, _):
+    return get_mysql_flexible_management_client(cli_ctx).maintenances
+
+
 def cf_mysql_check_resource_availability(cli_ctx, _):
     return get_mysql_flexible_management_client(cli_ctx).check_name_availability
 

--- a/src/azure-cli/azure/cli/command_modules/mysql/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/mysql/_help.py
@@ -447,6 +447,35 @@ examples:
     crafted: true
 """
 
+helps['mysql flexible-server maintenance'] = """
+type: group
+short-summary: Manage maintenance on a flexible server.
+"""
+
+helps['mysql flexible-server maintenance reschedule'] = """
+type: command
+short-summary: Reschedule the ongoing planned maintenance of a flexible server.
+examples:
+  - name: reschedule a existing maintenance '_T9Q-TS8' of the server 'testserver' under resource gruop 'testgroup' to a new start time 'UTC 20240601 09:00:00'
+    text: az mysql flexible-server maintenance reschedule --resource-group testgroup --server-name testserver --maintenance-name _T9Q-TS8 --start-time 2024-06-01T09:00:00Z
+"""
+
+helps['mysql flexible-server maintenance list'] = """
+type: command
+short-summary: List all of the maintenances of a flexible server.
+examples:
+  - name: List all of the maintenances of mysql flexible server 'testserver' under resource group 'testgroup'.
+    text: az mysql flexible-server maintenance list --resource-group testgroup --server-name testserver
+"""
+
+helps['mysql flexible-server maintenance show'] = """
+type: command
+short-summary: Get the specific maintenance of a flexible server by maintenance name.
+examples:
+  - name: Get a maintenance of mysql flexible server 'testserver' under resource group 'testgroup', with maintenance name '_T9Q-TS8'
+    text: az mysql flexible-server maintenance show --resource-group testgroup --server-name testserver --maintenance-name _T9Q-TS8
+"""
+
 helps['mysql flexible-server wait'] = """
 type: command
 short-summary: Wait for the flexible server to satisfy certain conditions.

--- a/src/azure-cli/azure/cli/command_modules/mysql/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/mysql/_params.py
@@ -202,6 +202,13 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
              'The default value is set to current time.'
     )
 
+    maintenance_reschedule_time_arg_type = CLIArgumentType(
+        options_list=['--start-time'],
+        default=get_current_time(),
+        help='The maintenance reschedule start time in UTC(ISO8601 format), e.g., 2017-04-26T02:10:00+00:00'
+             'The default value is set to current time.'
+    )
+
     source_server_arg_type = CLIArgumentType(
         options_list=['--source-server'],
         help='The name or resource ID of the source server to restore from.'
@@ -587,6 +594,21 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
 
     with self.argument_context('mysql flexible-server identity show') as c:
         c.argument('identity', options_list=['--identity', '-n'], help='Name or ID of identity to show.', validator=validate_identity)
+
+    with self.argument_context('mysql flexible-server maintenance reschedule') as c:
+        c.argument('resource_group_name', arg_type=resource_group_name_type, help='Resource Group Name of the server.')
+        c.argument('server_name', options_list=['--server-name', '-s'], help='The name of the server.')
+        c.argument('maintenance_name', options_list=['--maintenance-name', '-m'], help='The name of the maintenance.')
+        c.argument('maintenance_start_time', arg_type=maintenance_reschedule_time_arg_type, help='The new start time of the rescheduled maintenance.')
+
+    with self.argument_context('mysql flexible-server maintenance list') as c:
+        c.argument('resource_group_name', id_part=None, arg_type=resource_group_name_type, help='Resource Group Name of the server.')
+        c.argument('server_name', id_part=None, options_list=['--server-name', '-s'], help='The name of the server.')
+
+    with self.argument_context('mysql flexible-server maintenance show') as c:
+        c.argument('resource_group_name', arg_type=resource_group_name_type, help='Resource Group Name of the server.')
+        c.argument('server_name', options_list=['--server-name', '-s'], help='The name of the server.')
+        c.argument('maintenance_name', options_list=['--maintenance-name', '-m'], help='The name of the maintenance.')
 
     # ad-admin
     with self.argument_context('mysql flexible-server ad-admin') as c:

--- a/src/azure-cli/azure/cli/command_modules/mysql/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/mysql/_validators.py
@@ -553,3 +553,11 @@ def validate_action_name(namespace):
 def validate_branch(namespace):
     if not re.search(r'^[-_a-zA-Z0-9]+$', namespace.branch):
         raise ValidationError("The branch can only contain 0-9, a-z, A-Z, \'-\' and \'_\'.")
+
+
+def validate_and_format_maintenance_start_time(maintenance_start_time):
+    try:
+        return parser.parse(maintenance_start_time)
+    except:
+        raise ValidationError("The maintenance_start_time value has incorrect date format. "
+                              "Please use ISO format e.g., 2024-06-01T00:08:23+00:00")

--- a/src/azure-cli/azure/cli/command_modules/mysql/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/mysql/commands.py
@@ -15,7 +15,8 @@ from azure.cli.command_modules.mysql._client_factory import (
     cf_mysql_flexible_log,
     cf_mysql_flexible_backups,
     cf_mysql_flexible_adadmin,
-    cf_mysql_flexible_export)
+    cf_mysql_flexible_export,
+    cf_mysql_flexible_maintenances)
 from ._transformers import (
     table_transform_output,
     table_transform_output_list_servers,
@@ -81,6 +82,11 @@ def load_command_table(self, _):
     mysql_flexible_adadmin_sdk = CliCommandType(
         operations_tmpl='azure.mgmt.rdbms.mysql_flexibleservers.operations#AzureADAdministratorsOperations.{}',
         client_factory=cf_mysql_flexible_adadmin
+    )
+
+    mysql_flexible_maintenance_sdk = CliCommandType(
+        operations_tmpl='azure.mgmt.rdbms.mysql_flexibleservers.operations#MaintenancesOperations.{}',
+        client_factory=cf_mysql_flexible_maintenances
     )
 
     # MERU COMMANDS
@@ -210,3 +216,10 @@ def load_command_table(self, _):
                             custom_command_type=mysql_custom,
                             client_factory=cf_mysql_flexible_servers) as g:
         g.custom_command('reset', 'flexible_gtid_reset', supports_no_wait=True)
+
+    with self.command_group('mysql flexible-server maintenance', mysql_flexible_maintenance_sdk,
+                            custom_command_type=mysql_custom,
+                            client_factory=cf_mysql_flexible_maintenances) as g:
+        g.custom_command('reschedule', 'flexible_server_maintenance_reschedule')
+        g.custom_command('list', 'flexible_server_maintenance_list')
+        g.custom_show_command('show', 'flexible_server_maintenance_show')

--- a/src/azure-cli/azure/cli/command_modules/mysql/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/mysql/custom.py
@@ -33,7 +33,7 @@ from ._network import prepare_mysql_exist_private_dns_zone, prepare_mysql_exist_
 from ._validators import mysql_arguments_validator, mysql_auto_grow_validator, mysql_georedundant_backup_validator, mysql_restore_tier_validator, \
     mysql_retention_validator, mysql_sku_name_validator, mysql_storage_validator, validate_mysql_replica, validate_server_name, \
     validate_mysql_tier_update, validate_and_format_restore_point_in_time, validate_public_access_server, mysql_import_single_server_ready_validator, \
-    mysql_import_version_validator, mysql_import_storage_validator
+    mysql_import_version_validator, mysql_import_storage_validator, validate_and_format_maintenance_start_time
 
 logger = get_logger(__name__)
 DELEGATION_SERVICE_NAME = "Microsoft.DBforMySQL/flexibleServers"
@@ -1183,6 +1183,7 @@ def flexible_server_provision_network_resource(cmd, resource_group_name, server_
 
 
 def flexible_server_maintenance_reschedule(client, resource_group_name, server_name, maintenance_name, maintenance_start_time):
+    validate_and_format_maintenance_start_time(maintenance_start_time)
     parameters = mysql_flexibleservers.models.MaintenanceUpdate(maintenance_start_time=maintenance_start_time)
     return client.begin_update(resource_group_name=resource_group_name,
                                server_name=server_name,

--- a/src/azure-cli/azure/cli/command_modules/mysql/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/mysql/custom.py
@@ -1182,6 +1182,22 @@ def flexible_server_provision_network_resource(cmd, resource_group_name, server_
     return network, start_ip, end_ip
 
 
+def flexible_server_maintenance_reschedule(client, resource_group_name, server_name, maintenance_name, maintenance_start_time):
+    parameters = mysql_flexibleservers.models.MaintenanceUpdate(maintenance_start_time=maintenance_start_time)
+    return client.begin_update(resource_group_name=resource_group_name,
+                               server_name=server_name,
+                               maintenance_name=maintenance_name,
+                               parameters=parameters)
+
+
+def flexible_server_maintenance_list(client, resource_group_name, server_name):
+    return client.list(resource_group_name=resource_group_name, server_name=server_name)
+
+
+def flexible_server_maintenance_show(client, resource_group_name, server_name, maintenance_name):
+    return client.read(resource_group_name=resource_group_name, server_name=server_name, maintenance_name=maintenance_name)
+
+
 def flexible_server_exist_network_resource(cmd, resource_group_name, server_name, location, private_dns_zone_arguments=None, vnet=None, subnet=None):
     network = mysql_flexibleservers.models.Network()
     if private_dns_zone_arguments is None:

--- a/src/azure-cli/azure/cli/command_modules/mysql/tests/latest/recordings/test_mysql_flexible_server_maintenance_mgmt.yaml
+++ b/src/azure-cli/azure/cli/command_modules/mysql/tests/latest/recordings/test_mysql_flexible_server_maintenance_mgmt.yaml
@@ -1,0 +1,250 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server maintenance list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --server-name
+      User-Agent:
+      - AZURECLI/2.62.0 azsdk-python-core/1.28.0 Python/3.8.10 (Windows-10-10.0.22631-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/reschedule-cli-test/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-maintenance/maintenances?api-version=2023-10-01-preview
+  response:
+    body:
+      string: '{"value":[{"properties":{"maintenanceType":"RoutineMaintenance","maintenanceState":"ReScheduled","maintenanceName":"HNQ1-FB0","maintenanceStartTime":"2024-11-06T03:37:00+00:00","maintenanceEndTime":"2024-11-06T04:37:00+00:00","maintenanceAvailableScheduleMinTime":"2024-07-29T03:41:27.1819414+00:00","maintenanceTitle":"Routine
+        Maintenance: Rescheduled to Wed, 06 Nov 2024 03:37:00 GMT","maintenanceDescription":"Your
+        Azure Database For MySQL routine maintenance has been rescheduled. The new
+        maintenance window is scheduled to occur between Wed, 06 Nov 2024 03:37:00
+        GMT and Wed, 06 Nov 2024 04:37:00 GMT. During this maintenance, your instance
+        may experience a brief interruption in service. If you have any additional
+        questions or concerns, please contact support."},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/reschedule-cli-test/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-maintenance/maintenances/HNQ1-FB0","name":"HNQ1-FB0","type":"Microsoft.DBforMySQL/maintenances"}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1023'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 29 Jul 2024 03:41:26 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-msedge-ref:
+      - 'Ref A: 23EB1D4A13774A648FD1811B7DF3302F Ref B: MAA201060513049 Ref C: 2024-07-29T03:41:26Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server maintenance show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --server-name --maintenance-name
+      User-Agent:
+      - AZURECLI/2.62.0 azsdk-python-core/1.28.0 Python/3.8.10 (Windows-10-10.0.22631-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/reschedule-cli-test/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-maintenance/maintenances/HNQ1-FB0?api-version=2023-10-01-preview
+  response:
+    body:
+      string: '{"properties":{"maintenanceType":"RoutineMaintenance","maintenanceState":"ReScheduled","maintenanceName":"HNQ1-FB0","maintenanceStartTime":"2024-11-06T03:37:00+00:00","maintenanceEndTime":"2024-11-06T04:37:00+00:00","maintenanceAvailableScheduleMinTime":"2024-07-29T03:41:28.4945208+00:00","maintenanceTitle":"Routine
+        Maintenance: Rescheduled to Wed, 06 Nov 2024 03:37:00 GMT","maintenanceDescription":"Your
+        Azure Database For MySQL routine maintenance has been rescheduled. The new
+        maintenance window is scheduled to occur between Wed, 06 Nov 2024 03:37:00
+        GMT and Wed, 06 Nov 2024 04:37:00 GMT. During this maintenance, your instance
+        may experience a brief interruption in service. If you have any additional
+        questions or concerns, please contact support."},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/reschedule-cli-test/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-maintenance/maintenances/HNQ1-FB0","name":"HNQ1-FB0","type":"Microsoft.DBforMySQL/maintenances"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1011'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 29 Jul 2024 03:41:28 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-msedge-ref:
+      - 'Ref A: DA4A9D5132E947439D29E256AA9135EE Ref B: MAA201060515033 Ref C: 2024-07-29T03:41:27Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"maintenanceStartTime": "2024-11-06T03:41:00.000Z"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server maintenance reschedule
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '68'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - --resource-group --server-name --maintenance-name --start-time
+      User-Agent:
+      - AZURECLI/2.62.0 azsdk-python-core/1.28.0 Python/3.8.10 (Windows-10-10.0.22631-SP0)
+    method: PATCH
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/reschedule-cli-test/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-maintenance/maintenances/HNQ1-FB0?api-version=2023-10-01-preview
+  response:
+    body:
+      string: '{"operation":"UpdateMaintenanceManagementOperation","startTime":"2024-07-29T03:41:30.063Z"}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/de2d6cc8-81e0-46b4-a11c-e489eaa2853e?api-version=2023-10-01-preview&t=638578212902669306&c=MIIHhzCCBm-gAwIBAgITHgTSAvXh1GCKrw08WQAABNIC9TANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDYwHhcNMjQwNjI3MTUyNDA3WhcNMjUwNjIyMTUyNDA3WjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOX5t0OxQxE3upQbbFvsmp5T7gqPC72fDSg6G0QO-q7rqYToC8QZH_q_PRft3qJZILPcMnC3i05PTpzbeogSlCaa_AwlLL7W5xwBRGnsSFi6uqID-boEdPC1XBtfJ14hE4xgTlvyDFkeshYKWfG6lyrFXbpwsk-8W5euzj5uEAU138aMueyASKkhbn0w-sYa2oA_U3jECVOIlAwWtv49Wed78xbdxyOXsueDyzxDOoM-H1uA24aMiLn3z563K9_bYY4a6hsemVB7YhKwCV0dGFB2NlQuW_yO_VNKEK9b5n56xBisqDcyIAGbNaCFxMjAXplvF7azyX5n0rlTcXgQ5EUCAwEAAaOCBHQwggRwMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MB0GA1UdDgQWBBQdmu6OxIvudboSaHvi8VnT7XivcjAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwEwDAYKKwYBBAGCN3sEATAfBgNVHSMEGDAWgBTxRmjG8cPwKy19i2rhsvm-NfzRQTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAAE87bMgkwSJkJtWUWHywZrpdkdbMMJKKdyoixpEZVLQBkS9P248tTUDTQq_W-W_H7OUWFz7F2SmgWJcMU4lnrWQB7xGR2SU5N_Uq5D-F95ksx2I3ALBtLB8wC6t2cwtzjFIPYr9NPyCtZrnbgh6CAFqGpOq0mVkPAHZBfOfywStnkVpA4JYP0B8IIBfA4E-YqSFxC_9vSP8doGWlUkJhw7E1ylemxWU0jv_96awij-EayTYpo-pH2U6hG6hdW5nRZ929VEbgHmcDW03GdpvtqiZGWC3RdWgVHTZPvQ5XyUmZOaBQILallvd5D9QYh1VmY4oAl5QfafZ76IVrmfwu6c&s=tg6yeJnPAVq0uIiASUoKG9VZfdBvaojP3LpnY67zqLSCrZWKJzExs5AIh6GHlF5NZYLWtjqSGdKyMlVTWx2GeS7xGPyeNhB_MY8BWiyV7ShfnObn_ky8xanO7aFxOUKNo4W8dyHfWtU5f75pK4VtvuRZ7mrU5NMtPRDY93W2ALlXLJ7SwDQMmgQ6D2mYG710w6Ln7h0D64LWF2Vk-OYma8ilyhgjdSB52dkQZID85eA3Inf1cL46EuxCDwAuId_foqaTVRxCat8KW5nQi5rIduPRZoXjfDt8Go4Sy3CZlyfFwrhK3wPWxY1cR44rraIvPks58fnbs6cyIBLmLIwrDg&h=o3j_bdXn48n4a6u3NHGxKVFDak3s9SL1fkUO5ccNymg
+      cache-control:
+      - no-cache
+      content-length:
+      - '91'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 29 Jul 2024 03:41:29 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/de2d6cc8-81e0-46b4-a11c-e489eaa2853e?api-version=2023-10-01-preview&t=638578212902825288&c=MIIHhzCCBm-gAwIBAgITHgTSAvXh1GCKrw08WQAABNIC9TANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDYwHhcNMjQwNjI3MTUyNDA3WhcNMjUwNjIyMTUyNDA3WjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOX5t0OxQxE3upQbbFvsmp5T7gqPC72fDSg6G0QO-q7rqYToC8QZH_q_PRft3qJZILPcMnC3i05PTpzbeogSlCaa_AwlLL7W5xwBRGnsSFi6uqID-boEdPC1XBtfJ14hE4xgTlvyDFkeshYKWfG6lyrFXbpwsk-8W5euzj5uEAU138aMueyASKkhbn0w-sYa2oA_U3jECVOIlAwWtv49Wed78xbdxyOXsueDyzxDOoM-H1uA24aMiLn3z563K9_bYY4a6hsemVB7YhKwCV0dGFB2NlQuW_yO_VNKEK9b5n56xBisqDcyIAGbNaCFxMjAXplvF7azyX5n0rlTcXgQ5EUCAwEAAaOCBHQwggRwMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MB0GA1UdDgQWBBQdmu6OxIvudboSaHvi8VnT7XivcjAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwEwDAYKKwYBBAGCN3sEATAfBgNVHSMEGDAWgBTxRmjG8cPwKy19i2rhsvm-NfzRQTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAAE87bMgkwSJkJtWUWHywZrpdkdbMMJKKdyoixpEZVLQBkS9P248tTUDTQq_W-W_H7OUWFz7F2SmgWJcMU4lnrWQB7xGR2SU5N_Uq5D-F95ksx2I3ALBtLB8wC6t2cwtzjFIPYr9NPyCtZrnbgh6CAFqGpOq0mVkPAHZBfOfywStnkVpA4JYP0B8IIBfA4E-YqSFxC_9vSP8doGWlUkJhw7E1ylemxWU0jv_96awij-EayTYpo-pH2U6hG6hdW5nRZ929VEbgHmcDW03GdpvtqiZGWC3RdWgVHTZPvQ5XyUmZOaBQILallvd5D9QYh1VmY4oAl5QfafZ76IVrmfwu6c&s=yIMiF6AYOhStZBo2vIndhQyQopEypApo4bSeSQZTcMvrfyQ9FA4u_CNvXt24wpPCq6DVZNu4PPxnJmrk0AO3cmLaDhKkztLQ-QzlAAJ9uY80DjHWhtkg1RM3sxkC7V6MnBHz7zf5G2nWUPRCx-hNBiWNYdDfIpC2uuyIyh9C7p63p-VxTxzGSsKdc--xSueu68paXgiTKUa5050EMwWyFPhIUt8Yr_6uVU_XqzZ9MBrgFXCVHOKJJaziDsyyL1yJmolTdI8fntrgnkmg-hnrSgM5JFutB1pbC6s_hOcH7QpCyr0-s4r5WU0x8qhuvXiS8wpHCHjxHKyXXrho0mU1Tw&h=xoXOJR1NghN9kz4Lzw9kJI4wYvhjBLXSGO5loml01V0
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+      x-msedge-ref:
+      - 'Ref A: C0E7E48D44344B93AA01A3228E07C77F Ref B: MAA201060516023 Ref C: 2024-07-29T03:41:29Z'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server maintenance reschedule
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --server-name --maintenance-name --start-time
+      User-Agent:
+      - AZURECLI/2.62.0 azsdk-python-core/1.28.0 Python/3.8.10 (Windows-10-10.0.22631-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/de2d6cc8-81e0-46b4-a11c-e489eaa2853e?api-version=2023-10-01-preview&t=638578212902669306&c=MIIHhzCCBm-gAwIBAgITHgTSAvXh1GCKrw08WQAABNIC9TANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDYwHhcNMjQwNjI3MTUyNDA3WhcNMjUwNjIyMTUyNDA3WjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOX5t0OxQxE3upQbbFvsmp5T7gqPC72fDSg6G0QO-q7rqYToC8QZH_q_PRft3qJZILPcMnC3i05PTpzbeogSlCaa_AwlLL7W5xwBRGnsSFi6uqID-boEdPC1XBtfJ14hE4xgTlvyDFkeshYKWfG6lyrFXbpwsk-8W5euzj5uEAU138aMueyASKkhbn0w-sYa2oA_U3jECVOIlAwWtv49Wed78xbdxyOXsueDyzxDOoM-H1uA24aMiLn3z563K9_bYY4a6hsemVB7YhKwCV0dGFB2NlQuW_yO_VNKEK9b5n56xBisqDcyIAGbNaCFxMjAXplvF7azyX5n0rlTcXgQ5EUCAwEAAaOCBHQwggRwMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MB0GA1UdDgQWBBQdmu6OxIvudboSaHvi8VnT7XivcjAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwEwDAYKKwYBBAGCN3sEATAfBgNVHSMEGDAWgBTxRmjG8cPwKy19i2rhsvm-NfzRQTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAAE87bMgkwSJkJtWUWHywZrpdkdbMMJKKdyoixpEZVLQBkS9P248tTUDTQq_W-W_H7OUWFz7F2SmgWJcMU4lnrWQB7xGR2SU5N_Uq5D-F95ksx2I3ALBtLB8wC6t2cwtzjFIPYr9NPyCtZrnbgh6CAFqGpOq0mVkPAHZBfOfywStnkVpA4JYP0B8IIBfA4E-YqSFxC_9vSP8doGWlUkJhw7E1ylemxWU0jv_96awij-EayTYpo-pH2U6hG6hdW5nRZ929VEbgHmcDW03GdpvtqiZGWC3RdWgVHTZPvQ5XyUmZOaBQILallvd5D9QYh1VmY4oAl5QfafZ76IVrmfwu6c&s=tg6yeJnPAVq0uIiASUoKG9VZfdBvaojP3LpnY67zqLSCrZWKJzExs5AIh6GHlF5NZYLWtjqSGdKyMlVTWx2GeS7xGPyeNhB_MY8BWiyV7ShfnObn_ky8xanO7aFxOUKNo4W8dyHfWtU5f75pK4VtvuRZ7mrU5NMtPRDY93W2ALlXLJ7SwDQMmgQ6D2mYG710w6Ln7h0D64LWF2Vk-OYma8ilyhgjdSB52dkQZID85eA3Inf1cL46EuxCDwAuId_foqaTVRxCat8KW5nQi5rIduPRZoXjfDt8Go4Sy3CZlyfFwrhK3wPWxY1cR44rraIvPks58fnbs6cyIBLmLIwrDg&h=o3j_bdXn48n4a6u3NHGxKVFDak3s9SL1fkUO5ccNymg
+  response:
+    body:
+      string: '{"name":"de2d6cc8-81e0-46b4-a11c-e489eaa2853e","status":"Succeeded","startTime":"2024-07-29T03:41:30.063Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 29 Jul 2024 03:41:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-msedge-ref:
+      - 'Ref A: 0305BD03F6D745689424FDABBB55CE9F Ref B: MAA201060516023 Ref C: 2024-07-29T03:41:30Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server maintenance reschedule
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --server-name --maintenance-name --start-time
+      User-Agent:
+      - AZURECLI/2.62.0 azsdk-python-core/1.28.0 Python/3.8.10 (Windows-10-10.0.22631-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/reschedule-cli-test/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-maintenance/maintenances/HNQ1-FB0?api-version=2023-10-01-preview
+  response:
+    body:
+      string: '{"properties":{"maintenanceType":"RoutineMaintenance","maintenanceState":"ReScheduled","maintenanceName":"HNQ1-FB0","maintenanceStartTime":"2024-11-06T03:41:00+00:00","maintenanceEndTime":"2024-11-06T04:41:00+00:00","maintenanceAvailableScheduleMinTime":"2024-07-29T03:41:31.8851854+00:00","maintenanceTitle":"Routine
+        Maintenance: Rescheduled to Wed, 06 Nov 2024 03:41:00 GMT","maintenanceDescription":"Your
+        Azure Database For MySQL routine maintenance has been rescheduled. The new
+        maintenance window is scheduled to occur between Wed, 06 Nov 2024 03:41:00
+        GMT and Wed, 06 Nov 2024 04:41:00 GMT. During this maintenance, your instance
+        may experience a brief interruption in service. If you have any additional
+        questions or concerns, please contact support."},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/reschedule-cli-test/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-maintenance/maintenances/HNQ1-FB0","name":"HNQ1-FB0","type":"Microsoft.DBforMySQL/maintenances"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1011'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 29 Jul 2024 03:41:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-msedge-ref:
+      - 'Ref A: A3E1366DB1BF4B7CA5E7EF46B30D8C5F Ref B: MAA201060516023 Ref C: 2024-07-29T03:41:31Z'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/mysql/tests/latest/test_mysql_scenario.py
+++ b/src/azure-cli/azure/cli/command_modules/mysql/tests/latest/test_mysql_scenario.py
@@ -29,7 +29,8 @@ from azure.cli.testsdk import (
     KeyVaultPreparer,
     ScenarioTest,
     StringContainCheck,
-    live_only)
+    live_only,
+    record_only)
 
 from azure.mgmt.sql.models import AdvancedThreatProtectionState
 
@@ -2240,6 +2241,36 @@ class FlexibleServerAdvancedThreatProtectionScenarioTest(ScenarioTest):
                             checks=[
                                 JMESPathCheck('resourceGroup', resource_group),
                                 JMESPathCheck('state', new_defender_state)])
+
+
+class FlexibleServerMaintenanceMgmtScenarioTest(ScenarioTest):
+
+    @AllowLargeResponse()
+    @ResourceGroupPreparer(location='northeurope')
+    @record_only() # this test need a manually configured server.
+
+    def test_mysql_flexible_server_maintenance_mgmt(self, resource_group):
+        self._test_maintenance_mgmt('mysql', resource_group)
+    
+    def _test_maintenance_mgmt(self, database_engine, resource_group):
+        resource_group = "reschedule-cli-test"
+        server_name = "azuredbclitest-maintenance"
+        maintenance_list_response = self.cmd('{} flexible-server maintenance list --resource-group {} --server-name {}'
+                 .format(database_engine, resource_group, server_name)).get_output_in_json()
+        self.assertNotEqual(len(maintenance_list_response), 0)
+
+        maintenance_name = maintenance_list_response[0]['name']
+        maintenance_id = maintenance_list_response[0]['id']
+        maintenance_read_response = self.cmd('{} flexible-server maintenance show --resource-group {} --server-name {} --maintenance-name {}'
+                 .format(database_engine, resource_group, server_name, maintenance_name)).get_output_in_json()
+        self.assertEqual(maintenance_id, maintenance_read_response['id'])
+
+        reschedule_start_time = "2024-11-06T03:41Z"
+        maintenance_reschedule_response = self.cmd('{} flexible-server maintenance reschedule --resource-group {} --server-name {} --maintenance-name {} --start-time {}'
+                 .format(database_engine, resource_group, server_name, maintenance_name, reschedule_start_time)).get_output_in_json()
+        maintenance_rescheduled_time = parser.parse(maintenance_reschedule_response['maintenanceStartTime']).strftime('%Y-%m-%dT%H:%MZ')
+        self.assertEqual(reschedule_start_time, maintenance_rescheduled_time)
+
 
 class MySQLExportTest(ScenarioTest):
     profile = None


### PR DESCRIPTION
**Related command**
az mysql flexible-server maintenance show
az mysql flexible-server maintenance list
az mysql flexible-server maintenance reschedule

**Description**
Add az command group 'az mysql flexible-server maintenance' which contains above three az commands. These commands will support customers to manage their maintenance on Azure MySQL flexible servers.

**Testing Guide**
`az mysql flexible-server maintenance show --resource-group testgroup --server-name testserver --maintenance-name _T9Q-TS8`
**explanation:**  Get a maintenance of mysql flexible server 'testserver' under resource group 'testgroup', with maintenance name '_T9Q-TS8'

`az mysql flexible-server maintenance list --resource-group testgroup --server-name testserver`
**explanation:** List all of the maintenances of mysql flexible server 'testserver' under resource group 'testgroup'.

`az mysql flexible-server maintenance reschedule --resource-group testgroup --server-name testserver --maintenance-name _T9Q-TS8 --start-time 2024-06-01T09:00:00Z`
**explanation:** reschedule an existing maintenance '_T9Q-TS8' of the server 'testserver' under resource gruop 'testgroup' to a new start time 'UTC 20240601 

