### PR TITLE
[Profile] `az login`: Use device code flow in GitHub Codespaces

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -11,7 +11,7 @@ from enum import Enum
 from azure.cli.core._session import ACCOUNT
 from azure.cli.core.azclierror import AuthenticationError
 from azure.cli.core.cloud import get_active_cloud, set_cloud_subscription
-from azure.cli.core.util import in_cloud_console, can_launch_browser
+from azure.cli.core.util import in_cloud_console, can_launch_browser, is_github_codespaces
 from knack.log import get_logger
 from knack.util import CLIError
 
@@ -166,8 +166,7 @@ class Profile:
                 logger.info('No web browser is available. Fall back to device code.')
                 use_device_code = True
 
-            # https://docs.github.com/en/codespaces/developing-in-a-codespace/default-environment-variables-for-your-codespace
-            if not use_device_code and os.environ.get('CODESPACES'):
+            if not use_device_code and is_github_codespaces():
                 logger.info('GitHub Codespaces is detected. Fall back to device code.')
                 use_device_code = True
 

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -166,6 +166,11 @@ class Profile:
                 logger.info('No web browser is available. Fall back to device code.')
                 use_device_code = True
 
+            # https://docs.github.com/en/codespaces/developing-in-a-codespace/default-environment-variables-for-your-codespace
+            if not use_device_code and os.environ.get('CODESPACES'):
+                logger.info('GitHub Codespaces is detected. Fall back to device code.')
+                use_device_code = True
+
             if use_device_code:
                 user_identity = identity.login_with_device_code(scopes=scopes, **kwargs)
             else:

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -780,6 +780,11 @@ def can_launch_browser():
     return False
 
 
+def is_github_codespaces():
+    # https://docs.github.com/en/codespaces/developing-in-a-codespace/default-environment-variables-for-your-codespace
+    return os.environ.get('CODESPACES') == 'true'
+
+
 def get_command_type_kwarg(custom_command=False):
     return 'custom_command_type' if custom_command else 'command_type'
 


### PR DESCRIPTION
**Related command**
`az login`

**Description**<!--Mandatory-->
A temporary solution for https://github.com/Azure/azure-cli/issues/20315

Rework on @sinedied's original PR https://github.com/Azure/azure-cli/pull/27443

In [GitHub Codespaces](https://github.com/features/codespaces), `webbrowser.open()` can open a new tab in the current browser, this makes Azure CLI think a browser is available.

```py
$ python3
>>> webbrowser.get()
<webbrowser.GenericBrowser object at 0x770dbab24e30>
>>> webbrowser.get().name
'/vscode/bin/linux-x64/fee1edb8d6d72a0ddff41e5f71a671c23ed924b9/bin/helpers/browser.sh'
>>> webbrowser.open('https://www.microsoft.com/')
True
```

However, after a successful login, the auth code is sent to the redirect URL `http://localhost:xxxxx/` on the local machine, not the Codespace. 

Before we figure out a complete and secure solution with Entra team, we fall back to device code flow in GitHub Codespaces.

**Testing Guide**
In [GitHub Codespaces](https://github.com/features/codespaces), run

```
az login
```
