### PR TITLE
{Packaging} Update setuptools in Azure Linux RPM test

### DIFF
--- a/scripts/release/rpm/test_azurelinux_in_docker.sh
+++ b/scripts/release/rpm/test_azurelinux_in_docker.sh
@@ -14,7 +14,7 @@ time az self-test
 time az --version
 
 cd /azure-cli/
-python -m pip install setuptools
+python -m pip install --upgrade setuptools
 ./scripts/ci/build.sh
 
 # From Fedora36, when using `pip install --prefix` with root privileges, the package is installed into `{prefix}/local/lib`.


### PR DESCRIPTION
Rework for https://github.com/Azure/azure-cli/pull/30211.

In 70.1.0, `wheel` has already been vendored in `setuptools`: https://github.com/pypa/setuptools/pull/4369
However, Mariner uses an old version of setuptools, which can't build wheel without `wheel` package.
Update `setuptools` to latest version to fix the issue.

```
# build product packages
title 'Build Azure CLI and its command modules'
for setup_file in $(find src -name 'setup.py'); do
    pushd $(dirname ${setup_file}) >/dev/null
    echo "Building module at $(pwd) ..."
    python setup.py -q bdist_wheel -d $output_dir
    python setup.py -q sdist -d $sdist_dir
    popd >/dev/null
done
Build Azure CLI and its command modules
Building module at /azure-cli/src/azure-cli-telemetry ...
usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
   or: setup.py --help [cmd1 cmd2 ...]
   or: setup.py --help-commands
   or: setup.py cmd --help

error: invalid command 'bdist_wheel'

```

```
# mariner 2.0
root [ / ]# python3 -m pip list
Package    Version
---------- -------
pip        23.0.1
setuptools 58.1.0
```