### PR TITLE
{RDBMS} Removes print of params object in postgres flexible-server update

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
@@ -405,7 +405,6 @@ def flexible_server_update_custom_func(cmd, client, instance,
 
         params.high_availability = high_availability_param
 
-    print(params)
     return params
 
 


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az postgres flexible-server update`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Removes a `print` call to remove a python object being dumped in stout while using the cli

**Testing Guide**
<!--Example commands with explanations.-->

Before fix:
```sh
az postgres flexible-server update \
  --name server1 \
  --resource-group rg1 \
  --private-dns-zone private.postgres.database.azure.com
Using the existing private dns zone private.postgres.database.azure.com in resource group "rg1"
{'additional_properties': {}, 'sku': <azure.mgmt.rdbms.postgresql_flexibleservers.models._models_py3.Sku object at 0x1078f7450>, 'identity': None, 'tags': None, 'administrator_login_password': None, 'version': None, 'storage': <azure.mgmt.rdbms.postgresql_flexibleservers.models._models_py3.Storage object at 0x1078f73d0>, 'backup': <azure.mgmt.rdbms.postgresql_flexibleservers.models._models_py3.Backup object at 0x1078f7710>, 'high_availability': None, 'maintenance_window': <azure.mgmt.rdbms.postgresql_flexibleservers.models._models_py3.MaintenanceWindow object at 0x107901bd0>, 'auth_config': <azure.mgmt.rdbms.postgresql_flexibleservers.models._models_py3.AuthConfig object at 0x1078f5090>, 'data_encryption': None, 'create_mode': None, 'replication_role': None, 'replica': None, 'network': <azure.mgmt.rdbms.postgresql_flexibleservers.models._models_py3.Network object at 0x1078b0f10>}
{
  "administratorLogin": "adminuser",
  ...
}
```

After fix:
```sh
az postgres flexible-server update \
  --name server1 \
  --resource-group rg1 \
  --private-dns-zone private.postgres.database.azure.com
Using the existing private dns zone private.postgres.database.azure.com in resource group "rg1"
{
  "administratorLogin": "adminuser",
  ...
}
```

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->
{RDBMS} Removes print of params object in postgres flexible-server update

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
