### PR TITLE
[AKS] BREAKING CHANGE: `az aks trustedaccess rolebinding create`: Remove deprecated `-r` options

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_params.py
@@ -851,9 +851,6 @@ def load_arguments(self, _):
         c.argument('roles', help='comma-separated roles: Microsoft.Demo/samples/reader,Microsoft.Demo/samples/writer,...')
         c.argument(
             'source_resource_id',
-            options_list=[
-                '--source-resource-id',
-            ],
             help='The source resource id of the binding',
         )
 

--- a/src/azure-cli/azure/cli/command_modules/acs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_params.py
@@ -853,7 +853,6 @@ def load_arguments(self, _):
             'source_resource_id',
             options_list=[
                 '--source-resource-id',
-                c.deprecate(target='-r', redirect='--source-resource-id', hide=True),
             ],
             help='The source resource id of the binding',
         )


### PR DESCRIPTION
**Related command**
az aks trustedaccess rolebinding create

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
 '-r' options used to marked deprecated, now totally remove it

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[AKS] BREAKING CHANGE: `az aks trustedaccess rolebinding create`: Remove deprecated '-r' options

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
