### PR TITLE
[bicep] Correction in generate-params --help, RequiredOnly is the correct value

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_params.py
@@ -836,7 +836,7 @@ def load_arguments(self, _):
         c.argument('stdout', arg_type=bicep_stdout_type)
         c.argument('no_restore', arg_type=bicep_no_restore_type, help="When set, generates the parameters file without restoring external modules.")
         c.argument('output_format', help="Set output format. Valid values are ( json | bicepparam ).")
-        c.argument('include_params', help="Set include params. Valid values are ( all | required-only ).")
+        c.argument('include_params', help="Set include params. Valid values are ( all | RequiredOnly ).")
 
     with self.argument_context('bicep lint') as c:
         c.argument('file', arg_type=bicep_file_type, help="The path to the Bicep module file to lint in the file system.")


### PR DESCRIPTION
**Related command**
az bicep generate-params --help

**Description**
Minor error in the --help, it currently says required-only but it should be RequiredOnly.

**Testing Guide**
`az bicep generate-params -f main.bicep --output-format bicepparam --include-params  required-only`

The --include-params parameter only accepts values: RequiredOnly | All


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
