### PR TITLE
{CI} Improve CI speed by using multi-core agent

### DIFF
--- a/.azure-pipelines/templates/variables.yml
+++ b/.azure-pipelines/templates/variables.yml
@@ -1,5 +1,6 @@
 variables:
   ubuntu_pool: 'pool-ubuntu-2004'
+  ubuntu_multi_core_pool: 'pool-ubuntu-2004-multi-core'
   windows_pool: 'pool-windows-2019'
   ubuntu_arm64_pool: 'ubuntu-arm64-2004-pool'
   macos_pool: 'macOS-14'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ parameters:
   default:
   - name: AMD64
     value: amd64
-    pool: pool-ubuntu-2004
+    pool: pool-ubuntu-2004-multi-core
   - name: ARM64
     value: arm64
     pool: ubuntu-arm64-2004-pool

--- a/scripts/release/debian/test_deb_package.py
+++ b/scripts/release/debian/test_deb_package.py
@@ -13,6 +13,10 @@ mod_list = [mod for mod in sorted(os.listdir(root_dir)) if os.path.isdir(os.path
 
 pytest_base_cmd = '/opt/az/bin/python3 -m pytest -v --forked -p no:warnings --log-level=WARN'
 pytest_parallel_cmd = '{} -n auto'.format(pytest_base_cmd)
+
+# cloud: https://github.com/Azure/azure-cli/pull/14994
+# appservice: https://github.com/Azure/azure-cli/pull/19810
+# iot, resource, azure-cli-core: https://github.com/Azure/azure-cli/pull/26176
 serial_test_modules = ['botservice', 'network', 'cloud', 'appservice', 'iot', 'resource']
 
 for mod_name in mod_list:

--- a/scripts/release/rpm/test_rpm_package.py
+++ b/scripts/release/rpm/test_rpm_package.py
@@ -13,6 +13,10 @@ mod_list = [mod for mod in sorted(os.listdir(root_dir)) if os.path.isdir(os.path
 
 pytest_base_cmd = f'PYTHONPATH=/usr/lib64/az/lib/{python_version}/site-packages python -m pytest -v --forked -p no:warnings --log-level=WARN'
 pytest_parallel_cmd = '{} -n auto'.format(pytest_base_cmd)
+
+# cloud: https://github.com/Azure/azure-cli/pull/14994
+# appservice: https://github.com/Azure/azure-cli/pull/19810
+# iot, resource, azure-cli-core: https://github.com/Azure/azure-cli/pull/26176
 serial_test_modules = ['botservice', 'network', 'cloud', 'appservice', 'iot', 'resource']
 
 for mod_name in mod_list:


### PR DESCRIPTION
Use multi-core agent to build and run test for DEB and RPM.

`pytest` can create two workers to run the test now.

Save 20-30% of the time:
`Test Rpm Package Azure Linux 3.0 AMD64` drops from `2h 9m 32s` to `1h 34m 42s`
`Test Deb Packages Focal AMD64` drops from `1h 56m 16s` to `1h 24m 38s`
`Test Rpm Package Mariner 2.0 AMD64` drops from `1h 13m 27s` to `59m 33s`
`Test Rpm Package Red Hat Universal Base Image 8 AMD64` drops from `1h 5m 1s` to `50m 7s`

Known limitation:
1. Some modules are run in serial, such as `network`.
2. Some tests run much slower than others, slowing down the entire testing process. For example: `tests/latest/test_keyvault_commands.py::KeyVaultMgmtScenarioTest::test_keyvault_list_deleted ` takes 6 min.