### PR TITLE
{cli} changes for create and update FLowLog with User ManagedIdentity 

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_validators.py
@@ -240,10 +240,10 @@ def validate_managed_identity_resource_id(resource_id):
             '/subscriptions/{subscription}/resourceGroups/{resource_group}/providers/'
             'Microsoft.ManagedIdentity/userAssignedIdentities/{identity_name}')
 
-    if (parts[1] != 'subscriptions' or parts[3] != 'resourceGroups' or parts[5] != 'providers' or 
-        parts[6] != 'Microsoft.ManagedIdentity' or parts[7] != 'userAssignedIdentities'):
+    if (parts[1] != 'subscriptions' or parts[3] != 'resourceGroups' or parts[5] != 'providers' or
+            parts[6] != 'Microsoft.ManagedIdentity' or parts[7] != 'userAssignedIdentities'):
         raise ValueError(
-            'Invalid resource ID format for a managed identity. It should contain subscriptions,' 
+            'Invalid resource ID format for a managed identity. It should contain subscriptions,'
             'resourceGroups, providers/Microsoft.ManagedIdentity/userAssignedIdentities'
             'in the correct order.')
     return True

--- a/src/azure-cli/azure/cli/command_modules/network/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_validators.py
@@ -241,8 +241,9 @@ def validate_managed_identity_resource_id(resource_id):
 
     if (parts[1] != 'subscriptions' or parts[3] != 'resourceGroups' or parts[5] != 'providers'
         or parts[6] != 'Microsoft.ManagedIdentity' or parts[7] != 'userAssignedIdentities'):
-        raise ValueError("Invalid resource ID format for a managed identity. It should contain 'subscriptions', 'resourceGroups',"
-                         "'providers/Microsoft.ManagedIdentity/userAssignedIdentities' in the correct order.")
+        raise ValueError("Invalid resource ID format for a managed identity. It should contain 'subscriptions'," 
+                         "'resourceGroups', 'providers/Microsoft.ManagedIdentity/userAssignedIdentities'"
+                         "in the correct order.")
     return True
 
 

--- a/src/azure-cli/azure/cli/command_modules/network/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_validators.py
@@ -228,12 +228,11 @@ def validate_dns_record_type(namespace):
             else:
                 namespace.record_set_type = token
             return
-        
+
+
 def validate_managed_identity_resource_id(resource_id):
-  
     if resource_id.lower() == 'none':
         return True
-    
     parts = resource_id.split('/')
     if len(parts) != 9:
         raise ValueError("Invalid resource ID format for a managed identity. It should be in the format: "
@@ -242,9 +241,7 @@ def validate_managed_identity_resource_id(resource_id):
     if (parts[1] != 'subscriptions' or parts[3] != 'resourceGroups' or
         parts[5] != 'providers' or parts[6] != 'Microsoft.ManagedIdentity' or
         parts[7] != 'userAssignedIdentities'):
-        raise ValueError("Invalid resource ID format for a managed identity. It should contain 'subscriptions', 'resourceGroups', "
-                         "'providers/Microsoft.ManagedIdentity/userAssignedIdentities' in the correct order.")
-
+        raise ValueError("Invalid resource ID format for a managed identity. It should contain 'subscriptions', 'resourceGroups', 'providers/Microsoft.ManagedIdentity/userAssignedIdentities' in the correct order.")
     return True
 
 

--- a/src/azure-cli/azure/cli/command_modules/network/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_validators.py
@@ -235,11 +235,14 @@ def validate_managed_identity_resource_id(resource_id):
         return True
     parts = resource_id.split('/')
     if len(parts) != 9:
-        raise ValueError("Invalid resource ID format for a managed identity. It should be in the format: "
-                         "/subscriptions/{subscription}/resourceGroups/{resource_group}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identity_name}")
+        raise ValueError("Invalid resource ID format for a managed identity. It should be in the format:"
+                         "/subscriptions/{subscription}/resourceGroups/{resource_group}/providers/"
+                         "Microsoft.ManagedIdentity/userAssignedIdentities/{identity_name}")
 
-    if (parts[1] != 'subscriptions' or parts[3] != 'resourceGroups' or parts[5] != 'providers' or parts[6] != 'Microsoft.ManagedIdentity' or parts[7] != 'userAssignedIdentities'):
-        raise ValueError("Invalid resource ID format for a managed identity. It should contain 'subscriptions', 'resourceGroups', 'providers/Microsoft.ManagedIdentity/userAssignedIdentities' in the correct order.")
+    if (parts[1] != 'subscriptions' or parts[3] != 'resourceGroups' or parts[5] != 'providers'
+        or parts[6] != 'Microsoft.ManagedIdentity' or parts[7] != 'userAssignedIdentities'):
+        raise ValueError("Invalid resource ID format for a managed identity. It should contain 'subscriptions', 'resourceGroups',"
+                         "'providers/Microsoft.ManagedIdentity/userAssignedIdentities' in the correct order.")
     return True
 
 

--- a/src/azure-cli/azure/cli/command_modules/network/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_validators.py
@@ -228,6 +228,24 @@ def validate_dns_record_type(namespace):
             else:
                 namespace.record_set_type = token
             return
+        
+def validate_managed_identity_resource_id(resource_id):
+  
+    if resource_id.lower() == 'none':
+        return True
+    
+    parts = resource_id.split('/')
+    if len(parts) != 9:
+        raise ValueError("Invalid resource ID format for a managed identity. It should be in the format: "
+                         "/subscriptions/{subscription}/resourceGroups/{resource_group}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identity_name}")
+
+    if (parts[1] != 'subscriptions' or parts[3] != 'resourceGroups' or
+        parts[5] != 'providers' or parts[6] != 'Microsoft.ManagedIdentity' or
+        parts[7] != 'userAssignedIdentities'):
+        raise ValueError("Invalid resource ID format for a managed identity. It should contain 'subscriptions', 'resourceGroups', "
+                         "'providers/Microsoft.ManagedIdentity/userAssignedIdentities' in the correct order.")
+
+    return True
 
 
 def validate_user_assigned_identity(cmd, namespace):

--- a/src/azure-cli/azure/cli/command_modules/network/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_validators.py
@@ -235,15 +235,17 @@ def validate_managed_identity_resource_id(resource_id):
         return True
     parts = resource_id.split('/')
     if len(parts) != 9:
-        raise ValueError("Invalid resource ID format for a managed identity. It should be in the format:"
-                         "/subscriptions/{subscription}/resourceGroups/{resource_group}/providers/"
-                         "Microsoft.ManagedIdentity/userAssignedIdentities/{identity_name}")
+        raise ValueError(
+            'Invalid resource ID format for a managed identity. It should be in the format:'
+            '/subscriptions/{subscription}/resourceGroups/{resource_group}/providers/'
+            'Microsoft.ManagedIdentity/userAssignedIdentities/{identity_name}')
 
-    if (parts[1] != 'subscriptions' or parts[3] != 'resourceGroups' or parts[5] != 'providers'
-        or parts[6] != 'Microsoft.ManagedIdentity' or parts[7] != 'userAssignedIdentities'):
-        raise ValueError("Invalid resource ID format for a managed identity. It should contain 'subscriptions'," 
-                         "'resourceGroups', 'providers/Microsoft.ManagedIdentity/userAssignedIdentities'"
-                         "in the correct order.")
+    if (parts[1] != 'subscriptions' or parts[3] != 'resourceGroups' or parts[5] != 'providers' or 
+        parts[6] != 'Microsoft.ManagedIdentity' or parts[7] != 'userAssignedIdentities'):
+        raise ValueError(
+            'Invalid resource ID format for a managed identity. It should contain subscriptions,' 
+            'resourceGroups, providers/Microsoft.ManagedIdentity/userAssignedIdentities'
+            'in the correct order.')
     return True
 
 

--- a/src/azure-cli/azure/cli/command_modules/network/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_validators.py
@@ -238,9 +238,7 @@ def validate_managed_identity_resource_id(resource_id):
         raise ValueError("Invalid resource ID format for a managed identity. It should be in the format: "
                          "/subscriptions/{subscription}/resourceGroups/{resource_group}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identity_name}")
 
-    if (parts[1] != 'subscriptions' or parts[3] != 'resourceGroups' or
-        parts[5] != 'providers' or parts[6] != 'Microsoft.ManagedIdentity' or
-        parts[7] != 'userAssignedIdentities'):
+    if (parts[1] != 'subscriptions' or parts[3] != 'resourceGroups' or parts[5] != 'providers' or parts[6] != 'Microsoft.ManagedIdentity' or parts[7] != 'userAssignedIdentities'):
         raise ValueError("Invalid resource ID format for a managed identity. It should contain 'subscriptions', 'resourceGroups', 'providers/Microsoft.ManagedIdentity/userAssignedIdentities' in the correct order.")
     return True
 

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/watcher/flow_log/_create.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/watcher/flow_log/_create.py
@@ -43,9 +43,9 @@ class Create(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2022-01-01",
+        "version": "2023-11-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/networkwatchers/{}/flowlogs/{}", "2022-01-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/networkwatchers/{}/flowlogs/{}", "2023-11-01"],
         ]
     }
 
@@ -118,6 +118,29 @@ class Create(AAZCommand):
         )
 
         # define Arg Group "Parameters"
+
+        _args_schema = cls._args_schema
+        _args_schema.identity = AAZObjectArg(
+            options=["--identity"],
+            arg_group="Parameters",
+            help="FlowLog resource Managed Identity",
+        )
+
+        identity = cls._args_schema.identity
+        identity.type = AAZStrArg(
+            options=["type"],
+            help="The type of identity used for the resource. The type 'SystemAssigned, UserAssigned' includes both an implicitly created identity and a set of user assigned identities. The type 'None' will remove any identities from the virtual machine.",
+            enum={"None": "None", "SystemAssigned": "SystemAssigned", "SystemAssigned, UserAssigned": "SystemAssigned, UserAssigned", "UserAssigned": "UserAssigned"},
+        )
+        identity.user_assigned_identities = AAZDictArg(
+            options=["user-assigned-identities"],
+            help="The list of user identities associated with resource. The user identity dictionary key references will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'.",
+        )
+
+        user_assigned_identities = cls._args_schema.identity.user_assigned_identities
+        user_assigned_identities.Element = AAZObjectArg(
+            blank={},
+        )
 
         # define Arg Group "Properties"
 
@@ -258,7 +281,7 @@ class Create(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2022-01-01",
+                    "api-version", "2023-11-01",
                     required=True,
                 ),
             }
@@ -283,9 +306,19 @@ class Create(AAZCommand):
                 typ=AAZObjectType,
                 typ_kwargs={"flags": {"required": True, "client_flatten": True}}
             )
+            _builder.set_prop("identity", AAZObjectType, ".identity")
             _builder.set_prop("location", AAZStrType, ".location")
             _builder.set_prop("properties", AAZObjectType, typ_kwargs={"flags": {"client_flatten": True}})
             _builder.set_prop("tags", AAZDictType, ".tags")
+
+            identity = _builder.get(".identity")
+            if identity is not None:
+                identity.set_prop("type", AAZStrType, ".type")
+                identity.set_prop("userAssignedIdentities", AAZDictType, ".user_assigned_identities")
+
+            user_assigned_identities = _builder.get(".identity.userAssignedIdentities")
+            if user_assigned_identities is not None:
+                user_assigned_identities.set_elements(AAZObjectType, ".")
 
             properties = _builder.get(".properties")
             if properties is not None:
@@ -346,6 +379,7 @@ class Create(AAZCommand):
                 flags={"read_only": True},
             )
             _schema_on_200_201.id = AAZStrType()
+            _schema_on_200_201.identity = AAZObjectType()
             _schema_on_200_201.location = AAZStrType()
             _schema_on_200_201.name = AAZStrType(
                 flags={"read_only": True},
@@ -355,6 +389,33 @@ class Create(AAZCommand):
             )
             _schema_on_200_201.tags = AAZDictType()
             _schema_on_200_201.type = AAZStrType(
+                flags={"read_only": True},
+            )
+
+            identity = cls._schema_on_200_201.identity
+            identity.principal_id = AAZStrType(
+                serialized_name="principalId",
+                flags={"read_only": True},
+            )
+            identity.tenant_id = AAZStrType(
+                serialized_name="tenantId",
+                flags={"read_only": True},
+            )
+            identity.type = AAZStrType()
+            identity.user_assigned_identities = AAZDictType(
+                serialized_name="userAssignedIdentities",
+            )
+
+            user_assigned_identities = cls._schema_on_200_201.identity.user_assigned_identities
+            user_assigned_identities.Element = AAZObjectType()
+
+            _element = cls._schema_on_200_201.identity.user_assigned_identities.Element
+            _element.client_id = AAZStrType(
+                serialized_name="clientId",
+                flags={"read_only": True},
+            )
+            _element.principal_id = AAZStrType(
+                serialized_name="principalId",
                 flags={"read_only": True},
             )
 

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/watcher/flow_log/_update.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/watcher/flow_log/_update.py
@@ -40,9 +40,9 @@ class Update(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2022-01-01",
+        "version": "2023-11-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/networkwatchers/{}/flowlogs/{}", "2022-01-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/networkwatchers/{}/flowlogs/{}", "2023-11-01"],
         ]
     }
 
@@ -125,6 +125,33 @@ class Update(AAZCommand):
         )
 
         # define Arg Group "Parameters"
+
+        _args_schema = cls._args_schema
+        _args_schema.identity = AAZObjectArg(
+            options=["--identity"],
+            arg_group="Parameters",
+            help="FlowLog resource Managed Identity",
+            nullable=True,
+        )
+
+        identity = cls._args_schema.identity
+        identity.type = AAZStrArg(
+            options=["type"],
+            help="The type of identity used for the resource. The type 'SystemAssigned, UserAssigned' includes both an implicitly created identity and a set of user assigned identities. The type 'None' will remove any identities from the virtual machine.",
+            nullable=True,
+            enum={"None": "None", "SystemAssigned": "SystemAssigned", "SystemAssigned, UserAssigned": "SystemAssigned, UserAssigned", "UserAssigned": "UserAssigned"},
+        )
+        identity.user_assigned_identities = AAZDictArg(
+            options=["user-assigned-identities"],
+            help="The list of user identities associated with resource. The user identity dictionary key references will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'.",
+            nullable=True,
+        )
+
+        user_assigned_identities = cls._args_schema.identity.user_assigned_identities
+        user_assigned_identities.Element = AAZObjectArg(
+            nullable=True,
+            blank={},
+        )
 
         # define Arg Group "Properties"
 
@@ -269,7 +296,7 @@ class Update(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2022-01-01",
+                    "api-version", "2023-11-01",
                     required=True,
                 ),
             }
@@ -372,7 +399,7 @@ class Update(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2022-01-01",
+                    "api-version", "2023-11-01",
                     required=True,
                 ),
             }
@@ -430,9 +457,19 @@ class Update(AAZCommand):
                 value=instance,
                 typ=AAZObjectType
             )
+            _builder.set_prop("identity", AAZObjectType, ".identity")
             _builder.set_prop("location", AAZStrType, ".location")
             _builder.set_prop("properties", AAZObjectType, typ_kwargs={"flags": {"client_flatten": True}})
             _builder.set_prop("tags", AAZDictType, ".tags")
+
+            identity = _builder.get(".identity")
+            if identity is not None:
+                identity.set_prop("type", AAZStrType, ".type")
+                identity.set_prop("userAssignedIdentities", AAZDictType, ".user_assigned_identities")
+
+            user_assigned_identities = _builder.get(".identity.userAssignedIdentities")
+            if user_assigned_identities is not None:
+                user_assigned_identities.set_elements(AAZObjectType, ".")
 
             properties = _builder.get(".properties")
             if properties is not None:
@@ -490,6 +527,7 @@ class _UpdateHelper:
         if cls._schema_flow_log_read is not None:
             _schema.etag = cls._schema_flow_log_read.etag
             _schema.id = cls._schema_flow_log_read.id
+            _schema.identity = cls._schema_flow_log_read.identity
             _schema.location = cls._schema_flow_log_read.location
             _schema.name = cls._schema_flow_log_read.name
             _schema.properties = cls._schema_flow_log_read.properties
@@ -504,6 +542,7 @@ class _UpdateHelper:
             flags={"read_only": True},
         )
         flow_log_read.id = AAZStrType()
+        flow_log_read.identity = AAZObjectType()
         flow_log_read.location = AAZStrType()
         flow_log_read.name = AAZStrType(
             flags={"read_only": True},
@@ -513,6 +552,33 @@ class _UpdateHelper:
         )
         flow_log_read.tags = AAZDictType()
         flow_log_read.type = AAZStrType(
+            flags={"read_only": True},
+        )
+
+        identity = _schema_flow_log_read.identity
+        identity.principal_id = AAZStrType(
+            serialized_name="principalId",
+            flags={"read_only": True},
+        )
+        identity.tenant_id = AAZStrType(
+            serialized_name="tenantId",
+            flags={"read_only": True},
+        )
+        identity.type = AAZStrType()
+        identity.user_assigned_identities = AAZDictType(
+            serialized_name="userAssignedIdentities",
+        )
+
+        user_assigned_identities = _schema_flow_log_read.identity.user_assigned_identities
+        user_assigned_identities.Element = AAZObjectType()
+
+        _element = _schema_flow_log_read.identity.user_assigned_identities.Element
+        _element.client_id = AAZStrType(
+            serialized_name="clientId",
+            flags={"read_only": True},
+        )
+        _element.principal_id = AAZStrType(
+            serialized_name="principalId",
             flags={"read_only": True},
         )
 
@@ -575,6 +641,7 @@ class _UpdateHelper:
 
         _schema.etag = cls._schema_flow_log_read.etag
         _schema.id = cls._schema_flow_log_read.id
+        _schema.identity = cls._schema_flow_log_read.identity
         _schema.location = cls._schema_flow_log_read.location
         _schema.name = cls._schema_flow_log_read.name
         _schema.properties = cls._schema_flow_log_read.properties

--- a/src/azure-cli/azure/cli/command_modules/network/operations/watcher.py
+++ b/src/azure-cli/azure/cli/command_modules/network/operations/watcher.py
@@ -1143,17 +1143,17 @@ class NwFlowLogCreate(_NwFlowLogCreate):
         if has_value(args.user_assigned_identity):
             user_assigned_identity = args.user_assigned_identity.to_serialized_data()
             is_valid_miresource_id = validate_managed_identity_resource_id(user_assigned_identity)
-            if not is_valid_miresource_id: 
+            if not is_valid_miresource_id:
                 raise CLIError('Managed Identity resource id is invalid')
             if user_assigned_identity.lower() != 'none':
-                args.identity = { 
+                args.identity = {
                     "type": "UserAssigned",
                     "user_assigned_identities": {user_assigned_identity: {}}
                 }
             else:
-                args.identity =   {
+                args.identity = {
                     "type": "None"
-            }
+                }
 
         if has_value(args.retention):
             if args.retention > 0:
@@ -1271,17 +1271,16 @@ class NwFlowLogUpdate(_NwFlowLogUpdate):
             args.target_resource_id = args.nic
         elif has_value(args.nsg):
             args.target_resource_id = args.nsg
-            
         if has_value(args.retention) and args.retention > 0:
             args.retention_policy = {"days": args.retention, "enabled": True}
 
         if has_value(args.user_assigned_identity):
-            user_assigned_identity = args.user_assigned_identity.to_serialized_data()                
+            user_assigned_identity = args.user_assigned_identity.to_serialized_data()
             is_valid_miresource_id = validate_managed_identity_resource_id(user_assigned_identity)
-            if not is_valid_miresource_id: 
+            if not is_valid_miresource_id:
                 raise CLIError('Managed Identity resource id is invalid')
             if user_assigned_identity.lower() != 'none':
-                args.identity = { 
+                args.identity = {
                     "type": "UserAssigned",
                     "user_assigned_identities": {user_assigned_identity: {}}
                 }

--- a/src/azure-cli/azure/cli/command_modules/network/operations/watcher.py
+++ b/src/azure-cli/azure/cli/command_modules/network/operations/watcher.py
@@ -16,6 +16,7 @@ from azure.cli.core.aaz.utils import assign_aaz_list_arg
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.profiles import ResourceType
 from azure.cli.core.commands.validators import validate_tags
+from azure.cli.command_modules.network._validators import validate_managed_identity_resource_id
 from .._validators import _resolve_api_version
 
 from ..aaz.latest.network.watcher import RunConfigurationDiagnostic as _RunConfigurationDiagnostic
@@ -1062,6 +1063,13 @@ class NwFlowLogCreate(_NwFlowLogCreate):
                 minimum=10,
             )
         )
+       
+        args_schema.user_assigned_identity = AAZResourceIdArg(
+            options=["--user-assigned-identity"],
+            help="Name or ID of the ManagedIdentity Resource.",
+            required=False,
+        )
+
         args_schema.retention = AAZIntArg(
             options=['--retention'],
             help="Number of days to retain logs.",
@@ -1134,6 +1142,24 @@ class NwFlowLogCreate(_NwFlowLogCreate):
         elif has_value(args.nsg):
             args.target_resource_id = args.nsg
 
+        if has_value(args.user_assigned_identity):
+                user_assigned_identity = args.user_assigned_identity.to_serialized_data()
+                
+                is_valid_resource_id = validate_managed_identity_resource_id(user_assigned_identity)
+
+                if not is_valid_resource_id: 
+                    raise CLIError('Managed Identity resource id is invalid')
+                   
+                if user_assigned_identity.lower() != 'none':
+                     args.identity = { 
+                         "type" : "UserAssigned",
+                         "user_assigned_identities" : {user_assigned_identity: {}}
+                     }
+                else:
+                     args.identity =   {
+                         "type": "None"
+                     }
+
         if has_value(args.retention):
             if args.retention > 0:
                 args.retention_policy = {"days": args.retention, "enabled": True}
@@ -1178,6 +1204,11 @@ class NwFlowLogUpdate(_NwFlowLogUpdate):
                 maximum=60,
                 minimum=10,
             )
+        )
+        args_schema.user_assigned_identity = AAZResourceIdArg(
+            options=["--user-assigned-identity"],
+            help="Name or ID of the ManagedIdentity Resource.",
+            required=False,
         )
         args_schema.traffic_analytics_enabled = AAZBoolArg(
             options=['--traffic-analytics'], arg_group="Traffic Analytics", nullable=True,
@@ -1245,9 +1276,27 @@ class NwFlowLogUpdate(_NwFlowLogUpdate):
             args.target_resource_id = args.nic
         elif has_value(args.nsg):
             args.target_resource_id = args.nsg
-
+            
         if has_value(args.retention) and args.retention > 0:
             args.retention_policy = {"days": args.retention, "enabled": True}
+
+        if has_value(args.user_assigned_identity):
+            user_assigned_identity = args.user_assigned_identity.to_serialized_data()
+                
+            is_valid_resource_id = validate_managed_identity_resource_id(user_assigned_identity)
+
+            if not is_valid_resource_id: 
+                raise CLIError('Managed Identity resource id is invalid')
+                   
+            if user_assigned_identity.lower() != 'none':
+                args.identity = { 
+                    "type" : "UserAssigned",
+                    "user_assigned_identities" : {user_assigned_identity: {}}
+                }
+            else:
+                args.identity =  {
+                    "type": "None"
+                }
 
         if has_value(args.traffic_analytics_workspace):
             workspace = get_arm_resource_by_id(self.cli_ctx, args.traffic_analytics_workspace.to_serialized_data())

--- a/src/azure-cli/azure/cli/command_modules/network/operations/watcher.py
+++ b/src/azure-cli/azure/cli/command_modules/network/operations/watcher.py
@@ -1285,7 +1285,7 @@ class NwFlowLogUpdate(_NwFlowLogUpdate):
                     "user_assigned_identities": {user_assigned_identity: {}}
                 }
             else:
-                args.identity =  {
+                args.identity = {
                     "type": "None"
                 }
 

--- a/src/azure-cli/azure/cli/command_modules/network/operations/watcher.py
+++ b/src/azure-cli/azure/cli/command_modules/network/operations/watcher.py
@@ -1063,13 +1063,11 @@ class NwFlowLogCreate(_NwFlowLogCreate):
                 minimum=10,
             )
         )
-       
         args_schema.user_assigned_identity = AAZResourceIdArg(
             options=["--user-assigned-identity"],
             help="Name or ID of the ManagedIdentity Resource.",
             required=False,
         )
-
         args_schema.retention = AAZIntArg(
             options=['--retention'],
             help="Number of days to retain logs.",
@@ -1143,22 +1141,19 @@ class NwFlowLogCreate(_NwFlowLogCreate):
             args.target_resource_id = args.nsg
 
         if has_value(args.user_assigned_identity):
-                user_assigned_identity = args.user_assigned_identity.to_serialized_data()
-                
-                is_valid_resource_id = validate_managed_identity_resource_id(user_assigned_identity)
-
-                if not is_valid_resource_id: 
-                    raise CLIError('Managed Identity resource id is invalid')
-                   
-                if user_assigned_identity.lower() != 'none':
-                     args.identity = { 
-                         "type" : "UserAssigned",
-                         "user_assigned_identities" : {user_assigned_identity: {}}
-                     }
-                else:
-                     args.identity =   {
-                         "type": "None"
-                     }
+            user_assigned_identity = args.user_assigned_identity.to_serialized_data()
+            is_valid_miresource_id = validate_managed_identity_resource_id(user_assigned_identity)
+            if not is_valid_miresource_id: 
+                raise CLIError('Managed Identity resource id is invalid')
+            if user_assigned_identity.lower() != 'none':
+                args.identity = { 
+                    "type": "UserAssigned",
+                    "user_assigned_identities": {user_assigned_identity: {}}
+                }
+            else:
+                args.identity =   {
+                    "type": "None"
+            }
 
         if has_value(args.retention):
             if args.retention > 0:
@@ -1281,17 +1276,14 @@ class NwFlowLogUpdate(_NwFlowLogUpdate):
             args.retention_policy = {"days": args.retention, "enabled": True}
 
         if has_value(args.user_assigned_identity):
-            user_assigned_identity = args.user_assigned_identity.to_serialized_data()
-                
-            is_valid_resource_id = validate_managed_identity_resource_id(user_assigned_identity)
-
-            if not is_valid_resource_id: 
+            user_assigned_identity = args.user_assigned_identity.to_serialized_data()                
+            is_valid_miresource_id = validate_managed_identity_resource_id(user_assigned_identity)
+            if not is_valid_miresource_id: 
                 raise CLIError('Managed Identity resource id is invalid')
-                   
             if user_assigned_identity.lower() != 'none':
                 args.identity = { 
-                    "type" : "UserAssigned",
-                    "user_assigned_identities" : {user_assigned_identity: {}}
+                    "type": "UserAssigned",
+                    "user_assigned_identities": {user_assigned_identity: {}}
                 }
             else:
                 args.identity =  {


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**
This Pr involves making changes in 'network watcher flow-log create' and 'network watcher flow-log update` commands to now include an extra optional field --user-.assigned-identity. With new addition user will be able to create FLowlogs with MI and also delete MI associated with FL..

**Testing Guide**
- az network watcher flow-log create --enabled true --location centraluseuap --name mejaflowlogaug28 --vnet /subscriptions/af15e575-f948-49ac-bce0-252d028e9379/resourceGroups/mejacentralrg/providers/Microsoft.Network/virtualNetworks/vnetaug26 --resource-group NetworkWatcherRG  --storage-account /subscriptions/af15e575-f948-49ac-bce0-252d028e9379/resourceGroups/mejacentralrg/providers/Microsoft.Storage/storageAccounts/mejateststoragecentral --subscription af15e575-f948-49ac-bce0-252d028e9379 --format JSON --user-assigned-identity /subscriptions/af15e575-f948-49ac-bce0-252d028e9379/resourceGroups/mejacentralrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/idtest --debug

- az network watcher flow-log update --enabled true --location centraluseuap --name mejaflowlogaug28 --vnet /subscriptions/af15e575-f948-49ac-bce0-252d028e9379/resourceGroups/mejacentralrg/providers/Microsoft.Network/virtualNetworks/vnetaug26 --resource-group NetworkWatcherRG  --storage-account /subscriptions/af15e575-f948-49ac-bce0-252d028e9379/resourceGroups/mejacentralrg/providers/Microsoft.Storage/storageAccounts/mejateststoragecentral --user-assigned-identity none

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
