### PR TITLE
[Profile] BREAKING CHANGE: `az login`: `--password` no longer accepts service principal certificate

### DIFF
--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -38,6 +38,10 @@ WAM_PROMPT = (
     "Select the account you want to log in with. "
     "For more information on login with Azure CLI, see https://go.microsoft.com/fwlink/?linkid=2271136")
 
+PASSWORD_CERTIFICATE_WARNING = (
+    "Using --password to pass service principal certificate is deprecated and will be removed in a "
+    "future release. Use --certificate instead.")
+
 logger = get_logger(__name__)
 
 
@@ -304,7 +308,8 @@ class ServicePrincipalAuth:  # pylint: disable=too-many-instance-attributes
         return ServicePrincipalAuth(entry)
 
     @classmethod
-    def build_credential(cls, secret_or_certificate=None, client_assertion=None, use_cert_sn_issuer=None):
+    def build_credential(cls, secret_or_certificate=None, client_assertion=None,
+                         certificate=None, use_cert_sn_issuer=None):
         """Build credential from user input. The credential looks like below, but only one key can exist.
         {
             'client_secret': 'my_secret',
@@ -313,9 +318,15 @@ class ServicePrincipalAuth:  # pylint: disable=too-many-instance-attributes
         }
         """
         entry = {}
-        if secret_or_certificate:
+        if certificate:
+            entry[_CERTIFICATE] = os.path.expanduser(certificate)
+            if use_cert_sn_issuer:
+                entry[_USE_CERT_SN_ISSUER] = use_cert_sn_issuer
+        elif secret_or_certificate:
+            # TODO: Make secret_or_certificate secret only
             user_expanded = os.path.expanduser(secret_or_certificate)
             if os.path.isfile(user_expanded):
+                logger.warning(PASSWORD_CERTIFICATE_WARNING)
                 entry[_CERTIFICATE] = user_expanded
                 if use_cert_sn_issuer:
                     entry[_USE_CERT_SN_ISSUER] = use_cert_sn_issuer

--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -38,10 +38,6 @@ WAM_PROMPT = (
     "Select the account you want to log in with. "
     "For more information on login with Azure CLI, see https://go.microsoft.com/fwlink/?linkid=2271136")
 
-PASSWORD_CERTIFICATE_WARNING = (
-    "Using --password to pass service principal certificate is deprecated and will be removed in a "
-    "future release. Use --certificate instead.")
-
 logger = get_logger(__name__)
 
 
@@ -308,7 +304,7 @@ class ServicePrincipalAuth:  # pylint: disable=too-many-instance-attributes
         return ServicePrincipalAuth(entry)
 
     @classmethod
-    def build_credential(cls, secret_or_certificate=None, client_assertion=None,
+    def build_credential(cls, client_secret=None, client_assertion=None,
                          certificate=None, use_cert_sn_issuer=None):
         """Build credential from user input. The credential looks like below, but only one key can exist.
         {
@@ -318,20 +314,12 @@ class ServicePrincipalAuth:  # pylint: disable=too-many-instance-attributes
         }
         """
         entry = {}
-        if certificate:
+        if client_secret:
+            entry[_CLIENT_SECRET] = client_secret
+        elif certificate:
             entry[_CERTIFICATE] = os.path.expanduser(certificate)
             if use_cert_sn_issuer:
                 entry[_USE_CERT_SN_ISSUER] = use_cert_sn_issuer
-        elif secret_or_certificate:
-            # TODO: Make secret_or_certificate secret only
-            user_expanded = os.path.expanduser(secret_or_certificate)
-            if os.path.isfile(user_expanded):
-                logger.warning(PASSWORD_CERTIFICATE_WARNING)
-                entry[_CERTIFICATE] = user_expanded
-                if use_cert_sn_issuer:
-                    entry[_USE_CERT_SN_ISSUER] = use_cert_sn_issuer
-            else:
-                entry[_CLIENT_SECRET] = secret_or_certificate
         elif client_assertion:
             entry[_CLIENT_ASSERTION] = client_assertion
         return entry

--- a/src/azure-cli-core/azure/cli/core/auth/tests/test_identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/tests/test_identity.py
@@ -265,18 +265,12 @@ class TestServicePrincipalAuth(unittest.TestCase):
 
     def test_build_credential(self):
         # secret
-        cred = ServicePrincipalAuth.build_credential(secret_or_certificate="test_secret")
+        cred = ServicePrincipalAuth.build_credential(client_secret="test_secret")
         assert cred == {"client_secret": "test_secret"}
 
         # secret with '~', which is preserved as-is
-        cred = ServicePrincipalAuth.build_credential(secret_or_certificate="~test_secret")
+        cred = ServicePrincipalAuth.build_credential(client_secret="~test_secret")
         assert cred == {"client_secret": "~test_secret"}
-
-        # certificate as password (deprecated)
-        current_dir = os.path.dirname(os.path.realpath(__file__))
-        test_cert_file = os.path.join(current_dir, 'sp_cert.pem')
-        cred = ServicePrincipalAuth.build_credential(secret_or_certificate=test_cert_file)
-        assert cred == {'certificate': test_cert_file}
 
         # certificate
         current_dir = os.path.dirname(os.path.realpath(__file__))

--- a/src/azure-cli-core/azure/cli/core/auth/tests/test_identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/tests/test_identity.py
@@ -265,17 +265,23 @@ class TestServicePrincipalAuth(unittest.TestCase):
 
     def test_build_credential(self):
         # secret
-        cred = ServicePrincipalAuth.build_credential("test_secret")
+        cred = ServicePrincipalAuth.build_credential(secret_or_certificate="test_secret")
         assert cred == {"client_secret": "test_secret"}
 
         # secret with '~', which is preserved as-is
-        cred = ServicePrincipalAuth.build_credential("~test_secret")
+        cred = ServicePrincipalAuth.build_credential(secret_or_certificate="~test_secret")
         assert cred == {"client_secret": "~test_secret"}
+
+        # certificate as password (deprecated)
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        test_cert_file = os.path.join(current_dir, 'sp_cert.pem')
+        cred = ServicePrincipalAuth.build_credential(secret_or_certificate=test_cert_file)
+        assert cred == {'certificate': test_cert_file}
 
         # certificate
         current_dir = os.path.dirname(os.path.realpath(__file__))
         test_cert_file = os.path.join(current_dir, 'sp_cert.pem')
-        cred = ServicePrincipalAuth.build_credential(test_cert_file)
+        cred = ServicePrincipalAuth.build_credential(certificate=test_cert_file)
         assert cred == {'certificate': test_cert_file}
 
         # certificate path with '~', which expands to HOME folder
@@ -283,11 +289,12 @@ class TestServicePrincipalAuth(unittest.TestCase):
         home = os.path.expanduser('~')
         home_cert = os.path.join(home, 'sp_cert.pem')  # C:\Users\username\sp_cert.pem
         shutil.copyfile(test_cert_file, home_cert)
-        cred = ServicePrincipalAuth.build_credential(os.path.join('~', 'sp_cert.pem'))  # ~\sp_cert.pem
+        cred = ServicePrincipalAuth.build_credential(certificate=os.path.join('~', 'sp_cert.pem'))  # ~\sp_cert.pem
         assert cred == {'certificate': home_cert}
         os.remove(home_cert)
 
-        cred = ServicePrincipalAuth.build_credential(test_cert_file, use_cert_sn_issuer=True)
+        # Certificate with use_cert_sn_issuer=True
+        cred = ServicePrincipalAuth.build_credential(certificate=test_cert_file, use_cert_sn_issuer=True)
         assert cred == {'certificate': test_cert_file, 'use_cert_sn_issuer': True}
 
         # client assertion

--- a/src/azure-cli/azure/cli/command_modules/profile/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/__init__.py
@@ -8,7 +8,6 @@ from azure.cli.core.commands import CliCommandType
 from azure.cli.core.commands.parameters import get_enum_type
 
 from azure.cli.command_modules.profile._format import transform_account_list
-import azure.cli.command_modules.profile._help  # pylint: disable=unused-import
 
 from ._validators import validate_tenant
 
@@ -40,43 +39,67 @@ class ProfileCommandsLoader(AzCommandsLoader):
 
         return self.command_table
 
-    # pylint: disable=line-too-long
     def load_arguments(self, command):
         from azure.cli.core.api import get_subscription_id_list
 
         with self.argument_context('login') as c:
-            c.argument('password', options_list=['--password', '-p'], help="Credentials like user password, or for a service principal, provide client secret or a pem file with key and public certificate. Will prompt if not given.")
-            c.argument('service_principal', action='store_true', help='The credential representing a service principal.')
-            c.argument('username', options_list=['--username', '-u'], help='user name, service principal, or managed service identity ID')
-            c.argument('tenant', options_list=['--tenant', '-t'], help='The AAD tenant, must provide when using service principals.', validator=validate_tenant)
-            c.argument('allow_no_subscriptions', action='store_true', help="Support access tenants without subscriptions. It's uncommon but useful to run tenant level commands, such as 'az ad'")
+            c.argument('username', options_list=['--username', '-u'],
+                       help='User name, service principal client ID, or managed identity ID.')
+            c.argument('password', options_list=['--password', '-p'],
+                       help='Credentials like password for user, or for a service principal, provide client '
+                            'secret or a PEM file with key and public certificate. Will prompt if not given.')
+            c.argument('tenant', options_list=['--tenant', '-t'], validator=validate_tenant,
+                       help='The Microsoft Entra tenant, must provide when using a service principal.')
+            c.argument('scopes', options_list=['--scope'], nargs='+',
+                       help='Used in the /authorize request. It can cover only one static resource.')
+            c.argument('allow_no_subscriptions', action='store_true',
+                       help="Support accessing tenants without subscriptions. It's uncommon but useful to run "
+                            "tenant-level commands, such as 'az ad'.")
             c.ignore('_subscription')  # hide the global subscription parameter
-            c.argument('identity', options_list=('-i', '--identity'), action='store_true', help="Log in using the Virtual Machine's identity", arg_group='Managed Service Identity')
-            c.argument('identity_port', type=int, help="the port to retrieve tokens for login. Default: 50342", arg_group='Managed Service Identity')
+
+            # Device code flow
             c.argument('use_device_code', action='store_true',
-                       help="Use CLI's old authentication flow based on device code. CLI will also use this if it can't launch a browser in your behalf, e.g. in remote SSH or Cloud Shell")
-            c.argument('use_cert_sn_issuer', action='store_true', help='used with a service principal configured with Subject Name and Issuer Authentication in order to support automatic certificate rolls')
-            c.argument('scopes', options_list=['--scope'], nargs='+', help='Used in the /authorize request. It can cover only one static resource.')
-            c.argument('client_assertion', options_list=['--federated-token'], help='Federated token that can be used for OIDC token exchange.')
+                       help="Use device code flow. CLI will also use this if it can't launch a browser, "
+                            "e.g. in remote SSH or Cloud Shell.")
+
+            # Service principal
+            c.argument('service_principal', action='store_true',
+                       help='Log in with a service principal.')
+            c.argument('use_cert_sn_issuer', action='store_true',
+                       help='Use Subject Name + Issuer (SN+I) authentication in order to support automatic '
+                            'certificate rolls.')
+            c.argument('client_assertion', options_list=['--federated-token'],
+                       help='Federated token that can be used for OIDC token exchange.')
+
+            # Managed identity
+            c.argument('identity', options_list=('-i', '--identity'), action='store_true',
+                       help="Log in using managed identity", arg_group='Managed Identity')
 
         with self.argument_context('logout') as c:
             c.argument('username', help='account user, if missing, logout the current active account')
             c.ignore('_subscription')  # hide the global subscription parameter
 
         with self.argument_context('account') as c:
-            c.argument('subscription', options_list=['--subscription', '-s', '--name', '-n'], arg_group='', help='Name or ID of subscription.', completer=get_subscription_id_list)
+            c.argument('subscription', options_list=['--subscription', '-s', '--name', '-n'], arg_group='',
+                       completer=get_subscription_id_list, help='Name or ID of subscription.')
             c.ignore('_subscription')
 
         with self.argument_context('account list') as c:
-            c.argument('all', help="List all subscriptions from all clouds, rather than just 'Enabled' ones", action='store_true')
+            c.argument('all', action='store_true',
+                       help="List all subscriptions from all clouds, rather than just 'Enabled' ones", )
             c.argument('refresh', help="retrieve up-to-date subscriptions from server", action='store_true')
             c.ignore('_subscription')  # hide the global subscription parameter
 
         with self.argument_context('account get-access-token') as c:
-            c.argument('resource_type', get_enum_type(cloud_resource_types), options_list=['--resource-type'], arg_group='', help='Type of well-known resource.')
-            c.argument('resource', options_list=['--resource'], help='Azure resource endpoints in AAD v1.0.')
-            c.argument('scopes', options_list=['--scope'], nargs='*', help='Space-separated AAD scopes in AAD v2.0. Default to Azure Resource Manager.')
-            c.argument('tenant', options_list=['--tenant', '-t'], help='Tenant ID for which the token is acquired. Only available for user and service principal account, not for MSI or Cloud Shell account')
+            c.argument('resource_type', get_enum_type(cloud_resource_types), options_list=['--resource-type'],
+                       help='Type of well-known resource.')
+            c.argument('resource', options_list=['--resource'],
+                       help='Azure resource endpoints in Microsoft Entra v1.0.')
+            c.argument('scopes', options_list=['--scope'], nargs='*',
+                       help='Space-separated scopes in Microsoft Entra v2.0. Default to Azure Resource Manager.')
+            c.argument('tenant', options_list=['--tenant', '-t'],
+                       help='Tenant ID for which the token is acquired. Only available for user and service principal '
+                            'account, not for managed identity or Cloud Shell account')
 
 
 COMMAND_LOADER_CLS = ProfileCommandsLoader

--- a/src/azure-cli/azure/cli/command_modules/profile/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/__init__.py
@@ -80,7 +80,7 @@ class ProfileCommandsLoader(AzCommandsLoader):
             c.ignore('_subscription')  # hide the global subscription parameter
 
         with self.argument_context('account') as c:
-            c.argument('subscription', options_list=['--subscription', '-s', '--name', '-n'], arg_group='',
+            c.argument('subscription', options_list=['--subscription', '-s', '--name', '-n'],
                        completer=get_subscription_id_list, help='Name or ID of subscription.')
             c.ignore('_subscription')
 

--- a/src/azure-cli/azure/cli/command_modules/profile/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/__init__.py
@@ -46,8 +46,8 @@ class ProfileCommandsLoader(AzCommandsLoader):
             c.argument('username', options_list=['--username', '-u'],
                        help='User name, service principal client ID, or managed identity ID.')
             c.argument('password', options_list=['--password', '-p'],
-                       help='Credentials like password for user, or for a service principal, provide client '
-                            'secret or a PEM file with key and public certificate. Will prompt if not given.')
+                       help="Password for user account, or client secret for service principal. Will prompt if not "
+                            "given.")
             c.argument('tenant', options_list=['--tenant', '-t'], validator=validate_tenant,
                        help='The Microsoft Entra tenant, must provide when using a service principal.')
             c.argument('scopes', options_list=['--scope'], nargs='+',
@@ -65,6 +65,7 @@ class ProfileCommandsLoader(AzCommandsLoader):
             # Service principal
             c.argument('service_principal', action='store_true',
                        help='Log in with a service principal.')
+            c.argument('certificate', help='A PEM file with key and public certificate.')
             c.argument('use_cert_sn_issuer', action='store_true',
                        help='Use Subject Name + Issuer (SN+I) authentication in order to support automatic '
                             'certificate rolls.')

--- a/src/azure-cli/azure/cli/command_modules/profile/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/_help.py
@@ -21,10 +21,6 @@ long-summary: >-
     For more details, see https://go.microsoft.com/fwlink/?linkid=2276314
 
 
-    [WARNING] Using --password to pass service principal certificate is deprecated and will be removed in a
-    future release. Use --certificate instead.
-
-
     To log in with a service principal, specify --service-principal.
 
 

--- a/src/azure-cli/azure/cli/command_modules/profile/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/_help.py
@@ -21,6 +21,10 @@ long-summary: >-
     For more details, see https://go.microsoft.com/fwlink/?linkid=2276314
 
 
+    [WARNING] Using --password to pass service principal certificate is deprecated and will be removed in a
+    future release. Use --certificate instead.
+
+
     To log in with a service principal, specify --service-principal.
 
 
@@ -35,8 +39,8 @@ examples:
       text: az login -u johndoe@contoso.com -p VerySecret
     - name: Log in with a service principal using client secret. Use -p=secret if the first character of the password is '-'.
       text: az login --service-principal -u http://azure-cli-2016-08-05-14-31-15 -p VerySecret --tenant contoso.onmicrosoft.com
-    - name: Log in with a service principal using client certificate.
-      text: az login --service-principal -u http://azure-cli-2016-08-05-14-31-15 -p ~/mycertfile.pem --tenant contoso.onmicrosoft.com
+    - name: Log in with a service principal using certificate.
+      text: az login --service-principal -u http://azure-cli-2016-08-05-14-31-15 --certificate ~/mycertfile.pem --tenant contoso.onmicrosoft.com
     - name: Log in with a system-assigned managed identity.
       text: az login --identity
     - name: Log in with a user-assigned managed identity. You must specify the client ID, object ID or resource ID of the user-assigned managed identity with --username.

--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -115,8 +115,13 @@ def account_clear(cmd):
 
 
 # pylint: disable=inconsistent-return-statements, too-many-branches
-def login(cmd, username=None, password=None, service_principal=None, tenant=None, allow_no_subscriptions=False,
-          identity=False, use_device_code=False, use_cert_sn_issuer=None, scopes=None, client_assertion=None):
+def login(cmd, username=None, password=None, tenant=None, scopes=None, allow_no_subscriptions=False,
+          # Device code flow
+          use_device_code=False,
+          # Service principal
+          service_principal=None, use_cert_sn_issuer=None, client_assertion=None,
+          # Managed identity
+          identity=False):
     """Log in to access Azure subscriptions"""
 
     # quick argument usage check

--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -119,7 +119,7 @@ def login(cmd, username=None, password=None, tenant=None, scopes=None, allow_no_
           # Device code flow
           use_device_code=False,
           # Service principal
-          service_principal=None, use_cert_sn_issuer=None, client_assertion=None,
+          service_principal=None, certificate=None, use_cert_sn_issuer=None, client_assertion=None,
           # Managed identity
           identity=False):
     """Log in to access Azure subscriptions"""
@@ -148,7 +148,7 @@ def login(cmd, username=None, password=None, tenant=None, scopes=None, allow_no_
         logger.warning(_CLOUD_CONSOLE_LOGIN_WARNING)
 
     if username:
-        if not (password or client_assertion):
+        if not (password or client_assertion or certificate):
             try:
                 password = prompt_pass('Password: ')
             except NoTTYException:
@@ -158,7 +158,9 @@ def login(cmd, username=None, password=None, tenant=None, scopes=None, allow_no_
 
     if service_principal:
         from azure.cli.core.auth.identity import ServicePrincipalAuth
-        password = ServicePrincipalAuth.build_credential(password, client_assertion, use_cert_sn_issuer)
+        password = ServicePrincipalAuth.build_credential(
+            secret_or_certificate=password, client_assertion=client_assertion,
+            certificate=certificate, use_cert_sn_issuer=use_cert_sn_issuer)
 
     login_experience_v2 = cmd.cli_ctx.config.getboolean('core', 'login_experience_v2', fallback=True)
     # Send login_experience_v2 config to telemetry

--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -159,7 +159,7 @@ def login(cmd, username=None, password=None, tenant=None, scopes=None, allow_no_
     if service_principal:
         from azure.cli.core.auth.identity import ServicePrincipalAuth
         password = ServicePrincipalAuth.build_credential(
-            secret_or_certificate=password, client_assertion=client_assertion,
+            client_secret=password, client_assertion=client_assertion,
             certificate=certificate, use_cert_sn_issuer=use_cert_sn_issuer)
 
     login_experience_v2 = cmd.cli_ctx.config.getboolean('core', 'login_experience_v2', fallback=True)


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
Fix https://github.com/Azure/azure-cli/issues/28839
Follow up work on https://github.com/Azure/azure-cli/pull/30091

`--password` no longer accepts service principal certificate.

**Testing Guide**
```
> az login --service-principal --username xxx --password C:\Users\xxx\xxx.pem --tenant xxx --allow
AADSTS7000215: Invalid client secret provided. Ensure the secret being sent in the request is the client secret 
value, not the client secret ID, for a secret added to app 'xxx'.
```
