### PR TITLE
{RDBMS} `az postgres flexible-server list`: adding a null check to see if resource group passed is already null

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/validators.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/validators.py
@@ -813,8 +813,15 @@ def _pg_storage_type_validator(storage_type, auto_grow, high_availability, geo_r
 
 
 def check_resource_group(resource_group_name):
+    # check if rg is already null originally
+    if (not resource_group_name):
+        return False
+
+    # replace single and double quotes with empty string
     resource_group_name = resource_group_name.replace("'", '')
     resource_group_name = resource_group_name.replace('"', '')
+
+    # check if rg is empty after removing quotes
     if (not resource_group_name):
         return False
     return True


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az postgres flexible-server list

**Description**<!--Mandatory-->
This will fix the issue reported [here](https://github.com/Azure/azure-cli/issues/30303) by adding a null check prior to replacing the quotes with empty string.

**Testing Guide**
Visual check on the command, working fine.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

{RDBMS} `az postgres flexible-server list`: adding a null check to see if resource group passed is already null

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
