### PR TITLE
[Container Apps] az containerapp env httprouteconfig: Add CRUD commands with yaml

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/containerapp/_clients.py
+++ b/src/azure-cli/azure/cli/command_modules/containerapp/_clients.py
@@ -16,7 +16,7 @@ from knack.log import get_logger
 
 logger = get_logger(__name__)
 
-CURRENT_API_VERSION = "2024-03-01"
+CURRENT_API_VERSION = "2024-10-02-preview" # "2024-03-01"
 POLLING_TIMEOUT = 1200  # how many seconds before exiting
 POLLING_SECONDS = 2  # how many seconds between requests
 POLLING_TIMEOUT_FOR_MANAGED_CERTIFICATE = 1500  # how many seconds before exiting
@@ -768,6 +768,73 @@ class ManagedEnvironmentClient():
             resource_group_name,
             name,
             certificate_name,
+            cls.api_version)
+
+        return send_raw_request(cmd.cli_ctx, "DELETE", request_url, body=None)
+
+    @classmethod
+    def update_httprouteconfig(cls, cmd, resource_group_name, name, httprouteconfig_name, httprouteconfig_envelope):
+        management_hostname = cmd.cli_ctx.cloud.endpoints.resource_manager
+        sub_id = get_subscription_id(cmd.cli_ctx)
+        url_fmt = "{}/subscriptions/{}/resourceGroups/{}/providers/Microsoft.App/managedEnvironments/{}/httpRouteConfigs/{}?api-version={}"
+        request_url = url_fmt.format(
+            management_hostname.strip('/'),
+            sub_id,
+            resource_group_name,
+            name,
+            httprouteconfig_name,
+            cls.api_version)
+
+        r = send_raw_request(cmd.cli_ctx, "PUT", request_url, body=json.dumps(httprouteconfig_envelope))
+        return r.json()
+
+    @classmethod
+    def list_httprouteconfigs(cls, cmd, resource_group_name, name, formatter=lambda x: x):
+        route_list = []
+        management_hostname = cmd.cli_ctx.cloud.endpoints.resource_manager
+        sub_id = get_subscription_id(cmd.cli_ctx)
+        url_fmt = "{}/subscriptions/{}/resourceGroups/{}/providers/Microsoft.App/managedEnvironments/{}/httpRouteConfigs?api-version={}"
+        request_url = url_fmt.format(
+            management_hostname.strip('/'),
+            sub_id,
+            resource_group_name,
+            name,
+            cls.api_version)
+
+        r = send_raw_request(cmd.cli_ctx, "GET", request_url, body=None)
+        j = r.json()
+        for route in j["value"]:
+            formatted = formatter(route)
+            route_list.append(formatted)
+        return route_list
+
+    @classmethod
+    def show_httprouteconfig(cls, cmd, resource_group_name, name, httprouteconfig_name):
+        management_hostname = cmd.cli_ctx.cloud.endpoints.resource_manager
+        sub_id = get_subscription_id(cmd.cli_ctx)
+        url_fmt = "{}/subscriptions/{}/resourceGroups/{}/providers/Microsoft.App/managedEnvironments/{}/httpRouteConfigs/{}?api-version={}"
+        request_url = url_fmt.format(
+            management_hostname.strip('/'),
+            sub_id,
+            resource_group_name,
+            name,
+            httprouteconfig_name,
+            cls.api_version)
+
+        r = send_raw_request(cmd.cli_ctx, "GET", request_url, body=None)
+        return r.json()
+
+    @classmethod
+    def delete_httprouteconfig(cls, cmd, resource_group_name, name, httprouteconfig_name):
+        management_hostname = cmd.cli_ctx.cloud.endpoints.resource_manager
+        sub_id = get_subscription_id(cmd.cli_ctx)
+        url_fmt = "{}/subscriptions/{}/resourceGroups/{}/providers/Microsoft.App/managedEnvironments/{}/httpRouteConfigs/{}?api-version={}"
+        request_url = url_fmt.format(
+            management_hostname.strip('/'),
+            sub_id,
+            resource_group_name,
+            name,
+            httprouteconfig_name,
             cls.api_version)
 
         return send_raw_request(cmd.cli_ctx, "DELETE", request_url, body=None)

--- a/src/azure-cli/azure/cli/command_modules/containerapp/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/containerapp/_help.py
@@ -498,6 +498,56 @@ helps['containerapp env dapr-component remove'] = """
           az containerapp env dapr-component remove -g MyResourceGroup --dapr-component-name MyDaprComponentName --name MyEnvironment
 """
 
+helps['containerapp env httprouteconfig'] = """
+    type: group
+    short-summary: Commands to manage environment level http routing.
+"""
+
+helps['containerapp env httprouteconfig list'] = """
+    type: command
+    short-summary: List the http route configs in the environment.
+    examples:
+    - name: List the http route configs in the environment.
+      text: |
+          az containerapp env httprouteconfig list -g MyResourceGroup -n MyEnvironment
+"""
+
+helps['containerapp env httprouteconfig create'] = """
+    type: command
+    short-summary: Create a new http route config.
+    examples:
+    - name: Create a new route from a yaml file.
+      text: |
+          az containerapp env httprouteconfig create -g MyResourceGroup -n MyEnvironment --httprouteconfig-name configname --yaml config.yaml
+"""
+
+helps['containerapp env httprouteconfig update'] = """
+    type: command
+    short-summary: Update a http route config.
+    examples:
+    - name: Updates a route in the environment from a yaml file.
+      text: |
+          az containerapp env httprouteconfig update -g MyResourceGroup -n MyEnvironment --httprouteconfig-name configname --yaml config.yaml
+"""
+
+helps['containerapp env httprouteconfig show'] = """
+    type: command
+    short-summary: Show a http route config.
+    examples:
+    - name: Shows a route from the environment.
+      text: |
+          az containerapp env httprouteconfig show -g MyResourceGroup -n MyEnvironment --httprouteconfig-name configname
+"""
+
+helps['containerapp env httprouteconfig delete'] = """
+    type: command
+    short-summary: Delete a http route config.
+    examples:
+    - name: Deletes a route from the environment.
+      text: |
+          az containerapp env httprouteconfig delete -g MyResourceGroup -n MyEnvironment --httprouteconfig-name configname
+"""
+
 helps['containerapp env storage'] = """
     type: group
     short-summary: Commands to manage storage for the Container Apps environment.

--- a/src/azure-cli/azure/cli/command_modules/containerapp/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/containerapp/commands.py
@@ -49,6 +49,13 @@ def load_command_table(self, _):
         g.custom_command('update', 'update_managed_environment', supports_no_wait=True, exception_handler=ex_handler_factory())
         g.custom_command('list-usages', 'list_environment_usages', table_transformer=transform_usages_output)
 
+    with self.command_group('containerapp env httprouteconfig') as g:
+        g.custom_show_command('show', 'show_httprouteconfig')
+        g.custom_command('list', 'list_httprouteconfigs')
+        g.custom_command('create', 'update_httprouteconfig', exception_handler=ex_handler_factory())
+        g.custom_command('update', 'update_httprouteconfig', exception_handler=ex_handler_factory())
+        g.custom_command('delete', 'delete_httprouteconfig', confirmation=True, exception_handler=ex_handler_factory())
+
     with self.command_group('containerapp job') as g:
         g.custom_show_command('show', 'show_containerappsjob')
         g.custom_command('list', 'list_containerappsjob')

--- a/src/azure-cli/azure/cli/command_modules/containerapp/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/containerapp/custom.py
@@ -955,6 +955,46 @@ def delete_managed_environment(cmd, name, resource_group_name, no_wait=False):
     return containerapp_env_decorator.delete()
 
 
+def update_httprouteconfig(cmd, resource_group_name, name, httprouteconfig_name, yaml):
+    yaml_httprouteconfig = load_yaml_file(yaml)
+    # check if the type is dict
+    if not isinstance(yaml_httprouteconfig, dict):
+        raise ValidationError('Invalid YAML provided. Please see https://aka.ms/azure-container-apps-job-yaml for a valid YAML spec.')
+
+    httprouteconfig_envelope = {}
+
+    httprouteconfig_envelope["properties"] = yaml_httprouteconfig
+
+    try:
+        return ManagedEnvironmentClient.update_httprouteconfig(cmd, resource_group_name, name, httprouteconfig_name, httprouteconfig_envelope)
+    except Exception as e:
+        handle_raw_exception(e)
+
+
+def list_httprouteconfigs(cmd, resource_group_name, name):
+    _validate_subscription_registered(cmd, CONTAINER_APPS_RP)
+    try:
+        return ManagedEnvironmentClient.list_httprouteconfigs(cmd, resource_group_name, name)
+    except Exception as e:
+        handle_raw_exception(e)
+
+
+def show_httprouteconfig(cmd, resource_group_name, name, httprouteconfig_name):
+    _validate_subscription_registered(cmd, CONTAINER_APPS_RP)
+    try:
+        return ManagedEnvironmentClient.show_httprouteconfig(cmd, resource_group_name, name, httprouteconfig_name)
+    except Exception as e:
+        handle_raw_exception(e)
+
+
+def delete_httprouteconfig(cmd, resource_group_name, name, httprouteconfig_name):
+    _validate_subscription_registered(cmd, CONTAINER_APPS_RP)
+    try:
+        return ManagedEnvironmentClient.delete_httprouteconfig(cmd, resource_group_name, name, httprouteconfig_name)
+    except Exception as e:
+        handle_raw_exception(e)
+
+
 def create_containerappsjob(cmd,
                             name,
                             resource_group_name,


### PR DESCRIPTION
**Related command**
`containerapp env httprouteconfig`

**Description**
Adding new CRUD commands for the httprouteconfig feature. For now these only support YAML inputs.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
