### PR TITLE
{Packaging} Bump psutil to 6.1.0

### DIFF
--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -111,7 +111,7 @@ paramiko==3.4.0
 pbr==5.3.1
 pkginfo==1.8.2
 portalocker==2.3.2
-psutil==5.9.5
+psutil==6.1.0
 pycomposefile==0.0.30
 PyGithub==1.55
 PyJWT==2.4.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -112,7 +112,7 @@ paramiko==3.4.0
 pbr==5.3.1
 pkginfo==1.8.2
 portalocker==2.3.2
-psutil==5.9.5
+psutil==6.1.0
 pycomposefile==0.0.30
 PyGithub==1.55
 PyJWT==2.4.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -111,7 +111,7 @@ paramiko==3.4.0
 pbr==5.3.1
 pkginfo==1.8.2
 portalocker==2.3.2
-psutil==5.9.5
+psutil==6.1.0
 pycomposefile==0.0.30
 PyGithub==1.55
 PyJWT==2.4.0


### PR DESCRIPTION
Test Homebrew Formula failed with
```
==> python3.11 -m pip --python=/usr/local/Cellar/azure-cli/2.65.0/libexec/bin/py
Last 15 lines from /Users/runner/Library/Logs/Homebrew/azure-cli/115.python3.11:
    File "<string>", line 480, in main
  TypeError: 'color' is an invalid keyword argument for print()
  error: subprocess-exited-with-error
  
  × Building wheel for psutil (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> See above for output.
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  full command: /usr/local/Cellar/azure-cli/2.65.0/libexec/bin/python /usr/local/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py build_wheel /private/tmp/tmp2751l5nz
  cwd: /private/tmp/azure-cli--psutil-20241022-14446-ha2qbt/psutil-5.9.5
  Building wheel for psutil (pyproject.toml): finished with status 'error'
  ERROR: Failed building wheel for psutil
Failed to build psutil
ERROR: ERROR: Failed to build installable wheels for some pyproject.toml based projects (psutil)
```

`TypeError: 'color' is an invalid keyword argument for print()` caused by the misplaced parenthesis in https://github.com/giampaolo/psutil/blob/0d4900b073f8697ab21c47d823621bea61f39a3b/setup.py#L480-L481
```python
            elif MACOS:
                print(hilite("XCode (https://developer.apple.com/xcode/) "
                             "is not installed"), color="red", file=sys.stderr)
```

It was fixed in 5.9.6. https://github.com/giampaolo/psutil/commit/6e23a5129375ae19abadc0de49f920899b6e765c#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7

I'm not sure why this error suddenly occurs. It might be related to the `setuptools` version update. I've reported at https://github.com/pypa/setuptools/pull/4684#issuecomment-2428622889

Ref:
https://dev.azure.com/azclitools/public/_build/results?buildId=199172&view=logs&j=ebe8970d-a8af-5d7e-4086-8f4ce0be006b