### PR TITLE
[App Service] `az staticwebapp create` and `az staticwebapp update`: Add `Dedicated` as supported SKU

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -2802,7 +2802,7 @@ short-summary: Link or unlink a prexisting functionapp with a static webapp. Als
 
 helps['staticwebapp functions link'] = """
     type: command
-    short-summary: Link an Azure Function to a static webapp. Also known as "Bring your own Functions." Only one Azure Functions app is available to a single static web app. Static webapp SKU must be "Standard"
+    short-summary: Link an Azure Function to a static webapp. Also known as "Bring your own Functions." Only one Azure Functions app is available to a single static web app. Static webapp SKU must be "Standard" or "Dedicated"
     examples:
     - name: Link a function to a static webapp
       text: az staticwebapp functions link -n MyStaticAppName -g MyResourceGroup --function-resource-id "/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.Web/sites/<function-name>"
@@ -2835,7 +2835,7 @@ helps['staticwebapp backends validate'] = """
     long-summary: >
       Only one backend is available to a single static web app.
       If a backend was previously linked to another static Web App, the auth configuration must first be removed from the backend before linking to a different Static Web App.
-      Static web app SKU must be "Standard".
+      Static web app SKU must be "Standard" or "Dedicated".
       Supported backend types are Azure Functions, Azure API Management, Azure App Service, Azure Container Apps.
       Backend region must be provided for backends of type Azure Functions and Azure App Service.
       See https://learn.microsoft.com/azure/static-web-apps/apis-overview to learn more.
@@ -2852,7 +2852,7 @@ helps['staticwebapp backends link'] = """
     long-summary: >
       Only one backend is available to a single static web app.
       If a backend was previously linked to another static Web App, the auth configuration must first be removed from the backend before linking to a different Static Web App.
-      Static web app SKU must be "Standard".
+      Static web app SKU must be "Standard" or "Dedicated".
       Supported backend types are Azure Functions, Azure API Management, Azure App Service, Azure Container Apps.
       Backend region must be provided for backends of type Azure Functions and Azure App Service.
       See https://learn.microsoft.com/azure/static-web-apps/apis-overview to learn more.

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -78,7 +78,7 @@ def load_arguments(self, _):
 
     static_web_app_sku_arg_type = CLIArgumentType(
         help='The pricing tiers for Static Web App',
-        arg_type=get_enum_type(['Free', 'Standard'])
+        arg_type=get_enum_type(['Free', 'Standard', 'Dedicated'])
     )
 
     # use this hidden arg to give a command the right instance, that functionapp commands

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
@@ -160,6 +160,19 @@ class TestStaticAppCommands(unittest.TestCase):
         arg_list = self.staticapp_client.begin_create_or_update_static_site.call_args[1]
         self.assertEqual('Standard', arg_list["static_site_envelope"].sku.name)
 
+    def test_create_staticapp_with_dedicated_sku(self):
+        from azure.mgmt.web.models import StaticSiteARMResource, StaticSiteBuildProperties, SkuDescription
+        self.mock_cmd.get_models.return_value = StaticSiteARMResource, StaticSiteBuildProperties, SkuDescription
+
+        with mock.patch("azure.cli.command_modules.appservice.static_sites.show_staticsite", side_effect=[ResourceNotFoundError("msg"), None]):
+            create_staticsites(
+                self.mock_cmd, self.rg1, self.name1, self.location1,
+                self.source1, self.branch1, self.token1, sku='dedicated')
+
+        self.staticapp_client.begin_create_or_update_static_site.assert_called_once()
+        arg_list = self.staticapp_client.begin_create_or_update_static_site.call_args[1]
+        self.assertEqual('Dedicated', arg_list["static_site_envelope"].sku.name)
+
     def test_create_staticapp_missing_token(self):
         app_location = './src'
         api_location = './api/'

--- a/src/azure-cli/azure/cli/command_modules/appservice/utils.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/utils.py
@@ -122,6 +122,8 @@ def normalize_sku_for_staticapp(sku):
         return 'Free'
     if sku.lower() == 'standard':
         return 'Standard'
+    if sku.lower() == 'dedicated':
+        return 'Dedicated'
     raise ValidationError("Invalid sku(pricing tier), please refer to command help for valid values")
 
 


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az staticwebapp create`
`az staticwebapp update`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
For Static Web Apps, we have recently previewed the Dedicated SKU. Currently, the related staticwebapp commands only support Free and Standard SKU. This PR adds support for the Dedicated SKU, as well as adds it to supported features in help texts.

**Testing Guide**
<!--Example commands with explanations.-->
Added and ran a new unit test `test_create_staticapp_with_dedicated_sku`.

Also ran the following command (with actual values in place of sample values) with this code and verified a Dedicated SKU Static Web App was successfully created:
`az staticwebapp create -n name1 -g rg1 -s https://github.com/Contoso/My-First-Static-App -b dev -l EastUs2 --app-location app --sku Dedicated`

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
