### PR TITLE
{kubectl} Fix kubectl 404 Not Found issue by updating source_url to dl.k8s.io

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -1873,7 +1873,7 @@ def k8s_install_kubectl(cmd, client_version='latest', install_location=None, sou
     """
 
     if not source_url:
-        source_url = "https://storage.googleapis.com/kubernetes-release/release"
+        source_url = "https://dl.k8s.io/release"
         cloud_name = cmd.cli_ctx.cloud.name
         if cloud_name.lower() == 'azurechinacloud':
             source_url = 'https://mirror.azure.cn/kubernetes/kubectl'


### PR DESCRIPTION
**Description**<!--Mandatory-->

https://github.com/Azure/azure-cli/issues/30101

This PR should fix the initial issue reported. 
Downloading kubectl for latest version of 1.30 and 1.29 returned 404 Not found error. 
The "kubernetes-release" bucket has been deprecated which means its likely the bucket doesn't receive the latest updates anymore (check this - https://github.com/kubernetes/k8s.io/issues/1571)
This is related to kubernetes change (https://github.com/kubernetes/k8s.io/issues/2396) to move away from GCS bucket in GCP project.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
