### PR TITLE
[Compute] Fix issue 30009: az vm install-patches fix errors due to typos in install_patches function.

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -5382,7 +5382,7 @@ def set_disk_access(cmd, client, parameters, resource_group_name, disk_access_na
 def install_vm_patches(cmd, client, resource_group_name, vm_name, maximum_duration, reboot_setting, classifications_to_include_win=None, classifications_to_include_linux=None, kb_numbers_to_include=None, kb_numbers_to_exclude=None,
                        exclude_kbs_requiring_reboot=None, package_name_masks_to_include=None, package_name_masks_to_exclude=None, max_patch_publish_date=None, no_wait=False):
     VMInstallPatchesParameters, WindowsParameters, LinuxParameters = cmd.get_models('VirtualMachineInstallPatchesParameters', 'WindowsParameters', 'LinuxParameters')
-    windows_parameters = WindowsParameters(classifications_to_include=classifications_to_include_win, kb_numbers_to_inclunde=kb_numbers_to_include, kb_numbers_to_exclude=kb_numbers_to_exclude, exclude_kbs_requirig_reboot=exclude_kbs_requiring_reboot, max_patch_publish_date=max_patch_publish_date)
+    windows_parameters = WindowsParameters(classifications_to_include=classifications_to_include_win, kb_numbers_to_include=kb_numbers_to_include, kb_numbers_to_exclude=kb_numbers_to_exclude, exclude_kbs_requiring_reboot=exclude_kbs_requiring_reboot, max_patch_publish_date=max_patch_publish_date)
     linux_parameters = LinuxParameters(classifications_to_include=classifications_to_include_linux, package_name_masks_to_include=package_name_masks_to_include, package_name_masks_to_exclude=package_name_masks_to_exclude)
     install_patches_input = VMInstallPatchesParameters(maximum_duration=maximum_duration, reboot_setting=reboot_setting, linux_parameters=linux_parameters, windows_parameters=windows_parameters)
 


### PR DESCRIPTION
Fix #30009.


**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az vm install-patches

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Install_patches has paramerters with typos and throw the following error: Error given: kb_numbers_to_inclunde is not a known attribute of class <class 'azure.mgmt.compute.v2024_03_01.models._models_py3.WindowsParameters'> and will be ignored

exclude_kbs_requirig_reboot is not a known attribute of class <class 'azure.mgmt.compute.v2024_03_01.models._models_py3.WindowsParameters'> and will be ignored


Parameters should be kb_numbers_to_include and exclude_kbs_requiring_reboot respectively

Original pull request containing typos:
https://github.com/Azure/azure-cli/pull/17549/commits/3a5091e96092fa563e985df6b0339ba6ebc6ae66

**Testing Guide**
<!--Example commands with explanations.-->
 az vm install-patches --resource-group Repo --name myVM --maximum-duration PT4H --re
boot-setting IfRequired

give error:
kb_numbers_to_inclunde is not a known attribute of class <class 'azure.mgmt.compute.v2024_07_01.models._models_py3.WindowsParameters'> and will be ignored

exclude_kbs_requirig_reboot is not a known attribute of class <class 'azure.mgmt.compute.v2024_07_01.models._models_py3.WindowsParameters'> and will be ignored


**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
