### PR TITLE
[Core] Drop old Track 2 SDK authentication support

### DIFF
--- a/src/azure-cli-core/azure/cli/core/auth/adal_authentication.py
+++ b/src/azure-cli-core/azure/cli/core/auth/adal_authentication.py
@@ -7,7 +7,7 @@ import requests
 from knack.log import get_logger
 from msrestazure.azure_active_directory import MSIAuthentication
 
-from .util import _normalize_scopes, scopes_to_resource, AccessToken
+from .util import scopes_to_resource, AccessToken
 
 logger = get_logger(__name__)
 
@@ -39,7 +39,7 @@ class MSIAuthenticationWrapper(MSIAuthentication):
             raise AuthenticationError("VM SSH currently doesn't support managed identity.")
 
         # Use msrestazure to get access token
-        resource = scopes_to_resource(_normalize_scopes(scopes))
+        resource = scopes_to_resource(scopes)
         if resource:
             # If available, use resource provided by SDK
             self.resource = resource

--- a/src/azure-cli-core/azure/cli/core/auth/credential_adaptor.py
+++ b/src/azure-cli-core/azure/cli/core/auth/credential_adaptor.py
@@ -7,7 +7,7 @@ import requests
 from knack.log import get_logger
 from knack.util import CLIError
 
-from .util import resource_to_scopes, _normalize_scopes
+from .util import resource_to_scopes
 
 logger = get_logger(__name__)
 
@@ -62,7 +62,6 @@ class CredentialAdaptor:
         if 'data' in kwargs:
             filtered_kwargs['data'] = kwargs['data']
 
-        scopes = _normalize_scopes(scopes)
         token, _ = self._get_token(scopes, **filtered_kwargs)
         return token
 

--- a/src/azure-cli-core/azure/cli/core/auth/tests/test_util.py
+++ b/src/azure-cli-core/azure/cli/core/auth/tests/test_util.py
@@ -6,7 +6,7 @@
 # pylint: disable=protected-access
 
 import unittest
-from azure.cli.core.auth.util import scopes_to_resource, resource_to_scopes, _normalize_scopes, _generate_login_command
+from azure.cli.core.auth.util import scopes_to_resource, resource_to_scopes, _generate_login_command
 
 
 class TestUtil(unittest.TestCase):
@@ -49,21 +49,6 @@ class TestUtil(unittest.TestCase):
         # resource without trailing slash
         self.assertEqual(resource_to_scopes('https://managedhsm.azure.com'),
                          ['https://managedhsm.azure.com/.default'])
-
-    def test_normalize_scopes(self):
-        # Test no scopes
-        self.assertIsNone(_normalize_scopes(()))
-        self.assertIsNone(_normalize_scopes([]))
-        self.assertIsNone(_normalize_scopes(None))
-
-        # Test multiple scopes, with the first one discarded
-        scopes = _normalize_scopes(("https://management.core.windows.net//.default",
-                                    "https://management.core.chinacloudapi.cn//.default"))
-        self.assertEqual(list(scopes), ["https://management.core.chinacloudapi.cn//.default"])
-
-        # Test single scopes (the correct usage)
-        scopes = _normalize_scopes(("https://management.core.chinacloudapi.cn//.default",))
-        self.assertEqual(list(scopes), ["https://management.core.chinacloudapi.cn//.default"])
 
     def test_generate_login_command(self):
         # No parameter is given

--- a/src/azure-cli-core/azure/cli/core/auth/util.py
+++ b/src/azure-cli-core/azure/cli/core/auth/util.py
@@ -106,27 +106,6 @@ def scopes_to_resource(scopes):
     return scope
 
 
-def _normalize_scopes(scopes):
-    """Normalize scopes to workaround some SDK issues."""
-
-    # Track 2 SDKs generated before https://github.com/Azure/autorest.python/pull/239 don't maintain
-    # credential_scopes and call `get_token` with empty scopes.
-    # As a workaround, return None so that the CLI-managed resource is used.
-    if not scopes:
-        logger.debug("No scope is provided by the SDK, use the CLI-managed resource.")
-        return None
-
-    # Track 2 SDKs generated before https://github.com/Azure/autorest.python/pull/745 extend default
-    # credential_scopes with custom credential_scopes. Instead, credential_scopes should be replaced by
-    # custom credential_scopes. https://github.com/Azure/azure-sdk-for-python/issues/12947
-    # As a workaround, remove the first one if there are multiple scopes provided.
-    if len(scopes) > 1:
-        logger.debug("Multiple scopes are provided by the SDK, discarding the first one: %s", scopes[0])
-        return scopes[1:]
-
-    return scopes
-
-
 def check_result(result, **kwargs):
     """Parse the result returned by MSAL:
 

--- a/src/azure-cli-testsdk/azure/cli/testsdk/patches.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/patches.py
@@ -68,7 +68,10 @@ def patch_retrieve_token_for_user(unit_test):
             def __init__(self, *args, **kwargs):
                 super().__init__()
 
-            def get_token(*args, **kwargs):  # pylint: disable=unused-argument
+            def get_token(self, *scopes, **kwargs):  # pylint: disable=unused-argument
+                # Old Track 2 SDKs are no longer supported. https://github.com/Azure/azure-cli/pull/29690
+                assert len(scopes) == 1, "'scopes' must contain only one element."
+
                 from azure.core.credentials import AccessToken
                 import time
                 fake_raw_token = 'top-secret-token-for-you'


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
Resolve https://github.com/Azure/azure-cli/issues/20462

- Track 2 SDKs generated before https://github.com/Azure/autorest.python/pull/239 don't maintain `credential_scopes` and call `get_token` with empty scopes. As a workaround, return `None` so that the CLI-managed `resource` is used.

- Track 2 SDKs generated before https://github.com/Azure/autorest.python/pull/745 extend default `credential_scopes` with custom `credential_scopes`. Instead, `credential_scopes` should be replaced by custom `credential_scopes`. As a workaround, remove the first one if there are multiple scopes provided.

As CLI will no longer manage a `resource` after dropping Track 1 SDK support (https://github.com/Azure/azure-cli/pull/29631), this PR is a prerequisite.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
