### PR TITLE
{CI} Skip test_mysql_replica_mgmt

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/tests/latest/test_rdbms_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/tests/latest/test_rdbms_commands.py
@@ -894,6 +894,7 @@ class ProxyResourcesMgmtScenarioTest(ScenarioTest):
 
 class ReplicationMgmtScenarioTest(ScenarioTest):  # pylint: disable=too-few-public-methods
 
+    @live_only()
     @ResourceGroupPreparer(parameter_name='resource_group')
     def test_mysql_replica_mgmt(self, resource_group):
         self._test_replica_mgmt(resource_group, 'mysql')


### PR DESCRIPTION
This PR is a supplement to the https://github.com/Azure/azure-cli/pull/30164.

```
2024-10-29T04:21:37.3342779Z =================================== FAILURES ===================================
2024-10-29T04:21:37.3343200Z _____________ ReplicationMgmtScenarioTest.test_mysql_replica_mgmt ______________
2024-10-29T04:21:37.3344183Z [gw3] linux -- Python 3.12.7 /opt/az/bin/python3
2024-10-29T04:21:37.3344556Z self = <azure.cli.testsdk.base.ExecutionResult object at 0xffff97ac6180>
2024-10-29T04:21:37.3344963Z cli_ctx = <azure.cli.core.mock.DummyCli object at 0xffff9c62f6e0>
2024-10-29T04:21:37.3345865Z command = 'mysql server replica create -g clitest.rg000001 -n azuredbclirep1000003 -l westus --sku-name GP_Gen5_4 --source-serve...000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/servers/azuredbclitest000002'
2024-10-29T04:21:37.3346418Z expect_failure = False
2024-10-29T04:21:37.3346535Z 
2024-10-29T04:21:37.3346861Z     def _in_process_execute(self, cli_ctx, command, expect_failure=False):
2024-10-29T04:21:37.3347200Z         from io import StringIO
2024-10-29T04:21:37.3347543Z         from vcr.errors import CannotOverwriteExistingCassetteException
2024-10-29T04:21:37.3347863Z     
2024-10-29T04:21:37.3348213Z         if command.startswith('az '):
2024-10-29T04:21:37.3348713Z             command = command[3:]
2024-10-29T04:21:37.3348987Z     
2024-10-29T04:21:37.3349278Z         stdout_buf = StringIO()
2024-10-29T04:21:37.3349577Z         logging_buf = StringIO()
2024-10-29T04:21:37.3349853Z         try:
2024-10-29T04:21:37.3350203Z             # issue: stderr cannot be redirect in this form, as a result some failure information
2024-10-29T04:21:37.3350570Z             # is lost when command fails.
2024-10-29T04:21:37.3350934Z >           self.exit_code = cli_ctx.invoke(shlex.split(command), out_file=stdout_buf) or 0
2024-10-29T04:21:37.3351120Z 
2024-10-29T04:21:37.3351543Z /opt/az/lib/python3.12/site-packages/azure/cli/testsdk/base.py:302: 
2024-10-29T04:21:37.3351933Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2024-10-29T04:21:37.3352385Z /opt/az/lib/python3.12/site-packages/knack/cli.py:245: in invoke
2024-10-29T04:21:37.3353901Z     exit_code = self.exception_handler(ex)
2024-10-29T04:21:37.3354446Z /opt/az/lib/python3.12/site-packages/azure/cli/core/__init__.py:129: in exception_handler
2024-10-29T04:21:37.3354830Z     return handle_exception(ex)
2024-10-29T04:21:37.3355169Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2024-10-29T04:21:37.3355322Z 
2024-10-29T04:21:37.3356035Z ex = CLIError("Unable to get source server: (SubscriptionNotFound) The subscription '00000000-0000-0000-0000-000000000000' ...d.\nCode: SubscriptionNotFound\nMessage: The subscription '00000000-0000-0000-0000-000000000000' could not be found..")
2024-10-29T04:21:37.3356560Z args = (), kwargs = {}
2024-10-29T04:21:37.3356672Z 
2024-10-29T04:21:37.3357113Z     def _handle_main_exception(ex, *args, **kwargs):  # pylint: disable=unused-argument
2024-10-29T04:21:37.3357535Z         if isinstance(ex, CannotOverwriteExistingCassetteException):
2024-10-29T04:21:37.3357933Z             # This exception usually caused by a no match HTTP request. This is a product error
2024-10-29T04:21:37.3358312Z             # that is caused by change of SDK invocation.
2024-10-29T04:21:37.3358633Z             raise ex
2024-10-29T04:21:37.3358888Z     
2024-10-29T04:21:37.3359165Z >       raise CliExecutionError(ex)
2024-10-29T04:21:37.3359583Z E       azure.cli.testsdk.exceptions.CliExecutionError: The CLI throws exception CLIError during execution and fails the command.
2024-10-29T04:21:37.3359801Z 
2024-10-29T04:21:37.3360248Z /opt/az/lib/python3.12/site-packages/azure/cli/testsdk/patches.py:35: CliExecutionError
2024-10-29T04:21:37.3360446Z 
2024-10-29T04:21:37.3360765Z During handling of the above exception, another exception occurred:
2024-10-29T04:21:37.3360933Z 
2024-10-29T04:21:37.3361316Z self = <command_modules.rdbms.tests.latest.test_rdbms_commands.ReplicationMgmtScenarioTest testMethod=test_mysql_replica_mgmt>
2024-10-29T04:21:37.3361799Z resource_group = 'clitest.rg000001'
2024-10-29T04:21:37.3361940Z 
2024-10-29T04:21:37.3362327Z     @ResourceGroupPreparer(parameter_name='resource_group')
2024-10-29T04:21:37.3362707Z     def test_mysql_replica_mgmt(self, resource_group):
2024-10-29T04:21:37.3363361Z >       self._test_replica_mgmt(resource_group, 'mysql')
2024-10-29T04:21:37.3363509Z 
2024-10-29T04:21:37.3364024Z /opt/az/lib/python3.12/site-packages/azure/cli/command_modules/rdbms/tests/latest/test_rdbms_commands.py:899: 
2024-10-29T04:21:37.3364453Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2024-10-29T04:21:37.3365022Z /opt/az/lib/python3.12/site-packages/azure/cli/command_modules/rdbms/tests/latest/test_rdbms_commands.py:920: in _test_replica_mgmt
2024-10-29T04:21:37.3365601Z     self.cmd('{} server replica create -g {} -n {} -l westus --sku-name GP_Gen5_4 '
2024-10-29T04:21:37.3366117Z /opt/az/lib/python3.12/site-packages/azure/cli/testsdk/base.py:176: in cmd
2024-10-29T04:21:37.3366564Z     return execute(self.cli_ctx, command, expect_failure=expect_failure).assert_with_checks(checks)
2024-10-29T04:21:37.3367093Z /opt/az/lib/python3.12/site-packages/azure/cli/testsdk/base.py:251: in __init__
2024-10-29T04:21:37.3367661Z     self._in_process_execute(cli_ctx, command, expect_failure=expect_failure)
2024-10-29T04:21:37.3368204Z /opt/az/lib/python3.12/site-packages/azure/cli/testsdk/base.py:314: in _in_process_execute
2024-10-29T04:21:37.3368572Z     raise ex.exception
2024-10-29T04:21:37.3368996Z /opt/az/lib/python3.12/site-packages/knack/cli.py:233: in invoke
2024-10-29T04:21:37.3369371Z     cmd_result = self.invocation.execute(args)
2024-10-29T04:21:37.3369861Z /opt/az/lib/python3.12/site-packages/azure/cli/core/commands/__init__.py:666: in execute
2024-10-29T04:21:37.3370218Z     raise ex
2024-10-29T04:21:37.3370701Z /opt/az/lib/python3.12/site-packages/azure/cli/core/commands/__init__.py:733: in _run_jobs_serially
2024-10-29T04:21:37.3371112Z     results.append(self._run_job(expanded_arg, cmd_copy))
2024-10-29T04:21:37.3371619Z /opt/az/lib/python3.12/site-packages/azure/cli/core/commands/__init__.py:703: in _run_job
2024-10-29T04:21:37.3371996Z     result = cmd_copy(params)
2024-10-29T04:21:37.3372471Z /opt/az/lib/python3.12/site-packages/azure/cli/core/commands/__init__.py:336: in __call__
2024-10-29T04:21:37.3372864Z     return self.handler(*args, **kwargs)
2024-10-29T04:21:37.3373375Z /opt/az/lib/python3.12/site-packages/azure/cli/core/commands/command_operation.py:121: in handler
2024-10-29T04:21:37.3373757Z     return op(**command_args)
2024-10-29T04:21:37.3374093Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2024-10-29T04:21:37.3374244Z 
2024-10-29T04:21:37.3374565Z cmd = <azure.cli.core.commands.AzCliCommand object at 0xffff97926030>
2024-10-29T04:21:37.3374999Z client = <azure.mgmt.rdbms.mysql.operations._servers_operations.ServersOperations object at 0xffff97926960>
2024-10-29T04:21:37.3375543Z resource_group_name = 'clitest.rg000001', server_name = 'azuredbclirep1000003'
2024-10-29T04:21:37.3376192Z source_server = '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/servers/azuredbclitest000002'
2024-10-29T04:21:37.3376785Z no_wait = False, location = 'westus', sku_name = 'GP_Gen5_4', kwargs = {}
2024-10-29T04:21:37.3377205Z provider = 'Microsoft.DBforMySQL'
2024-10-29T04:21:37.3377805Z source_server_id_parts = {'children': '', 'name': 'azuredbclitest000002', 'namespace': 'Microsoft.DBforMySQL', 'resource_group': 'clitest.rg000001', ...}
2024-10-29T04:21:37.3378065Z 
2024-10-29T04:21:37.3378461Z     def _replica_create(cmd, client, resource_group_name, server_name, source_server, no_wait=False, location=None, sku_name=None, **kwargs):
2024-10-29T04:21:37.3378979Z         provider = 'Microsoft.DBforPostgreSQL'
2024-10-29T04:21:37.3379327Z         if isinstance(client, MySqlServersOperations):
2024-10-29T04:21:37.3379672Z             logger.warning(MYSQL_RETIRE_WARNING_MSG)
2024-10-29T04:21:37.3380086Z             provider = 'Microsoft.DBforMySQL'
2024-10-29T04:21:37.3380433Z         elif isinstance(client, MariaDBServersOperations):
2024-10-29T04:21:37.3380792Z             logger.warning(MARIADB_RETIRE_WARNING_MSG)
2024-10-29T04:21:37.3381373Z             provider = 'Microsoft.DBforMariaDB'
2024-10-29T04:21:37.3381699Z         # set source server id
2024-10-29T04:21:37.3382018Z         if not is_valid_resource_id(source_server):
2024-10-29T04:21:37.3382431Z             if len(source_server.split('/')) == 1:
2024-10-29T04:21:37.3382817Z                 source_server = resource_id(subscription=get_subscription_id(cmd.cli_ctx),
2024-10-29T04:21:37.3383197Z                                             resource_group=resource_group_name,
2024-10-29T04:21:37.3383530Z                                             namespace=provider,
2024-10-29T04:21:37.3383928Z                                             type='servers',
2024-10-29T04:21:37.3384240Z                                             name=source_server)
2024-10-29T04:21:37.3384533Z             else:
2024-10-29T04:21:37.3384977Z                 raise CLIError('The provided source-server {} is invalid.'.format(source_server))
2024-10-29T04:21:37.3385437Z     
2024-10-29T04:21:37.3385758Z         source_server_id_parts = parse_resource_id(source_server)
2024-10-29T04:21:37.3386081Z         try:
2024-10-29T04:21:37.3386574Z             source_server_object = client.get(source_server_id_parts['resource_group'], source_server_id_parts['name'])
2024-10-29T04:21:37.3386973Z         except HttpResponseError as e:
2024-10-29T04:21:37.3387427Z >           raise CLIError('Unable to get source server: {}.'.format(str(e)))
2024-10-29T04:21:37.3388053Z E           knack.util.CLIError: Unable to get source server: (SubscriptionNotFound) The subscription '00000000-0000-0000-0000-000000000000' could not be found.
2024-10-29T04:21:37.3388494Z E           Code: SubscriptionNotFound
2024-10-29T04:21:37.3388972Z E           Message: The subscription '00000000-0000-0000-0000-000000000000' could not be found..
2024-10-29T04:21:37.3389156Z 
2024-10-29T04:21:37.3389624Z /opt/az/lib/python3.12/site-packages/azure/cli/command_modules/rdbms/custom.py:337: CLIError
2024-10-29T04:21:37.3390149Z ------------------------------ Captured log call -------------------------------
2024-10-29T04:21:37.3391061Z WARNING  cli.azure.cli.command_modules.rdbms.custom:custom.py:98 Azure Database for MySQL - Single Server is scheduled for retirement (https://go.microsoft.com/fwlink/?linkid=2216041) by September 16, 2024. Migrate (https://go.microsoft.com/fwlink/?linkid=2202255) to Azure Database for MySQL- Flexible Server now.
2024-10-29T04:21:37.3391998Z WARNING  cli.azure.cli.command_modules.rdbms._flexible_server_util:_flexible_server_util.py:56 Checking the existence of the resource group 'clitest.rg000001'...
2024-10-29T04:21:37.3392917Z WARNING  cli.azure.cli.command_modules.rdbms._flexible_server_util:_flexible_server_util.py:58 Resource group 'clitest.rg000001' exists ? : True 
2024-10-29T04:21:37.3393675Z WARNING  cli.azure.cli.command_modules.rdbms.custom:custom.py:106 Creating mysql Server 'azuredbclitest000002' in group 'clitest.rg000001'...
2024-10-29T04:21:37.3394489Z WARNING  cli.azure.cli.command_modules.rdbms.custom:custom.py:107 Your server 'azuredbclitest000002' is using sku 'GP_Gen5_2' (Paid Tier). Please refer to https://aka.ms/mysql-pricing  for pricing details
2024-10-29T04:21:37.3395429Z WARNING  cli.azure.cli.command_modules.rdbms.custom:custom.py:168 Make a note of your password. If you forget, you would have to reset your password with 'az mysql server update -n azuredbclitest000002 -g clitest.rg000001 -p <new-password>'.
2024-10-29T04:21:37.3396174Z WARNING  cli.azure.cli.command_modules.rdbms.custom:custom.py:867 Creating mysql database 'defaultdb'...
2024-10-29T04:21:37.3397216Z WARNING  cli.azure.cli.command_modules.rdbms.custom:custom.py:317 Azure Database for MySQL - Single Server is scheduled for retirement (https://go.microsoft.com/fwlink/?linkid=2216041) by September 16, 2024. Migrate (https://go.microsoft.com/fwlink/?linkid=2202255) to Azure Database for MySQL- Flexible Server now.
2024-10-29T04:21:37.3397974Z ------------- generated xml file: /azure_cli_test_result/rdbms.xml -------------
2024-10-29T04:21:37.3398577Z =========================== short test summary info ============================
2024-10-29T04:21:37.3399044Z FAILED tests/latest/test_rdbms_commands.py::ReplicationMgmtScenarioTest::test_mysql_replica_mgmt
2024-10-29T04:21:37.3399499Z =================== 1 failed, 36 passed, 8 skipped in 30.53s ===================
```

Ref: https://dev.azure.com/azclitools/public/_build/results?buildId=201611&view=logs&jobId=e3d58f38-f120-52d4-9d7a-9847591da328&j=e3d58f38-f120-52d4-9d7a-9847591da328&t=95a8677a-ae64-591e-54ce-dbe38e361b97