### PR TITLE
[ACR] `az acr credential-set`: Improve help message

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_help.py
@@ -612,7 +612,7 @@ type: command
 short-summary: Create a credential set.
 examples:
   - name: Create a credential set.
-    text: az acr credential-set create -r myregistry -n MyRule -l docker.io -u https://MyKeyvault.vault.azure.net/secrets/usernamesecret -p https://MyKeyvault.vault.azure.net/secrets/passwordsecret
+    text: az acr credential-set create -r myregistry -n MyDockerHubCredSet -l docker.io -u https://MyKeyvault.vault.azure.net/secrets/usernamesecret -p https://MyKeyvault.vault.azure.net/secrets/passwordsecret
 """
 
 helps['acr credential-set update'] = """
@@ -620,7 +620,7 @@ type: command
 short-summary: Update the username or password Azure Key Vault secret ID on a credential set.
 examples:
   - name: Update the password Azure Key Vault secret ID.
-    text: az acr credential-set update -r myregistry -n MyRule -p https://MyKeyvault.vault.azure.net/secrets/newsecretname
+    text: az acr credential-set update -r myregistry -n MyDockerHubCredSet -p https://MyKeyvault.vault.azure.net/secrets/newsecretname
 """
 
 helps['acr credential-set delete'] = """


### PR DESCRIPTION
**Related command**
```
az acr credential-set create --help
az acr credential-set update --help
```

**Description**<!--Mandatory-->
The current help message for `az acr credential-set create --help` shows the following example:

```
Examples
    Create a credential set.
        az acr credential-set create -r myregistry -n MyRule -l docker.io -u
        https://MyKeyvault.vault.azure.net/secrets/usernamesecret -p
        https://MyKeyvault.vault.azure.net/secrets/passwordsecret
```

There are two problems with above example:
1. The `-n MyRule` flag is misleading, is makes new user think they have to specify the cache rule name here, however the value after `-n` should be the name of the _credential set_ the user is creating.
2. The _username secret_ value has been cut to the next line. It is better to have it directly follow the `-u` flag.

This commit updated the above example to make it clear to new users.

**Testing Guide**
Run the following two commands to check the output:
```
az acr credential-set create --help
az acr credential-set update --help
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
