### PR TITLE
{Profile} Update help message for arguments

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/profile/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/__init__.py
@@ -40,43 +40,67 @@ class ProfileCommandsLoader(AzCommandsLoader):
 
         return self.command_table
 
-    # pylint: disable=line-too-long
     def load_arguments(self, command):
         from azure.cli.core.api import get_subscription_id_list
 
         with self.argument_context('login') as c:
-            c.argument('password', options_list=['--password', '-p'], help="Credentials like user password, or for a service principal, provide client secret or a pem file with key and public certificate. Will prompt if not given.")
-            c.argument('service_principal', action='store_true', help='The credential representing a service principal.')
-            c.argument('username', options_list=['--username', '-u'], help='user name, service principal, or managed service identity ID')
-            c.argument('tenant', options_list=['--tenant', '-t'], help='The AAD tenant, must provide when using service principals.', validator=validate_tenant)
-            c.argument('allow_no_subscriptions', action='store_true', help="Support access tenants without subscriptions. It's uncommon but useful to run tenant level commands, such as 'az ad'")
+            c.argument('username', options_list=['--username', '-u'],
+                       help='User name, service principal client ID, or managed identity ID.')
+            c.argument('password', options_list=['--password', '-p'],
+                       help='Provide credentials such as a user password, a service principal secret or a PEM file '
+                            'with key and public certificate. Will prompt if not given.')
+            c.argument('tenant', options_list=['--tenant', '-t'], validator=validate_tenant,
+                       help='The Microsoft Entra tenant, must be provided when using a service principal.')
+            c.argument('scopes', options_list=['--scope'], nargs='+',
+                       help='Used in the /authorize request. It can cover only one static resource.')
+            c.argument('allow_no_subscriptions', action='store_true',
+                       help="Support accessing tenants without subscriptions. It's useful to run "
+                            "tenant-level commands, such as 'az ad'.")
             c.ignore('_subscription')  # hide the global subscription parameter
-            c.argument('identity', options_list=('-i', '--identity'), action='store_true', help="Log in using the Virtual Machine's identity", arg_group='Managed Service Identity')
-            c.argument('identity_port', type=int, help="the port to retrieve tokens for login. Default: 50342", arg_group='Managed Service Identity')
+
+            # Device code flow
             c.argument('use_device_code', action='store_true',
-                       help="Use CLI's old authentication flow based on device code. CLI will also use this if it can't launch a browser in your behalf, e.g. in remote SSH or Cloud Shell")
-            c.argument('use_cert_sn_issuer', action='store_true', help='used with a service principal configured with Subject Name and Issuer Authentication in order to support automatic certificate rolls')
-            c.argument('scopes', options_list=['--scope'], nargs='+', help='Used in the /authorize request. It can cover only one static resource.')
-            c.argument('client_assertion', options_list=['--federated-token'], help='Federated token that can be used for OIDC token exchange.')
+                       help="Use device code flow. Azure CLI will also use this if it can't launch a browser, "
+                            "e.g. in remote SSH or Cloud Shell.")
+
+            # Service principal
+            c.argument('service_principal', action='store_true',
+                       help='Log in with a service principal.')
+            c.argument('use_cert_sn_issuer', action='store_true',
+                       help='Use Subject Name + Issuer (SN+I) authentication in order to support automatic '
+                            'certificate rolls.')
+            c.argument('client_assertion', options_list=['--federated-token'],
+                       help='Federated token that can be used for OIDC token exchange.')
+
+            # Managed identity
+            c.argument('identity', options_list=('-i', '--identity'), action='store_true',
+                       help="Log in using managed identity", arg_group='Managed Identity')
 
         with self.argument_context('logout') as c:
             c.argument('username', help='account user, if missing, logout the current active account')
             c.ignore('_subscription')  # hide the global subscription parameter
 
         with self.argument_context('account') as c:
-            c.argument('subscription', options_list=['--subscription', '-s', '--name', '-n'], arg_group='', help='Name or ID of subscription.', completer=get_subscription_id_list)
+            c.argument('subscription', options_list=['--subscription', '-s', '--name', '-n'],
+                       completer=get_subscription_id_list, help='Name or ID of subscription.')
             c.ignore('_subscription')
 
         with self.argument_context('account list') as c:
-            c.argument('all', help="List all subscriptions from all clouds, rather than just 'Enabled' ones", action='store_true')
+            c.argument('all', action='store_true',
+                       help="List all subscriptions from all clouds, including subscriptions that are not 'Enabled'.")
             c.argument('refresh', help="retrieve up-to-date subscriptions from server", action='store_true')
             c.ignore('_subscription')  # hide the global subscription parameter
 
         with self.argument_context('account get-access-token') as c:
-            c.argument('resource_type', get_enum_type(cloud_resource_types), options_list=['--resource-type'], arg_group='', help='Type of well-known resource.')
-            c.argument('resource', options_list=['--resource'], help='Azure resource endpoints in AAD v1.0.')
-            c.argument('scopes', options_list=['--scope'], nargs='*', help='Space-separated AAD scopes in AAD v2.0. Default to Azure Resource Manager.')
-            c.argument('tenant', options_list=['--tenant', '-t'], help='Tenant ID for which the token is acquired. Only available for user and service principal account, not for MSI or Cloud Shell account')
+            c.argument('resource_type', get_enum_type(cloud_resource_types), options_list=['--resource-type'],
+                       help='Type of well-known resource.')
+            c.argument('resource', options_list=['--resource'],
+                       help='Azure resource endpoints in Microsoft Entra v1.0.')
+            c.argument('scopes', options_list=['--scope'], nargs='*',
+                       help='Space-separated scopes in Microsoft Entra v2.0. Default to Azure Resource Manager.')
+            c.argument('tenant', options_list=['--tenant', '-t'],
+                       help='Tenant ID for which the token is acquired. Only available for user and service principal '
+                            'account, not for managed identity or Cloud Shell account')
 
 
 COMMAND_LOADER_CLS = ProfileCommandsLoader

--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -115,8 +115,13 @@ def account_clear(cmd):
 
 
 # pylint: disable=inconsistent-return-statements, too-many-branches
-def login(cmd, username=None, password=None, service_principal=None, tenant=None, allow_no_subscriptions=False,
-          identity=False, use_device_code=False, use_cert_sn_issuer=None, scopes=None, client_assertion=None):
+def login(cmd, username=None, password=None, tenant=None, scopes=None, allow_no_subscriptions=False,
+          # Device code flow
+          use_device_code=False,
+          # Service principal
+          service_principal=None, use_cert_sn_issuer=None, client_assertion=None,
+          # Managed identity
+          identity=False):
     """Log in to access Azure subscriptions"""
 
     # quick argument usage check


### PR DESCRIPTION
**Related command**
`az login`

**Description**<!--Mandatory-->
Update help message for arguments, mainly including

1. Re-order the arguments to group them according to the identity type
2. Rename AAD to Microsoft Entra, similar to #27756
3. Rename MSI to managed identity: https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview
   > Managed identities for Azure resources is the new name for the service formerly known as Managed Service Identity (MSI).

**Testing Guide**
`az login -h`
