### PR TITLE
improve exception message on JMESPathChecks when actual result evaluates to false

### DIFF
--- a/src/azure-cli-testsdk/azure/cli/testsdk/checkers.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/checkers.py
@@ -30,11 +30,8 @@ class JMESPathCheck(object):  # pylint: disable=too-few-public-methods
             equals = actual_result == self._expected_result \
                 or str(actual_result).lower() == str(self._expected_result).lower()
         if not equals:
-            if actual_result:
-                raise JMESPathCheckAssertionError(self._query, self._expected_result, actual_result,
-                                                  execution_result.output)
-            raise JMESPathCheckAssertionError(self._query, self._expected_result, 'None',
-                                              execution_result.output)
+            raise JMESPathCheckAssertionError(self._query, self._expected_result, actual_result,
+                                                execution_result.output)
 
 
 class JMESPathCheckExists(object):  # pylint: disable=too-few-public-methods
@@ -74,12 +71,8 @@ class JMESPathCheckGreaterThan(object):  # pylint: disable=too-few-public-method
                                         jmespath.Options(collections.OrderedDict))
         if not actual_result > self._expected_result:
             expected_result_format = "> {}".format(self._expected_result)
-
-            if actual_result:
-                raise JMESPathCheckAssertionError(self._query, expected_result_format, actual_result,
-                                                  execution_result.output)
-            raise JMESPathCheckAssertionError(self._query, expected_result_format, 'None',
-                                              execution_result.output)
+            raise JMESPathCheckAssertionError(self._query, expected_result_format, actual_result,
+                                                execution_result.output)
 
 
 class JMESPathPatternCheck(object):  # pylint: disable=too-few-public-methods

--- a/src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/tests/test_checkers.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/tests/test_checkers.py
@@ -1,0 +1,54 @@
+import unittest
+import unittest.util
+import re
+
+import unittest.test
+
+from azure.cli.testsdk.checkers import JMESPathCheck, JMESPathCheckGreaterThan
+from azure.cli.testsdk.exceptions import JMESPathCheckAssertionError
+
+class TestCheckersWithNoneLikeValues(unittest.TestCase):
+    def _format_exception_message_regex(self, key: str, expected_value: str, actual_value: any) -> str:
+        return f"^Query '{re.escape(key)}' doesn't yield expected value '{re.escape(expected_value)}', instead the actual value is '{re.escape(str(actual_value))}'"
+
+    def test_jmes_path_check_none_like_values(self):
+        test_value_cases = [None, False, 0, "", [], {}]
+        with unittest.mock.patch('azure.cli.testsdk.base.ExecutionResult') as mock_execution_result:
+            for test_value in test_value_cases:
+                mock_execution_result.get_output_in_json.return_value = { "key": test_value }
+                check = JMESPathCheck("key", "value")
+
+                with self.assertRaisesRegex(JMESPathCheckAssertionError, self._format_exception_message_regex("key", "value", test_value), msg=f"Testing value '{test_value}'"):
+                    check(mock_execution_result)
+
+    def test_jmes_path_check_not_there(self):
+        with unittest.mock.patch('azure.cli.testsdk.base.ExecutionResult') as mock_execution_result:
+            mock_execution_result.get_output_in_json.return_value = { }
+            check = JMESPathCheck("key", "value")
+
+            with self.assertRaisesRegex(JMESPathCheckAssertionError, self._format_exception_message_regex("key", "value", "None")):
+                check(mock_execution_result)
+
+    def test_jmes_path_check_normal_value(self):
+        with unittest.mock.patch('azure.cli.testsdk.base.ExecutionResult') as mock_execution_result:
+            mock_execution_result.get_output_in_json.return_value = { "key": "value" }
+            check = JMESPathCheck("key", "not-value")
+            with self.assertRaisesRegex(JMESPathCheckAssertionError, self._format_exception_message_regex("key", "not-value", "value")):
+                check(mock_execution_result)
+
+    def test_jmes_path_check_none_like_values(self):
+        test_value_cases = [(False, True), (0, 1), ("", "value"), ([], [1])]
+        with unittest.mock.patch('azure.cli.testsdk.base.ExecutionResult') as mock_execution_result:
+            for test_value, check_value in test_value_cases:
+                mock_execution_result.get_output_in_json.return_value = { "key": test_value }
+                check = JMESPathCheckGreaterThan("key", check_value)
+
+                with self.assertRaisesRegex(JMESPathCheckAssertionError, self._format_exception_message_regex("key", f"> {check_value}", test_value), msg=f"Testing value '{test_value}'"):
+                    check(mock_execution_result)
+
+    def test_jmes_path_check_greater_than_normal_value(self):
+        with unittest.mock.patch('azure.cli.testsdk.base.ExecutionResult') as mock_execution_result:
+            mock_execution_result.get_output_in_json.return_value = { "key": 5 }
+            check = JMESPathCheckGreaterThan("key", 10)
+            with self.assertRaisesRegex(JMESPathCheckAssertionError, self._format_exception_message_regex("key", "> 10", 5)):
+                check(mock_execution_result)


### PR DESCRIPTION
**Related command**
Testing issue, so `azdev test` commands.

**Description**<!--Mandatory-->
When running scenario tests that use checks, like:
```
self.cmd(f"az some_command --output json", checks=[
    self.check("thing", True)
])
```

If the actual result in the check (in this case the value of `thing`) evaluates to `False` and does not match the expected result, the message in the exception that is raised is misleading. For example:

`````
>           raise JMESPathCheckAssertionError(self._query, self._expected_result, 'None',
                                              execution_result.output)
E           azure.cli.testsdk.exceptions.JMESPathCheckAssertionError: Query 'thing' doesn't yield expected value 'True', instead the actual value is 'None'. Data:
E           {
E             "otherThing": "value",
E             "thing": false
E           }
```

Here you can see that `thing` clearly is not `None`, despite the exception message.

This happens because in [JMESPatchCheck.__call__](https://github.com/Azure/azure-cli/blob/c43b13643970803326f46a675da91fcb23970ec6/src/azure-cli-testsdk/azure/cli/testsdk/checkers.py#L32-L37), the code that raises the error has this check:

```
if not equals:
    if actual_result:
        raise JMESPathCheckAssertionError(self._query, self._expected_result, actual_result,
                                          execution_result.output)
    raise JMESPathCheckAssertionError(self._query, self._expected_result, 'None',
                                      execution_result.output)
```

If `actual_result` is something like `False`, `""`, `[]`, `0`, or anything else would not go into the `if` clause, then the message will say the value is `None` rather than what it really is, which is confusing and can make debugging more difficult.

To fix this, I've simply removed the `if actual_result` check, since `None` will be formatted correctly if passed in to the error constructor anyway.

**Testing Guide**
`azdev test` passes all tests.

I also added unit tests for this, which can be run with
```
pytest src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/tests/
```

**History Notes**
{azure-cli-testsdk} Fix error message for certain failed tests.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
