### PR TITLE
{CI} Skip some tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -761,7 +761,7 @@ jobs:
 
 - job: TestRpmPackagesAzureLinux
   displayName: Test Rpm Package
-  timeoutInMinutes: 120
+  timeoutInMinutes: 180
   dependsOn:
   - BuildRpmPackagesAzureLinux
   - ExtractMetadata
@@ -855,7 +855,7 @@ jobs:
 
 - job: TestRpmPackage
   displayName: Test Rpm Package
-  timeoutInMinutes: 120
+  timeoutInMinutes: 180
   dependsOn:
     - BuildRpmPackages
     - ExtractMetadata
@@ -979,7 +979,7 @@ jobs:
       ArtifactName: $(deb_system)-$(distro)-$(arch)
 
 - job: TestDebPackages
-  timeoutInMinutes: 120
+  timeoutInMinutes: 180
   displayName: Test Deb Packages
   dependsOn:
   - BuildDebPackages

--- a/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_agentpool_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_agentpool_commands.py
@@ -3,11 +3,12 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from azure.cli.testsdk import ScenarioTest, StorageAccountPreparer, ResourceGroupPreparer, record_only
+from azure.cli.testsdk import ScenarioTest, StorageAccountPreparer, ResourceGroupPreparer, record_only, live_only
 
 
 class AcrAgentPoolCommandsTests(ScenarioTest):
 
+    @live_only()
     @ResourceGroupPreparer()
     def test_acr_agentpool(self, resource_group):
         # Agentpool prerequisites for agentpool testing

--- a/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_connectedregistry_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_connectedregistry_commands.py
@@ -3,11 +3,12 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from azure.cli.testsdk import ScenarioTest, StorageAccountPreparer, ResourceGroupPreparer, record_only
+from azure.cli.testsdk import ScenarioTest, StorageAccountPreparer, ResourceGroupPreparer, record_only, live_only
 
 
 class AcrConnectedRegistryCommandsTests(ScenarioTest):
 
+    @live_only()
     @ResourceGroupPreparer()
     def test_acr_connectedregistry(self, resource_group):
         # Agentpool prerequisites for connected registry testing

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
@@ -539,6 +539,7 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         # delete
         self.cmd('aks delete -g {resource_group} -n {name} --yes --no-wait', checks=[self.is_empty()])
 
+    @live_only()
     @AllowLargeResponse()
     @AKSCustomResourceGroupPreparer(random_name_length=17, name_prefix='clitest', location='westus2')
     def test_aks_create_and_update_with_http_proxy_config(self, resource_group, resource_group_location):

--- a/src/azure-cli/azure/cli/command_modules/iot/tests/latest/test_iot_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/tests/latest/test_iot_commands.py
@@ -7,7 +7,7 @@ import json
 from unittest import mock
 from knack.util import CLIError
 
-from azure.cli.testsdk import ResourceGroupPreparer, ScenarioTest, StorageAccountPreparer
+from azure.cli.testsdk import ResourceGroupPreparer, ScenarioTest, StorageAccountPreparer, live_only
 from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from azure.mgmt.iothub.models import RoutingSource
 from azure.cli.command_modules.iot.shared import IdentityType
@@ -840,6 +840,7 @@ class IoTHubTest(ScenarioTest):
         assert storage_cs_pattern in updated_hub['properties']['storageEndpoints']['$default']['connectionString']
         assert updated_hub['properties']['storageEndpoints']['$default']['containerName'] == containerName
 
+    @live_only()
     @AllowLargeResponse()
     @ResourceGroupPreparer(location='westus2')
     def test_hub_wait(self, resource_group, resource_group_location):

--- a/src/azure-cli/azure/cli/command_modules/rdbms/tests/latest/test_rdbms_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/tests/latest/test_rdbms_commands.py
@@ -77,6 +77,7 @@ class ServerMgmtScenarioTest(ScenarioTest):
     def test_mariadb_server_mgmt(self, resource_group_1, resource_group_2):
         self._test_server_mgmt('mariadb', resource_group_1, resource_group_2)
 
+    @live_only()
     @AllowLargeResponse()
     @ResourceGroupPreparer(parameter_name='resource_group_1')
     @ResourceGroupPreparer(parameter_name='resource_group_2')

--- a/src/azure-cli/azure/cli/command_modules/rdbms/tests/latest/test_rdbms_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/tests/latest/test_rdbms_commands.py
@@ -71,6 +71,7 @@ class ServerPreparer(AbstractPreparer, SingleValueReplacer):
 
 class ServerMgmtScenarioTest(ScenarioTest):
 
+    @live_only()
     @AllowLargeResponse()
     @ResourceGroupPreparer(parameter_name='resource_group_1')
     @ResourceGroupPreparer(parameter_name='resource_group_2')

--- a/src/azure-cli/azure/cli/command_modules/rdbms/tests/latest/test_rdbms_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/tests/latest/test_rdbms_commands.py
@@ -343,6 +343,7 @@ class ServerMgmtScenarioTest(ScenarioTest):
 
 class ProxyResourcesMgmtScenarioTest(ScenarioTest):
 
+    @live_only()
     @AllowLargeResponse()
     @ResourceGroupPreparer()
     @ServerPreparer(engine_type='mariadb')

--- a/src/azure-cli/azure/cli/command_modules/rdbms/tests/latest/test_rdbms_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/tests/latest/test_rdbms_commands.py
@@ -356,6 +356,7 @@ class ProxyResourcesMgmtScenarioTest(ScenarioTest):
         self._test_private_link_resource(resource_group, server, database_engine, 'mariadbServer')
         self._test_private_endpoint_connection(resource_group, server, database_engine)
 
+    @live_only()
     @AllowLargeResponse()
     @ResourceGroupPreparer()
     @ServerPreparer(engine_type='mysql')


### PR DESCRIPTION
The batched CI suddenly failed with `Message: The subscription '00000000-0000-0000-0000-000000000000' could not be found.` from Sep 25, 2024.
The Test Deb Packages and Test Rpm Package Azure Linux 3.0 fail. Not sure why distro use Python 3.9 still works.

The error is similar to https://github.com/Azure/azure-cli/pull/17185

For more detail, see Jiashuo's analysis at https://github.com/Azure/azure-cli/pull/18853#discussion_r1810260089 and https://github.com/Azure/azure-cli/pull/18611#discussion_r1810284183

Temporarily skip these tests to unblock release.