### PR TITLE
[Profile] `az account get-access-token`: Add `--client-id` argument

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -362,12 +362,10 @@ class Profile:
         identity.logout_all_users()
         identity.logout_all_service_principal()
 
-    def get_login_credentials(self, resource=None, client_id=None, subscription_id=None, aux_subscriptions=None,
-                              aux_tenants=None):
+    def get_login_credentials(self, resource=None, subscription_id=None, aux_subscriptions=None, aux_tenants=None):
         """Get a CredentialAdaptor instance to be used with both Track 1 and Track 2 SDKs.
 
         :param resource: The resource ID to acquire an access token. Only provide it for Track 1 SDKs.
-        :param client_id:
         :param subscription_id:
         :param aux_subscriptions:
         :param aux_tenants:
@@ -410,10 +408,10 @@ class Profile:
                     if sub[_TENANT_ID] != account[_TENANT_ID]:
                         external_tenants.append(sub[_TENANT_ID])
 
-            credential = self._create_credential(account, client_id=client_id)
+            credential = self._create_credential(account)
             external_credentials = []
             for external_tenant in external_tenants:
-                external_credentials.append(self._create_credential(account, external_tenant, client_id=client_id))
+                external_credentials.append(self._create_credential(account, tenant_id=external_tenant))
             from azure.cli.core.auth.credential_adaptor import CredentialAdaptor
             cred = CredentialAdaptor(credential,
                                      auxiliary_credentials=external_credentials,
@@ -423,7 +421,7 @@ class Profile:
                 str(account[_SUBSCRIPTION_ID]),
                 str(account[_TENANT_ID]))
 
-    def get_raw_token(self, resource=None, scopes=None, subscription=None, tenant=None):
+    def get_raw_token(self, resource=None, scopes=None, subscription=None, tenant=None, client_id=None):
         # Convert resource to scopes
         if resource and not scopes:
             from .auth.util import resource_to_scopes
@@ -460,7 +458,7 @@ class Profile:
                                                         scopes_to_resource(scopes))
 
         else:
-            cred = self._create_credential(account, tenant)
+            cred = self._create_credential(account, tenant_id=tenant, client_id=client_id)
 
         sdk_token = cred.get_token(*scopes)
         # Convert epoch int 'expires_on' to datetime string 'expiresOn' for backward compatibility
@@ -665,7 +663,7 @@ class Profile:
         """
         user_type = account[_USER_ENTITY][_USER_TYPE]
         username_or_sp_id = account[_USER_ENTITY][_USER_NAME]
-        tenant_id = tenant_id if tenant_id else account[_TENANT_ID]
+        tenant_id = tenant_id or account[_TENANT_ID]
         identity = _create_identity_instance(self.cli_ctx, self._authority, tenant_id=tenant_id, client_id=client_id)
 
         # User
@@ -694,7 +692,7 @@ class Profile:
             tenant = s[_TENANT_ID]
             subscriptions = []
             try:
-                identity_credential = self._create_credential(s, tenant)
+                identity_credential = self._create_credential(s, tenant_id=tenant)
                 if is_service_principal:
                     subscriptions = subscription_finder.find_using_specific_tenant(tenant, identity_credential)
                 else:
@@ -938,7 +936,7 @@ def _transform_subscription_for_multiapi(s, s_dict):
             s_dict[_MANAGED_BY_TENANTS] = [{_TENANT_ID: t.tenant_id} for t in s.managed_by_tenants]
 
 
-def _create_identity_instance(cli_ctx, *args, **kwargs):
+def _create_identity_instance(cli_ctx, authority, tenant_id=None, client_id=None):
     """Lazily import and create Identity instance to avoid unnecessary imports."""
     from .auth.identity import Identity
     from .util import should_encrypt_token_cache
@@ -955,9 +953,11 @@ def _create_identity_instance(cli_ctx, *args, **kwargs):
     # PREVIEW: In Azure Stack environment, use core.instance_discovery=false to disable MSAL's instance discovery.
     instance_discovery = cli_ctx.config.getboolean('core', 'instance_discovery', True)
 
-    return Identity(*args, encrypt=encrypt, use_msal_http_cache=use_msal_http_cache,
+    return Identity(authority, tenant_id=tenant_id, client_id=client_id,
+                    encrypt=encrypt,
+                    use_msal_http_cache=use_msal_http_cache,
                     enable_broker_on_windows=enable_broker_on_windows,
-                    instance_discovery=instance_discovery, **kwargs)
+                    instance_discovery=instance_discovery)
 
 
 def _on_azure_arc_windows():

--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -73,6 +73,7 @@ class Identity:  # pylint: disable=too-many-instance-attributes
         """
         self.authority = authority
         self.tenant_id = tenant_id
+        # This client ID is only used for PublicClientApplication, not ConfidentialClientApplication
         self.client_id = client_id or AZURE_CLI_CLIENT_ID
         self._encrypt = encrypt
         self._use_msal_http_cache = use_msal_http_cache

--- a/src/azure-cli/azure/cli/command_modules/profile/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/__init__.py
@@ -101,6 +101,8 @@ class ProfileCommandsLoader(AzCommandsLoader):
             c.argument('tenant', options_list=['--tenant', '-t'],
                        help='Tenant ID for which the token is acquired. Only available for user and service principal '
                             'account, not for managed identity or Cloud Shell account')
+            c.argument('client_id',
+                       help='A first-party app ID that can do single sign-on with Azure CLI.')
 
 
 COMMAND_LOADER_CLS = ProfileCommandsLoader

--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -70,7 +70,8 @@ def show_subscription(cmd, subscription=None):
     return profile.get_subscription(subscription)
 
 
-def get_access_token(cmd, subscription=None, resource=None, scopes=None, resource_type=None, tenant=None):
+def get_access_token(cmd, subscription=None, resource=None, scopes=None, resource_type=None, tenant=None,
+                     client_id=None):
     """
     get AAD token to access to a specified resource.
     Use 'az cloud show' command for other Azure resources
@@ -80,8 +81,8 @@ def get_access_token(cmd, subscription=None, resource=None, scopes=None, resourc
         resource = getattr(cmd.cli_ctx.cloud.endpoints, endpoints_attr_name)
 
     profile = Profile(cli_ctx=cmd.cli_ctx)
-    creds, subscription, tenant = profile.get_raw_token(subscription=subscription, resource=resource, scopes=scopes,
-                                                        tenant=tenant)
+    creds, subscription, tenant = profile.get_raw_token(
+        subscription=subscription, resource=resource, scopes=scopes, tenant=tenant, client_id=client_id)
 
     result = {
         'tokenType': creds[0],


### PR DESCRIPTION
**Related command**
`az account get-access-token`

**Description**<!--Mandatory-->
Requires https://github.com/Azure/azure-cli/pull/30300

This PR enables getting an access token for another first-party application that can do single sign-on with Azure CLI. For example, to get an access token for Azure PowerShell:

```
az account get-access-token --client-id 1950a258-227b-4e31-a9cf-717495945fc2
```

**Testing Guide**
```sh
# Sign in as Azure CLI
az login

# Get an access token as Azure PowerShell
az account get-access-token --client-id 1950a258-227b-4e31-a9cf-717495945fc2
```
