### PR TITLE
{Util} Introduce a centralized function for subprocessing

### DIFF
--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -1356,3 +1356,16 @@ def should_encrypt_token_cache(cli_ctx):
     encrypt = cli_ctx.config.getboolean('core', 'encrypt_token_cache', fallback=fallback)
 
     return encrypt
+
+
+def run_cmd(args, *, capture_output=False, timeout=None, check=False, encoding=None, env=None):
+    """Run command in a subprocess. It reduces (not eliminates) shell injection by forcing args to be a list
+    and shell=False. Other arguments are keyword-only. For their documentation, see
+    https://docs.python.org/3/library/subprocess.html#subprocess.run
+    """
+    if not isinstance(args, list):
+        raise CLIError("Invalid args. args must be a list.")
+
+    import subprocess
+    return subprocess.run(args, capture_output=capture_output, timeout=timeout, check=check,
+                          encoding=encoding, env=env)

--- a/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
@@ -28,7 +28,7 @@ from azure.cli.core.azclierror import (
     ClientRequestError,
     InvalidTemplateError,
 )
-from azure.cli.core.util import should_disable_connection_verify
+from azure.cli.core.util import should_disable_connection_verify, run_cmd
 
 # See: https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
 _semver_pattern = r"(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?"  # pylint: disable=line-too-long
@@ -324,20 +324,20 @@ def _extract_version(text):
 
 
 def _run_command(bicep_installation_path, args, custom_env=None):
-    process = subprocess.run(
+    process = run_cmd(
         [rf"{bicep_installation_path}"] + args,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
+        encoding='utf-8',
         env=custom_env)
 
     try:
         process.check_returncode()
-        command_warnings = process.stderr.decode("utf-8")
+        command_warnings = process.stderr
         if command_warnings:
             _logger.warning(command_warnings)
-        return process.stdout.decode("utf-8")
+        return process.stdout
     except subprocess.CalledProcessError:
-        stderr_output = process.stderr.decode("utf-8")
+        stderr_output = process.stderr
         errors = []
 
         for line in stderr_output.splitlines():

--- a/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
@@ -15,6 +15,7 @@ from urllib.parse import urlparse
 from urllib.request import urlopen
 from azure.cli.core._profile import Profile
 from azure.cli.core.api import get_config_dir
+from azure.cli.core.util import run_cmd
 from knack.log import get_logger
 from knack.util import CLIError
 from packaging.version import parse as parse_version
@@ -41,8 +42,7 @@ class AzCopy:
             try:
                 import re
                 args = ["azcopy", "--version"]
-                out_bytes = subprocess.check_output(args)
-                out_text = out_bytes.decode('utf-8')
+                out_text = run_cmd(args, capture_output=True, check=True, encoding='utf-8').stdout
                 version = re.findall(r"azcopy version (.+?)\n", out_text)[0]
                 if version and parse_version(version) >= parse_version(AZCOPY_VERSION):
                     self.executable = "azcopy"
@@ -84,8 +84,7 @@ class AzCopy:
         try:
             import re
             args = [self.executable] + ["--version"]
-            out_bytes = subprocess.check_output(args)
-            out_text = out_bytes.decode('utf-8')
+            out_text = run_cmd(args, capture_output=True, check=True, encoding='utf-8').stdout
             version = re.findall(r"azcopy version (.+?)\n", out_text)[0]
             return version
         except subprocess.CalledProcessError:
@@ -102,7 +101,7 @@ class AzCopy:
         if self.creds and self.creds.tenant_id:
             env_kwargs = {'AZCOPY_TENANT_ID': self.creds.tenant_id,
                           'AZCOPY_AUTO_LOGIN_TYPE': 'AzCLI'}
-        result = subprocess.call(args, env=dict(os.environ, **env_kwargs))
+        result = run_cmd(args, env=dict(os.environ, **env_kwargs)).returncode
         if result > 0:
             raise CLIError('Failed to perform {} operation.'.format(args[1]))
 


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
An alternative solution to https://github.com/Azure/azure-cli/pull/29503.

Judging by how `subprocess` is currently used:

https://github.com/Azure/azure-cli/blob/f1d068ece6789d8e77f3a1ee7c140b12982298a8/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py#L105

https://github.com/Azure/azure-cli/blob/cff8d9bad3e39aa69ab9ca108693c66088d615bc/src/azure-cli/azure/cli/command_modules/resource/_bicep.py#L327-L331

https://github.com/Azure/azure-cli/blob/f4cf2963264145541cc10628af1743e2c93d669f/src/azure-cli/azure/cli/command_modules/mysql/_util.py#L388

https://github.com/Azure/azure-cli/blob/91aace5f851b5e70504efbb89079bb6170d09e74/src/azure-cli/azure/cli/command_modules/rdbms/_flexible_server_util.py#L331

we only need to expose limited arguments:

- `args` (positional)
- `stdin` (keyword)
- `stdout` (keyword)
- `check` (keyword)
- `env` (keyword)

It is not necessary to expose all `*args` and `**kwargs` from `subprocess.run`. 

This PR introduces a centralized function `cmd` for subprocessing with a more explicit and simplified signature.

Internally, to adhere to https://docs.python.org/3/library/subprocess.html#using-the-subprocess-module, `cmd` uses the recommended function `subprocess.run`.

According to https://docs.python.org/3/library/subprocess.html#older-high-level-api, these old APIs are not exposed:

- `call`
- `check_call`
- `check_output`

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
