### PR TITLE
{core} `aaz`: fix aaz content builder `set_prop` for None value

### DIFF
--- a/src/azure-cli-core/azure/cli/core/aaz/_content_builder.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_content_builder.py
@@ -79,8 +79,9 @@ class AAZContentBuilder:
                             value[prop_name] = {}
                     else:
                         raise NotImplementedError()
-                sub_values.append(value[prop_name])
-                sub_args.append(sub_arg)
+                if value != None:
+                    sub_values.append(value[prop_name])
+                    sub_args.append(sub_arg)
 
         if sub_values:
             self._sub_prop_builders[prop_name] = AAZContentBuilder(sub_values, sub_args)

--- a/src/azure-cli-core/azure/cli/core/aaz/_content_builder.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_content_builder.py
@@ -79,7 +79,7 @@ class AAZContentBuilder:
                             value[prop_name] = {}
                     else:
                         raise NotImplementedError()
-                if value != None:
+                if value != None:  # noqa: E711, pylint: disable=singleton-comparison
                     sub_values.append(value[prop_name])
                     sub_args.append(sub_arg)
 


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

Fix None value when its sub property has not linked with arg_key
![image](https://github.com/user-attachments/assets/ac1afd60-ef9b-4ab0-b718-5aa775c85817)


**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
