### PR TITLE
{Packaging} Fix test RPM Azure Linux

### DIFF
--- a/scripts/release/rpm/test_azurelinux_in_docker.sh
+++ b/scripts/release/rpm/test_azurelinux_in_docker.sh
@@ -14,7 +14,7 @@ time az self-test
 time az --version
 
 cd /azure-cli/
-python -m pip install --upgrade pip setuptools
+python -m pip install setuptools
 ./scripts/ci/build.sh
 
 # From Fedora36, when using `pip install --prefix` with root privileges, the package is installed into `{prefix}/local/lib`.

--- a/scripts/release/rpm/test_rpm_in_docker.sh
+++ b/scripts/release/rpm/test_rpm_in_docker.sh
@@ -15,7 +15,7 @@ time az self-test
 time az --version
 
 cd /azure-cli/
-python -m pip install setuptools
+python -m pip install --upgrade pip setuptools
 ./scripts/ci/build.sh
 
 # From Fedora36, when using `pip install --prefix` with root privileges, the package is installed into `{prefix}/local/lib`.

--- a/scripts/release/rpm/test_rpm_in_docker.sh
+++ b/scripts/release/rpm/test_rpm_in_docker.sh
@@ -15,7 +15,7 @@ time az self-test
 time az --version
 
 cd /azure-cli/
-python -m pip install --upgrade pip setuptools
+python -m pip install setuptools
 ./scripts/ci/build.sh
 
 # From Fedora36, when using `pip install --prefix` with root privileges, the package is installed into `{prefix}/local/lib`.


### PR DESCRIPTION
pip can't be upgraded in Azure Linux 3, but it works fine on Mariner 2.0.

Since the pip version does not affect clitestsdk build, use the version installed by `python3-pip` package instead.

```
+ python -m pip install --upgrade pip setuptools
Requirement already satisfied: pip in /usr/lib/python3.12/site-packages (24.2)
Collecting pip
  Downloading pip-24.3.1-py3-none-any.whl.metadata (3.7 kB)
Collecting setuptools
  Downloading setuptools-75.2.0-py3-none-any.whl.metadata (6.9 kB)
Downloading pip-24.3.1-py3-none-any.whl (1.8 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.8/1.8 MB 31.6 MB/s eta 0:00:00
Downloading setuptools-75.2.0-py3-none-any.whl (1.2 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.2/1.2 MB 25.8 MB/s eta 0:00:00
Installing collected packages: setuptools, pip
  Attempting uninstall: pip
    Found existing installation: pip 24.2
error: uninstall-no-record-file

× Cannot uninstall pip 24.2
╰─> The package's contents are unknown: no RECORD file was found for pip.

hint: The package was installed by rpm. You should check if it can uninstall the package.
```

Ref: https://dev.azure.com/azclitools/public/_build/results?buildId=201368&view=logs&jobId=e3d58f38-f120-52d4-9d7a-9847591da328&j=4a070aa6-03ff-5caf-6490-ded6aca0ca24&t=9afa7565-c847-5b45-dd7a-f91034321474