### PR TITLE
{CI} Skip test_vmss_update_image

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_commands.py
@@ -4723,6 +4723,7 @@ class VMSSUpdateTests(ScenarioTest):
             self.check('upgradePolicy.automaticOsUpgradePolicy.enableAutomaticOsUpgrade', True)
         ])
 
+    @live_only()
     @AllowLargeResponse(size_kb=99999)
     @ResourceGroupPreparer(name_prefix='cli_test_vmss_update_image_', location='westus')
     def test_vmss_update_image(self):


### PR DESCRIPTION
This PR is a supplement to the https://github.com/Azure/azure-cli/pull/30164.

```
2024-10-25T13:00:24.9565306Z =================================== FAILURES ===================================
2024-10-25T13:00:24.9565695Z ____________________ VMSSUpdateTests.test_vmss_update_image ____________________
2024-10-25T13:00:24.9566296Z [gw3] linux -- Python 3.12.7 /opt/az/bin/python3
2024-10-25T13:00:24.9566647Z self = <azure.cli.testsdk.base.ExecutionResult object at 0xffff85571940>
2024-10-25T13:00:24.9567007Z cli_ctx = <azure.cli.core.mock.DummyCli object at 0xffff84dd7ad0>
2024-10-25T13:00:24.9567458Z command = 'vm deallocate -g cli_test_vmss_update_image_000001 -n vm1'
2024-10-25T13:00:24.9567777Z expect_failure = False
2024-10-25T13:00:24.9567882Z 
2024-10-25T13:00:24.9568175Z     def _in_process_execute(self, cli_ctx, command, expect_failure=False):
2024-10-25T13:00:24.9568506Z         from io import StringIO
2024-10-25T13:00:24.9568819Z         from vcr.errors import CannotOverwriteExistingCassetteException
2024-10-25T13:00:24.9569100Z     
2024-10-25T13:00:24.9569440Z         if command.startswith('az '):
2024-10-25T13:00:24.9569714Z             command = command[3:]
2024-10-25T13:00:24.9569950Z     
2024-10-25T13:00:24.9570196Z         stdout_buf = StringIO()
2024-10-25T13:00:24.9570785Z         logging_buf = StringIO()
2024-10-25T13:00:24.9571031Z         try:
2024-10-25T13:00:24.9571352Z             # issue: stderr cannot be redirect in this form, as a result some failure information
2024-10-25T13:00:24.9571685Z             # is lost when command fails.
2024-10-25T13:00:24.9572020Z >           self.exit_code = cli_ctx.invoke(shlex.split(command), out_file=stdout_buf) or 0
2024-10-25T13:00:24.9572194Z 
2024-10-25T13:00:24.9572583Z /opt/az/lib/python3.12/site-packages/azure/cli/testsdk/base.py:302: 
2024-10-25T13:00:24.9572941Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2024-10-25T13:00:24.9573651Z /opt/az/lib/python3.12/site-packages/knack/cli.py:245: in invoke
2024-10-25T13:00:24.9573990Z     exit_code = self.exception_handler(ex)
2024-10-25T13:00:24.9574454Z /opt/az/lib/python3.12/site-packages/azure/cli/core/__init__.py:129: in exception_handler
2024-10-25T13:00:24.9574810Z     return handle_exception(ex)
2024-10-25T13:00:24.9575116Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2024-10-25T13:00:24.9575260Z 
2024-10-25T13:00:24.9575932Z ex = ResourceNotFoundError("(SubscriptionNotFound) The subscription '00000000-0000-0000-0000-000000000000' could not be found.\nCode: SubscriptionNotFound\nMessage: The subscription '00000000-0000-0000-0000-000000000000' could not be found.")
2024-10-25T13:00:24.9576425Z args = (), kwargs = {}
2024-10-25T13:00:24.9576535Z 
2024-10-25T13:00:24.9576947Z     def _handle_main_exception(ex, *args, **kwargs):  # pylint: disable=unused-argument
2024-10-25T13:00:24.9577332Z         if isinstance(ex, CannotOverwriteExistingCassetteException):
2024-10-25T13:00:24.9577703Z             # This exception usually caused by a no match HTTP request. This is a product error
2024-10-25T13:00:24.9578048Z             # that is caused by change of SDK invocation.
2024-10-25T13:00:24.9578324Z             raise ex
2024-10-25T13:00:24.9578550Z     
2024-10-25T13:00:24.9578796Z >       raise CliExecutionError(ex)
2024-10-25T13:00:24.9579193Z E       azure.cli.testsdk.exceptions.CliExecutionError: The CLI throws exception ResourceNotFoundError during execution and fails the command.
2024-10-25T13:00:24.9579418Z 
2024-10-25T13:00:24.9579834Z /opt/az/lib/python3.12/site-packages/azure/cli/testsdk/patches.py:35: CliExecutionError
2024-10-25T13:00:24.9580021Z 
2024-10-25T13:00:24.9580310Z During handling of the above exception, another exception occurred:
2024-10-25T13:00:24.9580469Z 
2024-10-25T13:00:24.9581036Z self = <latest.test_vm_commands.VMSSUpdateTests testMethod=test_vmss_update_image>
2024-10-25T13:00:24.9581204Z 
2024-10-25T13:00:24.9581462Z     @AllowLargeResponse(size_kb=99999)
2024-10-25T13:00:24.9581908Z     @ResourceGroupPreparer(name_prefix='cli_test_vmss_update_image_', location='westus')
2024-10-25T13:00:24.9582257Z     def test_vmss_update_image(self):
2024-10-25T13:00:24.9582540Z         self.kwargs.update({
2024-10-25T13:00:24.9582853Z             'vm': 'vm1',
2024-10-25T13:00:24.9583172Z             'img': 'img1',
2024-10-25T13:00:24.9583512Z             'vmss': 'vmss1',
2024-10-25T13:00:24.9583834Z             'subnet': 'subnet1',
2024-10-25T13:00:24.9584164Z             'vnet': 'vnet1'
2024-10-25T13:00:24.9584407Z         })
2024-10-25T13:00:24.9584918Z         self.cmd('vm create -g {rg} -n {vm} --image OpenLogic:CentOS:7.5:latest --admin-username clitest1 --generate-ssh-key '
2024-10-25T13:00:24.9585478Z                  '--nsg-rule None --admin-username vmtest --subnet {subnet} --vnet-name {vnet}')
2024-10-25T13:00:24.9585790Z     
2024-10-25T13:00:24.9586041Z         # Disable default outbound access
2024-10-25T13:00:24.9586302Z         self.cmd(
2024-10-25T13:00:24.9586752Z             'network vnet subnet update -g {rg} --vnet-name {vnet} -n {subnet} --default-outbound-access false')
2024-10-25T13:00:24.9587065Z     
2024-10-25T13:00:24.9587608Z         self.cmd('vm run-command invoke -g {rg} -n {vm} --command-id RunShellScript --scripts "echo \'sudo waagent -deprovision+user --force\' | at -M now + 1 minutes" --no-wait')
2024-10-25T13:00:24.9588185Z         time.sleep(70)
2024-10-25T13:00:24.9588536Z >       self.cmd('vm deallocate -g {rg} -n {vm}')
2024-10-25T13:00:24.9588671Z 
2024-10-25T13:00:24.9589115Z /opt/az/lib/python3.12/site-packages/azure/cli/command_modules/vm/tests/latest/test_vm_commands.py:4745: 
2024-10-25T13:00:24.9589500Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2024-10-25T13:00:24.9589960Z /opt/az/lib/python3.12/site-packages/azure/cli/testsdk/base.py:176: in cmd
2024-10-25T13:00:24.9590370Z     return execute(self.cli_ctx, command, expect_failure=expect_failure).assert_with_checks(checks)
2024-10-25T13:00:24.9590866Z /opt/az/lib/python3.12/site-packages/azure/cli/testsdk/base.py:251: in __init__
2024-10-25T13:00:24.9591259Z     self._in_process_execute(cli_ctx, command, expect_failure=expect_failure)
2024-10-25T13:00:24.9591760Z /opt/az/lib/python3.12/site-packages/azure/cli/testsdk/base.py:314: in _in_process_execute
2024-10-25T13:00:24.9592098Z     raise ex.exception
2024-10-25T13:00:24.9592506Z /opt/az/lib/python3.12/site-packages/knack/cli.py:233: in invoke
2024-10-25T13:00:24.9592850Z     cmd_result = self.invocation.execute(args)
2024-10-25T13:00:24.9593317Z /opt/az/lib/python3.12/site-packages/azure/cli/core/commands/__init__.py:666: in execute
2024-10-25T13:00:24.9593644Z     raise ex
2024-10-25T13:00:24.9594108Z /opt/az/lib/python3.12/site-packages/azure/cli/core/commands/__init__.py:733: in _run_jobs_serially
2024-10-25T13:00:24.9594502Z     results.append(self._run_job(expanded_arg, cmd_copy))
2024-10-25T13:00:24.9594993Z /opt/az/lib/python3.12/site-packages/azure/cli/core/commands/__init__.py:714: in _run_job
2024-10-25T13:00:24.9595506Z     result = LongRunningOperation(cmd_copy.cli_ctx, 'Starting {}'.format(cmd_copy.name))(result)
2024-10-25T13:00:24.9596022Z /opt/az/lib/python3.12/site-packages/azure/cli/core/commands/__init__.py:1075: in __call__
2024-10-25T13:00:24.9596360Z     raise exception
2024-10-25T13:00:24.9596801Z /opt/az/lib/python3.12/site-packages/azure/cli/core/commands/__init__.py:1062: in __call__
2024-10-25T13:00:24.9597140Z     result = poller.result()
2024-10-25T13:00:24.9597578Z /opt/az/lib/python3.12/site-packages/azure/cli/core/aaz/_poller.py:108: in result
2024-10-25T13:00:24.9597906Z     self.wait(timeout)
2024-10-25T13:00:24.9598354Z /opt/az/lib/python3.12/site-packages/azure/core/tracing/decorator.py:94: in wrapper_use_tracer
2024-10-25T13:00:24.9598712Z     return func(*args, **kwargs)
2024-10-25T13:00:24.9599337Z /opt/az/lib/python3.12/site-packages/azure/cli/core/aaz/_poller.py:130: in wait
2024-10-25T13:00:24.9599669Z     raise self._exception
2024-10-25T13:00:24.9600100Z /opt/az/lib/python3.12/site-packages/azure/cli/core/aaz/_poller.py:83: in _start
2024-10-25T13:00:24.9600459Z     for polling_method in self._polling_generator:
2024-10-25T13:00:24.9600979Z /opt/az/lib/python3.12/site-packages/azure/cli/command_modules/vm/aaz/latest/vm/_deallocate.py:78: in _execute_operations
2024-10-25T13:00:24.9601405Z     yield self.VirtualMachinesDeallocate(ctx=self.ctx)()
2024-10-25T13:00:24.9601916Z /opt/az/lib/python3.12/site-packages/azure/cli/command_modules/vm/aaz/latest/vm/_deallocate.py:114: in __call__
2024-10-25T13:00:24.9602306Z     return self.on_error(session.http_response)
2024-10-25T13:00:24.9602632Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2024-10-25T13:00:24.9602768Z 
2024-10-25T13:00:24.9603130Z self = <azure.cli.command_modules.vm.aaz.latest.vm._deallocate.Deallocate.VirtualMachinesDeallocate object at 0xffff82652e70>
2024-10-25T13:00:24.9603693Z response = <RequestsTransportResponse: 404 Not Found, Content-Type: application/json; charset=utf-8>
2024-10-25T13:00:24.9603884Z 
2024-10-25T13:00:24.9604130Z     def on_error(self, response):
2024-10-25T13:00:24.9604404Z         """ handle errors in response
2024-10-25T13:00:24.9604646Z         """
2024-10-25T13:00:24.9604904Z         # raise common http errors
2024-10-25T13:00:24.9605353Z         error_type = self.error_map.get(response.status_code)
2024-10-25T13:00:24.9605646Z         if error_type:
2024-10-25T13:00:24.9605931Z >           raise error_type(response=response)
2024-10-25T13:00:24.9606499Z E           azure.core.exceptions.ResourceNotFoundError: (SubscriptionNotFound) The subscription '00000000-0000-0000-0000-000000000000' could not be found.
2024-10-25T13:00:24.9606902Z E           Code: SubscriptionNotFound
2024-10-25T13:00:24.9607358Z E           Message: The subscription '00000000-0000-0000-0000-000000000000' could not be found.
2024-10-25T13:00:24.9607536Z 
2024-10-25T13:00:24.9607974Z /opt/az/lib/python3.12/site-packages/azure/cli/core/aaz/_operation.py:329: ResourceNotFoundError
2024-10-25T13:00:24.9608478Z ------------------------------ Captured log call -------------------------------
2024-10-25T13:00:24.9609047Z WARNING  cli.azure.cli.command_modules.vm._validators:_validators.py:1394 Consider upgrading security for your workloads using Azure Trusted Launch VMs. To know more about Trusted Launch, please visit https://aka.ms/TrustedLaunch.
2024-10-25T13:00:24.9609720Z -------------- generated xml file: /azure_cli_test_result/vm.xml ---------------
2024-10-25T13:00:24.9610111Z =========================== short test summary info ============================
2024-10-25T13:00:24.9610506Z FAILED tests/latest/test_vm_commands.py::VMSSUpdateTests::test_vmss_update_image
```

Ref: https://dev.azure.com/azclitools/public/_build/results?buildId=201003&view=logs&jobId=788bfeb8-6c0f-5544-4e87-f6639738ee28&j=788bfeb8-6c0f-5544-4e87-f6639738ee28&t=9eb1d89a-c9da-5ad8-571d-2d09b1c8859f