### PR TITLE
{CI} Use macOS-14 agent

### DIFF
--- a/.azure-pipelines/templates/variables.yml
+++ b/.azure-pipelines/templates/variables.yml
@@ -2,4 +2,4 @@ variables:
   ubuntu_pool: 'pool-ubuntu-2004'
   windows_pool: 'pool-windows-2019'
   ubuntu_arm64_pool: 'ubuntu-arm64-2004-pool'
-  macos_pool: 'macOS-12'
+  macos_pool: 'macOS-14'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -138,7 +138,7 @@ jobs:
   displayName: 'Verify src/azure-cli/requirements.*.Darwin.txt'
   condition: succeeded()
   pool:
-    vmImage: 'macOS-12'
+    vmImage: ${{ variables.macos_pool }}
 
   steps:
   - task: UsePythonVersion@0
@@ -633,7 +633,7 @@ jobs:
   dependsOn: BuildHomebrewFormula
   condition: succeeded()
   pool:
-    vmImage: 'macOS-12'
+    vmImage: ${{ variables.macos_pool }}
   steps:
   - task: DownloadPipelineArtifact@1
     displayName: 'Download Metadata'
@@ -677,7 +677,7 @@ jobs:
   # condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual', 'Schedule'))
   condition: false
   pool:
-    vmImage: 'macOS-12'
+    vmImage: ${{ variables.macos_pool }}
   steps:
   - task: DownloadPipelineArtifact@1
     displayName: 'Download Metadata'


### PR DESCRIPTION
Test homebrew task fails because macos12 is deprecated.
```
Error: You are using macOS 12.
We (and Apple) do not provide support for this old version.
It is expected behaviour that some formulae will fail to build in this old version.
It is expected behaviour that Homebrew will be buggy and slow.
```
Homebrew can't be installed on macOS 12: https://github.com/Homebrew/brew/pull/18323

Ref:
- https://dev.azure.com/azclitools/public/_build/results?buildId=192519&view=logs&j=cc48ae93-a624-59ff-8a3e-2ebdb4b89e58&t=acd97aa3-1ffd-5990-e2c3-4ea47f198c07
- https://github.com/orgs/Homebrew/discussions/5603