### PR TITLE
[SQL] `az sql elastic-pool create`: Set `min_capacity` to `None` for non-serverless SKUs

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/sql/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/custom.py
@@ -3775,6 +3775,11 @@ def elastic_pool_create(
     # using capabilities.
     kwargs['sku'] = _find_elastic_pool_sku_from_capabilities(cmd.cli_ctx, kwargs['location'], sku)
 
+    # The min_capacity property is only applicable to serverless SKUs.
+    #
+    if not _is_serverless_slo(kwargs['sku'].name):
+        kwargs['min_capacity'] = None
+
     # Expand maintenance configuration id if needed
     kwargs['maintenance_configuration_id'] = _complete_maintenance_configuration_id(
         cmd.cli_ctx,

--- a/src/azure-cli/azure/cli/command_modules/sql/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/custom.py
@@ -3777,7 +3777,7 @@ def elastic_pool_create(
 
     # The min_capacity property is only applicable to serverless SKUs.
     #
-    if not _is_serverless_slo(kwargs['sku'].name):
+    if kwargs['sku'] is not None and not _is_serverless_slo(kwargs['sku'].name):
         kwargs['min_capacity'] = None
 
     # Expand maintenance configuration id if needed


### PR DESCRIPTION
**Related command**
`az sql elastic-pool create --db-dtu-min 20`
`az sql elastic-pool create --db-max-capacity 0.5`

**Description**
Requests to create elastic pools of SKUs that are not serverless should not contain the `min_capacity` property. Hence, this changeset sets it to `None` in those cases.

**Testing Guide**
Create an elastic pool either with the DTU or vCore model and pass the corresponding parameter to set the per-database min_capacity. With this fix, see how that parameter now only applies to the database, as expected.

```
az sql elastic-pool create -g test-rg -s test-svr --name stdpool3 --edition Standard --dtu 1200 --db-dtu-min 20 --db-dtu-max 100 --storage 1200GB
```
```
az sql elastic-pool create -g test-rg -s test-svr --name stdpool4 --edition GeneralPurpose --family Gen5 --capacity 4 --db-min-capacity 0.5 --db-max-capacity 2 --storage 120GB
```

**History Notes**
[SQL] `az sql elastic-pool create`: Set `min_capacity` to `None` for non-serverless SKUs

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
