### PR TITLE
{Packaging} Add `pip` to dependency

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -58,6 +58,7 @@ DEPENDENCIES = [
     'msrestazure~=0.6.4',
     'packaging>=20.9',
     'paramiko>=2.0.8,<4.0.0',
+    'pip',  # Homebrew does not install pip in venv, `az extension add` needs it
     'pkginfo>=1.5.0.1',
     # psutil can't install on cygwin: https://github.com/Azure/azure-cli/issues/9399
     'psutil>=5.9; sys_platform != "cygwin"',


### PR DESCRIPTION
Homebrew stops install `pip` in Python 3.12 venv(https://github.com/Homebrew/brew/pull/16306), which is needed in `az extension add`.

Ref: https://github.com/orgs/Homebrew/discussions/5600