### PR TITLE
{CI} Use old version setuptools in isolated build environment

### DIFF
--- a/.azure-pipelines/templates/azdev_setup.yml
+++ b/.azure-pipelines/templates/azdev_setup.yml
@@ -11,6 +11,10 @@ parameters:
 steps:
   - bash: |
       set -ev
+      
+      # Use old version setuptools in build environment, see https://github.com/pypa/setuptools/issues/4519
+      echo "setuptools<72" > constraints.txt
+      export PIP_CONSTRAINT=`pwd`/constraints.txt
 
       python -m venv env
       chmod +x env/bin/activate

--- a/scripts/ci/test_extensions.sh
+++ b/scripts/ci/test_extensions.sh
@@ -6,6 +6,10 @@ ls -la $share_folder/build
 
 ALL_MODULES=`find $share_folder/build/ -name "*.whl"`
 
+# Use old version setuptools in build environment, see https://github.com/pypa/setuptools/issues/4519
+echo "setuptools<72" > constraints.txt
+export PIP_CONSTRAINT=`pwd`/constraints.txt
+
 pip install -e ./tools
 [ -d privates ] && pip install -qqq privates/*.whl
 pip install $ALL_MODULES

--- a/scripts/ci/test_profile_integration.sh
+++ b/scripts/ci/test_profile_integration.sh
@@ -2,6 +2,10 @@
 
 . $(cd $(dirname $0); pwd)/artifacts.sh
 
+# Use old version setuptools in build environment, see https://github.com/pypa/setuptools/issues/4519
+echo "setuptools<72" > constraints.txt
+export PIP_CONSTRAINT=`pwd`/constraints.txt
+
 ls -la $share_folder/build
 
 ALL_MODULES=`find $share_folder/build/ -name "*.whl"`

--- a/scripts/install_full.sh
+++ b/scripts/install_full.sh
@@ -16,6 +16,10 @@ REPO_ROOT="$(dirname ${BASH_SOURCE[0]})/.."
 
 pushd ${REPO_ROOT} > /dev/null
 
+# Use old version setuptools in build environment, see https://github.com/pypa/setuptools/issues/4519
+echo "setuptools<72" > constraints.txt
+export PIP_CONSTRAINT=`pwd`/constraints.txt
+
 find src/ -name setup.py -type f | xargs -I {} dirname {} | grep -v azure-cli-testsdk | xargs pip install --no-deps
 pip install -r ./src/azure-cli/requirements.$(python ./scripts/get-python-version.py).$(uname).txt
 

--- a/scripts/release/debian/test_deb_in_docker.sh
+++ b/scripts/release/debian/test_deb_in_docker.sh
@@ -18,6 +18,10 @@ cd /azure-cli/
 ln -sf /opt/az/bin/python3 /usr/bin/python
 ./scripts/ci/build.sh
 
+# Use old version setuptools in build environment, see https://github.com/pypa/setuptools/issues/4519
+echo "setuptools<72" > constraints.txt
+export PIP_CONSTRAINT=`pwd`/constraints.txt
+
 /opt/az/bin/python3 -m pip install pytest
 /opt/az/bin/python3 -m pip install pytest-xdist
 /opt/az/bin/python3 -m pip install pytest-forked

--- a/scripts/release/rpm/test_mariner_in_docker.sh
+++ b/scripts/release/rpm/test_mariner_in_docker.sh
@@ -17,6 +17,10 @@ cd /azure-cli/
 pip install wheel
 ./scripts/ci/build.sh
 
+# Use old version setuptools in build environment, see https://github.com/pypa/setuptools/issues/4519
+echo "setuptools<72" > constraints.txt
+export PIP_CONSTRAINT=`pwd`/constraints.txt
+
 # From Fedora36, when using `pip install --prefix` with root privileges, the package is installed into `{prefix}/local/lib`.
 # In order to keep the original installation path, I have to set RPM_BUILD_ROOT
 # Ref https://docs.fedoraproject.org/en-US/fedora/latest/release-notes/developers/Development_Python/#_pipsetup_py_installation_with_prefix

--- a/scripts/release/rpm/test_rpm_in_docker.sh
+++ b/scripts/release/rpm/test_rpm_in_docker.sh
@@ -23,6 +23,10 @@ pip install wheel
 # Ref https://docs.fedoraproject.org/en-US/fedora/latest/release-notes/developers/Development_Python/#_pipsetup_py_installation_with_prefix
 export RPM_BUILD_ROOT=/
 
+# Use old version setuptools in build environment, see https://github.com/pypa/setuptools/issues/4519
+echo "setuptools<72" > constraints.txt
+export PIP_CONSTRAINT=`pwd`/constraints.txt
+
 pip install pytest --prefix /usr/lib64/az
 pip install pytest-xdist --prefix /usr/lib64/az
 pip install pytest-forked --prefix /usr/lib64/az


### PR DESCRIPTION
`vcrpy` and `bcrypt` can't be installed with latest `setuptools`.
Pin it to previous version in build environment.
> -c, --constraint <file>
Constrain versions using the given constraints file. This option can be used multiple times.
>
> (environment variable: PIP_CONSTRAINT)  --- https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-c

```
Collecting vcrpy
  Downloading vcrpy-6.0.1.tar.gz (84 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 84.8/84.8 kB 755.9 kB/s eta 0:00:00
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [20 lines of output]
      Traceback (most recent call last):
        File "/usr/local/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/usr/local/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/usr/local/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
                 ^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-wbp_9tw8/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 327, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-wbp_9tw8/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 297, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-wbp_9tw8/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 497, in run_setup
          super().run_setup(setup_script=setup_script)
        File "/tmp/pip-build-env-wbp_9tw8/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 313, in run_setup
          exec(code, locals())
        File "<string>", line 9, in <module>
      ModuleNotFoundError: No module named 'setuptools.command.test'
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```

PS: The homebrew formula does still not work, as homebrew installs `bcrypt==3.2.0` from source. I'll fixed it in a new PR.

**Some extensions may also fail to install if their dependencies are not compatible with latest `setuptools`.**

Ref:
- https://github.com/pypa/setuptools/pull/4458
- https://github.com/pypa/setuptools/issues/4519
- https://pip.pypa.io/en/stable/user_guide/#constraints-files
