### PR TITLE
{Core} Decouple MSAL credentials from SDK `get_token` protocol

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -11,6 +11,7 @@ from enum import Enum
 from azure.cli.core._session import ACCOUNT
 from azure.cli.core.azclierror import AuthenticationError
 from azure.cli.core.cloud import get_active_cloud, set_cloud_subscription
+from azure.cli.core.auth.credential_adaptor import CredentialAdaptor
 from azure.cli.core.util import in_cloud_console, can_launch_browser, is_github_codespaces
 from knack.log import get_logger
 from knack.util import CLIError
@@ -313,9 +314,10 @@ class Profile:
         import jwt
         identity_type = MsiAccountTypes.system_assigned
         from .auth.msal_credentials import ManagedIdentityCredential
+        from .auth.constants import ACCESS_TOKEN
 
         cred = ManagedIdentityCredential()
-        token = cred.get_token(*self._arm_scope).token
+        token = cred.acquire_token(self._arm_scope)[ACCESS_TOKEN]
         logger.info('Managed identity: token was retrieved. Now trying to initialize local accounts...')
         decode = jwt.decode(token, algorithms=['RS256'], options={"verify_signature": False})
         tenant = decode['tid']
@@ -339,9 +341,10 @@ class Profile:
     def login_in_cloud_shell(self):
         import jwt
         from .auth.msal_credentials import CloudShellCredential
+        from .auth.constants import ACCESS_TOKEN
 
         cred = CloudShellCredential()
-        token = cred.get_token(*self._arm_scope).token
+        token = cred.acquire_token(self._arm_scope)[ACCESS_TOKEN]
         logger.info('Cloud Shell token was retrieved. Now trying to initialize local accounts...')
         decode = jwt.decode(token, algorithms=['RS256'], options={"verify_signature": False})
         tenant = decode['tid']
@@ -397,21 +400,19 @@ class Profile:
         if in_cloud_console() and account[_USER_ENTITY].get(_CLOUD_SHELL_ID):
             # Cloud Shell
             from .auth.msal_credentials import CloudShellCredential
-            from azure.cli.core.auth.credential_adaptor import CredentialAdaptor
             # The credential must be wrapped by CredentialAdaptor so that it can work with Track 1 SDKs.
-            cred = CredentialAdaptor(CloudShellCredential())
+            sdk_cred = CredentialAdaptor(CloudShellCredential())
 
         elif managed_identity_type:
             # managed identity
             if _on_azure_arc():
                 from .auth.msal_credentials import ManagedIdentityCredential
-                from azure.cli.core.auth.credential_adaptor import CredentialAdaptor
                 # The credential must be wrapped by CredentialAdaptor so that it can work with Track 1 SDKs.
-                cred = CredentialAdaptor(ManagedIdentityCredential())
+                sdk_cred = CredentialAdaptor(ManagedIdentityCredential())
             else:
                 # The resource is merely used by msrestazure to get the first access token.
                 # It is not actually used in an API invocation.
-                cred = MsiAccountTypes.msi_auth_factory(
+                sdk_cred = MsiAccountTypes.msi_auth_factory(
                     managed_identity_type, managed_identity_id,
                     self.cli_ctx.cloud.endpoints.active_directory_resource_id)
 
@@ -431,10 +432,9 @@ class Profile:
             external_credentials = []
             for external_tenant in external_tenants:
                 external_credentials.append(self._create_credential(account, tenant_id=external_tenant))
-            from azure.cli.core.auth.credential_adaptor import CredentialAdaptor
-            cred = CredentialAdaptor(credential, auxiliary_credentials=external_credentials)
+            sdk_cred = CredentialAdaptor(credential, auxiliary_credentials=external_credentials)
 
-        return (cred,
+        return (sdk_cred,
                 str(account[_SUBSCRIPTION_ID]),
                 str(account[_TENANT_ID]))
 
@@ -460,7 +460,7 @@ class Profile:
             if tenant:
                 raise CLIError("Tenant shouldn't be specified for Cloud Shell account")
             from .auth.msal_credentials import CloudShellCredential
-            cred = CloudShellCredential()
+            sdk_cred = CredentialAdaptor(CloudShellCredential())
 
         elif managed_identity_type:
             # managed identity
@@ -468,16 +468,16 @@ class Profile:
                 raise CLIError("Tenant shouldn't be specified for managed identity account")
             if _on_azure_arc():
                 from .auth.msal_credentials import ManagedIdentityCredential
-                cred = ManagedIdentityCredential()
+                sdk_cred = CredentialAdaptor(ManagedIdentityCredential())
             else:
                 from .auth.util import scopes_to_resource
-                cred = MsiAccountTypes.msi_auth_factory(managed_identity_type, managed_identity_id,
-                                                        scopes_to_resource(scopes))
+                sdk_cred = MsiAccountTypes.msi_auth_factory(managed_identity_type, managed_identity_id,
+                                                            scopes_to_resource(scopes))
 
         else:
-            cred = self._create_credential(account, tenant_id=tenant)
+            sdk_cred = CredentialAdaptor(self._create_credential(account, tenant_id=tenant))
 
-        sdk_token = cred.get_token(*scopes)
+        sdk_token = sdk_cred.get_token(*scopes)
         # Convert epoch int 'expires_on' to datetime string 'expiresOn' for backward compatibility
         # WARNING: expiresOn is deprecated and will be removed in future release.
         import datetime
@@ -856,7 +856,6 @@ class SubscriptionFinder:
             specific_tenant_credential = identity.get_user_credential(username)
 
             try:
-
                 subscriptions = self.find_using_specific_tenant(tenant_id, specific_tenant_credential,
                                                                 tenant_id_description=t)
             except AuthenticationError as ex:
@@ -927,9 +926,9 @@ class SubscriptionFinder:
             raise CLIInternalError("Unable to get '{}' in profile '{}'"
                                    .format(ResourceType.MGMT_RESOURCE_SUBSCRIPTIONS, self.cli_ctx.cloud.profile))
         api_version = get_api_version(self.cli_ctx, ResourceType.MGMT_RESOURCE_SUBSCRIPTIONS)
-        client_kwargs = _prepare_mgmt_client_kwargs_track2(self.cli_ctx, credential)
-
-        client = client_type(credential, api_version=api_version,
+        sdk_cred = CredentialAdaptor(credential)
+        client_kwargs = _prepare_mgmt_client_kwargs_track2(self.cli_ctx, sdk_cred)
+        client = client_type(sdk_cred, api_version=api_version,
                              base_url=self.cli_ctx.cloud.endpoints.resource_manager,
                              **client_kwargs)
         return client

--- a/src/azure-cli-core/azure/cli/core/auth/constants.py
+++ b/src/azure-cli-core/azure/cli/core/auth/constants.py
@@ -4,3 +4,6 @@
 # --------------------------------------------------------------------------------------------
 
 AZURE_CLI_CLIENT_ID = '04b07795-8ddb-461a-bbee-02f9e1bf7b46'
+
+ACCESS_TOKEN = 'access_token'
+EXPIRES_IN = "expires_in"

--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -192,9 +192,8 @@ class Identity:  # pylint: disable=too-many-instance-attributes
         """
         sp_auth = ServicePrincipalAuth.build_from_credential(self.tenant_id, client_id, credential)
         client_credential = sp_auth.get_msal_client_credential()
-        cca = ConfidentialClientApplication(client_id, client_credential=client_credential, **self._msal_app_kwargs)
-        result = cca.acquire_token_for_client(scopes)
-        check_result(result)
+        cred = ServicePrincipalCredential(client_id, client_credential, **self._msal_app_kwargs)
+        cred.acquire_token(scopes)
 
         # Only persist the service principal after a successful login
         entry = sp_auth.get_entry_to_persist()

--- a/src/azure-cli-core/azure/cli/core/auth/msal_credentials.py
+++ b/src/azure-cli-core/azure/cli/core/auth/msal_credentials.py
@@ -4,16 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 """
-Credentials defined in this module are alternative implementations of credentials provided by Azure Identity.
-
-These credentials implement azure.core.credentials.TokenCredential by exposing `get_token` method for Track 2
-SDK invocation.
-
-If you want to implement your own credential, the credential must also expose `get_token` method.
-
-`get_token` method takes `scopes` as positional arguments and other optional `kwargs`, such as `claims`, `data`.
-The return value should be a named tuple containing two elements: token (str), expires_on (int). You may simply use
-azure.cli.core.auth.util.AccessToken to build the return value. See below credentials as examples.
+Credentials to acquire tokens from MSAL.
 """
 
 from knack.log import get_logger
@@ -22,7 +13,7 @@ from msal import (PublicClientApplication, ConfidentialClientApplication,
                   ManagedIdentityClient, SystemAssignedManagedIdentity)
 
 from .constants import AZURE_CLI_CLIENT_ID
-from .util import check_result, build_sdk_access_token
+from .util import check_result
 
 logger = get_logger(__name__)
 
@@ -30,7 +21,7 @@ logger = get_logger(__name__)
 class UserCredential:  # pylint: disable=too-few-public-methods
 
     def __init__(self, client_id, username, **kwargs):
-        """User credential implementing get_token interface.
+        """User credential wrapping msal.application.PublicClientApplication
 
         :param client_id: Client ID of the CLI.
         :param username: The username for user credential.
@@ -52,14 +43,16 @@ class UserCredential:  # pylint: disable=too-few-public-methods
 
         self._account = accounts[0]
 
-    def get_token(self, *scopes, claims=None, **kwargs):
-        # scopes = ['https://pas.windows.net/CheckMyAccess/Linux/.default']
-        logger.debug("UserCredential.get_token: scopes=%r, claims=%r, kwargs=%r", scopes, claims, kwargs)
+    def acquire_token(self, scopes, claims=None, **kwargs):
+        # scopes must be a list.
+        # For acquiring SSH certificate, scopes is ['https://pas.windows.net/CheckMyAccess/Linux/.default']
+        # kwargs is already sanitized by CredentialAdaptor, so it can be safely passed to MSAL
+        logger.debug("UserCredential.acquire_token: scopes=%r, claims=%r, kwargs=%r", scopes, claims, kwargs)
 
         if claims:
             logger.warning('Acquiring new access token silently for tenant %s with claims challenge: %s',
                            self._msal_app.authority.tenant, claims)
-        result = self._msal_app.acquire_token_silent_with_error(list(scopes), self._account, claims_challenge=claims,
+        result = self._msal_app.acquire_token_silent_with_error(scopes, self._account, claims_challenge=claims,
                                                                 **kwargs)
 
         from azure.cli.core.azclierror import AuthenticationError
@@ -82,7 +75,7 @@ class UserCredential:  # pylint: disable=too-few-public-methods
                 success_template, error_template = read_response_templates()
 
                 result = self._msal_app.acquire_token_interactive(
-                    list(scopes), login_hint=self._account['username'],
+                    scopes, login_hint=self._account['username'],
                     port=8400 if self._msal_app.authority.is_adfs else None,
                     success_template=success_template, error_template=error_template, **kwargs)
                 check_result(result)
@@ -91,25 +84,24 @@ class UserCredential:  # pylint: disable=too-few-public-methods
             # launch browser, but show the error message and `az login` command instead.
             else:
                 raise
-        return build_sdk_access_token(result)
+        return result
 
 
 class ServicePrincipalCredential:  # pylint: disable=too-few-public-methods
 
     def __init__(self, client_id, client_credential, **kwargs):
-        """Service principal credential implementing get_token interface.
+        """Service principal credential wrapping msal.application.ConfidentialClientApplication.
 
         :param client_id: The service principal's client ID.
         :param client_credential: client_credential that will be passed to MSAL.
         """
-        self._msal_app = ConfidentialClientApplication(client_id, client_credential, **kwargs)
+        self._msal_app = ConfidentialClientApplication(client_id, client_credential=client_credential, **kwargs)
 
-    def get_token(self, *scopes, **kwargs):
-        logger.debug("ServicePrincipalCredential.get_token: scopes=%r, kwargs=%r", scopes, kwargs)
-
-        result = self._msal_app.acquire_token_for_client(list(scopes), **kwargs)
+    def acquire_token(self, scopes, **kwargs):
+        logger.debug("ServicePrincipalCredential.acquire_token: scopes=%r, kwargs=%r", scopes, kwargs)
+        result = self._msal_app.acquire_token_for_client(scopes, **kwargs)
         check_result(result)
-        return build_sdk_access_token(result)
+        return result
 
 
 class CloudShellCredential:  # pylint: disable=too-few-public-methods
@@ -126,12 +118,11 @@ class CloudShellCredential:  # pylint: disable=too-few-public-methods
             #   token_cache=...
         )
 
-    def get_token(self, *scopes, **kwargs):
-        logger.debug("CloudShellCredential.get_token: scopes=%r, kwargs=%r", scopes, kwargs)
-        # kwargs is already sanitized by CredentialAdaptor, so it can be safely passed to MSAL
-        result = self._msal_app.acquire_token_interactive(list(scopes), prompt="none", **kwargs)
+    def acquire_token(self, scopes, **kwargs):
+        logger.debug("CloudShellCredential.acquire_token: scopes=%r, kwargs=%r", scopes, kwargs)
+        result = self._msal_app.acquire_token_interactive(scopes, prompt="none", **kwargs)
         check_result(result, scopes=scopes)
-        return build_sdk_access_token(result)
+        return result
 
 
 class ManagedIdentityCredential:  # pylint: disable=too-few-public-methods
@@ -143,10 +134,10 @@ class ManagedIdentityCredential:  # pylint: disable=too-few-public-methods
         import requests
         self._msal_client = ManagedIdentityClient(SystemAssignedManagedIdentity(), http_client=requests.Session())
 
-    def get_token(self, *scopes, **kwargs):
-        logger.debug("ManagedIdentityCredential.get_token: scopes=%r, kwargs=%r", scopes, kwargs)
+    def acquire_token(self, scopes, **kwargs):
+        logger.debug("ManagedIdentityCredential.acquire_token: scopes=%r, kwargs=%r", scopes, kwargs)
 
         from .util import scopes_to_resource
         result = self._msal_client.acquire_token_for_client(resource=scopes_to_resource(scopes))
         check_result(result)
-        return build_sdk_access_token(result)
+        return result

--- a/src/azure-cli-core/azure/cli/core/auth/util.py
+++ b/src/azure-cli-core/azure/cli/core/auth/util.py
@@ -140,9 +140,6 @@ def check_result(result, **kwargs):
 
 
 def build_sdk_access_token(token_entry):
-    import time
-    request_time = int(time.time())
-
     # MSAL token entry sample:
     # {
     #     'access_token': 'eyJ0eXAiOiJKV...',
@@ -153,7 +150,8 @@ def build_sdk_access_token(token_entry):
     # Importing azure.core.credentials.AccessToken is expensive.
     # This can slow down commands that doesn't need azure.core, like `az account get-access-token`.
     # So We define our own AccessToken.
-    return AccessToken(token_entry["access_token"], request_time + token_entry["expires_in"])
+    from .constants import ACCESS_TOKEN, EXPIRES_IN
+    return AccessToken(token_entry[ACCESS_TOKEN], _now_timestamp() + token_entry[EXPIRES_IN])
 
 
 def decode_access_token(access_token):
@@ -177,3 +175,8 @@ def read_response_templates():
         error_template = f.read()
 
     return success_template, error_template
+
+
+def _now_timestamp():
+    import time
+    return int(time.time())

--- a/src/azure-cli-testsdk/azure/cli/testsdk/patches.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/patches.py
@@ -68,16 +68,16 @@ def patch_retrieve_token_for_user(unit_test):
             def __init__(self, *args, **kwargs):
                 super().__init__()
 
-            def get_token(self, *scopes, **kwargs):  # pylint: disable=unused-argument
+            def acquire_token(self, scopes, **kwargs):  # pylint: disable=unused-argument
                 # Old Track 2 SDKs are no longer supported. https://github.com/Azure/azure-cli/pull/29690
                 assert len(scopes) == 1, "'scopes' must contain only one element."
-
-                from azure.core.credentials import AccessToken
-                import time
                 fake_raw_token = 'top-secret-token-for-you'
-                now = int(time.time())
-                return AccessToken(fake_raw_token, now + 3600)
-
+                return {
+                    'access_token': fake_raw_token,
+                    'token_type': 'Bearer',
+                    'expires_in': 1800,
+                    'token_source': 'cache'
+                }
         return UserCredentialMock()
 
     mock_in_unit_test(unit_test, 'azure.cli.core.auth.identity.Identity.get_user_credential', get_user_credential_mock)


### PR DESCRIPTION
## Description

This PR mainly changes the functionality and logic of MSAL credentials and `CredentialAdaptor`:

### MSAL credentials
Decouple MSAL credentials from SDK's `get_token` protocol. Make MSAL credentials implement `acquire_token` and return MSAL token `dict`.

### `CredentialAdaptor`

`CredentialAdaptor` was initially introduced as an adaptor for both Track 1 and Track 2 SDKs by implementing both `signed_session` and `get_token` protocol. As Track 1 SDK and `signed_session` support has been dropped (https://github.com/Azure/azure-cli/pull/29631), `CredentialAdaptor` is now repurposed as an adaptor between Track 2 SDK and MSAL credentials. So we move `AccessToken`'s building logic to `CredentialAdaptor` and make `CredentialAdaptor` implement `get_token()`.

In the future, `CredentialAdaptor` will be changed to implement the new `get_token_info()` protocol (https://github.com/Azure/azure-sdk-for-python/pull/36565, https://github.com/Azure/azure-sdk-for-python/pull/36882).