### PR TITLE
{compute-recommender} Remove default --ids from cli parameters

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/compute_recommender/aaz/latest/compute_recommender/_spot_placement_recommender.py
+++ b/src/azure-cli/azure/cli/command_modules/compute_recommender/aaz/latest/compute_recommender/_spot_placement_recommender.py
@@ -45,8 +45,7 @@ class SpotPlacementRecommender(AAZCommand):
 
         _args_schema = cls._args_schema
         _args_schema.location = AAZResourceLocationArg(
-            required=True,
-            id_part="name",
+            required=True
         )
 
         # define Arg Group "SpotPlacementScoresInput"


### PR DESCRIPTION
**Related command**
az compute-recommender spot-placement-recommender

**Description**<!--Mandatory-->
In order to resolve the cli user confusion, this pr removes the default --ids from the az compute-recommender spot-placement-recommender cli parameters
**Testing Guide**
`az compute-recommender spot-placement-recommender --help`
Now, the help output has no --ids
**History Notes**

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
