### PR TITLE
[AKS] `az aks create/update`: Support UserAssigned Managed Identity for grafana linking in managed prometheus

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/amg/link.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/amg/link.py
@@ -28,8 +28,8 @@ def link_grafana_instance(cmd, raw_parameters, azure_monitor_workspace_resource_
         )
         headers = ['User-Agent=azuremonitormetrics.link_grafana_instance']
         grafanaArmResponse = send_raw_request(cmd.cli_ctx, "GET", grafanaURI, body={}, headers=headers)
-        
-         # Check if 'identity' and 'type' exist in the response
+
+        # Check if 'identity' and 'type' exist in the response
         identity_info = grafanaArmResponse.json().get("identity", {})
         identity_type = identity_info.get("type", "").lower()
 


### PR DESCRIPTION
**Related command**

```az aks create -n kaveeshcli22 -g kaveeshcli --location westeurope --enable-azure-monitor-metrics --azure-monitor-workspace-resource-id "{full_id}" --grafana-resource-id "{full_id}"```

```az aks create -n kaveeshcli22 -g kaveeshcli --disable-azure-monitor-metrics ```


**Description**<!--Mandatory-->
Azure Managed Grafana now has support for UserAssigned Managed Identity and we're adding support for it in the managed prometheus addon.

**Testing Guide**
- Set context to one of the air gapped clouds
- Use the command with the grafana-resource-id parameter similar to `az aks create -n kaveeshcli22 -g kaveeshcli --location {cluster_location} --enable-azure-monitor-metrics --azure-monitor-workspace-resource-id "{full_id}" --grafana-resource-id "{full_id}"` and it should result in a a successful result. Please use a grafana resource that is creating/updated using a user assigned managed identity
---
This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
