### PR TITLE
[ARM] `az ts create`: Fix incorrect handling of whitespace in string values

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_packing_engine.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_packing_engine.py
@@ -37,8 +37,8 @@ def process_template(template, preserve_order=True, file_path=None):
     # In order to solve the package conflict introduced by jsmin, the jsmin code is referenced into json_min
     minified = json_min(template)
 
-    # Remove extra spaces, compress multiline string(s)
-    result = re.sub(r'\s\s+', ' ', minified, flags=re.DOTALL)
+    # Compress multiline string(s) to adhere to the official JSON format
+    result = minified.replace('\r', '\\r').replace('\n', '\\n')
 
     try:
         return shell_safe_json_parse(result, preserve_order)


### PR DESCRIPTION
**Related command**
`az ts create`

**Description**<!--Mandatory-->
`az ts create`: Fix incorrect handling of whitespace in string values
Reimplementation of #29437

<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
```sh
az ts create \
  --resource-group myrg \
  --name myTemplateSpec \
  --version 1.0 \
  --template-file ./main.bicep
```

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[ARM] `az ts create`: Fix incorrect handling of whitespace in string values

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
