### PR TITLE
{Core} `aaz`: Empty identity only applies to remove subcommand

### DIFF
--- a/src/azure-cli-core/azure/cli/core/aaz/_field_value.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_field_value.py
@@ -478,7 +478,7 @@ class AAZIdentityObject(AAZObject):  # pylint: disable=too-few-public-methods
 
         result = self._build_identity(calculate_data, result)
 
-        if not result:
+        if not result and calculate_data.get("action", None) == "remove":
             result = {"type": "None"}  # empty identity
 
         if not result and self._is_patch:


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
some developers don't wanna input {"type": "None"} for the empty identity, so better not to input.

before:
<img width="1264" alt="image" src="https://github.com/user-attachments/assets/e8e9fadd-431f-46f8-b6b4-2d2df9e31579">

after:
![image](https://github.com/user-attachments/assets/fb43f47d-8b13-4ff7-ae9e-392dbae1a2f6)


**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
