### PR TITLE
[Profile] `az login`: Add `--certificate` for authenticating with service principal certificate

### DIFF
--- a/src/azure-cli-core/azure/cli/core/auth/tests/test_identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/tests/test_identity.py
@@ -265,17 +265,23 @@ class TestServicePrincipalAuth(unittest.TestCase):
 
     def test_build_credential(self):
         # secret
-        cred = ServicePrincipalAuth.build_credential("test_secret")
+        cred = ServicePrincipalAuth.build_credential(secret_or_certificate="test_secret")
         assert cred == {"client_secret": "test_secret"}
 
         # secret with '~', which is preserved as-is
-        cred = ServicePrincipalAuth.build_credential("~test_secret")
+        cred = ServicePrincipalAuth.build_credential(secret_or_certificate="~test_secret")
         assert cred == {"client_secret": "~test_secret"}
+
+        # certificate as password (deprecated)
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        test_cert_file = os.path.join(current_dir, 'sp_cert.pem')
+        cred = ServicePrincipalAuth.build_credential(secret_or_certificate=test_cert_file)
+        assert cred == {'certificate': test_cert_file}
 
         # certificate
         current_dir = os.path.dirname(os.path.realpath(__file__))
         test_cert_file = os.path.join(current_dir, 'sp_cert.pem')
-        cred = ServicePrincipalAuth.build_credential(test_cert_file)
+        cred = ServicePrincipalAuth.build_credential(certificate=test_cert_file)
         assert cred == {'certificate': test_cert_file}
 
         # certificate path with '~', which expands to HOME folder
@@ -283,11 +289,12 @@ class TestServicePrincipalAuth(unittest.TestCase):
         home = os.path.expanduser('~')
         home_cert = os.path.join(home, 'sp_cert.pem')  # C:\Users\username\sp_cert.pem
         shutil.copyfile(test_cert_file, home_cert)
-        cred = ServicePrincipalAuth.build_credential(os.path.join('~', 'sp_cert.pem'))  # ~\sp_cert.pem
+        cred = ServicePrincipalAuth.build_credential(certificate=os.path.join('~', 'sp_cert.pem'))  # ~\sp_cert.pem
         assert cred == {'certificate': home_cert}
         os.remove(home_cert)
 
-        cred = ServicePrincipalAuth.build_credential(test_cert_file, use_cert_sn_issuer=True)
+        # Certificate with use_cert_sn_issuer=True
+        cred = ServicePrincipalAuth.build_credential(certificate=test_cert_file, use_cert_sn_issuer=True)
         assert cred == {'certificate': test_cert_file, 'use_cert_sn_issuer': True}
 
         # client assertion

--- a/src/azure-cli/azure/cli/command_modules/profile/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/__init__.py
@@ -47,8 +47,7 @@ class ProfileCommandsLoader(AzCommandsLoader):
             c.argument('username', options_list=['--username', '-u'],
                        help='User name, service principal client ID, or managed identity ID.')
             c.argument('password', options_list=['--password', '-p'],
-                       help='Provide credentials such as a user password, a service principal secret or a PEM file '
-                            'with key and public certificate. Will prompt if not given.')
+                       help='User password or service principal secret. Will prompt if not given.')
             c.argument('tenant', options_list=['--tenant', '-t'], validator=validate_tenant,
                        help='The Microsoft Entra tenant, must be provided when using a service principal.')
             c.argument('scopes', options_list=['--scope'], nargs='+',
@@ -66,6 +65,7 @@ class ProfileCommandsLoader(AzCommandsLoader):
             # Service principal
             c.argument('service_principal', action='store_true',
                        help='Log in with a service principal.')
+            c.argument('certificate', help='PEM file with key and public certificate.')
             c.argument('use_cert_sn_issuer', action='store_true',
                        help='Use Subject Name + Issuer (SN+I) authentication in order to support automatic '
                             'certificate rolls.')

--- a/src/azure-cli/azure/cli/command_modules/profile/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/_help.py
@@ -21,6 +21,10 @@ long-summary: >-
     For more details, see https://go.microsoft.com/fwlink/?linkid=2276314
 
 
+    [WARNING] Passing the service principal certificate with `--password` is deprecated and will be removed
+    by version 2.74. Please use `--certificate` instead.
+
+
     To log in with a service principal, specify --service-principal.
 
 
@@ -35,8 +39,8 @@ examples:
       text: az login -u johndoe@contoso.com -p VerySecret
     - name: Log in with a service principal using client secret. Use -p=secret if the first character of the password is '-'.
       text: az login --service-principal -u http://azure-cli-2016-08-05-14-31-15 -p VerySecret --tenant contoso.onmicrosoft.com
-    - name: Log in with a service principal using client certificate.
-      text: az login --service-principal -u http://azure-cli-2016-08-05-14-31-15 -p ~/mycertfile.pem --tenant contoso.onmicrosoft.com
+    - name: Log in with a service principal using certificate.
+      text: az login --service-principal -u http://azure-cli-2016-08-05-14-31-15 --certificate ~/mycertfile.pem --tenant contoso.onmicrosoft.com
     - name: Log in with a system-assigned managed identity.
       text: az login --identity
     - name: Log in with a user-assigned managed identity. You must specify the client ID, object ID or resource ID of the user-assigned managed identity with --username.

--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -119,7 +119,7 @@ def login(cmd, username=None, password=None, tenant=None, scopes=None, allow_no_
           # Device code flow
           use_device_code=False,
           # Service principal
-          service_principal=None, use_cert_sn_issuer=None, client_assertion=None,
+          service_principal=None, certificate=None, use_cert_sn_issuer=None, client_assertion=None,
           # Managed identity
           identity=False):
     """Log in to access Azure subscriptions"""
@@ -148,7 +148,7 @@ def login(cmd, username=None, password=None, tenant=None, scopes=None, allow_no_
         logger.warning(_CLOUD_CONSOLE_LOGIN_WARNING)
 
     if username:
-        if not (password or client_assertion):
+        if not (password or client_assertion or certificate):
             try:
                 password = prompt_pass('Password: ')
             except NoTTYException:
@@ -158,7 +158,10 @@ def login(cmd, username=None, password=None, tenant=None, scopes=None, allow_no_
 
     if service_principal:
         from azure.cli.core.auth.identity import ServicePrincipalAuth
-        password = ServicePrincipalAuth.build_credential(password, client_assertion, use_cert_sn_issuer)
+        password = ServicePrincipalAuth.build_credential(
+            secret_or_certificate=password,
+            certificate=certificate, use_cert_sn_issuer=use_cert_sn_issuer,
+            client_assertion=client_assertion)
 
     login_experience_v2 = cmd.cli_ctx.config.getboolean('core', 'login_experience_v2', fallback=True)
     # Send login_experience_v2 config to telemetry


### PR DESCRIPTION
**Related command**
`az login`

**Description**<!--Mandatory-->
Fix https://github.com/Azure/azure-cli/issues/28839
Require https://github.com/Azure/azure-cli/pull/30090

1. Add `--certificate` for authenticating with service principal certificate
2. Deprecate using `--password` to pass service principal certificate

**Testing Guide**
```sh
az login --service-principal --username xxx --certificate xxx --tenant xxx

# Old way. Will show a warning.
az login --service-principal --username xxx --password xxx --tenant xxx
```

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Profile] `az login`: Passing the service principal certificate with `--password` is deprecated and will be removed by version 2.74. Please use `--certificate` instead.
