### PR TITLE
[Container App] Fix #29980: `az containerapp`: Polling animation should use `stdout` rather than `stderr`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/containerapp/_clients.py
+++ b/src/azure-cli/azure/cli/command_modules/containerapp/_clients.py
@@ -31,15 +31,15 @@ class PollingAnimation():
         self.currTicker = 0
 
     def tick(self):
-        sys.stderr.write('\r')
-        sys.stderr.write(self.tickers[self.currTicker] + " Running ..")
-        sys.stderr.flush()
+        sys.stdout.write('\r')
+        sys.stdout.write(self.tickers[self.currTicker] + " Running ..")
+        sys.stdout.flush()
         self.currTicker += 1
         self.currTicker = self.currTicker % len(self.tickers)
 
     def flush(self):
-        sys.stderr.flush()
-        sys.stderr.write("\r\033[K")
+        sys.stdout.flush()
+        sys.stdout.write("\r\033[K")
 
 
 def poll_status(cmd, request_url):  # pylint: disable=inconsistent-return-statements


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
Fix issue: https://github.com/Azure/azure-cli/issues/29980

The ##[error]
/ Running ..
| Running ..

was log with `sys.stderr` when polling the result of updating containerapp:
https://github.com/Azure/azure-cli/blob/095d5249b248b4f6a7df603526a69080523e3f0a/src/azure-cli/azure/cli/command_modules/containerapp/_clients.py#L35

It should not use `sys.stderr`, it should be `sys.stdout`.


**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).

