### PR TITLE
{Packaging} Bump paramiko to 3.5.0 

### DIFF
--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -109,7 +109,7 @@ msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2
 packaging==23.2
-paramiko==3.4.0
+paramiko==3.5.0
 pbr==5.3.1
 pkginfo==1.8.2
 portalocker==2.3.2

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -110,7 +110,7 @@ msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2
 packaging==23.2
-paramiko==3.4.0
+paramiko==3.5.0
 pbr==5.3.1
 pkginfo==1.8.2
 portalocker==2.3.2

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -109,7 +109,7 @@ msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2
 packaging==23.2
-paramiko==3.4.0
+paramiko==3.5.0
 pbr==5.3.1
 pkginfo==1.8.2
 portalocker==2.3.2


### PR DESCRIPTION
Resolve https://github.com/Azure/azure-cli/issues/30048

Bump to latest version to eliminate the warning:
```
/usr/local/lib/python3.11/site-packages/paramiko/pkey.py:100: CryptographyDeprecationWarning: TripleDES has been moved to cryptography.hazmat.decrepit.ciphers.algorithms.TripleDES and will be removed from this module in 48.0.0.
  "cipher": algorithms.TripleDES,
/usr/local/lib/python3.11/site-packages/paramiko/transport.py:259: CryptographyDeprecationWarning: TripleDES has been moved to cryptography.hazmat.decrepit.ciphers.algorithms.TripleDES and will be removed from this module in 48.0.0.
  "class": algorithms.TripleDES,
```
See https://github.com/Azure/azure-cli/issues/30048#issuecomment-2463678148