### PR TITLE
Updating documentation to reflect correct --dryrun behaviour

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_help.py
@@ -133,7 +133,7 @@ type: command
 short-summary: Add a CORS rule for a storage account.
 examples:
   - name: Add a CORS rule for a storage account
-    text: |.
+    text: |
         az storage account blob-service-properties cors-rule add --account-name mystorageaccount --resource-group myresourcegroup --allowed-origins "http://*.contoso.com" --allowed-methods PUT GET --max-age 200
 """
 

--- a/src/azure-cli/azure/cli/command_modules/storage/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_help.py
@@ -133,7 +133,7 @@ type: command
 short-summary: Add a CORS rule for a storage account.
 examples:
   - name: Add a CORS rule for a storage account
-    text: |
+    text: |.
         az storage account blob-service-properties cors-rule add --account-name mystorageaccount --resource-group myresourcegroup --allowed-origins "http://*.contoso.com" --allowed-methods PUT GET --max-age 200
 """
 
@@ -928,8 +928,6 @@ parameters:
   - name: --dryrun
     type: bool
     short-summary: Show the summary of the operations to be taken instead of actually deleting the file(s).
-    long-summary: If this is specified, it will ignore all the Precondition Arguments that include --if-modified-since and --if-unmodified-since. So the file(s) will be deleted with the command without --dryrun may be different from the result list with --dryrun flag on.
-  - name: --if-match
     type: string
     short-summary: An ETag value, or the wildcard character (*). Specify this header to perform the operation only if the resource's ETag matches the value specified.
   - name: --if-none-match


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

The documentation suggests that `--dryrun` used in `az storage blob delete-batch` would ignore precondition arguments, which is false. Updating documentation to reflect correct behaviour.

**Testing Guide**
<!--Example commands with explanations.-->

```
date=`date -d "10 days ago" '+%Y-%m-%dT%H:%MZ'`
az storage blob delete-batch -s mycontainer --account-name mystorageaccount --pattern "*.py" --if-unmodified-since $date --auth-mode login
```

The above example would respect the `--if-unmodified-since $date` precondition argument.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
