### PR TITLE
[Redis] `az redis update`: Support `--no-wait` and default to `True`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/redis/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/redis/commands.py
@@ -64,7 +64,7 @@ def load_command_table(self, _):
         g.command('list-keys', 'list_keys')
         g.custom_command('regenerate-keys', 'cli_redis_regenerate_key')
         g.show_command('show', 'get')
-        g.generic_update_command('update', setter_name='custom_update_setter', setter_type=redis_operations_custom, custom_func_name='cli_redis_update')
+        g.generic_update_command('update', setter_name='custom_update_setter', setter_type=redis_operations_custom, custom_func_name='cli_redis_update', supports_no_wait=True)
         g.command('flush', 'begin_flush_cache', confirmation=True)
 
     with self.command_group('redis patch-schedule', redis_patch, custom_command_type=redis_patch_schedules_custom) as g:

--- a/src/azure-cli/azure/cli/command_modules/redis/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/redis/custom.py
@@ -6,6 +6,7 @@
 from knack.log import get_logger
 from knack.util import CLIError
 from azure.cli.command_modules.redis._client_factory import cf_redis
+from azure.cli.core.util import sdk_no_wait
 
 logger = get_logger(__name__)
 
@@ -80,9 +81,9 @@ def cli_redis_update(cmd, instance, sku=None, vm_size=None):
     return update_params
 
 
-def custom_update_setter(client, resource_group_name, name, parameters):
+def custom_update_setter(client, resource_group_name, name, parameters, no_wait=True):
     # Custom update setter is used to match behavior from when update was not a LRO
-    return client.begin_update(resource_group_name, name, parameters).result(0)
+    return sdk_no_wait(no_wait, client.begin_update, resource_group_name, name, parameters)
 
 
 # pylint: disable=unused-argument


### PR DESCRIPTION
Related command
az redis update

Description
Resolves issue discussed here https://github.com/Azure/azure-cli/pull/24979#discussion_r1450185925

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
