### PR TITLE
[App Service] `az webapp config access-restriction add/remove`: Allow skipping service tag validation

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -1074,6 +1074,7 @@ subscription than the app service environment, please use the resource ID for --
             c.argument('vnet_resource_group', help='Resource group of virtual network (default is web app resource group)')
             c.argument('http_headers', nargs='+', help="space-separated http headers in a format of `<name>=<value>`")
             c.argument('skip_service_tag_validation',
+                       options_list=['--skip-service-tag-validation', '-s'],
                        help='Skip validating public service tags',
                        arg_type=get_three_state_flag())
         with self.argument_context(scope + ' config access-restriction remove') as c:
@@ -1091,6 +1092,7 @@ subscription than the app service environment, please use the resource ID for --
             c.argument('action', arg_type=get_enum_type(ACCESS_RESTRICTION_ACTION_TYPES),
                        help="Allow or deny access")
             c.argument('skip_service_tag_validation',
+                       options_list=['--skip-service-tag-validation', '-s'],
                        help='Skip validating public service tags',
                        arg_type=get_three_state_flag())
         with self.argument_context(scope + ' config access-restriction set') as c:

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -1074,7 +1074,7 @@ subscription than the app service environment, please use the resource ID for --
             c.argument('vnet_resource_group', help='Resource group of virtual network (default is web app resource group)')
             c.argument('http_headers', nargs='+', help="space-separated http headers in a format of `<name>=<value>`")
             c.argument('skip_service_tag_validation',
-                       options_list=['--skip-service-tag-validation', '-s'],
+                       options_list=['--skip-service-tag-validation', '-k'],
                        help='Skip validating public service tags',
                        arg_type=get_three_state_flag())
         with self.argument_context(scope + ' config access-restriction remove') as c:
@@ -1092,7 +1092,7 @@ subscription than the app service environment, please use the resource ID for --
             c.argument('action', arg_type=get_enum_type(ACCESS_RESTRICTION_ACTION_TYPES),
                        help="Allow or deny access")
             c.argument('skip_service_tag_validation',
-                       options_list=['--skip-service-tag-validation', '-s'],
+                       options_list=['--skip-service-tag-validation', '-k'],
                        help='Skip validating public service tags',
                        arg_type=get_three_state_flag())
         with self.argument_context(scope + ' config access-restriction set') as c:

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -1073,6 +1073,9 @@ subscription than the app service environment, please use the resource ID for --
                        arg_type=get_three_state_flag())
             c.argument('vnet_resource_group', help='Resource group of virtual network (default is web app resource group)')
             c.argument('http_headers', nargs='+', help="space-separated http headers in a format of `<name>=<value>`")
+            c.argument('skip_service_tag_validation',
+                       help='Skip validating public service tags',
+                       arg_type=get_three_state_flag())
         with self.argument_context(scope + ' config access-restriction remove') as c:
             c.argument('name', arg_type=(webapp_name_arg_type if scope == 'webapp' else functionapp_name_arg_type))
             c.argument('rule_name', options_list=['--rule-name', '-r'],
@@ -1087,6 +1090,9 @@ subscription than the app service environment, please use the resource ID for --
                        arg_type=get_three_state_flag())
             c.argument('action', arg_type=get_enum_type(ACCESS_RESTRICTION_ACTION_TYPES),
                        help="Allow or deny access")
+            c.argument('skip_service_tag_validation',
+                       help='Skip validating public service tags',
+                       arg_type=get_three_state_flag())
         with self.argument_context(scope + ' config access-restriction set') as c:
             c.argument('name', arg_type=(webapp_name_arg_type if scope == 'webapp' else functionapp_name_arg_type))
             c.argument('use_same_restrictions_for_scm_site',

--- a/src/azure-cli/azure/cli/command_modules/appservice/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_validators.py
@@ -348,17 +348,18 @@ def _validate_service_tag_format(cmd, namespace):
         service_tag_full_list = ListServiceTags(cli_ctx=cmd.cli_ctx)(command_args={
             "location": webapp.location
         })
-        if service_tag_full_list is None or "values" not in service_tag_full_list:
-            logger.warning('Not able to get full Service Tag list. Cannot validate Service Tag.')
-            return
-        for tag in input_tags:
-            valid_tag = False
-            for tag_full_list in service_tag_full_list["values"]:
-                if tag.lower() == tag_full_list["name"].lower():
-                    valid_tag = True
-                    continue
-            if not valid_tag:
-                raise InvalidArgumentValueError('Unknown Service Tag: ' + tag)
+        if namespace.skip_service_tag_validation is None:
+            if service_tag_full_list is None or "values" not in service_tag_full_list:
+                logger.warning('Not able to get full Service Tag list. Cannot validate Service Tag.')
+                return
+            for tag in input_tags:
+                valid_tag = False
+                for tag_full_list in service_tag_full_list["values"]:
+                    if tag.lower() == tag_full_list["name"].lower():
+                        valid_tag = True
+                        continue
+                if not valid_tag:
+                    raise InvalidArgumentValueError('Unknown Service Tag: ' + tag)
 
 
 def _validate_service_tag_existence(cmd, namespace):

--- a/src/azure-cli/azure/cli/command_modules/appservice/access_restrictions.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/access_restrictions.py
@@ -41,12 +41,14 @@ def add_webapp_access_restriction(
         action='Allow', ip_address=None, subnet=None,
         vnet_name=None, description=None, scm_site=False,
         ignore_missing_vnet_service_endpoint=False, slot=None, vnet_resource_group=None,
-        service_tag=None, http_headers=None):
+        service_tag=None, http_headers=None, skip_service_tag_validation=None):
     configs = get_site_configs(cmd, resource_group_name, name, slot)
     if (int(service_tag is not None) + int(ip_address is not None) +
             int(subnet is not None) != 1):
         err_msg = 'Please specify either: --subnet or --ip-address or --service-tag'
         raise MutuallyExclusiveArgumentError(err_msg)
+    if (skip_service_tag_validation is not None):
+        logger.warning('Skipping service tag validation.')
 
     # get rules list
     access_rules = configs.scm_ip_security_restrictions if scm_site else configs.ip_security_restrictions
@@ -89,13 +91,16 @@ def add_webapp_access_restriction(
 
 def remove_webapp_access_restriction(cmd, resource_group_name, name, rule_name=None, action='Allow',
                                      ip_address=None, subnet=None, vnet_name=None, scm_site=False, slot=None,
-                                     service_tag=None):
+                                     service_tag=None, skip_service_tag_validation=None):
     configs = get_site_configs(cmd, resource_group_name, name, slot)
     input_rule_types = (int(service_tag is not None) + int(ip_address is not None) +
                         int(subnet is not None))
     if input_rule_types > 1:
         err_msg = 'Please specify either: --subnet or --ip-address or --service-tag'
         raise MutuallyExclusiveArgumentError(err_msg)
+    if (skip_service_tag_validation is not None):
+        logger.warning('Skipping service tag validation.')
+
     rule_instance = None
     # get rules list
     access_rules = configs.scm_ip_security_restrictions if scm_site else configs.ip_security_restrictions
@@ -110,7 +115,7 @@ def remove_webapp_access_restriction(cmd, resource_group_name, name, rule_name=N
                     continue
                 rule_instance = rule
                 break
-        elif service_tag:
+        elif service_tag:            
             if rule.ip_address and rule.ip_address.lower() == service_tag.lower() and rule.action == action:
                 if rule_name and (not rule.name or (rule.name and rule.name.lower() != rule_name.lower())):
                     continue

--- a/src/azure-cli/azure/cli/command_modules/appservice/access_restrictions.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/access_restrictions.py
@@ -115,7 +115,7 @@ def remove_webapp_access_restriction(cmd, resource_group_name, name, rule_name=N
                     continue
                 rule_instance = rule
                 break
-        elif service_tag:            
+        elif service_tag:
             if rule.ip_address and rule.ip_address.lower() == service_tag.lower() and rule.action == action:
                 if rule_name and (not rule.name or (rule.name and rule.name.lower() != rule_name.lower())):
                     continue


### PR DESCRIPTION
**Related command**
`az webapp config access-restriction`

**Description**<!--Mandatory-->
We have seen multiple issues raised where caller is challenged with getting the list of service tags. We typically find the cause and ignore it in code, but we have now added a new flag `--skip-service-tags-validation` which will allow the caller to skip the validation of service tags and not have to wait for a new release to fix the issue. This will be helpful for customers who are blocked by this issue and need a quick workaround, and this is only client side validation. Backend will ultimately validate the service tags.

We will also be allowing MSFT internals to use this flag to bypass the validation as well for internal service tags.

**Testing Guide**
az webapp config access-restriction add --priority 200 -g <app-name> -n <app-name> --service-tag <tag-name> --skip-service-tag-validation

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
