### PR TITLE
{Pylint} Fix use-dict-literal

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -42,7 +42,6 @@ disable=
     use-maxsplit-arg,
     arguments-renamed,
     consider-using-in,
-    use-dict-literal,
     consider-using-dict-items,
     consider-using-enumerate,
     redundant-u-string-prefix,

--- a/scripts/temp_help/help_convert.py
+++ b/scripts/temp_help/help_convert.py
@@ -189,7 +189,7 @@ def _get_new_yaml_dict(help_dict):
         if "parameters" in help_dict:
             parameters = []
             for param in help_dict["parameters"]:
-                new_param = dict()
+                new_param = {}
                 if "name" in param:
                     options = param["name"].split()
                     new_param["name"] = max(options, key=lambda x: len(x))
@@ -205,7 +205,7 @@ def _get_new_yaml_dict(help_dict):
         if "examples" in help_dict:
             elem_examples = []
             for ex in help_dict["examples"]:
-                new_ex = dict()
+                new_ex = {}
                 if "name" in ex:
                     new_ex["summary"] = ex["name"]
                 if "text" in ex:

--- a/scripts/temp_help/help_convert.py
+++ b/scripts/temp_help/help_convert.py
@@ -173,7 +173,7 @@ def get_all_mod_names():
 
 def _get_new_yaml_dict(help_dict):
 
-    result = dict(version=1, content=[])
+    result = {"version": 1, "content": []}
     content = result['content']
 
     for command_or_group, yaml_text in help_dict.items():
@@ -181,7 +181,7 @@ def _get_new_yaml_dict(help_dict):
 
         type = help_dict["type"]
 
-        elem = {type: dict(name=command_or_group)}
+        elem = {type: {"name": command_or_group}}
         elem_content = elem[type]
 
         _convert_summaries(old_dict=help_dict, new_dict=elem_content)

--- a/src/azure-cli-core/azure/cli/core/aaz/_field_value.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_field_value.py
@@ -449,7 +449,7 @@ class AAZList(AAZBaseValue):
 
 class AAZIdentityObject(AAZObject):  # pylint: disable=too-few-public-methods
     def to_serialized_data(self, processor=None, **kwargs):
-        calculate_data = dict()
+        calculate_data = {}
         if self._data == AAZUndefined:
             result = AAZUndefined
 

--- a/src/azure-cli-core/azure/cli/core/command_recommender.py
+++ b/src/azure-cli-core/azure/cli/core/command_recommender.py
@@ -462,7 +462,7 @@ def get_parameter_kwargs(args):
     :type: dict
     """
 
-    parameter_kwargs = dict()
+    parameter_kwargs = {}
     for index, parameter in enumerate(args):
         if parameter.startswith('-'):
 
@@ -501,7 +501,7 @@ def replace_parameter_values(target_command, source_kwargs, param_mappings):
         :return: The replaced value for target_param
         :type: str
         """
-        standard_source_kwargs = dict()
+        standard_source_kwargs = {}
 
         for param, val in source_kwargs.items():
             if param in param_mappings:

--- a/src/azure-cli-core/azure/cli/core/commands/client_factory.py
+++ b/src/azure-cli-core/azure/cli/core/commands/client_factory.py
@@ -147,7 +147,7 @@ def _prepare_client_kwargs_track2(cli_ctx):
         pass
 
     # Prepare custom headers, used by HeadersPolicy
-    headers = {**cli_ctx.data['headers']}
+    headers = dict(cli_ctx.data['headers'])
 
     # - Prepare CommandName header
     command_name_suffix = ';completer-request' if cli_ctx.data['completer_active'] else ''

--- a/src/azure-cli-core/azure/cli/core/commands/client_factory.py
+++ b/src/azure-cli-core/azure/cli/core/commands/client_factory.py
@@ -147,7 +147,7 @@ def _prepare_client_kwargs_track2(cli_ctx):
         pass
 
     # Prepare custom headers, used by HeadersPolicy
-    headers = dict(cli_ctx.data['headers'])
+    headers = {**cli_ctx.data['headers']}
 
     # - Prepare CommandName header
     command_name_suffix = ';completer-request' if cli_ctx.data['completer_active'] else ''

--- a/src/azure-cli-core/azure/cli/core/commands/command_operation.py
+++ b/src/azure-cli-core/azure/cli/core/commands/command_operation.py
@@ -68,8 +68,7 @@ class BaseCommandOperation:
     def load_getter_op_arguments(self, getter_op_path, cmd_args=None):
         """ Load arguments from function signature of getter command op """
         op = self.get_op_handler(getter_op_path)
-        getter_args = dict(
-            extract_args_from_signature(op, excluded_params=EXCLUDED_PARAMS))
+        getter_args = {**extract_args_from_signature(op, excluded_params=EXCLUDED_PARAMS)}
         cmd_args = cmd_args or {}
         cmd_args.update(getter_args)
         # The cmd argument is required when calling self.handler function.
@@ -386,7 +385,7 @@ class WaitCommandOperation(BaseCommandOperation):
         from azure.cli.core.commands.arm import EXCLUDED_NON_CLIENT_PARAMS
 
         op = self.get_op_handler(self.op_path)
-        getter_args = dict(extract_args_from_signature(op, excluded_params=EXCLUDED_NON_CLIENT_PARAMS))
+        getter_args = {**extract_args_from_signature(op, excluded_params=EXCLUDED_NON_CLIENT_PARAMS)}
         self.cmd = command_args.get('cmd') if 'cmd' in getter_args else command_args.pop('cmd')
 
         client_arg_name = self.resolve_client_arg_name(self.op_path)

--- a/src/azure-cli-core/azure/cli/core/commands/command_operation.py
+++ b/src/azure-cli-core/azure/cli/core/commands/command_operation.py
@@ -68,7 +68,7 @@ class BaseCommandOperation:
     def load_getter_op_arguments(self, getter_op_path, cmd_args=None):
         """ Load arguments from function signature of getter command op """
         op = self.get_op_handler(getter_op_path)
-        getter_args = {**extract_args_from_signature(op, excluded_params=EXCLUDED_PARAMS)}
+        getter_args = dict(extract_args_from_signature(op, excluded_params=EXCLUDED_PARAMS))
         cmd_args = cmd_args or {}
         cmd_args.update(getter_args)
         # The cmd argument is required when calling self.handler function.
@@ -385,7 +385,7 @@ class WaitCommandOperation(BaseCommandOperation):
         from azure.cli.core.commands.arm import EXCLUDED_NON_CLIENT_PARAMS
 
         op = self.get_op_handler(self.op_path)
-        getter_args = {**extract_args_from_signature(op, excluded_params=EXCLUDED_NON_CLIENT_PARAMS)}
+        getter_args = dict(extract_args_from_signature(op, excluded_params=EXCLUDED_NON_CLIENT_PARAMS))
         self.cmd = command_args.get('cmd') if 'cmd' in getter_args else command_args.pop('cmd')
 
         client_arg_name = self.resolve_client_arg_name(self.op_path)

--- a/src/azure-cli-core/azure/cli/core/commands/command_operation.py
+++ b/src/azure-cli-core/azure/cli/core/commands/command_operation.py
@@ -315,14 +315,14 @@ class GenericUpdateCommandOperation(BaseCommandOperation):     # pylint: disable
 
     def load_setter_op_arguments(self):
         op = self.get_op_handler(self.setter_op_path)
-        return {k: v for k, v in extract_args_from_signature(op, excluded_params=EXCLUDED_PARAMS)}
+        return dict(extract_args_from_signature(op, excluded_params=EXCLUDED_PARAMS))
 
     def load_custom_function_op_arguments(self):
         if not self.custom_function_op_path:
             return {}
         op = self.get_op_handler(self.custom_function_op_path)
         self.apply_doc_string(op)  # pylint: disable=protected-access
-        return {k: v for k, v in extract_args_from_signature(op, excluded_params=EXCLUDED_PARAMS)}
+        return dict(extract_args_from_signature(op, excluded_params=EXCLUDED_PARAMS))
 
     def description_loader(self):
         """ Callback function of CLICommand description_loader """

--- a/src/azure-cli-core/azure/cli/core/commands/command_operation.py
+++ b/src/azure-cli-core/azure/cli/core/commands/command_operation.py
@@ -315,14 +315,14 @@ class GenericUpdateCommandOperation(BaseCommandOperation):     # pylint: disable
 
     def load_setter_op_arguments(self):
         op = self.get_op_handler(self.setter_op_path)
-        return dict(extract_args_from_signature(op, excluded_params=EXCLUDED_PARAMS))
+        return {k: v for k, v in extract_args_from_signature(op, excluded_params=EXCLUDED_PARAMS)}
 
     def load_custom_function_op_arguments(self):
         if not self.custom_function_op_path:
             return {}
         op = self.get_op_handler(self.custom_function_op_path)
         self.apply_doc_string(op)  # pylint: disable=protected-access
-        return dict(extract_args_from_signature(op, excluded_params=EXCLUDED_PARAMS))
+        return {k: v for k, v in extract_args_from_signature(op, excluded_params=EXCLUDED_PARAMS)}
 
     def description_loader(self):
         """ Callback function of CLICommand description_loader """

--- a/src/azure-cli-core/azure/cli/core/commands/parameters.py
+++ b/src/azure-cli-core/azure/cli/core/commands/parameters.py
@@ -420,7 +420,7 @@ class AzArgumentContext(ArgumentsContext):
             return
 
         if not patches:
-            patches = dict()
+            patches = {}
 
         # fetch the documentation for model parameters first. for models, which are the classes
         # derive from msrest.serialization.Model and used in the SDK API to carry parameters, the

--- a/src/azure-cli-core/azure/cli/core/commands/parameters.py
+++ b/src/azure-cli-core/azure/cli/core/commands/parameters.py
@@ -440,7 +440,7 @@ class AzArgumentContext(ArgumentsContext):
                 :return: The argument of specific type.
                 """
                 ns = vars(namespace)
-                kwargs = dict((k, ns[k]) for k in ns if k in set(expanded_arguments))
+                kwargs = {k: ns[k] for k in ns if k in set(expanded_arguments)}
 
                 setattr(namespace, assigned_arg, model_type(**kwargs))
 

--- a/src/azure-cli-core/azure/cli/core/commands/template_create.py
+++ b/src/azure-cli-core/azure/cli/core/commands/template_create.py
@@ -59,22 +59,22 @@ def _validate_name_or_id(
         resource_id_parts = parse_resource_id(property_value)
         value_supplied_was_id = True
     elif has_parent:
-        resource_id_parts = dict(
-            name=parent_value,
-            resource_group=resource_group_name,
-            namespace=parent_type.split('/')[0],
-            type=parent_type.split('/')[1],
-            subscription=get_subscription_id(cli_ctx),
-            child_name_1=property_value,
-            child_type_1=property_type)
+        resource_id_parts = {
+            "name": parent_value,
+            "resource_group": resource_group_name,
+            "namespace": parent_type.split('/')[0],
+            "type": parent_type.split('/')[1],
+            "subscription": get_subscription_id(cli_ctx),
+            "child_name_1": property_value,
+            "child_type_1": property_type}
         value_supplied_was_id = False
     else:
-        resource_id_parts = dict(
-            name=property_value,
-            resource_group=resource_group_name,
-            namespace=property_type.split('/')[0],
-            type=property_type.split('/')[1],
-            subscription=get_subscription_id(cli_ctx))
+        resource_id_parts = {
+            "name": property_value,
+            "resource_group": resource_group_name,
+            "namespace": property_type.split('/')[0],
+            "type": property_type.split('/')[1],
+            "subscription": get_subscription_id(cli_ctx)}
         value_supplied_was_id = False
     return (resource_id_parts, value_supplied_was_id)
 

--- a/src/azure-cli-core/azure/cli/core/tests/test_util.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_util.py
@@ -514,7 +514,7 @@ class TestHandleException(unittest.TestCase):
         # create test HttpOperationError Exception
         err_msg = "Bad Request because of some incorrect param"
         err_code = "BadRequest"
-        err = dict(error=dict(code=err_code, message=err_msg))
+        err = {"error": {"code": err_code, "message": err_msg}}
         response_text = json.dumps(err)
         mock_http_error = self._get_mock_HttpOperationError(response_text)
 
@@ -533,7 +533,7 @@ class TestHandleException(unittest.TestCase):
 
         # create test HttpOperationError Exception
         err_msg = "BadRequest"
-        err = dict(error=err_msg)
+        err = {"error": err_msg}
         response_text = json.dumps(err)
         mock_http_error = self._get_mock_HttpOperationError(response_text)
 

--- a/src/azure-cli-telemetry/azure/cli/telemetry/components/telemetry_client.py
+++ b/src/azure-cli-telemetry/azure/cli/telemetry/components/telemetry_client.py
@@ -23,7 +23,7 @@ class CliTelemetryClient:
     def __init__(self, batch=100, sender=None):
         from azure.cli.telemetry.components.telemetry_logging import get_logger
 
-        self._clients = dict()
+        self._clients = {}
         self._counter = 0
         self._batch = batch
         self._sender = sender or _NoRetrySender

--- a/src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/tests/test_recording_processor.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/tests/test_recording_processor.py
@@ -107,11 +107,14 @@ class TestRecordingProcessors(unittest.TestCase):
 
         for template in body_templates:
             mock_sub_id = str(uuid.uuid4())
-            mock_response = dict({'body': {}})
-            mock_response['body']['string'] = template.format(mock_sub_id)
-            mock_response['headers'] = {'Location': [location_header_template.format(mock_sub_id)],
-                                        'azure-asyncoperation': [asyncoperation_header_template.format(mock_sub_id)],
-                                        'content-type': ['application/json']}
+            mock_response = {
+                'body': {'string': template.format(mock_sub_id)},
+                'headers': {
+                    'Location': [location_header_template.format(mock_sub_id)],
+                    'azure-asyncoperation': [asyncoperation_header_template.format(mock_sub_id)],
+                    'content-type': ['application/json'],
+                }
+            }
             rp.process_response(mock_response)
             self.assertEqual(mock_response['body']['string'], template.format(replaced_subscription_id))
 
@@ -127,11 +130,12 @@ class TestRecordingProcessors(unittest.TestCase):
         rp = SubscriptionRecordingProcessor(replaced_subscription_id)
 
         mock_sub_id = str(uuid.uuid4())
-        mock_response = dict({'body': {}})
-        mock_response['body']['string'] = mock_sub_id
-        mock_response['headers'] = {
-            'Location': [location_header_template.format(mock_sub_id)],
-            'content-type': ['application/foo']
+        mock_response = {
+            'body': {'string': mock_sub_id},
+            'headers': {
+                'Location': [location_header_template.format(mock_sub_id)],
+                'content-type': ['application/foo'],
+            }
         }
 
         # action

--- a/src/azure-cli/azure/cli/command_modules/acr/connected_registry.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/connected_registry.py
@@ -203,7 +203,7 @@ def acr_connected_registry_update(cmd,  # pylint: disable=too-many-locals, too-m
         errors = sorted(duplicate_notifications)
         raise ArgumentUsageError(
             'Update ambiguity. Duplicate notifications list were provided with ' +
-            f'--add-notifications and --remove-notifications arguments.\n{errors}')
+            '--add-notifications and --remove-notifications arguments.\n{}'.format(errors))
 
     current_notifications_set = set(current_connected_registry.notifications_list) \
         if current_connected_registry.notifications_list else set()

--- a/src/azure-cli/azure/cli/command_modules/acr/connected_registry.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/connected_registry.py
@@ -108,7 +108,7 @@ def acr_connected_registry_create(cmd,  # pylint: disable=too-many-locals, too-m
             client_token_list[i] = build_token_id(
                 subscription_id, resource_group_name, registry_name, client_token_name)
 
-    notifications_set = set(list(notifications)) \
+    notifications_set = set(notifications) \
         if notifications else set()
 
     ConnectedRegistry, LoggingProperties, SyncProperties, ParentProperties = cmd.get_models(
@@ -192,10 +192,10 @@ def acr_connected_registry_update(cmd,  # pylint: disable=too-many-locals, too-m
     client_token_list = list(client_token_set) if client_token_set != current_client_token_set else None
 
     # Add or remove from the current notifications list
-    add_notifications_set = set(list(add_notifications)) \
+    add_notifications_set = set(add_notifications) \
         if add_notifications else set()
 
-    remove_notifications_set = set(list(remove_notifications)) \
+    remove_notifications_set = set(remove_notifications) \
         if remove_notifications else set()
 
     duplicate_notifications = set.intersection(add_notifications_set, remove_notifications_set)
@@ -203,7 +203,7 @@ def acr_connected_registry_update(cmd,  # pylint: disable=too-many-locals, too-m
         errors = sorted(duplicate_notifications)
         raise ArgumentUsageError(
             'Update ambiguity. Duplicate notifications list were provided with ' +
-            '--add-notifications and --remove-notifications arguments.\n{}'.format(errors))
+            f'--add-notifications and --remove-notifications arguments.\n{errors}')
 
     current_notifications_set = set(current_connected_registry.notifications_list) \
         if current_connected_registry.notifications_list else set()

--- a/src/azure-cli/azure/cli/command_modules/acr/task.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/task.py
@@ -1132,7 +1132,7 @@ def _build_identities_info(cmd, identities, is_remove=False):
         if is_remove:
             identity.user_assigned_identities = dict.fromkeys(external_identities)
         else:
-            identity.user_assigned_identities = dict.fromkeys(external_identities, UserIdentityProperties())
+            identity.user_assigned_identities = {e: UserIdentityProperties() for e in external_identities}
     return identity
 
 

--- a/src/azure-cli/azure/cli/command_modules/acr/task.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/task.py
@@ -1130,9 +1130,9 @@ def _build_identities_info(cmd, identities, is_remove=False):
     identity = IdentityProperties(type=identity_types)
     if external_identities:
         if is_remove:
-            identity.user_assigned_identities = {e: None for e in external_identities}
+            identity.user_assigned_identities = dict.fromkeys(external_identities)
         else:
-            identity.user_assigned_identities = {e: UserIdentityProperties() for e in external_identities}
+            identity.user_assigned_identities = dict.fromkeys(external_identities, UserIdentityProperties())
     return identity
 
 

--- a/src/azure-cli/azure/cli/command_modules/acs/base_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/base_decorator.py
@@ -155,7 +155,7 @@ class BaseAKSContext:
         self.raw_param = raw_parameters
         self.models = models
         self.decorator_mode = decorator_mode
-        self.intermediates = dict()
+        self.intermediates = {}
 
     def get_intermediate(self, variable_name: str, default_value: Any = None) -> Any:
         """Get the value of an intermediate by its name.

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -169,13 +169,18 @@ class AKSManagedClusterModels(AKSAgentPoolModels):
         :return: SimpleNamespace
         """
         if self.__loadbalancer_models is None:
-            load_balancer_models = {
-                "ManagedClusterLoadBalancerProfile": self.ManagedClusterLoadBalancerProfile,
-                "ManagedClusterLoadBalancerProfileManagedOutboundIPs": self.ManagedClusterLoadBalancerProfileManagedOutboundIPs,
-                "ManagedClusterLoadBalancerProfileOutboundIPs": self.ManagedClusterLoadBalancerProfileOutboundIPs,
-                "ManagedClusterLoadBalancerProfileOutboundIPPrefixes": self.ManagedClusterLoadBalancerProfileOutboundIPPrefixes,
-                "ResourceReference": self.ResourceReference
-            }
+            load_balancer_models = {}
+            load_balancer_models["ManagedClusterLoadBalancerProfile"] = self.ManagedClusterLoadBalancerProfile
+            load_balancer_models[
+                "ManagedClusterLoadBalancerProfileManagedOutboundIPs"
+            ] = self.ManagedClusterLoadBalancerProfileManagedOutboundIPs
+            load_balancer_models[
+                "ManagedClusterLoadBalancerProfileOutboundIPs"
+            ] = self.ManagedClusterLoadBalancerProfileOutboundIPs
+            load_balancer_models[
+               "ManagedClusterLoadBalancerProfileOutboundIPPrefixes"
+            ] = self.ManagedClusterLoadBalancerProfileOutboundIPPrefixes
+            load_balancer_models["ResourceReference"] = self.ResourceReference
             self.__loadbalancer_models = SimpleNamespace(**load_balancer_models)
         return self.__loadbalancer_models
 

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -169,18 +169,13 @@ class AKSManagedClusterModels(AKSAgentPoolModels):
         :return: SimpleNamespace
         """
         if self.__loadbalancer_models is None:
-            load_balancer_models = {}
-            load_balancer_models["ManagedClusterLoadBalancerProfile"] = self.ManagedClusterLoadBalancerProfile
-            load_balancer_models[
-                "ManagedClusterLoadBalancerProfileManagedOutboundIPs"
-            ] = self.ManagedClusterLoadBalancerProfileManagedOutboundIPs
-            load_balancer_models[
-                "ManagedClusterLoadBalancerProfileOutboundIPs"
-            ] = self.ManagedClusterLoadBalancerProfileOutboundIPs
-            load_balancer_models[
-                "ManagedClusterLoadBalancerProfileOutboundIPPrefixes"
-            ] = self.ManagedClusterLoadBalancerProfileOutboundIPPrefixes
-            load_balancer_models["ResourceReference"] = self.ResourceReference
+            load_balancer_models = {
+                "ManagedClusterLoadBalancerProfile": self.ManagedClusterLoadBalancerProfile,
+                "ManagedClusterLoadBalancerProfileManagedOutboundIPs": self.ManagedClusterLoadBalancerProfileManagedOutboundIPs,
+                "ManagedClusterLoadBalancerProfileOutboundIPs": self.ManagedClusterLoadBalancerProfileOutboundIPs,
+                "ManagedClusterLoadBalancerProfileOutboundIPPrefixes": self.ManagedClusterLoadBalancerProfileOutboundIPPrefixes,
+                "ResourceReference": self.ResourceReference
+            }
             self.__loadbalancer_models = SimpleNamespace(**load_balancer_models)
         return self.__loadbalancer_models
 

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -178,7 +178,7 @@ class AKSManagedClusterModels(AKSAgentPoolModels):
                 "ManagedClusterLoadBalancerProfileOutboundIPs"
             ] = self.ManagedClusterLoadBalancerProfileOutboundIPs
             load_balancer_models[
-               "ManagedClusterLoadBalancerProfileOutboundIPPrefixes"
+                "ManagedClusterLoadBalancerProfileOutboundIPPrefixes"
             ] = self.ManagedClusterLoadBalancerProfileOutboundIPPrefixes
             load_balancer_models["ResourceReference"] = self.ResourceReference
             self.__loadbalancer_models = SimpleNamespace(**load_balancer_models)

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -4139,10 +4139,10 @@ class AKSManagedClusterContext(BaseAKSContext):
             if cluster_autoscaler_profile and self.mc and self.mc.auto_scaler_profile:
                 # shallow copy should be enough for string-to-string dictionary
                 copy_of_raw_dict = self.mc.auto_scaler_profile.__dict__.copy()
-                new_options_dict = dict(
-                    (key.replace("-", "_"), value)
-                    for (key, value) in cluster_autoscaler_profile.items()
-                )
+                new_options_dict = {
+                    key.replace("-", "_"): value
+                    for key, value in cluster_autoscaler_profile.items()
+                }
                 copy_of_raw_dict.update(new_options_dict)
                 cluster_autoscaler_profile = copy_of_raw_dict
 

--- a/src/azure-cli/azure/cli/command_modules/apim/tests/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/apim/tests/__init__.py
@@ -23,7 +23,7 @@ logger = logging.getLogger('azure.cli.testsdk')
 logger.addHandler(logging.StreamHandler())
 __path__ = __import__('pkgutil').extend_path(__path__, __name__)
 exceptions = []
-test_map = dict()
+test_map = {}
 SUCCESSED = "successed"
 FAILED = "failed"
 
@@ -56,7 +56,7 @@ def try_manual(func):
         func_to_call = get_func_to_call()
         logger.info("running %s()...", func.__name__)
         try:
-            test_map[func.__name__] = dict()
+            test_map[func.__name__] = {}
             test_map[func.__name__]["result"] = SUCCESSED
             test_map[func.__name__]["error_message"] = ""
             test_map[func.__name__]["error_stack"] = ""

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -1001,7 +1001,7 @@ def set_webapp(cmd, resource_group_name, name, slot=None, skip_dns_registration=
     instance = kwargs['parameters']
     client = web_client_factory(cmd.cli_ctx)
     updater = client.web_apps.begin_create_or_update_slot if slot else client.web_apps.begin_create_or_update
-    kwargs = dict(resource_group_name=resource_group_name, name=name, site_envelope=instance)
+    kwargs = {"resource_group_name": resource_group_name, "name": name, "site_envelope": instance}
     if slot:
         kwargs['slot'] = slot
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -1103,7 +1103,7 @@ def set_functionapp(cmd, resource_group_name, name, slot=None, **kwargs):
     instance = kwargs['parameters']
     client = web_client_factory(cmd.cli_ctx)
     updater = client.web_apps.begin_create_or_update_slot if slot else client.web_apps.begin_create_or_update
-    kwargs = dict(resource_group_name=resource_group_name, name=name, site_envelope=instance)
+    kwargs = {"resource_group_name": resource_group_name, "name": name, "site_envelope": instance}
     if slot:
         kwargs['slot'] = slot
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -3870,7 +3870,7 @@ class _StackRuntimeHelper(_AbstractStackRuntimeHelper):
                      linux=False,
                      is_auto_update=None):
             self.display_name = display_name
-            self.configs = configs if configs is not None else dict()
+            self.configs = configs if configs is not None else {}
             self.github_actions_properties = github_actions_properties
             self.linux = linux
             self.is_auto_update = is_auto_update
@@ -4225,7 +4225,7 @@ class _FlexFunctionAppStackRuntimeHelper:
     def _format_version_names(self, runtime_to_version):
         formatted_runtime_to_version = {}
         for runtime, versions in runtime_to_version.items():
-            formatted_runtime_to_version[runtime] = formatted_runtime_to_version.get(runtime, dict())
+            formatted_runtime_to_version[runtime] = formatted_runtime_to_version.get(runtime, {})
             for version_name, version_info in versions.items():
                 formatted_name = self._format_version_name(version_name)
                 if formatted_name in formatted_runtime_to_version[runtime]:
@@ -4268,7 +4268,7 @@ class _FlexFunctionAppStackRuntimeHelper:
                             'github_actions_properties': self.GithubActionsProperties(**github_actions_properties)
                         }
 
-                        runtime_to_version[runtime_name] = runtime_to_version.get(runtime_name, dict())
+                        runtime_to_version[runtime_name] = runtime_to_version.get(runtime_name, {})
                         runtime_to_version[runtime_name][runtime_version] = runtime_version_properties
 
         runtime_to_version = self._format_version_names(runtime_to_version)
@@ -4337,8 +4337,8 @@ class _FunctionAppStackRuntimeHelper(_AbstractStackRuntimeHelper):
             self.is_preview = is_preview
             self.supported_func_versions = [] if not supported_func_versions else supported_func_versions
             self.linux = linux
-            self.app_settings_dict = dict() if not app_settings_dict else app_settings_dict
-            self.site_config_dict = dict() if not site_config_dict else site_config_dict
+            self.app_settings_dict = {} if not app_settings_dict else app_settings_dict
+            self.site_config_dict = {} if not site_config_dict else site_config_dict
             self.app_insights = app_insights
             self.default = default
             self.github_actions_properties = github_actions_properties
@@ -4460,7 +4460,7 @@ class _FunctionAppStackRuntimeHelper(_AbstractStackRuntimeHelper):
     def _format_version_names(self, runtime_to_version):
         formatted_runtime_to_version = {}
         for runtime, versions in runtime_to_version.items():
-            formatted_runtime_to_version[runtime] = formatted_runtime_to_version.get(runtime, dict())
+            formatted_runtime_to_version[runtime] = formatted_runtime_to_version.get(runtime, {})
             for version_name, version_info in versions.items():
                 formatted_name = self._format_version_name(version_name)
                 if formatted_name in formatted_runtime_to_version[runtime]:
@@ -4497,12 +4497,12 @@ class _FunctionAppStackRuntimeHelper(_AbstractStackRuntimeHelper):
                     self.KEYS.GIT_HUB_ACTION_SETTINGS: runtime_settings.git_hub_action_settings
                 }
 
-                runtime_to_version[runtime_name] = runtime_to_version.get(runtime_name, dict())
+                runtime_to_version[runtime_name] = runtime_to_version.get(runtime_name, {})
                 runtime_to_version[runtime_name][minor_version_name] = runtime_version_properties
 
         # obtain end of life date for all runtime versions
         if runtime_settings.end_of_life_date is not None:
-            runtime_to_version_eol[runtime_name] = runtime_to_version_eol.get(runtime_name, dict())
+            runtime_to_version_eol[runtime_name] = runtime_to_version_eol.get(runtime_name, {})
             runtime_to_version_eol[runtime_name][minor_version_name] = runtime_settings.end_of_life_date
 
     def _create_runtime_from_properties(self, runtime_name, version_name, version_properties, linux):
@@ -5000,7 +5000,7 @@ def create_functionapp(cmd, resource_group_name, name, storage_account, plan=Non
 
     site_config_dict = matched_runtime.site_config_dict if not flexconsumption_location \
         else SiteConfigPropertiesDictionary()
-    app_settings_dict = matched_runtime.app_settings_dict if not flexconsumption_location else dict()
+    app_settings_dict = matched_runtime.app_settings_dict if not flexconsumption_location else {}
 
     con_string = _validate_and_get_connection_string(cmd.cli_ctx, resource_group_name, storage_account)
 

--- a/src/azure-cli/azure/cli/command_modules/backup/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom.py
@@ -456,7 +456,7 @@ def assign_identity(client, resource_group_name, vault_name, system_assigned=Non
 
     if user_assigned is not None:
         userid = UserIdentity()
-        user_assigned_identity = dict()
+        user_assigned_identity = {}
         for userMSI in user_assigned:
             user_assigned_identity[userMSI] = userid
         if system_assigned is not None or curr_identity_type in ["systemassigned", "systemassigned, userassigned"]:
@@ -499,7 +499,7 @@ def remove_identity(client, resource_group_name, vault_name, system_assigned=Non
         userid = None
         remove_count_of_userMSI = 0
         totaluserMSI = 0
-        user_assigned_identity = dict()
+        user_assigned_identity = {}
         for element in curr_identity_details.user_assigned_identities.keys():
             if element in user_assigned:
                 remove_count_of_userMSI += 1

--- a/src/azure-cli/azure/cli/command_modules/billing/generated/action.py
+++ b/src/azure-cli/azure/cli/command_modules/billing/generated/action.py
@@ -92,7 +92,7 @@ class AddLabels(argparse.Action):
             properties = defaultdict(list)
             for (k, v) in (x.split('=', 1) for x in values):
                 properties[k].append(v)
-            properties = {**properties}
+            properties = dict(properties)
         except ValueError:
             raise CLIError('usage error: {} [KEY=VALUE ...]'.format(option_string))
         d = {}

--- a/src/azure-cli/azure/cli/command_modules/billing/generated/action.py
+++ b/src/azure-cli/azure/cli/command_modules/billing/generated/action.py
@@ -92,7 +92,7 @@ class AddLabels(argparse.Action):
             properties = defaultdict(list)
             for (k, v) in (x.split('=', 1) for x in values):
                 properties[k].append(v)
-            properties = dict(properties)
+            properties = {**properties}
         except ValueError:
             raise CLIError('usage error: {} [KEY=VALUE ...]'.format(option_string))
         d = {}

--- a/src/azure-cli/azure/cli/command_modules/billing/tests/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/billing/tests/__init__.py
@@ -23,7 +23,7 @@ logger = logging.getLogger('azure.cli.testsdk')
 logger.addHandler(logging.StreamHandler())
 __path__ = __import__('pkgutil').extend_path(__path__, __name__)
 exceptions = []
-test_map = dict()
+test_map = {}
 SUCCESSED = "successed"
 FAILED = "failed"
 
@@ -57,7 +57,7 @@ def try_manual(func):
         func_to_call = get_func_to_call()
         logger.info("running %s()...", func.__name__)
         try:
-            test_map[func.__name__] = dict()
+            test_map[func.__name__] = {}
             test_map[func.__name__]["result"] = SUCCESSED
             test_map[func.__name__]["error_message"] = ""
             test_map[func.__name__]["error_stack"] = ""

--- a/src/azure-cli/azure/cli/command_modules/container/_format.py
+++ b/src/azure-cli/azure/cli/command_modules/container/_format.py
@@ -10,7 +10,7 @@ def _get_images(container_group):
     """Get all images of a container group. """
     containers = container_group.get('containers')
     if containers is not None and containers:
-        images = set([])
+        images = set()
         for container in containers:
             images.add(container['image'])
         return ','.join(images)

--- a/src/azure-cli/azure/cli/command_modules/containerapp/_transformers.py
+++ b/src/azure-cli/azure/cli/command_modules/containerapp/_transformers.py
@@ -31,12 +31,12 @@ def transform_sensitive_values(response_json):
             for (key, val) in rule.items():
                 if key != "name":
                     if val.get("metadata"):
-                        val["metadata"] = dict((k, "") for k, v in val.get("metadata").items())
+                        val["metadata"] = {k: "" for k, v in val.get("metadata").items()}
 
     if safe_get(response_json, "properties", "configuration", "eventTriggerConfig") and "scale" in response_json["properties"]["configuration"]["eventTriggerConfig"]:
         for rule in safe_get(response_json, "properties", "configuration", "eventTriggerConfig", "scale", "rules", default=[]):
             if rule.get("metadata"):
-                rule["metadata"] = dict((k, "") for k, v in rule.get("metadata").items())
+                rule["metadata"] = {k: "" for k, v in rule.get("metadata").items()}
 
     return response_json
 

--- a/src/azure-cli/azure/cli/command_modules/containerapp/_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/containerapp/_utils.py
@@ -1974,7 +1974,14 @@ def parse_oryx_mariner_tag(tag: str) -> OryxMarinerRunImgTagProperty:
         if len(re_matches) == 0:
             tag_obj = None
         else:
-            tag_obj = dict(fullTag=tag, version=SemVer.parse(re_matches[0][0]), framework=tag_split[2], marinerVersion=re_matches[0][2], architectures=None, support="lts")
+            tag_obj = {
+                fullTag=tag,
+                version=SemVer.parse(re_matches[0][0]),
+                framework=tag_split[2],
+                marinerVersion=re_matches[0][2],
+                architectures=None,
+                support="lts"
+            }
     else:
         tag_obj = None
     return tag_obj

--- a/src/azure-cli/azure/cli/command_modules/containerapp/_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/containerapp/_utils.py
@@ -1975,12 +1975,12 @@ def parse_oryx_mariner_tag(tag: str) -> OryxMarinerRunImgTagProperty:
             tag_obj = None
         else:
             tag_obj = {
-                fullTag=tag,
-                version=SemVer.parse(re_matches[0][0]),
-                framework=tag_split[2],
-                marinerVersion=re_matches[0][2],
-                architectures=None,
-                support="lts"
+                "fullTag": tag,
+                "version": SemVer.parse(re_matches[0][0]),
+                "framework": tag_split[2],
+                "marinerVersion": re_matches[0][2],
+                "architectures": None,
+                "support": "lts",
             }
     else:
         tag_obj = None

--- a/src/azure-cli/azure/cli/command_modules/databoxedge/tests/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/databoxedge/tests/__init__.py
@@ -23,7 +23,7 @@ logger = logging.getLogger('azure.cli.testsdk')
 logger.addHandler(logging.StreamHandler())
 __path__ = __import__('pkgutil').extend_path(__path__, __name__)
 exceptions = []
-test_map = dict()
+test_map = {}
 SUCCESSED = "successed"
 FAILED = "failed"
 
@@ -56,7 +56,7 @@ def try_manual(func):
         func_to_call = get_func_to_call()
         logger.info("running %s()...", func.__name__)
         try:
-            test_map[func.__name__] = dict()
+            test_map[func.__name__] = {}
             test_map[func.__name__]["result"] = SUCCESSED
             test_map[func.__name__]["error_message"] = ""
             test_map[func.__name__]["error_stack"] = ""

--- a/src/azure-cli/azure/cli/command_modules/feedback/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/feedback/custom.py
@@ -500,7 +500,7 @@ def _display_recent_commands(cmd):
 
     command_log_files = command_log_files[-9:]
 
-    max_len_dict = dict(name_len=0, success_len=0, time_len=0)
+    max_len_dict = {"name_len": 0, "success_len": 0, "time_len": 0}
 
     for log_file in command_log_files:
         max_len_dict["name_len"] = max(len(log_file.get_command_name_str()), max_len_dict["name_len"])

--- a/src/azure-cli/azure/cli/command_modules/hdinsight/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/hdinsight/custom.py
@@ -66,7 +66,7 @@ def create_cluster(cmd, client, cluster_name, resource_group_name, cluster_type,
 
     # Format dictionary/free-form arguments
     if not cluster_configurations:
-        cluster_configurations = dict()
+        cluster_configurations = {}
 
     if component_version:
         # See validator
@@ -77,7 +77,7 @@ def create_cluster(cmd, client, cluster_name, resource_group_name, cluster_type,
     if 'gateway' in cluster_configurations:
         gateway_config = cluster_configurations['gateway']
     else:
-        gateway_config = dict()
+        gateway_config = {}
     if http_username and 'restAuthCredential.username' in gateway_config:
         raise CLIError('An HTTP username must be specified either as a command-line parameter '
                        'or in the cluster configuration, but not both.')

--- a/src/azure-cli/azure/cli/command_modules/lab/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/lab/custom.py
@@ -264,7 +264,7 @@ def claim_vm(cmd, lab_name=None, name=None, resource_group_name=None):
 def _export_parameters(arm_template):
     parameters = []
     if arm_template and arm_template.get('contents') and arm_template['contents'].get('parameters'):
-        default_values = dict()
+        default_values = {}
         if arm_template.get('parametersValueFilesInfo'):
             for parameter_value_file_info in arm_template.get('parametersValueFilesInfo'):
                 if isinstance(parameter_value_file_info['parametersValueInfo'], dict):
@@ -273,7 +273,7 @@ def _export_parameters(arm_template):
 
         if isinstance(arm_template['contents']['parameters'], dict):
             for k in arm_template['contents']['parameters']:
-                param = dict()
+                param = {}
                 param['name'] = k
                 param['value'] = default_values.get(k, "")
                 parameters.append(param)

--- a/src/azure-cli/azure/cli/command_modules/lab/validators.py
+++ b/src/azure-cli/azure/cli/command_modules/lab/validators.py
@@ -374,7 +374,7 @@ def _update_artifacts(artifacts, lab_resource_id):
             parameters = artifact.get('parameters', [])
 
         if artifact_id:
-            result_artifact = dict()
+            result_artifact = {}
             result_artifact['artifact_id'] = _update_artifact_id(artifact_id, lab_resource_id)
             result_artifact['parameters'] = parameters
             result_artifacts.append(result_artifact)

--- a/src/azure-cli/azure/cli/command_modules/marketplaceordering/tests/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/marketplaceordering/tests/__init__.py
@@ -23,7 +23,7 @@ logger = logging.getLogger('azure.cli.testsdk')
 logger.addHandler(logging.StreamHandler())
 __path__ = __import__('pkgutil').extend_path(__path__, __name__)
 exceptions = []
-test_map = dict()
+test_map = {}
 SUCCESSED = "successed"
 FAILED = "failed"
 
@@ -56,7 +56,7 @@ def try_manual(func):
         func_to_call = get_func_to_call()
         logger.info("running %s()...", func.__name__)
         try:
-            test_map[func.__name__] = dict()
+            test_map[func.__name__] = {}
             test_map[func.__name__]["result"] = SUCCESSED
             test_map[func.__name__]["error_message"] = ""
             test_map[func.__name__]["error_stack"] = ""

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_monitor_activity_log_alert.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_monitor_activity_log_alert.py
@@ -174,14 +174,17 @@ class TestMonitorActivityLogAlert(ScenarioTest):
         update_cmd = 'az monitor activity-log alert update -n {} -g {} '.format(name, resource_group)
 
         state = self.cmd(update_cmd + '-c category=Security and level=Informational').get_output_in_json()
-        condition_dict = dict((each['field'], each['equals']) for each in state['condition']['allOf'])
+        condition_dict = {each['field']: each['equals'] for each in state['condition']['allOf']}
         self.assertEqual(2, len(condition_dict))
         self.assertEqual('Informational', condition_dict['level'])
         self.assertEqual('Security', condition_dict['category'])
 
         state = self.cmd(update_cmd + '-c level=Error and category=Security and resourceGroup={}'.format(
             resource_group)).get_output_in_json()
-        condition_dict = dict((each['field'], each['equals']) for each in state['condition']['allOf'])
+        condition_dict = {
+            each['field']: each['equals']
+            for each in state['condition']['allOf']
+        }
         self.assertEqual(3, len(condition_dict))
         self.assertEqual('Error', condition_dict['level'])
         self.assertEqual('Security', condition_dict['category'])

--- a/src/azure-cli/azure/cli/command_modules/monitor/transformers.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/transformers.py
@@ -94,7 +94,7 @@ def metrics_table(results):
     for value_group in results['value']:
         name = value_group['name']['localizedValue']
         for series in value_group['timeseries']:
-            metadata = dict((m['name']['localizedValue'], m['value']) for m in series['metadatavalues'])
+            metadata = {m['name']['localizedValue']: m['value'] for m in series['metadatavalues']}
 
             for data in series['data']:
                 row = OrderedDict()

--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -2400,7 +2400,7 @@ def update_ddos_plan(cmd, resource_group_name, ddos_plan_name, tags=None, vnets=
         Show_Ddos_Protection = Show(cli_ctx=cmd.cli_ctx)
         show_args = Show_Ddos_Protection(show_args)
         logger.info('Attempting to update the VNets attached to the DDoS protection plan.')
-        vnet_ids = set([])
+        vnet_ids = set()
         if len(vnets) == 1 and not vnets[0]:
             pass
         else:
@@ -2408,7 +2408,7 @@ def update_ddos_plan(cmd, resource_group_name, ddos_plan_name, tags=None, vnets=
         if 'virtualNetworks' in show_args:
             existing_vnet_ids = {x['id'] for x in show_args['virtualNetworks']}
         else:
-            existing_vnet_ids = set([])
+            existing_vnet_ids = set()
         from azure.cli.core.commands import LongRunningOperation
         for vnet_id in vnet_ids.difference(existing_vnet_ids):
             logger.info("Adding VNet '%s' to plan.", vnet_id)
@@ -2443,7 +2443,7 @@ def _to_snake(s):
 
 def _convert_to_snake_case(element):
     if isinstance(element, dict):
-        ret = dict()
+        ret = {}
         for k, v in element.items():
             ret[_to_snake(k)] = _convert_to_snake_case(v)
 
@@ -2520,7 +2520,7 @@ def update_dns_soa_record(cmd, resource_group_name, zone_name, host=None, email=
     })
 
     record_camal = record_set["SOARecord"]
-    record = dict()
+    record = {}
     record["host"] = host or record_camal.get("host", None)
     record["email"] = email or record_camal.get("email", None)
     record["serial_number"] = serial_number or record_camal.get("serialNumber", None)
@@ -3137,7 +3137,7 @@ def _add_save_record(cmd, record, record_type, record_set_name, resource_group_n
             "subscription": subscription_id,
             "resource_group": resource_group_name
         })
-        record_set = dict()
+        record_set = {}
         record_set["ttl"] = ret.get("TTL", None)
         record_set[record_snake] = ret.get(record_camel, None)
         record_set = _convert_to_snake_case(record_set)
@@ -3172,7 +3172,7 @@ def _remove_record(cli_ctx, record, record_type, record_set_name, resource_group
         "resource_group": resource_group_name,
         "record_type": record_type
     })
-    record_set = dict()
+    record_set = {}
     record_set["ttl"] = ret.get("TTL", None)
     record_set[record_snake] = ret.get(record_camel, None)
     record_set = _convert_to_snake_case(record_set)

--- a/src/azure-cli/azure/cli/command_modules/privatedns/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/custom.py
@@ -875,7 +875,7 @@ def _to_snake(s):
 
 def _convert_to_snake_case(element):
     if isinstance(element, dict):
-        ret = dict()
+        ret = {}
         for k, v in element.items():
             ret[_to_snake(k)] = _convert_to_snake_case(v)
 
@@ -940,7 +940,7 @@ def _privatedns_add_save_record(cmd, record, record_type, relative_record_set_na
             "record_type": record_type,
             "name": relative_record_set_name
         })
-        record_set = dict()
+        record_set = {}
         record_set["ttl"] = ret.get("ttl", None)
         record_set[record_snake] = ret.get(record_camel, None)
         record_set = _convert_to_snake_case(record_set)
@@ -1036,7 +1036,7 @@ def update_privatedns_soa_record(cmd, resource_group_name, private_zone_name, ho
     })
 
     record_camal = record_set["soaRecord"]
-    record = dict()
+    record = {}
     record["host"] = host or record_camal.get("host", None)
     record["email"] = email or record_camal.get("email", None)
     record["serial_number"] = serial_number or record_camal.get("serialNumber", None)
@@ -1099,7 +1099,7 @@ def _privatedns_remove_record(cmd, record, record_type, relative_record_set_name
         "record_type": record_type,
         "name": relative_record_set_name
     })
-    record_set = dict()
+    record_set = {}
     record_set["ttl"] = ret.get("ttl", None)
     record_set[record_snake] = ret.get(record_camel, None)
     record_set = _convert_to_snake_case(record_set)

--- a/src/azure-cli/azure/cli/command_modules/security/actions.py
+++ b/src/azure-cli/azure/cli/command_modules/security/actions.py
@@ -46,7 +46,7 @@ class _AppendToDictionaryAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         items = getattr(namespace, self.dest, None)
         if items is None:
-            items = dict()
+            items = {}
         key = values[0]
         value = values[1]
         if key in items:
@@ -97,7 +97,7 @@ class GetExtension(argparse._AppendAction):
 
     def get_action(self, values, option_string):  # pylint: disable=no-self-use
         try:
-            properties = dict()
+            properties = {}
             for (k, v) in (x.split('=', 1) for x in values):
                 if k == "isEnabled":
                     properties["is_enabled"] = v

--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/_utils.py
@@ -219,7 +219,7 @@ def create_key_vault_reference_connection_if_not_exist(cmd, client, source_id, k
     key_vault_connections = []
     for connection in client.list(resource_uri=source_id):
         connection = todict(connection)
-        if connection.get('targetService', dict()).get('id') == key_vault_id:
+        if connection.get('targetService', {}).get('id') == key_vault_id:
             key_vault_connections.append(connection)
 
     source_name = get_source_resource_name(cmd)
@@ -270,8 +270,8 @@ def get_auth_if_no_valid_key_vault_connection(source_name, source_id, key_vault_
     # any connection with csi enabled is a valid connection
     if source_name == RESOURCE.KubernetesCluster:
         for connection in key_vault_connections:
-            if connection.get('targetService', dict()).get(
-                    'resourceProperties', dict()).get('connectAsKubernetesCsiDriver'):
+            if connection.get('targetService', {}).get(
+                    'resourceProperties', {}).get('connectAsKubernetesCsiDriver'):
                 return
         return {'authType': 'userAssignedIdentity'}
 
@@ -349,7 +349,7 @@ def create_app_config_connection_if_not_exist(cmd, client, source_id, app_config
     logger.warning('looking for valid app configuration connections')
     for connection in client.list(resource_uri=source_id):
         connection = todict(connection)
-        if connection.get('targetService', dict()).get('id') == app_config_id:
+        if connection.get('targetService', {}).get('id') == app_config_id:
             logger.warning('Valid app configuration connection found.')
             return
 

--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/_validators.py
@@ -81,7 +81,7 @@ def get_resource_type_by_id(resource_id):
     '''Get source or target resource type by resource id
     '''
     target_type = None
-    all_resources = dict()
+    all_resources = {}
     all_resources.update(SOURCE_RESOURCES)
     all_resources.update(TARGET_RESOURCES)
     for _type, _id in all_resources.items():
@@ -158,7 +158,7 @@ def get_client_type(cmd, namespace):
             # use '*Version' property to decide
             if client_type is None:
                 for prop, _type in prop_type_map.items():
-                    if output.get('siteConfig', dict()).get(prop, None) is not None:
+                    if output.get('siteConfig', {}).get(prop, None) is not None:
                         client_type = _type
                         break
         except Exception:  # pylint: disable=broad-except
@@ -297,7 +297,7 @@ def opt_out_auth(namespace):
 def intelligent_experience(cmd, namespace, missing_args):
     '''Use local context and interactive inputs to get arg values
     '''
-    cmd_arg_values = dict()
+    cmd_arg_values = {}
     # use commandline source/target resource args
     for arg in missing_args:
         if getattr(namespace, arg, None) is not None:
@@ -325,7 +325,7 @@ def intelligent_experience(cmd, namespace, missing_args):
             'Auth info is not specified, use default one: --user-account')
     if cmd.cli_ctx.local_context.is_on:
         # arguments found in local context
-        context_arg_values = dict()
+        context_arg_values = {}
         for arg in missing_args:
             if arg not in cmd_arg_values:
                 if get_local_context_value(cmd, arg):
@@ -455,7 +455,7 @@ def get_missing_source_args(cmd, namespace):
     '''Get source resource related args
     '''
     source = get_source_resource_name(cmd)
-    missing_args = dict()
+    missing_args = {}
 
     for arg, content in SOURCE_RESOURCES_PARAMS.get(source, {}).items():
         missing_args[arg] = content
@@ -473,7 +473,7 @@ def get_missing_source_create_args(cmd, namespace):
     '''Get source resource related args in create
     '''
     source = get_source_resource_name(cmd)
-    missing_args = dict()
+    missing_args = {}
 
     args = SOURCE_RESOURCES_CREATE_PARAMS.get(source)
     if args:
@@ -488,7 +488,7 @@ def get_missing_target_args(cmd):
     '''Get target resource related args
     '''
     target = get_target_resource_name(cmd)
-    missing_args = dict()
+    missing_args = {}
 
     if target in TARGET_RESOURCES_PARAMS:
         for arg, content in TARGET_RESOURCES_PARAMS.get(target).items():
@@ -502,7 +502,7 @@ def get_missing_auth_args(cmd, namespace):
     '''
     source = get_source_resource_name(cmd)
     target = get_target_resource_name(cmd)
-    missing_args = dict()
+    missing_args = {}
 
     # check if there are auth_info related params
     auth_param_exist = False
@@ -551,7 +551,7 @@ def get_missing_auth_args(cmd, namespace):
 def get_missing_connection_name(namespace):
     '''Get connection_name arg if user didn't provide it in command line
     '''
-    missing_args = dict()
+    missing_args = {}
     if getattr(namespace, 'connection_name', None) is None:
         missing_args['connection_name'] = {
             'help': 'The connection name',
@@ -564,7 +564,7 @@ def get_missing_connection_name(namespace):
 def get_missing_client_type(namespace):
     '''Get client_type arg if user didn't provide it in command line
     '''
-    missing_args = dict()
+    missing_args = {}
     if getattr(namespace, 'client_type', None) is None:
         missing_args['client_type'] = {
             'help': 'Client type of the connection',
@@ -577,7 +577,7 @@ def get_missing_client_type(namespace):
 def validate_local_default_params(cmd, namespace):  # pylint: disable=unused-argument
     '''Get missing args of local connection command
     '''
-    missing_args = dict()
+    missing_args = {}
 
     if getattr(namespace, 'id', None):
         namespace.id = namespace.id.lower()
@@ -610,7 +610,7 @@ def apply_local_default_params(cmd, namespace, arg_values):  # pylint: disable=u
 
 
 def validate_local_list_params(cmd, namespace):  # pylint: disable=unused-argument
-    missing_args = dict()
+    missing_args = {}
     if getattr(namespace, 'resource_group', None) is None:
         missing_args.update(LOCAL_CONNECTION_PARAMS.get("resource_group"))
     return missing_args
@@ -619,7 +619,7 @@ def validate_local_list_params(cmd, namespace):  # pylint: disable=unused-argume
 def validate_list_params(cmd, namespace):
     '''Get missing args of list command
     '''
-    missing_args = dict()
+    missing_args = {}
     if not validate_source_resource_id(cmd, namespace):
         missing_args.update(get_missing_source_args(cmd, namespace))
     return missing_args
@@ -628,7 +628,7 @@ def validate_list_params(cmd, namespace):
 def validate_create_params(cmd, namespace):
     '''Get missing args of create command
     '''
-    missing_args = dict()
+    missing_args = {}
     if not validate_source_resource_id(cmd, namespace):
         missing_args.update(get_missing_source_args(cmd, namespace))
     missing_args.update(get_missing_source_create_args(cmd, namespace))
@@ -642,7 +642,7 @@ def validate_create_params(cmd, namespace):
 def validate_local_create_params(cmd, namespace):
     '''Get missing args of create command
     '''
-    missing_args = dict()
+    missing_args = {}
 
     if not validate_target_resource_id(cmd, namespace):
         missing_args.update(get_missing_target_args(cmd))
@@ -653,7 +653,7 @@ def validate_local_create_params(cmd, namespace):
 def validate_addon_params(cmd, namespace):
     '''Get missing args of add command with '--new'
     '''
-    missing_args = dict()
+    missing_args = {}
     if not validate_source_resource_id(cmd, namespace):
         missing_args.update(get_missing_source_args(cmd, namespace))
     missing_args.update(get_missing_auth_args(cmd, namespace))
@@ -663,7 +663,7 @@ def validate_addon_params(cmd, namespace):
 def validate_update_params(cmd, namespace):
     '''Get missing args of update command
     '''
-    missing_args = dict()
+    missing_args = {}
     if not validate_connection_id(namespace) and not validate_source_resource_id(cmd, namespace):
         missing_args.update(get_missing_source_args(cmd, namespace))
     # missing_args.update(get_missing_auth_args(cmd, namespace))
@@ -674,7 +674,7 @@ def validate_update_params(cmd, namespace):
 def validate_local_update_params(cmd, namespace):  # pylint: disable=unused-argument
     '''Get missing args of update command
     '''
-    missing_args = dict()
+    missing_args = {}
     # missing_args.update(get_missing_auth_args(cmd, namespace))
     return missing_args
 
@@ -682,7 +682,7 @@ def validate_local_update_params(cmd, namespace):  # pylint: disable=unused-argu
 def validate_default_params(cmd, namespace):
     '''Get missing args of commands except for list, create
     '''
-    missing_args = dict()
+    missing_args = {}
     if not validate_connection_id(namespace):
         missing_args.update(get_missing_source_args(cmd, namespace))
     missing_args.update(get_missing_connection_name(namespace))
@@ -945,20 +945,20 @@ def validate_kafka_params(cmd, namespace):
 def validate_service_state(linker_parameters):
     '''Validate whether user provided params are applicable to service state
     '''
-    target_type = linker_parameters.get('target_service', dict()).get('type')
+    target_type = linker_parameters.get('target_service', {}).get('type')
 
     # AzureResource and other types (e.g., FabricResource, SelfHostedResource)
     if target_type == "AzureResource":
-        target_id = linker_parameters.get('target_service', dict()).get('id')
+        target_id = linker_parameters.get('target_service', {}).get('id')
     else:
-        target_id = linker_parameters.get('target_service', dict()).get('endpoint')
+        target_id = linker_parameters.get('target_service', {}).get('endpoint')
 
     for target, resource_id in TARGET_RESOURCES.items():
         matched = re.match(get_resource_regex(resource_id), target_id, re.IGNORECASE)
         if matched:
             target_type = target
 
-    if target_type == RESOURCE.AppConfig and linker_parameters.get('auth_info', dict()).get('auth_type') == 'secret':
+    if target_type == RESOURCE.AppConfig and linker_parameters.get('auth_info', {}).get('auth_type') == 'secret':
         segments = parse_resource_id(target_id)
         rg = segments.get('resource_group')
         name = segments.get('name')

--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/custom.py
@@ -260,7 +260,7 @@ def connection_validate(cmd, client,
     # HACK: get linker first to infer target resource type so that user token can be
     # set to work around OBO
     linker = todict(client.get(resource_uri=source_id, linker_name=connection_name))
-    target_id = linker.get('targetService', dict()).get('id', '')
+    target_id = linker.get('targetService', {}).get('id', '')
     target_type = get_resource_type_by_id(target_id)
     source_type = get_source_resource_name(cmd)
     client = set_user_token_by_source_and_target(client, cmd.cli_ctx, source_type, target_type)

--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/tests/latest/test_webapp_addon_scenario.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/tests/latest/test_webapp_addon_scenario.py
@@ -42,7 +42,7 @@ class WebAppAddonScenarioTest(ScenarioTest):
         connection_name = 'testconn_postgres'
         connection = self.cmd('webapp connection create postgres --source-id {} '
                               '--connection {} --new'.format(source_id, connection_name)).get_output_in_json()
-        target_id = connection.get('targetService', dict()).get('id')
+        target_id = connection.get('targetService', {}).get('id')
         connection_id = connection.get('id')
 
         # validate the created postgres
@@ -72,7 +72,7 @@ class WebAppAddonScenarioTest(ScenarioTest):
         connection_name = 'testconn_keyvault'
         connection = self.cmd('webapp connection create keyvault --source-id {} '
                               '--connection {} --new'.format(source_id, connection_name)).get_output_in_json()
-        target_id = connection.get('targetService', dict()).get('id')
+        target_id = connection.get('targetService', {}).get('id')
         connection_id = connection.get('id')
 
         # validate the created postgres
@@ -101,7 +101,7 @@ class WebAppAddonScenarioTest(ScenarioTest):
         connection_name = 'testconn_storageblob'
         connection = self.cmd('webapp connection create storage-blob --source-id {} '
                               '--connection {} --new'.format(source_id, connection_name)).get_output_in_json()
-        target_id = connection.get('targetService', dict()).get('id')
+        target_id = connection.get('targetService', {}).get('id')
         connection_id = connection.get('id')
 
         # validate the created postgres

--- a/src/azure-cli/azure/cli/command_modules/sql/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/_params.py
@@ -296,7 +296,7 @@ storage_param_type = CLIArgumentType(
                                                                 "kB": 1.0 / (1024 * 1024),
                                                                 "MB": 1.0 / 1024,
                                                                 "GB": 1,
-                                                                "TB": 1024},
+                                                                "TB": 1024}),
     help='The storage size. If no unit is specified, defaults to gigabytes (GB).',
     validator=validate_managed_instance_storage_size)
 

--- a/src/azure-cli/azure/cli/command_modules/sql/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/_params.py
@@ -89,8 +89,8 @@ class SizeWithUnitConverter:  # pylint: disable=too-few-public-methods
             unit_map=None):
         self.unit = unit
         self.result_type = result_type
-        self.unit_map = unit_map or dict(B=1, kB=1024, MB=1024 * 1024, GB=1024 * 1024 * 1024,
-                                         TB=1024 * 1024 * 1024 * 1024)
+        self.unit_map = unit_map or {"B": 1, "kB": 1024, "MB": 1024 * 1024, "GB": 1024 * 1024 * 1024,
+                                     "TB": 1024 * 1024 * 1024 * 1024}
 
     def __call__(self, value):
         numeric_part = ''.join(itertools.takewhile(str.isdigit, value))
@@ -292,11 +292,11 @@ server_key_type_param_type = CLIArgumentType(
 
 storage_param_type = CLIArgumentType(
     options_list=['--storage'],
-    type=SizeWithUnitConverter('GB', result_type=int, unit_map=dict(B=1.0 / (1024 * 1024 * 1024),
-                                                                    kB=1.0 / (1024 * 1024),
-                                                                    MB=1.0 / 1024,
-                                                                    GB=1,
-                                                                    TB=1024)),
+    type=SizeWithUnitConverter('GB', result_type=int, unit_map={"B": 1.0 / (1024 * 1024 * 1024),
+                                                                "kB": 1.0 / (1024 * 1024),
+                                                                "MB": 1.0 / 1024,
+                                                                "GB": 1,
+                                                                "TB": 1024},
     help='The storage size. If no unit is specified, defaults to gigabytes (GB).',
     validator=validate_managed_instance_storage_size)
 

--- a/src/azure-cli/azure/cli/command_modules/sql/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/_validators.py
@@ -30,7 +30,7 @@ def create_args_for_complex_type(arg_ctx, dest, model_type, arguments):
             :return: The argument of specific type.
             '''
             ns = vars(namespace)
-            kwargs = dict((k, ns[k]) for k in ns if k in set(expanded_arguments))
+            kwargs = {k: ns[k] for k in ns if k in set(expanded_arguments)}
             setattr(namespace, assigned_arg, model_type(**kwargs))
 
         return _expansion_validator_impl

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/file.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/file.py
@@ -315,7 +315,7 @@ def storage_file_copy_batch(cmd, client, source_client, share_name=None, destina
 
         # the cache of existing directories in the destination file share. the cache helps to avoid
         # repeatedly create existing directory so as to optimize the performance.
-        existing_dirs = set([])
+        existing_dirs = set()
 
         # pylint: disable=inconsistent-return-statements
         def action_blob_copy(blob_name):
@@ -335,7 +335,7 @@ def storage_file_copy_batch(cmd, client, source_client, share_name=None, destina
 
         # the cache of existing directories in the destination file share. the cache helps to avoid
         # repeatedly create existing directory so as to optimize the performance.
-        existing_dirs = set([])
+        existing_dirs = set()
 
         # pylint: disable=inconsistent-return-statements
         def action_file_copy(file_info):

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/file.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/file.py
@@ -133,7 +133,7 @@ def list_share_files(cmd, client, directory_name=None, timeout=None, exclude_dir
 
     if exclude_dir:
         t_file_properties = cmd.get_models('_models#FileProperties', resource_type=ResourceType.DATA_STORAGE_FILESHARE)
-        return list(f for f in results if isinstance(f, t_file_properties))
+        return [f for f in results if isinstance(f, t_file_properties)]
     return results
 
 

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/file_azure_stack.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/file_azure_stack.py
@@ -193,7 +193,7 @@ def storage_file_copy_batch(cmd, client, source_client, destination_share=None, 
 
         # the cache of existing directories in the destination file share. the cache helps to avoid
         # repeatedly create existing directory so as to optimize the performance.
-        existing_dirs = set([])
+        existing_dirs = set()
 
         if not source_sas:
             source_sas = create_short_lived_container_sas(cmd, source_client.account_name, source_client.account_key,
@@ -221,7 +221,7 @@ def storage_file_copy_batch(cmd, client, source_client, destination_share=None, 
 
         # the cache of existing directories in the destination file share. the cache helps to avoid
         # repeatedly create existing directory so as to optimize the performance.
-        existing_dirs = set([])
+        existing_dirs = set()
 
         if not source_sas:
             source_sas = create_short_lived_share_sas(cmd, source_client.account_name, source_client.account_key,

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/file_azure_stack.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/file_azure_stack.py
@@ -121,7 +121,7 @@ def storage_file_upload_batch(cmd, client, destination, source, destination_path
 
         return client.make_file_url(destination, dir_name, file_name)
 
-    return list(_upload_action(src, dst) for src, dst in source_files)
+    return [_upload_action(src, dst) for src, dst in source_files]
 
 
 def storage_file_download_batch(cmd, client, source, destination, pattern=None, dryrun=False, validate_content=False,
@@ -164,7 +164,7 @@ def storage_file_download_batch(cmd, client, source, destination, pattern=None, 
         client.get_file_to_path(**get_file_args)
         return client.make_file_url(source, *pair)
 
-    return list(_download_action(f) for f in source_files)
+    return [_download_action(f) for f in source_files]
 
 
 def storage_file_copy_batch(cmd, client, source_client, destination_share=None, destination_path=None,

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/fs_directory.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/fs_directory.py
@@ -35,8 +35,8 @@ def list_fs_directories(client, path=None, recursive=True, num_results=None, tim
 def get_directory_properties(client, timeout=None):
     from .._transformers import transform_fs_access_output
     prop = todict(client.get_directory_properties(timeout=timeout))
-    acl = transform_fs_access_output(client.get_access_control(timeout=timeout))
-    result = dict(prop, **acl)
+    acl = transform_fs_access_output(client.get_accessF_control(timeout=timeout))
+    result = {**prop, ** acl}
     return result
 
 

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/fs_directory.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/fs_directory.py
@@ -29,14 +29,14 @@ def exists(cmd, client, timeout=None):
 def list_fs_directories(client, path=None, recursive=True, num_results=None, timeout=None):
     generator = client.get_paths(path=path, recursive=recursive, timeout=timeout, max_results=num_results)
 
-    return list(f for f in generator if f.is_directory)
+    return [f for f in generator if f.is_directory]
 
 
 def get_directory_properties(client, timeout=None):
     from .._transformers import transform_fs_access_output
     prop = todict(client.get_directory_properties(timeout=timeout))
-    acl = transform_fs_access_output(client.get_accessF_control(timeout=timeout))
-    result = {**prop, ** acl}
+    acl = transform_fs_access_output(client.get_access_control(timeout=timeout))
+    result = dict(prop, **acl)
     return result
 
 

--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -4217,7 +4217,7 @@ def update_vmss(cmd, resource_group_name, name, license_type=None, no_wait=False
         else:
             vmss.sku.name = vm_sku
 
-    sku_profile = dict()
+    sku_profile = {}
     if skuprofile_vmsizes is not None or skuprofile_allostrat is not None:
         if skuprofile_vmsizes is not None:
             sku_profile_vmsizes_list = []

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2019_03_01/test_vm_actions.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2019_03_01/test_vm_actions.py
@@ -513,7 +513,7 @@ class TestActions(unittest.TestCase):
         for test_sku, expected in sku_tests.values():
             if isinstance(expected, dict):
                 # build info dict from expected values.
-                info_dict = {lun: dict(managedDisk={'storageAccountType': None}) for lun in expected if lun != "os"}
+                info_dict = {lun: {"managedDisk": {'storageAccountType': None}} for lun in expected if lun != "os"}
                 if "os" in expected:
                     info_dict["os"] = {}
 
@@ -525,7 +525,10 @@ class TestActions(unittest.TestCase):
                         self.assertEqual(info_dict[lun]['managedDisk']['storageAccountType'], expected[lun])
             elif expected is None:
                 dummy_expected = ["os", 1, 2]
-                info_dict = {lun: dict(managedDisk={'storageAccountType': None}) for lun in dummy_expected if lun != "os"}
+                info_dict = {
+                    lun: {"managedDisk": {'storageAccountType': None}}
+                    for lun in dummy_expected if lun != "os"
+                }
                 if "os" in dummy_expected:
                     info_dict["os"] = {}
 

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2020_09_01/test_vm_actions.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2020_09_01/test_vm_actions.py
@@ -513,7 +513,7 @@ class TestActions(unittest.TestCase):
         for test_sku, expected in sku_tests.values():
             if isinstance(expected, dict):
                 # build info dict from expected values.
-                info_dict = {lun: dict(managedDisk={'storageAccountType': None}) for lun in expected if lun != "os"}
+                info_dict = {lun: {"managedDisk": {'storageAccountType': None} for lun in expected if lun != "os"}}
                 if "os" in expected:
                     info_dict["os"] = {}
 
@@ -525,7 +525,8 @@ class TestActions(unittest.TestCase):
                         self.assertEqual(info_dict[lun]['managedDisk']['storageAccountType'], expected[lun])
             elif expected is None:
                 dummy_expected = ["os", 1, 2]
-                info_dict = {lun: dict(managedDisk={'storageAccountType': None}) for lun in dummy_expected if lun != "os"}
+                info_dict = {lun: {"managedDisk": {'storageAccountType': None}}
+                             for lun in dummy_expected if lun != "os"}
                 if "os" in dummy_expected:
                     info_dict["os"] = {}
 

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2020_09_01/test_vm_actions.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2020_09_01/test_vm_actions.py
@@ -513,7 +513,7 @@ class TestActions(unittest.TestCase):
         for test_sku, expected in sku_tests.values():
             if isinstance(expected, dict):
                 # build info dict from expected values.
-                info_dict = {lun: {"managedDisk": {'storageAccountType': None} for lun in expected if lun != "os"}}
+                info_dict = {lun: {"managedDisk": {'storageAccountType': None}} for lun in expected if lun != "os"}
                 if "os" in expected:
                     info_dict["os"] = {}
 

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
@@ -662,7 +662,7 @@ class TestActions(unittest.TestCase):
         for test_sku, expected in sku_tests.values():
             if isinstance(expected, dict):
                 # build info dict from expected values.
-                info_dict = {"lun": {"managedDisk": {'storageAccountType': None} for lun in expected if lun != "os"}}
+                info_dict = {"lun": {"managedDisk": {'storageAccountType': None}} for lun in expected if lun != "os"}
                 if "os" in expected:
                     info_dict["os"] = {}
 
@@ -675,10 +675,8 @@ class TestActions(unittest.TestCase):
             elif expected is None:
                 dummy_expected = ["os", 1, 2]
                 info_dict = {
-                    "lun": {
-                        "managedDisk": {'storageAccountType': None}
-                        for lun in dummy_expected if lun != "os"
-                    }
+                    lun: {"managedDisk": {'storageAccountType': None}}
+                    for lun in dummy_expected if lun != "os"
                 }
                 if "os" in dummy_expected:
                     info_dict["os"] = {}

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
@@ -662,7 +662,7 @@ class TestActions(unittest.TestCase):
         for test_sku, expected in sku_tests.values():
             if isinstance(expected, dict):
                 # build info dict from expected values.
-                info_dict = {lun: dict(managedDisk={'storageAccountType': None}) for lun in expected if lun != "os"}
+                info_dict = {"lun": {"managedDisk": {'storageAccountType': None} for lun in expected if lun != "os"}}
                 if "os" in expected:
                     info_dict["os"] = {}
 
@@ -674,7 +674,12 @@ class TestActions(unittest.TestCase):
                         self.assertEqual(info_dict[lun]['managedDisk']['storageAccountType'], expected[lun])
             elif expected is None:
                 dummy_expected = ["os", 1, 2]
-                info_dict = {lun: dict(managedDisk={'storageAccountType': None}) for lun in dummy_expected if lun != "os"}
+                info_dict = {
+                    "lun": {
+                        "managedDisk": {'storageAccountType': None}
+                        for lun in dummy_expected if lun != "os"
+                    }
+                }
                 if "os" in dummy_expected:
                     info_dict["os"] = {}
 

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
@@ -662,7 +662,7 @@ class TestActions(unittest.TestCase):
         for test_sku, expected in sku_tests.values():
             if isinstance(expected, dict):
                 # build info dict from expected values.
-                info_dict = {"lun": {"managedDisk": {'storageAccountType': None}} for lun in expected if lun != "os"}
+                info_dict = {lun: {"managedDisk": {'storageAccountType': None}} for lun in expected if lun != "os"}
                 if "os" in expected:
                     info_dict["os"] = {}
 


### PR DESCRIPTION
**Related command**

Various commands are "affected" by this. Please check the diff.

**Description**

[flake8-comprehensions](https://pypi.org/project/flake8-comprehensions/) has the two suggestions I try to remedy.

```
    Rewrite set([]) as set()
    Rewrite dict([]) as {}
```

You can check the marginal benefits with `timeit` in `ipython`.

I wonder why these two rules are disabled in `pylintrc`. Maybe it's for historic reasons.

```
    use-dict-literal,
    consider-using-dict-items,
```

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
