### PR TITLE
{Core} Bump MSAL to 1.31.0

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -54,7 +54,7 @@ DEPENDENCIES = [
     'jmespath',
     'knack~=0.11.0',
     'msal-extensions==1.2.0',
-    'msal[broker]==1.30.0',
+    'msal[broker]==1.31.0',
     'msrestazure~=0.6.4',
     'packaging>=20.9',
     'paramiko>=2.0.8,<4.0.0',

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -103,7 +103,7 @@ jmespath==0.9.5
 jsondiff==2.0.0
 knack==0.11.0
 msal-extensions==1.2.0
-msal[broker]==1.30.0
+msal[broker]==1.31.0
 msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -104,7 +104,7 @@ jmespath==0.9.5
 jsondiff==2.0.0
 knack==0.11.0
 msal-extensions==1.2.0
-msal[broker]==1.30.0
+msal[broker]==1.31.0
 msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -103,7 +103,7 @@ jmespath==0.9.5
 jsondiff==2.0.0
 knack==0.11.0
 msal-extensions==1.2.0
-msal[broker]==1.30.0
+msal[broker]==1.31.0
 msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2


### PR DESCRIPTION
**Description**<!--Mandatory-->
Bump MSAL to 1.31.0 (https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/742) to adopt https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/731.

`IDENTITY_ENDPOINT` and `IMDS_ENDPOINT` env vars may not be present on Linux Arc-enabled servers. https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/731 added another detection method which checks `/var/opt/azcmagent/bin/himds` and returns the token endpoint `http://localhost:40342/metadata/identity/oauth2/token`. This makes https://github.com/Azure/azure-cli/pull/29187 work on Linux Arc-enabled servers.
