### PR TITLE
[Packaging] Include `jq` in Azure Linux docker image

### DIFF
--- a/azure-linux.dockerfile
+++ b/azure-linux.dockerfile
@@ -6,8 +6,9 @@
 ARG IMAGE
 FROM $IMAGE
 
-# Azure Linux base image does not contain Mozilla CA certificates, install ca-certificates package to prevent CERTIFICATE_VERIFY_FAILED errors, see https://github.com/Azure/azure-cli/issues/26026
-RUN --mount=type=bind,target=/azure-cli.rpm,source=./docker-temp/azure-cli.rpm tdnf install ca-certificates /azure-cli.rpm -y && tdnf clean all && rm -rf /var/cache/tdnf
+# ca-certificates: Azure Linux base image does not contain Mozilla CA certificates, install it to prevent CERTIFICATE_VERIFY_FAILED errors, see https://github.com/Azure/azure-cli/issues/26026
+# jq: It's widely used for parsing JSON output in Azure CLI and has a small size. See https://github.com/Azure/azure-cli/issues/29830
+RUN --mount=type=bind,target=/azure-cli.rpm,source=./docker-temp/azure-cli.rpm tdnf install ca-certificates jq /azure-cli.rpm -y && tdnf clean all && rm -rf /var/cache/tdnf
 
 ENV AZ_INSTALLER=DOCKER
 CMD bash


### PR DESCRIPTION
Add `jq` into image because it's widely used and small.

Resolve #29830