### PR TITLE
[Misc] homebrew: Generate shell completions for bash, fish, and zsh

### DIFF
--- a/scripts/release/homebrew/docker/formula_template.txt
+++ b/scripts/release/homebrew/docker/formula_template.txt
@@ -50,7 +50,8 @@ class AzureCli < Formula
       AZ_INSTALLER=HOMEBREW #{libexec}/bin/python -Im azure.cli \"$@\"
     EOS
 
-    bash_completion.install "az.completion" => "az"
+    generate_completions_from_executable(libexec/"bin/register-python-argcomplete", "az",
+                                         base_name: "az", shell_parameter_format: :arg)
   end
 
   test do


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

Misc

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

This switches to generate the completion with `register-python-argcomplete` directly, similarly to other Python tools like pipx in Homebrew.

The `az.completion.sh` script is not the actual completion, but runs `eval`: https://github.com/Azure/azure-cli/blob/3194af8f245f6d7e30ad70813c58eef779142482/src/azure-cli/az.completion.sh#L11

This also adds completion support for zsh and fish.

Initially raised at Homebrew/homebrew-core#192912, but it was pointed out that the source of truth is here.

**Testing Guide**
<!--Example commands with explanations.-->

Follow https://github.com/Homebrew/homebrew-core/blob/9ce8743dc3ea3a130f80dc2c120e896c7eaf47a0/CONTRIBUTING.md#to-contribute-a-fix-to-the-foo-formula

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Misc] homebrew: Generate shell completions for bash, fish, and zsh

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
