### PR TITLE
[dla] `az dla`: Deprecate azure datalake analytics from CLI

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/dla/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/dla/commands.py
@@ -187,5 +187,5 @@ def load_command_table(self, _):
         g.show_command('show', 'get')
         g.command('delete', 'delete')
 
-    with self.command_group('dla', is_preview=True):
+    with self.command_group('dla', deprecate_info=self.deprecate(expiration='2.67.0')):
         pass


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az dla`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Azure Data Lake analytics has been retired as of Feb 29, 2024: [migrate-to-azure-synapse-analytics](https://azure.microsoft.com/en-us/updates/migrate-to-azure-synapse-analytics/)
This PR is for deprecate it from CLI

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
