### PR TITLE
{Core} Fix display inconsistent and `ExactVersion` definition bug in Upcoming Breaking Change Pre-announcement

### DIFF
--- a/doc/how_to_introduce_breaking_changes.md
+++ b/doc/how_to_introduce_breaking_changes.md
@@ -263,13 +263,13 @@ This way, the pre-announcement wouldn't be display unless running into the branc
 Before you publish the breaking changes, you need to make sure that the announcement is ready for the Upcoming Breaking Change Documentation. To do that, run this command:
 
 ```commandline
-azdev breaking-change collect
+azdev genereate-breaking-change-report
 ```
 
 If your breaking change is not for the next breaking change window, you can see all the announcements by using `--target-version None` like this:
 
 ```commandline
-azdev breaking-change collect --target-version None
+azdev genereate-breaking-change-report --target-version None
 ```
 
 The output should be a json object including the pre-announcement you made.
@@ -291,5 +291,5 @@ The Upcoming Breaking Change Documentation includes:
 The documentation is generated through `azdev` tool. You can preview the documentation locally through the following command.
 
 ```commandline
-azdev breaking-change collect CLI --output-format markdown
+azdev genereate-breaking-change-report CLI --output-format markdown
 ```

--- a/src/azure-cli-core/azure/cli/core/breaking_change.py
+++ b/src/azure-cli-core/azure/cli/core/breaking_change.py
@@ -162,13 +162,13 @@ class NextBreakingChangeWindow(TargetVersion):
 # pylint: disable=too-few-public-methods
 class ExactVersion(TargetVersion):
     def __init__(self, version):
-        self.version = version
+        self._version = version
 
     def __str__(self):
-        return f'in {self.version}'
+        return f'in {self._version}'
 
     def version(self):
-        return self.version()
+        return self._version
 
 
 # pylint: disable=too-few-public-methods
@@ -315,7 +315,7 @@ class AzCLIDeprecate(BreakingChange):
         elif object_type:
             msg = "This {} has been deprecated and will be removed ".format(object_type)
         else:
-            msg = "`{}` has been deprecated and will be removed ".format(target)
+            msg = "'{}' has been deprecated and will be removed ".format(target)
         msg += str(target_version) + '.'
         if redirect:
             msg += " Use '{}' instead.".format(redirect)
@@ -323,7 +323,7 @@ class AzCLIDeprecate(BreakingChange):
 
     @property
     def message(self):
-        return self._build_message(self.kwargs.get('object_type'), self.target, self.kwargs.get('expiration'),
+        return self._build_message(self.kwargs.get('object_type'), self.target, self.target_version,
                                    self.kwargs.get('redirect'))
 
     def to_tag(self, cli_ctx, **kwargs):


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

* Command in azdev to collect upcoming breaking change information will be renamed to `azdev genereate-breaking-change-report`
* Fix a bug when calling `version()` of `ExactVersion`
* Unify the deprecate warning message from `_breaking_change.py`
* Use `target_version` instead of `expiration` when collecting deprecation breaking change message.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
