### PR TITLE
{Telemetry} Fix telemetry lost due to concurrency issue

### DIFF
--- a/src/azure-cli-telemetry/azure/cli/telemetry/__init__.py
+++ b/src/azure-cli-telemetry/azure/cli/telemetry/__init__.py
@@ -82,7 +82,6 @@ def save(config_dir, payload):
 
 
 def main():
-    from azure.cli.telemetry.components.telemetry_note import TelemetryNote
     from azure.cli.telemetry.components.records_collection import RecordsCollection
     from azure.cli.telemetry.components.telemetry_client import CliTelemetryClient
     from azure.cli.telemetry.components.telemetry_logging import config_logging_for_upload, get_logger

--- a/src/azure-cli-telemetry/azure/cli/telemetry/components/records_collection.py
+++ b/src/azure-cli-telemetry/azure/cli/telemetry/components/records_collection.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-import datetime
 import os
 import shutil
 import stat
@@ -60,7 +59,7 @@ class RecordsCollection:
     def _add_record(self, content_line):
         """ Parse a line in the recording file. """
         try:
-            time, content = content_line.split(',', 1)
+            _, content = content_line.split(',', 1)
             self._records.append(content)
         except ValueError as err:
             self._logger.warning("Fail to parse a line of the record %s. Error %s.", content_line, err)

--- a/src/azure-cli-telemetry/azure/cli/telemetry/components/records_collection.py
+++ b/src/azure-cli-telemetry/azure/cli/telemetry/components/records_collection.py
@@ -27,16 +27,13 @@ class RecordsCollection:
     def next_send(self):
         return self._next_send
 
-    def snapshot_and_read(self):
-        """ Scan the telemetry cache files and move all the rotated files to a temp directory. """
-        from azure.cli.telemetry.const import TELEMETRY_CACHE_DIR
-
-        folder = os.path.join(self._config_dir, TELEMETRY_CACHE_DIR)
-        if not os.path.isdir(folder):
+    def snapshot_and_read(self, cache_dir):
+        """ Scan the telemetry cache files. """
+        if not os.path.isdir(cache_dir):
             return
 
         # Collect all cache/cache.x files
-        candidates = [(fn, os.stat(os.path.join(folder, fn))) for fn in os.listdir(folder)]
+        candidates = [(fn, os.stat(os.path.join(cache_dir, fn))) for fn in os.listdir(cache_dir)]
 
         # sort the cache files base on their last modification time.
         candidates = [(fn, file_stat) for fn, file_stat in candidates if stat.S_ISREG(file_stat.st_mode)]
@@ -46,27 +43,15 @@ class RecordsCollection:
             self._logger.info('No cache to be uploaded.')
             return
 
-        tmp = tempfile.mkdtemp()
-        self._logger.info('%d cache files to move.', len(candidates))
-        self._logger.info('Create temp folder %s', tmp)
+        self._logger.info('%d cache files to upload.', len(candidates))
 
-        for each in candidates:
-            if stat.S_ISREG(each[1].st_mode):
-                try:
-                    # Platform question: if this op is atom
-                    shutil.move(os.path.join(folder, each[0]), os.path.join(tmp, each[0]))
-                    self._logger.info('Move file %s to %s', os.path.join(folder, each[0]), os.path.join(tmp, each[0]))
-                except IOError as err:
-                    self._logger.warning('Fail to move file from %s to %s. Reason: %s.',
-                                         os.path.join(folder, each[0]), os.path.join(tmp, each[0]), err)
+        for each in os.listdir(cache_dir):
+            self._read_file(os.path.join(cache_dir, each))
 
-        for each in os.listdir(tmp):
-            self._read_file(os.path.join(tmp, each))
-
-        shutil.rmtree(tmp,
+        shutil.rmtree(cache_dir,
                       ignore_errors=True,
                       onerror=lambda _, p, tr: self._logger.error('Fail to remove file %s', p))
-        self._logger.info('Remove directory %s', tmp)
+        self._logger.info('Remove directory %s', cache_dir)
 
     def _read_file(self, path):
         """ Read content of a telemetry cache file and parse them into records. """

--- a/src/azure-cli-telemetry/azure/cli/telemetry/util.py
+++ b/src/azure-cli-telemetry/azure/cli/telemetry/util.py
@@ -15,17 +15,19 @@ def save_payload(config_dir, payload):
     logger = logging.getLogger('telemetry.save')
 
     if payload:
-        cache_saver = _create_rotate_file_logger(config_dir)
+        cache_saver, cache_dir = _create_rotate_file_logger(config_dir)
         if cache_saver:
             cache_saver.info(payload)
-            logger.info('Save telemetry record of length %d in cache', len(payload))
+            logger.info('Save telemetry record of length %d in cache file under %s', len(payload), cache_dir)
 
-            return True
-    return False
+            return cache_dir
+    return None
 
 
 def _create_rotate_file_logger(log_dir):
-    cache_name = os.path.join(log_dir, 'telemetry', 'cache')
+    from datetime import datetime
+    now = datetime.now()
+    cache_name = os.path.join(log_dir, 'telemetry', now.strftime('%Y%m%d%H%M%S%f')[:-3], 'cache')
     try:
         if not os.path.exists(os.path.dirname(cache_name)):
             os.makedirs(os.path.dirname(cache_name))
@@ -37,7 +39,7 @@ def _create_rotate_file_logger(log_dir):
 
         logger = logging.Logger(name='telemetry_cache', level=logging.INFO)
         logger.addHandler(handler)
-        return logger
+        return logger, os.path.dirname(cache_name)
     except OSError as err:
         logging.getLogger('telemetry.save').warning('Fail to create telemetry cache directory for %s. Reason %s.',
                                                     cache_name,


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
This PR is for fixing telemetry lost due to concurrency issue.

At the stage when we still had telemetry local cache, here's the process of uploading telemetry:
1. save cli records in telemetry cache file
2. check telemetry note file
2.1 if it's not enough time since last telemetry uploading time, exit
2.2 if it has been long enough since last telemetry uploading time, start a subprocess for uploading
3. within the uploading subprocess
3.1 check telemetry note file again to ensure it has been enough time since last telemetry sent time
3.2 get `last_sent_time` from telemetry note file
3.3 read all cli records from telemetry cache file where `record_time > last_sent_time`
3.4 remove cache file as it has been loaded in 3.3
3.5 uploading all records from 3.3
3.6 update `last_sent_time` for telemetry note file

Since https://github.com/Azure/azure-cli/pull/26854, we have dropped telemetry cache. So step 2 and step 3.1 are removed. We won't check if it has been "enough time" since last uploading, we do the uploading every time. So here's the new process:
1. save cli records in telemetry cache file
2. start a subprocess for uploading
3. within the uploading subprocess
3.1 get `last_sent_time` from telemetry note file
3.2 read all cli records from telemetry cache file where `record_time > last_sent_time`
3.3 remove cache file as it has been loaded in 3.2
3.4 uploading all records from 3.3
3.5 update `last_sent_time` for telemetry note file

But this enlarges concurrency issue as we increased the frequency. Operations on two files may encounter concurrency issue, one is the telemetry cache file (step 1, step 3.2, step 3.3), another is telemetry note file (step 3.1, step 3.5):
- Imagine a subprocess for command A and main process for command B are executing at the same time and the real execution order is subprocess A 3.2 -> main process B -> subprocess A 3.3, then we will lose the cli record for command B because it's not loaded in 3.2 but deleted in 3.3
- Then for telemetry note file, there's lock mechanism. If subprocess A and subprocess B are both acquiring a lock to access telemetry note file, only one will success, the other will fail with `portallocker.AlreadyLocked` error, see https://github.com/Azure/azure-cli/blob/ad96375e3940108bb011e4efb51be0cd748af4a7/src/azure-cli-telemetry/azure/cli/telemetry/components/telemetry_note.py#L72-L76 https://github.com/Azure/azure-cli/blob/ad96375e3940108bb011e4efb51be0cd748af4a7/src/azure-cli-telemetry/azure/cli/telemetry/__init__.py#L109-L112 The failed one will exit uploading directly which means we may also lose the telemetry

So the fix also comes from two part:
- for the telemetry cache file, we log in separate cache file for each cli execution to avoid reading and writing for the same file
- for the telemetry note file, as we have already dropped the last sent time check, we don't need telemetry not file either, so just simply remove step 3.1 and step 3.5

**Testing Guide**
<!--Example commands with explanations.-->
Run a cli script which contains many cli commands
Check $HOME/.azure/logs/telemetry.log and see if all command records have been uploaded



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
