### PR TITLE
[Monitor] `az monitor action-group create`: Adjust formatting of `--actions` help message 

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/monitor/operations/action_groups.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/operations/action_groups.py
@@ -358,7 +358,8 @@ class ActionGroupTestNotificationCreate(_ActionGroupTestNotificationCreate):
         args_schema.receiver_actions = AAZCustomListArg(
             options=["--add-actions"],
             singular_options=["--add-action", "-a"],
-            help="Add receivers to the action group." + '''
+            help='''
+        Add receivers to the action group.
         Usage:   --add-action TYPE NAME [ARG ...]
         Email:
             Format:     --add-action email NAME EMAIL_ADDRESS [usecommonalertschema]

--- a/src/azure-cli/azure/cli/command_modules/monitor/operations/action_groups.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/operations/action_groups.py
@@ -144,7 +144,8 @@ class ActionGroupCreate(_ActionGroupCreate):
         args_schema.receiver_actions = AAZCustomListArg(
             options=["--actions"],
             singular_options=["--action", "-a"],
-            help="Add receivers to the action group during the creation." + '''
+            help='''
+        Add receivers to the action group during the creation.
         Usage:   --action TYPE NAME [ARG ...]
         Email:
             Format:     --action email NAME EMAIL_ADDRESS [usecommonalertschema]
@@ -225,7 +226,8 @@ class ActionGroupUpdate(_ActionGroupUpdate):
         args_schema.receiver_actions = AAZCustomListArg(
             options=["--add-actions"],
             singular_options=["--add-action", "-a"],
-            help="Add receivers to the action group." + '''
+            help='''
+        Add receivers to the action group.
         Usage:   --add-action TYPE NAME [ARG ...]
         Email:
             Format:     --add-action email NAME EMAIL_ADDRESS [usecommonalertschema]


### PR DESCRIPTION
When you concatenate a regular string with a multi-line string using the + operator, the multi-line string loses its formatting and is treated as a single line.

To preserve the formatting of the multi-line string, you should use a different approach.

I've updated these to include the entire text within triple quotes without concatenation.

**Related command**
az monitor action-group create
az monitor action-group update
az monitor action-group notification create

**Description**<!--Mandatory-->
There were multi line strings for the additional data for these command parameters that were broken and just showed large blocks of text. 

**Testing Guide**
just the help notes for the create and update commands. 

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Monitor] `az monitor action-group create`: Adjust formatting of `--actions` help message
[Monitor] `az monitor action-group update`: Adjust formatting of `--add-actions` help message
[Monitor] `az monitor action-group notification create`: Adjust formatting of `--add-actions` help message

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
