### PR TITLE
{Core} Only pass `data` to MSAL as `kwargs`

### DIFF
--- a/src/azure-cli-core/azure/cli/core/auth/credential_adaptor.py
+++ b/src/azure-cli-core/azure/cli/core/auth/credential_adaptor.py
@@ -57,12 +57,13 @@ class CredentialAdaptor:
     def get_token(self, *scopes, **kwargs):
         logger.debug("CredentialAdaptor.get_token: scopes=%r, kwargs=%r", scopes, kwargs)
 
-        # SDK azure-keyvault-keys 4.5.0b5 passes tenant_id as kwargs, but we don't support tenant_id for now,
-        # so discard it.
-        kwargs.pop('tenant_id', None)
+        # Discard unsupported kwargs: tenant_id, enable_cae
+        filtered_kwargs = {}
+        if 'data' in kwargs:
+            filtered_kwargs['data'] = kwargs['data']
 
         scopes = _normalize_scopes(scopes)
-        token, _ = self._get_token(scopes, **kwargs)
+        token, _ = self._get_token(scopes, **filtered_kwargs)
         return token
 
     def get_auxiliary_tokens(self, *scopes, **kwargs):


### PR DESCRIPTION
**Description**<!--Mandatory-->
Azure CLI currently passes `kwargs` received by `get_token()` directly to MSAL. Since SDK is adding more keyword arguments, such as `enable_cae` (https://github.com/Azure/azure-sdk-for-python/pull/37358), this will cause failure as `enable_cae` is not recognized by MSAL.

This PR changes the behavior so that only `data` is passed to MSAL as `kwargs`.

Also see https://github.com/AzureAD/microsoft-authentication-library-for-python/issues/755

**Testing Guide**
1. Follow https://learn.microsoft.com/en-us/entra/identity/devices/howto-vm-sign-in-azure-ad-linux to enable connecting via Microsoft Entra ID and OpenSSH
2. `az extension add --name ssh`
3. `az ssh vm -n xxx -g xxx`