### PR TITLE
{Microsoft Entra ID} `az ad sp create-for-rbac`: Update examples and warnings

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_help.py
@@ -528,18 +528,27 @@ long-summary: >-
     You may also use `az role assignment create` to create role assignments for this service principal later.
     See [steps to add a role assignment](https://aka.ms/azadsp-more) for more information.
 examples:
-  - name: Create without role assignment.
-    text: az ad sp create-for-rbac
-  - name: Create using a custom display name.
-    text: az ad sp create-for-rbac -n MyApp
-  - name: Create with a Contributor role assignments on specified scopes. To retrieve current subscription ID, run `az account show --query id --output tsv`.
-    text: az ad sp create-for-rbac -n MyApp --role Contributor --scopes /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup2
-  - name: Create using a self-signed certificate.
-    text: az ad sp create-for-rbac --create-cert
-  - name: Create using a self-signed certificate, and store it within KeyVault.
-    text: az ad sp create-for-rbac --keyvault MyVault --cert CertName --create-cert
-  - name: Create using existing certificate in KeyVault.
-    text: az ad sp create-for-rbac --keyvault MyVault --cert CertName
+- name: Create without role assignment.
+  text: az ad sp create-for-rbac
+- name: Create using a custom display name.
+  text: az ad sp create-for-rbac -n MyApp
+- name: Create with a Contributor role assignments on specified scopes. To retrieve current subscription ID, run `az account show --query id --output tsv`.
+  text: az ad sp create-for-rbac -n MyApp --role Contributor --scopes /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup2
+- name: Create using a self-signed certificate.
+  text: az ad sp create-for-rbac --create-cert
+- name: Create using an existing certificate string.
+  text: az ad sp create-for-rbac --cert "MIICoT..."
+- name: Create using an existing certificate file.
+  text: |-
+      az ad sp create-for-rbac --cert "@~/cert.pem"
+      `cert.pem` contains the following content
+      -----BEGIN CERTIFICATE-----  <<< this line is optional
+      MIICoT...
+      -----END CERTIFICATE-----    <<< this line is optional
+- name: Create using a self-signed certificate, and store it within Azure Key Vault.
+  text: az ad sp create-for-rbac --keyvault MyVault --cert CertName --create-cert
+- name: Create using existing certificate in Azure Key Vault.
+  text: az ad sp create-for-rbac --keyvault MyVault --cert CertName
 """
 
 helps['ad sp credential'] = """

--- a/src/azure-cli/azure/cli/command_modules/role/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_params.py
@@ -205,7 +205,7 @@ def load_arguments(self, _):
             c.argument('cert', arg_group='keyCredential', validator=validate_cert,
                        help='Certificate to use for credentials. When used with `--keyvault,`, indicates the name of the '
                             'cert to use or create. Otherwise, supply a PEM or DER formatted public certificate string. '
-                            'Use `@{path}` to load from a file. Do not include private key info.')
+                            'Use `@{path}` to load from a file. Do not include the private key.')
             c.argument('create_cert', arg_group='keyCredential', action='store_true',
                        help='Create a self-signed certificate to use for the credential. Only the current OS user has '
                             'read/write permission to this certificate. Use with `--keyvault` to create the certificate in '

--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -1302,14 +1302,10 @@ def create_service_principal_for_rbac(
     }
     if cert_file:
         logger.warning(
-            "Please copy %s to a safe place. When you run 'az login', provide the file path in the --password argument",
+            "Please copy %s to a safe place. When you run `az login`, provide the file path in the --certificate "
+            "argument",
             cert_file)
         result['fileWithCertAndPrivateKey'] = cert_file
-
-    login_hint = ('To log in with this service principal, run:\n'
-                  f'az login --service-principal --username {app_id} --password {password or cert_file} '
-                  f'--tenant {graph_client.tenant}')
-    logger.info(login_hint)
     return result
 
 


### PR DESCRIPTION
**Related command**
`az ad sp create-for-rbac`

**Description**<!--Mandatory-->

- Add examples for using `--cert` to clarify https://github.com/MicrosoftDocs/azure-docs-cli/issues/4734
- Change warning messages for `--create-cert` according to https://github.com/Azure/azure-cli/pull/30091

**Testing Guide**
`az ad sp create-for-rbac -h`
