### PR TITLE
{IoT} `az iot hub policy renew-key`: Service-side HIS renewal of IoT Hub policy keys

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/iot/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/custom.py
@@ -70,7 +70,7 @@ from azure.cli.command_modules.iot._constants import SYSTEM_ASSIGNED_IDENTITY
 from azure.cli.command_modules.iot.shared import EndpointType, EncodingFormat, RenewKeyType, AuthenticationType, IdentityType
 from azure.cli.command_modules.iot._client_factory import resource_service_factory
 from azure.cli.command_modules.iot._client_factory import iot_hub_service_factory
-from azure.cli.command_modules.iot._utils import open_certificate, generate_key
+from azure.cli.command_modules.iot._utils import open_certificate
 
 
 logger = get_logger(__name__)
@@ -904,9 +904,9 @@ def iot_hub_policy_key_renew(cmd, client, hub_name, policy_name, regenerate_key,
     updated_policies = [p for p in policies if p.key_name.lower() != policy_name.lower()]
     requested_policy = [p for p in policies if p.key_name.lower() == policy_name.lower()]
     if regenerate_key == RenewKeyType.Primary.value:
-        requested_policy[0].primary_key = generate_key()
+        requested_policy[0].primary_key = None
     if regenerate_key == RenewKeyType.Secondary.value:
-        requested_policy[0].secondary_key = generate_key()
+        requested_policy[0].secondary_key = None
     if regenerate_key == RenewKeyType.Swap.value:
         temp = requested_policy[0].primary_key
         requested_policy[0].primary_key = requested_policy[0].secondary_key


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az iot hub policy renew-key`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

This moves key generation for IoT Hub policy key renewals to the service side, rather than the client.

**Testing Guide**
<!--Example commands with explanations.-->

This change is completely hidden from the user interface. The following example command should continue to renew policy keys for the IoT Hub:
`az iot hub policy renew-key --name {policyName} --hub-name {hubName} --resource-group {resourceGroupName} --rk primary` 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
