### PR TITLE
{Packaging} Remove `without_pip` in homebrew formula

### DIFF
--- a/scripts/release/homebrew/docker/formula_generate.py
+++ b/scripts/release/homebrew/docker/formula_generate.py
@@ -134,7 +134,8 @@ def update_formula() -> str:
 
     # update python version
     text = re.sub('depends_on "python@.*"', f'depends_on "python@{PYTHON_VERSION}"', text, 1)
-    text = re.sub(r'virtualenv_create\(libexec, "python.*"', f'virtualenv_create(libexec, "python{PYTHON_VERSION}"', text, 1)  # pylint: disable=line-too-long
+    venv_str = f'venv = virtualenv_create(libexec, "python{PYTHON_VERSION}", system_site_packages: false)'
+    text = re.sub(r'venv = virtualenv_create.*', venv_str, text, 1)
 
     # update url and sha256 of azure-cli
     text = re.sub('url ".*"', 'url "{}"'.format(HOMEBREW_UPSTREAM_URL), text, 1)


### PR DESCRIPTION
This parameter is removed in 3.12 and raises this error: `ArgumentError: virtualenv_create's without_pip is deprecated starting with Python 3.12`

Ref: https://dev.azure.com/azclitools/public/_build/results?buildId=201003&view=logs&jobId=ebe8970d-a8af-5d7e-4086-8f4ce0be006b&j=ebe8970d-a8af-5d7e-4086-8f4ce0be006b&t=3f22f999-770c-5d06-3bb8-1a936f5d8384