### PR TITLE
{RDBMS} `az postgres flexible-server update`: Fix bug not able to enable password authentication during update

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
@@ -1531,8 +1531,8 @@ def _update_login(server_name, resource_group_name, auth_config, password_auth, 
         if not administrator_login_password:
             administrator_login_password = generate_password(administrator_login_password)
             logger.warning('Make a note of password "%s". You can '
-                'reset your password with "az postgres flexible-server update -n %s -g %s -p <new-password>".',
-                administrator_login_password, server_name, resource_group_name)
+                           'reset your password with "az postgres flexible-server update -n %s -g %s -p <new-password>".',
+                           administrator_login_password, server_name, resource_group_name)
 
     return administrator_login, administrator_login_password
 


### PR DESCRIPTION
**Related command**
`az postgres flexible-server update`

**Description**<!--Mandatory-->
If you create a server with password authentication disabled and AAD enabled:
_az postgres flexible-server create --resource-group rg-test --name testpostgresqlserver --password-auth Disabled --active-directory-auth Enabled --location eastus --version 16 --high-availability Disabled --tier GeneralPurpose --public-access Enabled_

And then try to enable it using the update command:
_az postgres flexible-server update --resource-group rg-test --name testpostgresqlserver --password-auth Enabled

It fails with this error:
_(EngineCredentialsNotProvided) The admin credentials are required for creating admin role while enabling Password Authentication and must be provided.
Code: EngineCredentialsNotProvided
Message: The admin credentials are required for creating admin role while enabling Password Authentication and must be provided._

Fix:
Allow "--password-auth Enabled" to work during update. Generate password for user if "--admin-login-password" parameter was not passed in. Also generate username.

**Testing Guide**
az postgres flexible-server update --resource-group rg --name test-1027-721 --password-auth Enabled
**Make a note of password "LSssssssssssssssseeee". You can reset your password with "az postgres flexible-server update -n test-1027-721 -g rg -p <new-password>".**
{
  **"administratorLogin": "gleefuloil1",**
  "administratorLoginPassword": null,
  "authConfig": {
    "activeDirectoryAuth": "Enabled",
    "passwordAuth": "Enabled",
    "tenantId": "xxxxxxxxxxxxxxxxxxxxxxxx"
  }


**History Notes**
{RDBMS} `az postgres flexible-server update`: Fix bug not able to enable password authentication during update