### PR TITLE
Update Homebrew formula to support Python 3.12

### DIFF
--- a/scripts/release/homebrew/docker/formula_generate.py
+++ b/scripts/release/homebrew/docker/formula_generate.py
@@ -19,7 +19,7 @@ TEMPLATE_FILE_NAME = 'formula_template.txt'
 CLI_VERSION = os.environ['CLI_VERSION']
 HOMEBREW_UPSTREAM_URL = os.environ['HOMEBREW_UPSTREAM_URL']
 HOMEBREW_FORMULAR_LATEST = "https://raw.githubusercontent.com/Homebrew/homebrew-core/master/Formula/a/azure-cli.rb"
-PYTHON_VERSION = '3.11'
+PYTHON_VERSION = '3.12'
 
 
 def main():


### PR DESCRIPTION
Homebrew packaging script update.

az cli now supports Python 3.12, so can this Homebrew bottle build script be updated so it no longer lists Py3.11 as a requirement?

Not sure if https://github.com/Azure/azure-cli/blob/dev/scripts/release/homebrew/docker/formula_template.txt#L20 also needs to be bumped?

Related:

- https://github.com/Homebrew/homebrew-core/pull/180221
- https://github.com/Azure/azure-cli/issues/27673
- https://github.com/Homebrew/homebrew-core/pull/192912
- [2.65.0 release notes → Packaging → _"Support Python 3.12"_](https://github.com/MicrosoftDocs/azure-docs-cli/blob/main/docs-ref-conceptual/release-notes-azure-cli.md#packaging-1)