### PR TITLE
{Core} Add dict transformation for typespec generated SDKs

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -38,7 +38,7 @@ from knack.invocation import CommandInvoker
 from knack.preview import ImplicitPreviewItem, PreviewItem, resolve_preview_info
 from knack.experimental import ImplicitExperimentalItem, ExperimentalItem, resolve_experimental_info
 from knack.log import get_logger, CLILogging
-from knack.util import CLIError, CommandResultItem, todict, to_camel_case
+from knack.util import CLIError, CommandResultItem
 from knack.events import EVENT_INVOKER_TRANSFORM_RESULT
 from knack.validators import DefaultStr
 
@@ -115,15 +115,6 @@ def _expand_file_prefixed_files(args):
 def _pre_command_table_create(cli_ctx, args):
     cli_ctx.refresh_request_id()
     return _expand_file_prefixed_files(args)
-
-
-def _convert_camel_case(obj):
-    if isinstance(obj, dict):
-        result = {to_camel_case(k): _convert_camel_case(v) for (k, v) in obj.items()}
-        return result
-    if isinstance(obj, list):
-        return [_convert_camel_case(a) for a in obj]
-    return obj
 
 
 # pylint: disable=too-many-instance-attributes
@@ -724,10 +715,7 @@ class AzCliCommandInvoker(CommandInvoker):
             elif _is_paged(result):
                 result = list(result)
 
-            # This is added for new models from typespec generated SDKs
-            # These models store data in `__dict__['_data']` instead of in `__dict__`
-            if result and hasattr(result, 'as_dict') and not hasattr(result, '_attribute_map'):
-                result = _convert_camel_case(result.as_dict())
+            from ..util import todict
             result = todict(result, AzCliCommandInvoker.remove_additional_prop_layer)
 
             event_data = {'result': result}

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -125,6 +125,7 @@ def _convert_camel_case(obj):
         return [_convert_camel_case(a) for a in obj]
     return obj
 
+
 # pylint: disable=too-many-instance-attributes
 class CacheObject:
 

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -715,6 +715,10 @@ class AzCliCommandInvoker(CommandInvoker):
             elif _is_paged(result):
                 result = list(result)
 
+            # This is added for new models from typespec generated SDKs
+            # These models store data in `__dict__['_data']` instead of in `__dict__`
+            if result and hasattr(result, 'as_dict'):
+                result = result.as_dict()
             result = todict(result, AzCliCommandInvoker.remove_additional_prop_layer)
 
             event_data = {'result': result}

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -725,7 +725,7 @@ class AzCliCommandInvoker(CommandInvoker):
 
             # This is added for new models from typespec generated SDKs
             # These models store data in `__dict__['_data']` instead of in `__dict__`
-            if result and hasattr(result, 'as_dict'):
+            if result and hasattr(result, 'as_dict') and not hasattr(obj, '_attribute_map'):
                 result = _convert_camel_case(result.as_dict())
             result = todict(result, AzCliCommandInvoker.remove_additional_prop_layer)
 

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -725,7 +725,7 @@ class AzCliCommandInvoker(CommandInvoker):
 
             # This is added for new models from typespec generated SDKs
             # These models store data in `__dict__['_data']` instead of in `__dict__`
-            if result and hasattr(result, 'as_dict') and not hasattr(obj, '_attribute_map'):
+            if result and hasattr(result, 'as_dict') and not hasattr(result, '_attribute_map'):
                 result = _convert_camel_case(result.as_dict())
             result = todict(result, AzCliCommandInvoker.remove_additional_prop_layer)
 

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -646,7 +646,7 @@ def todict(obj, post_processor=None):
     # The base model stores data in obj.__dict__['_data'] instead of in obj.__dict__
     # We need to call obj.as_dict() to extract data for this kind of model
     if hasattr(obj, 'as_dict') and not hasattr(obj, '_attribute_map'):
-        result = {to_camel_case(k): todict(v, post_processor) for k, v in obj.as_dict()}
+        result = {to_camel_case(k): todict(v, post_processor) for k, v in obj.as_dict().items()}
         return post_processor(obj, result) if post_processor else result
     if hasattr(obj, '_asdict'):
         return todict(obj._asdict(), post_processor)

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -624,15 +624,6 @@ def b64_to_hex(s):
     return hex_data
 
 
-def recursively_to_camel_case(obj):
-    if isinstance(obj, dict):
-        result = {to_camel_case(k): recursively_to_camel_case(v) for (k, v) in obj.items()}
-        return result
-    if isinstance(obj, list):
-        return [recursively_to_camel_case(a) for a in obj]
-    return obj
-
-
 def todict(obj, post_processor=None):
     """
     Convert an object to a dictionary. Use 'post_processor(original_obj, dictionary)' to update the

--- a/src/azure-cli/azure/cli/command_modules/keyvault/_transformers.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_transformers.py
@@ -474,13 +474,3 @@ def transform_certificate_issuer_admin_list(result, **command_args):
         } for contact in admin_contacts]
         return ret
     return result
-
-
-def transform_security_domain_output(result, **command_args):
-    if not result or isinstance(result, dict):
-        return result
-    ret = {
-        'status': getattr(result, 'status', None),
-        'statusDetails': getattr(result, 'status_details', None)
-    }
-    return ret

--- a/src/azure-cli/azure/cli/command_modules/keyvault/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/commands.py
@@ -12,7 +12,7 @@ from azure.cli.command_modules.keyvault._client_factory import (
     get_client, get_client_factory, Clients, is_azure_stack_profile)
 
 from azure.cli.command_modules.keyvault._transformers import (
-    filter_out_managed_resources, transform_security_domain_output,
+    filter_out_managed_resources,
     multi_transformers, transform_key_decryption_output, keep_max_results, transform_key_list_output,
     transform_key_output, transform_key_encryption_output, transform_key_random_output,
     transform_secret_list, transform_deleted_secret_list, transform_secret_set,
@@ -145,11 +145,9 @@ def load_command_table(self, _):
         with self.command_group('keyvault security-domain', data_security_domain_entity.command_type) as g:
             g.keyvault_custom('init-recovery', 'security_domain_init_recovery')
             g.keyvault_custom('restore-blob', 'security_domain_restore_blob')
-            g.keyvault_custom('upload', 'security_domain_upload', supports_no_wait=True,
-                              transform=transform_security_domain_output)
-            g.keyvault_custom('download', 'security_domain_download', supports_no_wait=True,
-                              transform=transform_security_domain_output)
-            g.keyvault_custom('wait', '_wait_security_domain_operation', transform=transform_security_domain_output)
+            g.keyvault_custom('upload', 'security_domain_upload', supports_no_wait=True)
+            g.keyvault_custom('download', 'security_domain_download', supports_no_wait=True)
+            g.keyvault_custom('wait', '_wait_security_domain_operation')
 
     with self.command_group('keyvault key', data_key_entity.command_type) as g:
         g.keyvault_custom('create', 'create_key', transform=transform_key_output, validator=validate_key_create)


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
SDK models have changed when we move from swagger generated to typespec generated. This cause issues for `knack.util.todict` to do the formatter over command output. We call https://github.com/Azure/azure-cli/blob/eb55296b4f3280b0df1d557de99f6f9b828180b3/src/azure-cli-core/azure/cli/core/commands/__init__.py#L718 to convert the command result for easier format. Here's how [todict](https://github.com/microsoft/knack/blob/b1164b57d777711fd3954cf11f18ffb06ab1ca5b/knack/util.py#L133-L156) is implemented in `knack`:
```Python
def todict(obj, post_processor=None):  # pylint: disable=too-many-return-statements
    """
    Convert an object to a dictionary. Use 'post_processor(original_obj, dictionary)' to update the
    dictionary in the process
    """
    if isinstance(obj, dict):
        result = {k: todict(v, post_processor) for (k, v) in obj.items()}
        return post_processor(obj, result) if post_processor else result
    if isinstance(obj, list):
        return [todict(a, post_processor) for a in obj]
    if isinstance(obj, Enum):
        return obj.value
    if isinstance(obj, (date, time, datetime)):
        return obj.isoformat()
    if isinstance(obj, timedelta):
        return str(obj)
    if hasattr(obj, '_asdict'):
        return todict(obj._asdict(), post_processor)
    if hasattr(obj, '__dict__'):
        result = {to_camel_case(k): todict(v, post_processor)
                  for k, v in obj.__dict__.items()
                  if not callable(v) and not k.startswith('_')}
        return post_processor(obj, result) if post_processor else result
    return obj
```
Currently working with **swagger generated models**, it runs into `hasattr(obj, '__dict__')` and transforms `obj.__dict__.items()` one by one if the item isn't private starting with `_`.

But now for **typespec generated models**, a new [base model](https://github.com/mccoyp/azure-sdk-for-python/blob/000f7af897937c8146dea5da28cd74dd4ef0f16e/sdk/keyvault/azure-keyvault-securitydomain/azure/keyvault/securitydomain/_model_base.py#L493) is designed to store all data in `__dict__['_data']`. In such case, we won't get anything by iterating `__dict__` as before. The new model provides a `as_dict` func instead to transform the model object to dict.

Here's an example for **swagger generated models**(old) and **typespec generated models**(new)
```
SecurityDomainUploadStatus (old)
__dict__: {'status': 'Success', 'status_details': 'The resource is active.'}
as_dict(): {'status': 'Success', 'status_details': 'The resource is active.'}

SecurityDomainUploadStatus (new)
__dict__: {'_data': {'status': 'Success', 'status_details': 'The resource is active.'}}
as_dict(): {'status': 'Success', 'status_details': 'The resource is active.'}
```

There are three workarounds:
- ask each module which uses typespec generated SDKs to call `obj.as_dict()` or get needed attributes by themselves (eg. https://github.com/Azure/azure-cli/pull/30252#discussion_r1833871743)
- update `knack.util.todict` to detect `hasattr(obj, 'as_dict')`
- overwrite `knack.util.todict` in `azure.cli.core` to detect `hasattr(obj, 'as_dict')`

This PR works for the third solution.


**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
