### PR TITLE
[RDBMS] `az postgres flexible-server migration create` Add AWS_AURORA as a migration source type for PostgreSql

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/_helptext_pg.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_helptext_pg.py
@@ -555,7 +555,7 @@ examples:
       --migration-name testmigration --properties "migrationConfig.json" --migration-option Migrate
   - name: >
       To start a migration for other than PostgreSQLSingleServer, soureType and sslMode must be specified in properties file. These properties are defined as: \n
-      sourceType: Values can be - on-premises, AWS_RDS, AzureVM, PostgreSQLSingleServer \n
+      sourceType: Values can be - on-premises, AWS_AURORA, AWS_RDS, AzureVM, PostgreSQLSingleServer \n
       sslMode:  SSL modes for migration. SSL mode for PostgreSQLSingleServer is VerifyFull and Prefer/Require for other source types. \n
       Sample migrationConfig.json shown below. \n
       {

--- a/src/azure-cli/azure/cli/command_modules/rdbms/_helptext_pg.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_helptext_pg.py
@@ -555,7 +555,7 @@ examples:
       --migration-name testmigration --properties "migrationConfig.json" --migration-option Migrate
   - name: >
       To start a migration for other than PostgreSQLSingleServer, soureType and sslMode must be specified in properties file. These properties are defined as: \n
-      sourceType: Values can be - on-premises, AWS_AURORA, AWS_RDS, AzureVM, PostgreSQLSingleServer \n
+      sourceType: Values can be - OnPremises, AWS_AURORA, AWS_RDS, AzureVM, PostgreSQLSingleServer \n
       sslMode:  SSL modes for migration. SSL mode for PostgreSQLSingleServer is VerifyFull and Prefer/Require for other source types. \n
       Sample migrationConfig.json shown below. \n
       {


### PR DESCRIPTION
**Related command**
`az postgres flexible-server migration create`

**Description**<!--Mandatory-->
Document AWS Aurora as now a supported migration source for PostgreSQL Flexible Server. This also fixes a typo, updating `on-premises` to the correct `OnPremises`.

**Testing Guide**
From AWS create either an AWS Aurora database. Then create a "migrationConfig.json" file with the following:

```json
{
  "properties": {
    "sourceDBServerResourceId": "<<hostname or IP address>>:<<port>>@<<username>>",
    "secretParameters": {
      "adminCredentials": {
        "sourceServerPassword": "password",
        "targetServerPassword": "password"
      },
      "sourceServerUserName": "postgres",
      "targetServerUserName": "fspguser"
    },
    "dBsToMigrate": [
      "<<some database name>>, <<some other database name>>"
    ],
    "overwriteDbsInTarget": "true",
    "sourceType": "AWS_AURORA",
    "sslMode": "Prefer"
  }
}
```

Run the command: 
```powershell
az postgres flexible-server migration create --subscription {subscriptionId} --resource-group {some-resource-group} --name {some-postgres-flexible-server-name} --migration-name {some-migration-name} --properties "migrationConfig.json" --migration-option {Validate or Migrate}
```

History Notes

[RDBMS] `az postgres flexible-server migration create`: Add AWS Aurora as a migration source for PostgreSQL Flexible Server

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
