### PR TITLE
[Core] PREVIEW: Support managed identity on Azure Arc-enabled Linux server

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -220,8 +220,8 @@ class Profile:
         return deepcopy(consolidated)
 
     def login_with_managed_identity(self, identity_id=None, allow_no_subscriptions=None):
-        if _on_azure_arc_windows():
-            return self.login_with_managed_identity_azure_arc_windows(
+        if _on_azure_arc():
+            return self.login_with_managed_identity_azure_arc(
                 identity_id=identity_id, allow_no_subscriptions=allow_no_subscriptions)
 
         import jwt
@@ -286,7 +286,7 @@ class Profile:
         self._set_subscriptions(consolidated)
         return deepcopy(consolidated)
 
-    def login_with_managed_identity_azure_arc_windows(self, identity_id=None, allow_no_subscriptions=None):
+    def login_with_managed_identity_azure_arc(self, identity_id=None, allow_no_subscriptions=None):
         import jwt
         identity_type = MsiAccountTypes.system_assigned
         from .auth.msal_credentials import ManagedIdentityCredential
@@ -388,7 +388,7 @@ class Profile:
 
         elif managed_identity_type:
             # managed identity
-            if _on_azure_arc_windows():
+            if _on_azure_arc():
                 from .auth.msal_credentials import ManagedIdentityCredential
                 from azure.cli.core.auth.credential_adaptor import CredentialAdaptor
                 # The credential must be wrapped by CredentialAdaptor so that it can work with Track 1 SDKs.
@@ -449,7 +449,7 @@ class Profile:
             # managed identity
             if tenant:
                 raise CLIError("Tenant shouldn't be specified for managed identity account")
-            if _on_azure_arc_windows():
+            if _on_azure_arc():
                 from .auth.msal_credentials import ManagedIdentityCredential
                 cred = ManagedIdentityCredential()
             else:
@@ -960,6 +960,7 @@ def _create_identity_instance(cli_ctx, authority, tenant_id=None, client_id=None
                     instance_discovery=instance_discovery)
 
 
-def _on_azure_arc_windows():
-    # This indicates an Azure Arc-enabled Windows server
-    return "IDENTITY_ENDPOINT" in os.environ and "IMDS_ENDPOINT" in os.environ
+def _on_azure_arc():
+    # This indicates an Azure Arc-enabled server
+    from msal.managed_identity import get_managed_identity_source, AZURE_ARC
+    return get_managed_identity_source() == AZURE_ARC

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -53,7 +53,7 @@ DEPENDENCIES = [
     'jmespath',
     'knack~=0.11.0',
     'msal-extensions==1.2.0',
-    'msal[broker]==1.31.0',
+    'msal[broker]==1.31.1',
     'msrestazure~=0.6.4',
     'packaging>=20.9',
     'pkginfo>=1.5.0.1',

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -104,7 +104,7 @@ jmespath==0.9.5
 jsondiff==2.0.0
 knack==0.11.0
 msal-extensions==1.2.0
-msal[broker]==1.31.0
+msal[broker]==1.31.1
 msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -105,7 +105,7 @@ jmespath==0.9.5
 jsondiff==2.0.0
 knack==0.11.0
 msal-extensions==1.2.0
-msal[broker]==1.31.0
+msal[broker]==1.31.1
 msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -104,7 +104,7 @@ jmespath==0.9.5
 jsondiff==2.0.0
 knack==0.11.0
 msal-extensions==1.2.0
-msal[broker]==1.31.0
+msal[broker]==1.31.1
 msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2


### PR DESCRIPTION
**Related command**
`az login --identity`

**Description**<!--Mandatory-->
- Close https://github.com/Azure/azure-cli/issues/16573
- Require https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/763

This is only a temporary solution.

If Azure Arc is detected, Azure CLI uses MSAL for managed identity authentication. For other platforms, such as VM and App Service, the existing logic is preserved. These platforms' migration will be done in https://github.com/Azure/azure-cli/pull/25959.