### PR TITLE
{Misc.} Remove deprecated `assertEquals`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_commands.py
@@ -585,7 +585,7 @@ class AcrCommandsTests(ScenarioTest):
         self.assertTrue('systemAssigned' in result['type'])
         self.assertTrue('userAssigned' in result['type'])
         self.assertTrue(len(result['userAssignedIdentities']) == 1)
-        self.assertEquals(list(result['userAssignedIdentities'].keys())[0].lower(), self.kwargs['identity_id'].lower())
+        self.assertEqual(list(result['userAssignedIdentities'].keys())[0].lower(), self.kwargs['identity_id'].lower())
 
         # remove identities
         import time

--- a/src/azure-cli/azure/cli/command_modules/ams/tests/latest/test_ams_live_event_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/tests/latest/test_ams_live_event_scenarios.py
@@ -146,7 +146,7 @@ class AmsLiveEventTests(ScenarioTest):
 
         self.assertNotEqual('Stopping', live_event['resourceState'])
         self.assertNotEqual('Stopped', live_event['resourceState'])
-        self.assertEquals('StandBy', live_event['resourceState'])
+        self.assertEqual('StandBy', live_event['resourceState'])
 
     @ResourceGroupPreparer()
     @StorageAccountPreparer(parameter_name='storage_account_for_create')

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_commands.py
@@ -1097,15 +1097,15 @@ class AppConfigAppServiceImportExportLiveScenarioTest(LiveScenarioTest):
         # Assert first reference is in the right format
         app_settings = self.cmd('webapp config appsettings list -g {rg} -n {appservice_account}').get_output_in_json()
         exported_keys = next(x for x in app_settings if x['name'] == entry_key)
-        self.assertEquals(exported_keys['name'], entry_key)
-        self.assertEquals(exported_keys['value'], expected_reference)
-        self.assertEquals(exported_keys['slotSetting'], False)
+        self.assertEqual(exported_keys['name'], entry_key)
+        self.assertEqual(exported_keys['value'], expected_reference)
+        self.assertEqual(exported_keys['slotSetting'], False)
 
         # Assert second reference is of right format
         exported_keys = next(x for x in app_settings if x['name'] == entry_key2)
-        self.assertEquals(exported_keys['name'], entry_key2)
-        self.assertEquals(exported_keys['value'], expected_reference2)
-        self.assertEquals(exported_keys['slotSetting'], False)
+        self.assertEqual(exported_keys['name'], entry_key2)
+        self.assertEqual(exported_keys['value'], expected_reference2)
+        self.assertEqual(exported_keys['slotSetting'], False)
 
 
         # Test to confirm the right app configuration reference

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2019_03_01/test_vm_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2019_03_01/test_vm_commands.py
@@ -842,7 +842,7 @@ class VMAvailSetScenarioTest(ScenarioTest):
             self.check('[0].name', '{availset}')
         ])
         result = self.cmd('vm availability-set list --query "[?name==\'availset-test\']"').get_output_in_json()
-        self.assertEquals(1, len(result))
+        self.assertEqual(1, len(result))
         self.cmd('vm availability-set list-sizes -g {rg} -n {availset}',
                  checks=self.check('type(@)', 'array'))
         self.cmd('vm availability-set show -g {rg} -n {availset}',


### PR DESCRIPTION
`assertEquals` is removed in 3.12. It's replaced by `assertEqual`

Ref:

https://docs.python.org/3/whatsnew/3.12.html#id3