### PR TITLE
{RDBMS} `az postgres flexible-server replica create`: Update replica create help text to show example of cross resource group creation

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/_helptext_pg.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_helptext_pg.py
@@ -766,12 +766,11 @@ examples:
     text: az postgres flexible-server replica create --replica-name testreplicaserver -g testGroup --source-server testserver --location testLocation
   - name: Create a read replica 'testreplicaserver' for 'testserver' with custom --storage-size and --sku.
     text: az postgres flexible-server replica create --replica-name testreplicaserver -g testGroup --source-server testserver --sku-name Standard_D4ds_v5 --storage-size 256
-  - name: Create a read replica 'testreplicaserver' for 'testserver', where 'testreplicaserver' is in a different resource group 'newTestGroup'. \\
+  - name: Create a read replica 'testreplicaserver' for 'testserver', where 'testreplicaserver' is in a different resource group 'newTestGroup'. \
       Here --resource-group is for the read replica's resource group, and --source-server must be passed as resource ID.
     text: >
-      az postgres flexible-server replica create --replica-name testreplicaserver -g newTestGroup \\
-        --source-server /subscriptions/{sourceSubscriptionId}/resourceGroups/{sourceResourceGroup}/providers/Microsoft.DBforPostgreSQL/flexibleServers/{sourceServerName} \\
-        --location testLocation
+      az postgres flexible-server replica create --replica-name testreplicaserver -g newTestGroup \
+        --source-server /subscriptions/{sourceSubscriptionId}/resourceGroups/{sourceResourceGroup}/providers/Microsoft.DBforPostgreSQL/flexibleServers/{sourceServerName} --location testLocation
 """
 
 helps['postgres flexible-server replica list'] = """

--- a/src/azure-cli/azure/cli/command_modules/rdbms/_helptext_pg.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_helptext_pg.py
@@ -289,13 +289,13 @@ examples:
     text: az postgres flexible-server restore --resource-group testGroup --name testserverNew --source-server testserver
   - name: >
       Restore 'testserver' to current point-in-time as a new server 'testserverNew' in a different resource group. \\
-      Here --restore-group is for the target server's resource group, and --source-server must be passed as resource ID.
+      Here --resource-group is for the target server's resource group, and --source-server must be passed as resource ID.
     text: >
       az postgres flexible-server restore --resource-group testGroup --name testserverNew \\
         --source-server /subscriptions/{testSubscription}/resourceGroups/{sourceResourceGroup}/providers/Microsoft.DBforPostgreSQL/flexibleServers/{sourceServerName}
   - name: >
       Restore 'testserver' to current point-in-time as a new server 'testserverNew' in a different subscription. \\
-      Here --restore-group is for the target server's resource group, and --source-server must be passed as resource ID. \\
+      Here --resource-group is for the target server's resource group, and --source-server must be passed as resource ID. \\
       This resource ID can be in a subscription different than the subscription used for az account set.
     text: >
       az postgres flexible-server restore --resource-group testGroup --name testserverNew \\
@@ -749,23 +749,29 @@ helps['postgres flexible-server replica create'] = """
 type: command
 short-summary: Create a read replica for a server.
 examples:
-  - name: Create a read replica 'testReplicaServer' for 'testserver' with public or private access in the specified zone and location if available.
-    text: az postgres flexible-server replica create --replica-name testReplicaServer -g testGroup --source-server testserver --zone 3 --location testLocation
-  - name: Create a read replica 'testReplicaServer' with new subnet for 'testserver' with private access.
+  - name: Create a read replica 'testreplicaserver' for 'testserver' with public or private access in the specified zone and location if available.
+    text: az postgres flexible-server replica create --replica-name testreplicaserver -g testGroup --source-server testserver --zone 3 --location testLocation
+  - name: Create a read replica 'testreplicaserver' with new subnet for 'testserver' with private access.
     text: >
-      az postgres flexible-server replica create --replica-name testReplicaServer -g testGroup \\
+      az postgres flexible-server replica create --replica-name testreplicaserver -g testGroup \\
         --source-server testserver --zone 3 --location testLocation \\
         --vnet newVnet --subnet newSubnet \\
         --address-prefixes 172.0.0.0/16 --subnet-prefixes 172.0.0.0/24 \\
         --private-dns-zone testDNS.postgres.database.azure.com
   - name: >
-      Create a read replica 'testReplicaServer' for 'testserver' with public or private access \
+      Create a read replica 'testreplicaserver' for 'testserver' with public or private access \
       in the specified location if available. Since zone is not passed, it will automatically pick up zone in the \
       replica location which is different from source server, if available, else will pick up zone same as source server \
       in the replica location if available, else will set the zone as None, i.e. No preference
-    text: az postgres flexible-server replica create --replica-name testReplicaServer -g testGroup --source-server testserver --location testLocation
-  - name: Create a read replica 'testReplicaServer' for 'testserver' with custom --storage-size and --sku.
-    text: az postgres flexible-server replica create --replica-name testReplicaServer -g testGroup --source-server testserver --sku-name Standard_D4ds_v5 --storage-size 256
+    text: az postgres flexible-server replica create --replica-name testreplicaserver -g testGroup --source-server testserver --location testLocation
+  - name: Create a read replica 'testreplicaserver' for 'testserver' with custom --storage-size and --sku.
+    text: az postgres flexible-server replica create --replica-name testreplicaserver -g testGroup --source-server testserver --sku-name Standard_D4ds_v5 --storage-size 256
+  - name: Create a read replica 'testreplicaserver' for 'testserver', where 'testreplicaserver' is in a different resource group 'newTestGroup'. \\
+      Here --resource-group is for the read replica's resource group, and --source-server must be passed as resource ID.
+    text: >
+      az postgres flexible-server replica create --replica-name testreplicaserver -g newTestGroup \\
+        --source-server /subscriptions/{sourceSubscriptionId}/resourceGroups/{sourceResourceGroup}/providers/Microsoft.DBforPostgreSQL/flexibleServers/{sourceServerName} \\
+        --location testLocation
 """
 
 helps['postgres flexible-server replica list'] = """
@@ -780,22 +786,22 @@ helps['postgres flexible-server replica stop-replication'] = """
 type: command
 short-summary: Stop replication to a read replica and make it a read/write server.
 examples:
-  - name: Stop replication to 'testReplicaServer' and make it a read/write server.
-    text: az postgres flexible-server replica stop-replication -g testGroup -n testReplicaServer
+  - name: Stop replication to 'testreplicaserver' and make it a read/write server.
+    text: az postgres flexible-server replica stop-replication -g testGroup -n testreplicaserver
 """
 
 helps['postgres flexible-server replica promote'] = """
 type: command
 short-summary: Stop replication of a read replica and promote it to an independent server or as a primary server.
 examples:
-  - name: Stop replication to 'testReplicaServer' and promote it a standalone read/write server.
-    text: az postgres flexible-server replica promote -g testGroup -n testReplicaServer
-  - name: Stop replication to 'testReplicaServer' and promote it a standalone read/write server with forced data sync.
-    text: az postgres flexible-server replica promote -g testGroup -n testReplicaServer --promote-mode standalone --promote-option forced
+  - name: Stop replication to 'testreplicaserver' and promote it a standalone read/write server.
+    text: az postgres flexible-server replica promote -g testGroup -n testreplicaserver
+  - name: Stop replication to 'testreplicaserver' and promote it a standalone read/write server with forced data sync.
+    text: az postgres flexible-server replica promote -g testGroup -n testreplicaserver --promote-mode standalone --promote-option forced
   - name: >
-      Stop replication to 'testReplicaServer' and promote it to primary server with planned data sync. \
+      Stop replication to 'testreplicaserver' and promote it to primary server with planned data sync. \
       The replica you are promoting must have the reader virtual endpoint assigned, or you will receive an error on promotion.
-    text: az postgres flexible-server replica promote -g testGroup -n testReplicaServer --promote-mode switchover --promote-option planned
+    text: az postgres flexible-server replica promote -g testGroup -n testreplicaserver --promote-mode switchover --promote-option planned
 """
 
 helps['postgres flexible-server geo-restore'] = """
@@ -815,7 +821,7 @@ examples:
         --private-dns-zone testDNS.postgres.database.azure.com --location newLocation
   - name: >
       Geo-restore 'testserver' to current point-in-time as a new server 'testserverNew' in a different subscription / resource group. \\
-      Here --restore-group is for the target server's resource group, and --source-server must be passed as resource ID. \\
+      Here --resource-group is for the target server's resource group, and --source-server must be passed as resource ID. \\
       This resource ID can be in a subscription different than the subscription used for az account set.
     text: >
       az postgres flexible-server geo-restore --resource-group testGroup --name testserverNew --location newLocation \\

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
@@ -220,7 +220,7 @@ def flexible_server_restore(cmd, client,
 
         pg_byok_validator(byok_identity, byok_key, backup_byok_identity, backup_byok_key, geo_redundant_backup)
 
-        instance = client.get(resource_group_name, id_parts['name'])
+        instance = client.get(id_parts['resource_group'], id_parts['name'])
         storage = postgresql_flexibleservers.models.Storage(type=storage_type if instance.storage.type != "PremiumV2_LRS" else None)
 
         parameters = postgresql_flexibleservers.models.Server(


### PR DESCRIPTION
**Related command**
`az postgres flexible-server replica create`

**Description**<!--Mandatory-->
FSPG replica create help page shall have example about how to create Replica in different resource group.
Correct examples to use all lowercase for server names.
Correct spelling mistakes.
Use id_parts to get resource group.

**Testing Guide**
Proof example works:
az postgres flexible-server replica create **--replica-name nas-503-rep -g rmendizabal** --source-server /subscriptions/s/resourceGroups/nasc-runner/providers/Microsoft.DBforPostgreSQL/flexibleServers/nasc-pg812 --location testlocation
{
   ...
  "id": "/subscriptions/s/**resourceGroups/rmendizabal**/providers/Microsoft.DBforPostgreSQL/flexibleServers/**nas-503-rep**",
  ...
  "sourceServerResourceId": "/subscriptions/s/resourceGroups/nasc-runner/providers/Microsoft.DBforPostgreSQL/flexibleServers/nasc-pg812",


