### PR TITLE
{Misc.} Remove `is_packaged_installed`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/_utils.py
@@ -386,15 +386,6 @@ def create_app_config_connection_if_not_exist(cmd, client, source_id, app_config
                          parameters=parameters)
 
 
-def is_packaged_installed(package_name):
-    import pkg_resources
-    installed_packages = pkg_resources.working_set
-    # pylint: disable=not-an-iterable
-    pkg_installed = any((package_name) in d.key.lower()
-                        for d in installed_packages)
-    return pkg_installed
-
-
 def get_object_id_of_current_user():
     signed_in_user_info = run_cli_cmd('az account show -o json')
     if not isinstance(signed_in_user_info, dict):


### PR DESCRIPTION
This function was introduced in https://github.com/Azure/azure-cli/pull/24408, and its reference was removed in https://github.com/Azure/azure-cli/pull/26029

Remove it to eliminate the dependency of  `setuptools`, see https://github.com/Azure/azure-cli/pull/27196#discussion_r1675047314