### PR TITLE
{Misc} Remove some Python 2.7 legacy code

### DIFF
--- a/scripts/curl_install_pypi/install.py
+++ b/scripts/curl_install_pypi/install.py
@@ -23,19 +23,8 @@ import tempfile
 import shutil
 import subprocess
 import hashlib
-try:
-    # Attempt to load python 3 module
-    from urllib.request import urlopen
-except ImportError:
-    # Import python 2 version
-    from urllib2 import urlopen
+from urllib.request import urlopen
 
-try:
-    # Rename raw_input to input to support Python 2
-    input = raw_input
-except NameError:
-    # Python 3 doesn't have raw_input
-    pass
 
 AZ_DISPATCH_TEMPLATE = """#!/usr/bin/env bash
 {install_dir}/bin/python -m azure.cli "$@"

--- a/scripts/curl_install_pypi/install.py
+++ b/scripts/curl_install_pypi/install.py
@@ -193,7 +193,7 @@ def _backup_rc(rc_file):
     try:
         shutil.copyfile(rc_file, rc_file+'.backup')
         print_status("Backed up '{}' to '{}'".format(rc_file, rc_file+'.backup'))
-    except (OSError, IOError):
+    except OSError:
         pass
 
 
@@ -222,7 +222,7 @@ def _find_line_in_file(file_path, search_pattern):
             for line in search_file:
                 if search_pattern in line:
                     return True
-    except (OSError, IOError):
+    except OSError:
         pass
     return False
 

--- a/src/azure-cli-core/azure/cli/core/_help_loaders.py
+++ b/src/azure-cli-core/azure/cli/core/_help_loaders.py
@@ -15,14 +15,9 @@ import yaml
 
 logger = get_logger(__name__)
 
-try:
-    ABC = abc.ABC
-except AttributeError:  # Python 2.7, abc exists, but not ABC
-    ABC = abc.ABCMeta('ABC', (object,), {'__slots__': ()})
-
 
 # BaseHelpLoader defining versioned loader interface. Also contains some helper methods.
-class BaseHelpLoader(ABC):
+class BaseHelpLoader(abc.ABC):
     def __init__(self, help_ctx=None):
         self.help_ctx = help_ctx
         self._entry_data = None

--- a/src/azure-cli-core/azure/cli/core/_session.py
+++ b/src/azure-cli-core/azure/cli/core/_session.py
@@ -36,7 +36,7 @@ class Session(MutableMapping):
                     self.save()
             with open(self.filename, 'r', encoding=self._encoding) as f:
                 self.data = json.load(f)
-        except (OSError, IOError, json.JSONDecodeError) as load_exception:
+        except (OSError, json.JSONDecodeError) as load_exception:
             # OSError / IOError should imply file not found issues which are expected on fresh runs (e.g. on build
             # agents or new systems). A parse error indicates invalid/bad data in the file. We do not wish to warn
             # on missing files since we expect that, but do if the data isn't parsing as expected.

--- a/src/azure-cli-core/azure/cli/core/aaz/_operation.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_operation.py
@@ -7,6 +7,8 @@
 
 import json
 
+from urllib.parse import quote
+
 from azure.core.exceptions import ClientAuthenticationError, ResourceExistsError, ResourceNotFoundError, \
     HttpResponseError
 from azure.cli.core.azclierror import InvalidArgumentValueError
@@ -19,10 +21,6 @@ from ._field_type import AAZSimpleType, AAZObjectType, AAZBaseDictType, AAZListT
 from ._field_value import AAZList, AAZObject, AAZBaseDictValue
 from .exceptions import AAZInvalidValueError
 
-try:
-    from urllib import quote  # type: ignore
-except ImportError:
-    from urllib.parse import quote  # type: ignore
 
 
 class AAZOperation:

--- a/src/azure-cli-core/azure/cli/core/aaz/_operation.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_operation.py
@@ -22,7 +22,6 @@ from ._field_value import AAZList, AAZObject, AAZBaseDictValue
 from .exceptions import AAZInvalidValueError
 
 
-
 class AAZOperation:
 
     def __init__(self, ctx):

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -42,8 +42,6 @@ from knack.util import CLIError, CommandResultItem, todict
 from knack.events import EVENT_INVOKER_TRANSFORM_RESULT
 from knack.validators import DefaultStr
 
-t_JSONDecodeError = json.JSONDecodeError
-
 logger = get_logger(__name__)
 DEFAULT_CACHE_TTL = '10'
 

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -92,7 +92,7 @@ def _expand_file_prefixed_files(args):
         if ix == 0:
             try:
                 return _load_file(poss_file)
-            except IOError:
+            except OSError:
                 logger.debug("Failed to load '%s', assume not a file", arg)
                 return arg
 

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -42,10 +42,7 @@ from knack.util import CLIError, CommandResultItem, todict
 from knack.events import EVENT_INVOKER_TRANSFORM_RESULT
 from knack.validators import DefaultStr
 
-try:
-    t_JSONDecodeError = json.JSONDecodeError
-except AttributeError:  # in Python 2.7
-    t_JSONDecodeError = ValueError
+t_JSONDecodeError = json.JSONDecodeError
 
 logger = get_logger(__name__)
 DEFAULT_CACHE_TTL = '10'
@@ -471,7 +468,7 @@ def cached_put(cmd_obj, operation, parameters, *args, setter_arg_name='parameter
     obj_path = os.path.join(obj_dir, obj_file)
     try:
         os.remove(obj_path)
-    except (OSError, IOError):  # FileNotFoundError introduced in Python 3
+    except FileNotFoundError:
         pass
     return result
 

--- a/src/azure-cli-core/azure/cli/core/commands/progress.py
+++ b/src/azure-cli-core/azure/cli/core/commands/progress.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
-from __future__ import division
 import sys
 
 from humanfriendly.terminal.spinners import Spinner

--- a/src/azure-cli-core/azure/cli/core/keys.py
+++ b/src/azure-cli-core/azure/cli/core/keys.py
@@ -16,11 +16,7 @@ def is_valid_ssh_rsa_public_key(openssh_pubkey):
     # http://stackoverflow.com/questions/2494450/ssh-rsa-public-key-validation-using-a-regular-expression # pylint: disable=line-too-long
     # A "good enough" check is to see if the key starts with the correct header.
     import struct
-    try:
-        from base64 import decodebytes as base64_decode
-    except ImportError:
-        # deprecated and redirected to decodebytes in Python 3
-        from base64 import decodestring as base64_decode
+    from base64 import decodestring as base64_decode
 
     parts = openssh_pubkey.split()
     if len(parts) < 2:

--- a/src/azure-cli-core/azure/cli/core/keys.py
+++ b/src/azure-cli-core/azure/cli/core/keys.py
@@ -16,7 +16,7 @@ def is_valid_ssh_rsa_public_key(openssh_pubkey):
     # http://stackoverflow.com/questions/2494450/ssh-rsa-public-key-validation-using-a-regular-expression # pylint: disable=line-too-long
     # A "good enough" check is to see if the key starts with the correct header.
     import struct
-    from base64 import decodestring as base64_decode
+    from base64 import decodebytes as base64_decode
 
     parts = openssh_pubkey.split()
     if len(parts) < 2:

--- a/src/azure-cli-core/azure/cli/core/keys.py
+++ b/src/azure-cli-core/azure/cli/core/keys.py
@@ -44,7 +44,7 @@ def generate_ssh_keys(private_key_filepath, public_key_filepath):
                                public_key_filepath, pub_ssh_dir)
 
                 return public_key
-        except IOError as e:
+        except OSError as e:
             raise CLIError(e)
 
     ssh_dir = os.path.dirname(private_key_filepath)

--- a/src/azure-cli-core/azure/cli/core/tests/test_aaz_prompt.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_aaz_prompt.py
@@ -7,10 +7,7 @@ import json
 import random
 
 import unittest
-try:
-    import mock
-except ImportError:
-    from unittest import mock
+from unittest import mock
 
 from azure.cli.core import azclierror
 from azure.cli.core.aaz import exceptions as aazerror

--- a/src/azure-cli-core/azure/cli/core/tests/test_keys.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_keys.py
@@ -64,7 +64,7 @@ class TestGenerateSSHKeys(unittest.TestCase):
         with mock.patch('azure.cli.core.keys.open') as mocked_open:
             # mock failed call to read
             mocked_f = mocked_open.return_value.__enter__.return_value
-            mocked_f.read = mock.MagicMock(side_effect=IOError("Mocked IOError"))
+            mocked_f.read = mock.MagicMock(side_effect=OSError("Mocked IOError"))
 
             # assert that CLIError raised when generate_ssh_keys is called
             with self.assertRaises(CLIError):

--- a/src/azure-cli-telemetry/azure/cli/telemetry/__init__.py
+++ b/src/azure-cli-telemetry/azure/cli/telemetry/__init__.py
@@ -106,7 +106,7 @@ def main():
             # another upload process is running.
             logger.info('Lock out from note file under %s which means another process is running. Exit 0.', config_dir)
             sys.exit(0)
-        except IOError as err:
+        except OSError as err:
             logger.warning('Unexpected IO Error %s. Exit 1.', err)
             sys.exit(1)
         except Exception as err:  # pylint: disable=broad-except

--- a/src/azure-cli-telemetry/azure/cli/telemetry/components/records_collection.py
+++ b/src/azure-cli-telemetry/azure/cli/telemetry/components/records_collection.py
@@ -51,7 +51,7 @@ class RecordsCollection:
                     self._add_record(line)
 
                 self._logger.info("Processed file %s into %d records.", path, len(self._records))
-        except IOError as err:
+        except OSError as err:
             self._logger.warning("Fail to open file %s. Reason: %s.", path, err)
 
     def _add_record(self, content_line):

--- a/src/azure-cli-telemetry/azure/cli/telemetry/components/telemetry_client.py
+++ b/src/azure-cli-telemetry/azure/cli/telemetry/components/telemetry_client.py
@@ -6,17 +6,11 @@
 import json
 import datetime
 
+import urllib.request as http_client_t
+from urllib.error import HTTPError
+
 from applicationinsights import TelemetryClient
 from applicationinsights.channel import SynchronousSender, SynchronousQueue, TelemetryChannel
-
-try:
-    # Python 2.x
-    import urllib2 as http_client_t
-    from urllib2 import HTTPError
-except ImportError:
-    # Python 3.x
-    import urllib.request as http_client_t
-    from urllib.error import HTTPError
 
 
 class CliTelemetryClient:

--- a/src/azure-cli-telemetry/azure/cli/telemetry/components/telemetry_logging.py
+++ b/src/azure-cli-telemetry/azure/cli/telemetry/components/telemetry_logging.py
@@ -45,5 +45,5 @@ def _ensure_telemetry_log_folder(config_dir):
         if not os.path.isdir(ret):
             os.makedirs(ret)
         return ret
-    except (OSError, IOError, TypeError):
+    except (OSError, TypeError):
         return None

--- a/src/azure-cli-telemetry/azure/cli/telemetry/components/telemetry_note.py
+++ b/src/azure-cli-telemetry/azure/cli/telemetry/components/telemetry_note.py
@@ -41,7 +41,7 @@ class TelemetryNote(portalocker.utils.Lock):
             last_send = datetime.datetime.strptime(raw, '%Y-%m-%dT%H:%M:%S')
             self._logger.info("Read timestamp from the note. The last send was %s.", last_send)
             return last_send
-        except (AttributeError, ValueError, IOError) as err:
+        except (OSError, AttributeError, ValueError) as err:
             self._logger.warning("Fail to parse or read the timestamp '%s' in the note file. Set the last send time "
                                  "to minimal. Reason: %s", raw, err)
             return fallback
@@ -54,7 +54,7 @@ class TelemetryNote(portalocker.utils.Lock):
                 self.fh.write(next_send.strftime('%Y-%m-%dT%H:%M:%S'))
                 self.fh.truncate()
                 break
-            except IOError:
+            except OSError:
                 self._logger.warning('Fail to update the note file. This is the %d try.', retry + 1)
         else:
             # TODO: how to save this?

--- a/src/azure-cli-telemetry/azure/cli/telemetry/tests/test_telemetry_client.py
+++ b/src/azure-cli-telemetry/azure/cli/telemetry/tests/test_telemetry_client.py
@@ -8,16 +8,10 @@ from unittest import mock
 import os
 import unittest
 
-from applicationinsights.channel import SynchronousSender
+import urllib.request as http_client_t
+from urllib.error import HTTPError
 
-try:
-    # Python 2.x
-    import urllib2 as http_client_t
-    from urllib2 import HTTPError
-except ImportError:
-    # Python 3.x
-    import urllib.request as http_client_t
-    from urllib.error import HTTPError
+from applicationinsights.channel import SynchronousSender
 
 from azure.cli.telemetry.components.telemetry_client import (CliTelemetryClient, _NoRetrySender, http_client_t)
 

--- a/src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/base.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/base.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
 import unittest
 import os
 import inspect

--- a/src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/patches.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/patches.py
@@ -23,8 +23,7 @@ def patch_long_run_operation_delay(unit_test):
 
 
 def mock_in_unit_test(unit_test, target, replacement):
-    try:
-        import unittest.mock as mock
+    from unittest.mock as mock
     except ImportError:
         import mock
     import unittest

--- a/src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/patches.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/patches.py
@@ -23,9 +23,7 @@ def patch_long_run_operation_delay(unit_test):
 
 
 def mock_in_unit_test(unit_test, target, replacement):
-    from unittest.mock as mock
-    except ImportError:
-        import mock
+    import unittest.mock as mock
     import unittest
 
     if not isinstance(unit_test, unittest.TestCase):

--- a/src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/recording_processors.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/recording_processors.py
@@ -111,16 +111,12 @@ class LargeResponseBodyReplacer(RecordingProcessor):
         if is_text_payload(response) and not is_json_payload(response):
             body = response['body']['string']
 
-            # backward compatibility. under 2.7 response body is unicode, under 3.5 response body is
-            # bytes. when set the value back, the same type must be used.
-            body_is_string = isinstance(body, str)
-
             content_in_string = (response['body']['string'] or b'').decode('utf-8')
             index = content_in_string.find(LargeResponseBodyProcessor.control_flag)
 
             if index > -1:
                 length = int(content_in_string[index + len(LargeResponseBodyProcessor.control_flag):])
-                if body_is_string:
+                if isinstance(body, str):
                     response['body']['string'] = '0' * length
                 else:
                     response['body']['string'] = bytes([0] * length)

--- a/src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/tests/test_config.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/tests/test_config.py
@@ -7,10 +7,7 @@ import os
 import tempfile
 import unittest
 
-try:
-    import mock
-except ImportError:
-    from unittest import mock
+from unittest import mock
 
 from azure.cli.testsdk.scenario_tests.const import ENV_LIVE_TEST
 

--- a/src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/tests/test_recording_processor.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/tests/test_recording_processor.py
@@ -5,10 +5,7 @@
 
 import json
 
-try:
-    import unittest.mock as mock
-except ImportError:
-    import mock
+from unittest import mock
 import unittest
 import uuid
 

--- a/src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/tests/test_utilities.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/tests/test_utilities.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 import os
 import unittest
-import mock
+from unittest import mock
 from azure.cli.testsdk.scenario_tests.utilities import (
     create_random_name, get_sha1_hash, is_text_payload, is_json_payload)
 

--- a/src/azure-cli/azure/cli/command_modules/acr/_archive_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_archive_utils.py
@@ -7,7 +7,6 @@ import tarfile
 import os
 import re
 import codecs
-from io import open
 import requests
 from knack.log import get_logger
 from knack.util import CLIError

--- a/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
@@ -3,10 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-try:
-    from urllib.parse import urlencode, urlparse, urlunparse
-except ImportError:
-    from urllib import urlencode
+from urllib.parse import urlencode, urlparse, urlunparse
 
 import time
 from json import loads

--- a/src/azure-cli/azure/cli/command_modules/acr/helm.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/helm.py
@@ -227,7 +227,7 @@ def acr_helm_install_cli(client_version='2.16.3', install_location=None, yes=Fal
 
                 if os.path.splitext(f.name)[0] in ('helm', 'tiller'):
                     os.chmod(target_path, os.stat(target_path).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
-    except IOError as e:
+    except OSError as e:
         import traceback
         logger.debug(traceback.format_exc())
         raise CLIError('Error while installing {} to {}: {}'.format(cli, install_dir, e))

--- a/src/azure-cli/azure/cli/command_modules/acr/manifest.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/manifest.py
@@ -5,10 +5,7 @@
 
 from datetime import datetime, timedelta
 
-try:
-    from urllib.parse import unquote
-except ImportError:
-    from urllib import unquote
+from urllib.parse import unquote
 
 from knack.log import get_logger
 from azure.cli.core.util import user_confirmation

--- a/src/azure-cli/azure/cli/command_modules/acr/repository.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/repository.py
@@ -3,10 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-try:
-    from urllib.parse import unquote
-except ImportError:
-    from urllib import unquote
+from urllib.parse import unquote
 
 from knack.util import CLIError
 from knack.log import get_logger

--- a/src/azure-cli/azure/cli/command_modules/acr/tests/hybrid_2020_09_01/test_acr_commands_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/tests/hybrid_2020_09_01/test_acr_commands_mock.py
@@ -3,10 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-try:
-    from urllib.parse import urlencode
-except ImportError:
-    from urllib import urlencode
+from urllib.parse import urlencode
 import json
 import unittest
 from unittest import mock

--- a/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_commands_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_commands_mock.py
@@ -3,10 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-try:
-    from urllib.parse import urlencode
-except ImportError:
-    from urllib import urlencode
+from urllib.parse import urlencode
 import json
 import unittest
 from unittest import mock

--- a/src/azure-cli/azure/cli/command_modules/acs/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_validators.py
@@ -3,8 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import unicode_literals
-
 import os
 import re
 from ipaddress import ip_network

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -1471,7 +1471,7 @@ def load_kubernetes_configuration(filename):
     try:
         with open(filename) as stream:
             return yaml.safe_load(stream)
-    except (IOError, OSError) as ex:
+    except OSError as ex:
         if getattr(ex, 'errno', 0) == errno.ENOENT:
             raise CLIError('{} does not exist'.format(filename))
         raise
@@ -1922,7 +1922,7 @@ def k8s_install_kubectl(cmd, client_version='latest', install_location=None, sou
         _urlretrieve(file_url, install_location)
         os.chmod(install_location,
                  os.stat(install_location).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
-    except IOError as ex:
+    except OSError as ex:
         raise CLIError(
             'Connection error while attempting to download client ({})'.format(ex))
 
@@ -1986,7 +1986,7 @@ def k8s_install_kubelogin(cmd, client_version='latest', install_location=None, s
             logger.warning('Downloading client to "%s" from "%s"',
                            download_path, file_url)
             _urlretrieve(file_url, download_path)
-        except IOError as ex:
+        except OSError as ex:
             raise CLIError(
                 'Connection error while attempting to download client ({})'.format(ex))
         _unzip(download_path, tmp_dir)

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -996,7 +996,7 @@ class AKSManagedClusterContext(BaseAKSContext):
             # Use subscription id to provide uniqueness and prevent DNS name clashes
             name_part = re.sub('[^A-Za-z0-9-]', '', name)[0:10]
             if not name_part[0].isalpha():
-                name_part = (str('a') + name_part)[0:10]
+                name_part = ('a' + name_part)[0:10]
             resource_group_part = re.sub(
                 '[^A-Za-z0-9-]', '', resource_group_name)[0:16]
             dns_name_prefix = '{}-{}-{}'.format(name_part, resource_group_part, subscription_id[0:6])

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_agentpool_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_agentpool_decorator.py
@@ -2087,7 +2087,7 @@ class AKSAgentPoolAddDecoratorCommonTestCase(unittest.TestCase):
             {
                 "priority": CONST_SCALE_SET_PRIORITY_SPOT,
                 "eviction_policy": CONST_SPOT_EVICTION_POLICY_DEALLOCATE,
-                "spot_max_price": float(1.2345),
+                "spot_max_price": 1.2345,
             },
             self.resource_type,
             self.agentpool_decorator_mode,
@@ -2103,7 +2103,7 @@ class AKSAgentPoolAddDecoratorCommonTestCase(unittest.TestCase):
         ground_truth_agentpool_1 = self.create_initialized_agentpool_instance(
             scale_set_priority=CONST_SCALE_SET_PRIORITY_SPOT,
             scale_set_eviction_policy=CONST_SPOT_EVICTION_POLICY_DEALLOCATE,
-            spot_max_price=float(1.2345),
+            spot_max_price=1.2345,
         )
         self.assertEqual(dec_agentpool_1, ground_truth_agentpool_1)
 

--- a/src/azure-cli/azure/cli/command_modules/apim/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/apim/custom.py
@@ -611,7 +611,7 @@ def apim_api_export(client, resource_group_name, service_name, api_id, export_fo
                 f.write(xml_string)
             else:
                 f.write(str(exportedResultContent))
-    except IOError as e:
+    except OSError as e:
         logger.warning("Error writing exported API to file.: %s", e)
 
     # Write the response to a file

--- a/src/azure-cli/azure/cli/command_modules/appconfig/_kv_helpers.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/_kv_helpers.py
@@ -5,7 +5,6 @@
 
 # pylint: disable=line-too-long,too-many-nested-blocks,too-many-lines,too-many-return-statements
 
-import io
 import json
 from itertools import chain
 from json import JSONDecodeError
@@ -91,7 +90,7 @@ def __read_with_appropriate_encoding(file_path, format_):
     detected_encoding = __check_file_encoding(file_path)
 
     try:
-        with io.open(file_path, 'r', encoding=default_encoding) as config_file:
+        with open(file_path, 'r', encoding=default_encoding) as config_file:
             if format_ == 'json':
                 config_data = json.load(config_file)
                 # Only accept json objects
@@ -110,7 +109,7 @@ def __read_with_appropriate_encoding(file_path, format_):
         if detected_encoding == default_encoding:
             raise
 
-        with io.open(file_path, 'r', encoding=detected_encoding) as config_file:
+        with open(file_path, 'r', encoding=detected_encoding) as config_file:
             if format_ == 'json':
                 config_data = json.load(config_file)
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/_create_util.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_create_util.py
@@ -77,7 +77,7 @@ def zip_contents_from_dir(dirPath, lang):
                 zip_dotnet_project_references(abs_src, "{}".format(zip_file_path))
             except (OSError, ValueError, TypeError, ParseError, BadZipFile, LargeZipFile):
                 logger.warning("Analysing and bundling dotnet project references have failed.")
-    except IOError as e:
+    except OSError as e:
         if e.errno == 13:
             raise CLIError('Insufficient permissions to create a zip in current directory. '
                            'Please re-run the command with administrator privileges')

--- a/src/azure-cli/azure/cli/command_modules/batch/_command_type.py
+++ b/src/azure-cli/azure/cli/command_modules/batch/_command_type.py
@@ -404,7 +404,7 @@ class BatchArgumentTree:
             if namespace.json_file:
                 try:
                     namespace.json_file = get_file_json(namespace.json_file)
-                except EnvironmentError:
+                except OSError:
                     raise ValueError("Cannot access JSON request file: " + namespace.json_file)
                 except ValueError as err:
                     raise ValueError(f"Invalid JSON file: {err}")

--- a/src/azure-cli/azure/cli/command_modules/batch/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/batch/_validators.py
@@ -204,7 +204,7 @@ def validate_json_file(namespace):
     if namespace.json_file:
         try:
             get_file_json(namespace.json_file)
-        except EnvironmentError:
+        except OSError:
             raise ValueError("Cannot access JSON request file: " + namespace.json_file)
         except ValueError as err:
             raise ValueError(f"Invalid JSON file: {err}")
@@ -215,7 +215,7 @@ def validate_cert_file(namespace):
     try:
         with open(namespace.certificate_file, "rb"):
             pass
-    except EnvironmentError:
+    except OSError:
         raise ValueError("Cannot access certificate file: " + namespace.certificate_file)
 
 
@@ -250,7 +250,7 @@ def validate_file_destination(namespace):
     elif not os.path.isdir(file_dir):
         try:
             os.mkdir(file_dir)
-        except EnvironmentError as exp:
+        except OSError as exp:
             message = "Directory {} does not exist, and cannot be created: {}"
             raise ValueError(message.format(file_dir, exp))
     if os.path.isfile(file_path):

--- a/src/azure-cli/azure/cli/command_modules/batch/tests/latest/recording_processors.py
+++ b/src/azure-cli/azure/cli/command_modules/batch/tests/latest/recording_processors.py
@@ -140,7 +140,4 @@ class KeyReplacement:
 
 
 def _byte_to_str(byte_or_str):
-    try:
-        return str(byte_or_str, 'utf-8') if isinstance(byte_or_str, bytes) else byte_or_str
-    except TypeError:  # python 2 doesn't allow decoding through str
-        return str(byte_or_str)
+    return str(byte_or_str, 'utf-8') if isinstance(byte_or_str, bytes) else byte_or_str

--- a/src/azure-cli/azure/cli/command_modules/botservice/kudu_client.py
+++ b/src/azure-cli/azure/cli/command_modules/botservice/kudu_client.py
@@ -11,12 +11,7 @@ import zipfile
 import requests
 import urllib3
 
-try:
-    # Try importing Python 3 urllib.parse
-    from urllib.parse import quote
-except ImportError:
-    # If urllib.parse was not imported, use Python 2 module urlparse
-    from urllib import quote  # pylint: disable=import-error
+from urllib.parse import quote
 
 from knack.util import CLIError
 from azure.cli.command_modules.botservice.http_response_validator import HttpResponseValidator

--- a/src/azure-cli/azure/cli/command_modules/botservice/web_app_operations.py
+++ b/src/azure-cli/azure/cli/command_modules/botservice/web_app_operations.py
@@ -3,16 +3,11 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+from urllib.parse import urlsplit
+
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.mgmt.web import WebSiteManagementClient
 from azure.mgmt.web.models import HostType
-
-try:
-    # Try importing Python 3 urllib.parse
-    from urllib.parse import urlsplit
-except ImportError:
-    # If urllib.parse was not imported, use Python 2 module urlparse
-    from urlparse import urlsplit  # pylint: disable=import-error
 
 
 class WebAppOperations:

--- a/src/azure-cli/azure/cli/command_modules/configure/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/configure/custom.py
@@ -175,7 +175,7 @@ def show_cache_contents(cmd, resource_group_name, item_name, resource_type):
     try:
         with open(item_path, 'r') as cache_file:
             cache_obj = json.loads(cache_file.read())
-    except (OSError, IOError):
+    except OSError:
         raise CLIError('Not found in cache: {}'.format(item_path))
     return cache_obj['_payload']
 
@@ -185,7 +185,7 @@ def delete_cache_contents(cmd, resource_group_name, item_name, resource_type):
     item_path = os.path.join(directory, resource_group_name, resource_type, '{}.json'.format(item_name))
     try:
         os.remove(item_path)
-    except (OSError, IOError):
+    except OSError:
         logger.info('%s not found in object cache.', item_path)
 
 
@@ -195,5 +195,5 @@ def purge_cache_contents():
     directory = os.path.join(get_config_dir(), 'object_cache')
     try:
         shutil.rmtree(directory)
-    except (OSError, IOError) as ex:
+    except OSError as ex:
         logger.debug(ex)

--- a/src/azure-cli/azure/cli/command_modules/container/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/container/custom.py
@@ -1054,10 +1054,10 @@ def _flush_stdin(ws, buff, lock):
             buff.clear()
             lock.release()
             ws.send(x, opcode=0x2)  # OPCODE_BINARY = 0x2
-        except (OSError, IOError, websocket.WebSocketConnectionClosedException) as e:
+        except (OSError, websocket.WebSocketConnectionClosedException) as e:
             if isinstance(e, websocket.WebSocketConnectionClosedException):
                 pass
-            elif e.errno == 9:  # [Errno 9] Bad file descriptor
+            elif e.errno == errno.EBADF:  # [Errno 9] Bad file descriptor
                 pass
             elif e.args and e.args[0] == errno.EINTR:
                 pass

--- a/src/azure-cli/azure/cli/command_modules/containerapp/_archive_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/containerapp/_archive_utils.py
@@ -8,7 +8,6 @@ import tarfile
 import os
 import re
 import codecs
-from io import open
 import requests
 from knack.log import get_logger
 from azure.core.exceptions import HttpResponseError

--- a/src/azure-cli/azure/cli/command_modules/containerapp/_decorator_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/containerapp/_decorator_utils.py
@@ -17,7 +17,7 @@ def load_yaml_file(file_name):
     try:
         with open(file_name) as stream:  # pylint: disable=unspecified-encoding
             return yaml.safe_load(stream.read().replace('\x00', ''))
-    except (IOError, OSError) as ex:
+    except OSError as ex:
         if getattr(ex, 'errno', 0) == errno.ENOENT:
             raise ValidationError('{} does not exist'.format(file_name)) from ex
         raise

--- a/src/azure-cli/azure/cli/command_modules/containerapp/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/containerapp/custom.py
@@ -142,7 +142,7 @@ def load_yaml_file(file_name):
     try:
         with open(file_name) as stream:  # pylint: disable=unspecified-encoding
             return yaml.safe_load(stream.read().replace('\x00', ''))
-    except (IOError, OSError) as ex:
+    except OSError as ex:
         if getattr(ex, 'errno', 0) == errno.ENOENT:
             raise ValidationError('{} does not exist'.format(file_name)) from ex
         raise

--- a/src/azure-cli/azure/cli/command_modules/feedback/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/feedback/custom.py
@@ -259,7 +259,7 @@ class CommandLogFile:
         try:
             with open(file_name, 'r') as log_fp:
                 log_record_list = _get_log_record_list(log_fp, p_id)
-        except IOError:
+        except OSError:
             logger.debug("Failed to open command log file %s", file_name)
             return {}
 

--- a/src/azure-cli/azure/cli/command_modules/iot/sas_token_auth.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/sas_token_auth.py
@@ -7,10 +7,7 @@ from base64 import b64encode, b64decode
 from hashlib import sha256
 from hmac import HMAC
 from time import time
-try:
-    from urllib import (urlencode, quote)
-except ImportError:
-    from urllib.parse import (urlencode, quote)  # pylint: disable=import-error
+from urllib import urlencode, quote
 from msrest.authentication import Authentication
 
 

--- a/src/azure-cli/azure/cli/command_modules/iot/sas_token_auth.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/sas_token_auth.py
@@ -7,7 +7,7 @@ from base64 import b64encode, b64decode
 from hashlib import sha256
 from hmac import HMAC
 from time import time
-from urllib import urlencode, quote
+from urllib.parse import urlencode, quote
 from msrest.authentication import Authentication
 
 

--- a/src/azure-cli/azure/cli/command_modules/keyvault/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_validators.py
@@ -459,7 +459,7 @@ def certificate_type(string):
         with open(os.path.expanduser(string), 'rb') as f:
             cert_data = f.read()
         return cert_data
-    except (IOError, OSError) as e:
+    except OSError as e:
         raise CLIError("Unable to load certificate file '{}': {}.".format(string, e.strerror))
 
 

--- a/src/azure-cli/azure/cli/command_modules/lab/validators.py
+++ b/src/azure-cli/azure/cli/command_modules/lab/validators.py
@@ -499,7 +499,7 @@ def _is_valid_ssh_rsa_public_key(openssh_pubkey):
     # http://stackoverflow.com/questions/2494450/ssh-rsa-public-key-validation-using-a-regular-expression
     # A "good enough" check is to see if the key starts with the correct header.
     import struct
-    from base64 import decodestring as base64_decode
+    from base64 import decodebytes as base64_decode
     parts = openssh_pubkey.split()
     if len(parts) < 2:
         return False

--- a/src/azure-cli/azure/cli/command_modules/lab/validators.py
+++ b/src/azure-cli/azure/cli/command_modules/lab/validators.py
@@ -499,11 +499,7 @@ def _is_valid_ssh_rsa_public_key(openssh_pubkey):
     # http://stackoverflow.com/questions/2494450/ssh-rsa-public-key-validation-using-a-regular-expression
     # A "good enough" check is to see if the key starts with the correct header.
     import struct
-    try:
-        from base64 import decodebytes as base64_decode
-    except ImportError:
-        # deprecated and redirected to decodebytes in Python 3
-        from base64 import decodestring as base64_decode
+    from base64 import decodestring as base64_decode
     parts = openssh_pubkey.split()
     if len(parts) < 2:
         return False

--- a/src/azure-cli/azure/cli/command_modules/network/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_validators.py
@@ -491,7 +491,7 @@ def get_servers_validator(camel_case=False):
             try:
                 socket.inet_aton(item)  # pylint:disable=no-member
                 servers.append({'ipAddress' if camel_case else 'ip_address': item})
-            except OSError:  # pylint:disable=no-member
+            except OSError:
                 servers.append({'fqdn': item})
         namespace.servers = servers if servers else None
 

--- a/src/azure-cli/azure/cli/command_modules/network/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_validators.py
@@ -491,7 +491,7 @@ def get_servers_validator(camel_case=False):
             try:
                 socket.inet_aton(item)  # pylint:disable=no-member
                 servers.append({'ipAddress' if camel_case else 'ip_address': item})
-            except socket.error:  # pylint:disable=no-member
+            except OSError:  # pylint:disable=no-member
                 servers.append({'fqdn': item})
         namespace.servers = servers if servers else None
 

--- a/src/azure-cli/azure/cli/command_modules/network/azure_stack/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/azure_stack/custom.py
@@ -248,7 +248,7 @@ def export_zone(cmd, resource_group_name, zone_name, file_name=None):  # pylint:
         try:
             with open(file_name, 'w') as f:
                 f.write(zone_file_content)
-        except IOError:
+        except OSError:
             raise CLIError('Unable to export to file: {}'.format(file_name))
 
 

--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -432,7 +432,7 @@ class AddressPoolCreate(_AddressPoolCreate):
             try:
                 socket.inet_aton(str(server))  # pylint:disable=no-member
                 return {"ip_address": server}
-            except OSError:  # pylint:disable=no-member
+            except OSError:
                 return {"fqdn": server}
 
         args.backend_addresses = assign_aaz_list_arg(
@@ -478,7 +478,7 @@ class AddressPoolUpdate(_AddressPoolUpdate):
             try:
                 socket.inet_aton(str(server))  # pylint:disable=no-member
                 return {"ip_address": server}
-            except OSError:  # pylint:disable=no-member
+            except OSError:
                 return {"fqdn": server}
 
         args.backend_addresses = assign_aaz_list_arg(

--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -432,7 +432,7 @@ class AddressPoolCreate(_AddressPoolCreate):
             try:
                 socket.inet_aton(str(server))  # pylint:disable=no-member
                 return {"ip_address": server}
-            except socket.error:  # pylint:disable=no-member
+            except OSError:  # pylint:disable=no-member
                 return {"fqdn": server}
 
         args.backend_addresses = assign_aaz_list_arg(
@@ -478,7 +478,7 @@ class AddressPoolUpdate(_AddressPoolUpdate):
             try:
                 socket.inet_aton(str(server))  # pylint:disable=no-member
                 return {"ip_address": server}
-            except socket.error:  # pylint:disable=no-member
+            except OSError:  # pylint:disable=no-member
                 return {"fqdn": server}
 
         args.backend_addresses = assign_aaz_list_arg(
@@ -2653,7 +2653,7 @@ def export_zone(cmd, resource_group_name, zone_name, file_name=None):  # pylint:
         try:
             with open(file_name, 'w') as f:
                 f.write(zone_file_content)
-        except IOError:
+        except OSError:
             raise CLIError('Unable to export to file: {}'.format(file_name))
 
 

--- a/src/azure-cli/azure/cli/command_modules/privatedns/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/custom.py
@@ -230,7 +230,7 @@ def export_zone(cmd, resource_group_name, private_zone_name, file_name=None):
         try:
             with open(file_name, 'w') as f:
                 f.write(zone_file_content)
-        except IOError:
+        except OSError:
             raise CLIError('Unable to export to file: {}'.format(file_name))
 
 

--- a/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
@@ -158,7 +158,7 @@ def ensure_bicep_installation(cli_ctx, release_tag=None, target_platform=None, s
                 "Successfully installed Bicep CLI to %s",
                 installation_path,
             )
-    except IOError as err:
+    except OSError as err:
         raise ClientRequestError(f"Error while attempting to download Bicep CLI: {err}")
 
 
@@ -190,7 +190,7 @@ def get_bicep_available_release_tags():
         os.environ.setdefault("CURL_CA_BUNDLE", certifi.where())
         response = requests.get("https://aka.ms/BicepReleases", verify=_requests_verify)
         return [release["tag_name"] for release in response.json()]
-    except IOError as err:
+    except OSError as err:
         raise ClientRequestError(f"Error while attempting to retrieve available Bicep versions: {err}.")
 
 
@@ -258,7 +258,7 @@ def _load_bicep_version_check_result_from_cache():
             cache_expired = datetime.now() - last_check_time > _bicep_version_check_cache_ttl
 
             return latest_release_tag, cache_expired
-    except (IOError, JSONDecodeError):
+    except (OSError, JSONDecodeError):
         return None, True
 
 

--- a/src/azure-cli/azure/cli/command_modules/resource/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_validators.py
@@ -9,10 +9,7 @@ import argparse
 from azure.cli.core.azclierror import ArgumentUsageError
 
 from knack.util import CLIError
-try:
-    from urllib.parse import urlparse, urlsplit
-except ImportError:
-    from urlparse import urlparse, urlsplit  # pylint: disable=import-error
+from urllib.parse import urlparse, urlsplit
 
 MSI_LOCAL_ID = '[system]'
 

--- a/src/azure-cli/azure/cli/command_modules/servicefabric/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/servicefabric/custom.py
@@ -8,14 +8,11 @@
 import os
 import time
 
+from urllib.parse import urlparse
+
 from OpenSSL import crypto
 from cryptography.hazmat.primitives.serialization import pkcs12
 from cryptography.hazmat.primitives import hashes
-
-try:
-    from urllib.parse import urlparse
-except ImportError:
-    from urlparse import urlparse  # pylint: disable=import-error
 
 from azure.cli.core.util import CLIError, get_file_json, b64_to_hex, sdk_no_wait
 from azure.cli.core.commands import LongRunningOperation

--- a/src/azure-cli/azure/cli/command_modules/storage/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_params.py
@@ -2242,7 +2242,6 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
         c.argument('expiry', type=get_datetime_type(True), help='expiration UTC datetime in (Y-m-d\'T\'H:M:S\'Z\')')
         c.ignore('auth_mode')
 
-    from six import u as unicode_string
     for item in ['get', 'peek', 'put', 'update', 'delete', 'clear']:
         with self.argument_context('storage message {}'.format(item)) as c:
             c.extra('queue_name', queue_name_type, required=True)
@@ -2257,7 +2256,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
                             'the :func:`~get_messages` or :func:`~update_message` operation.')
 
     with self.argument_context('storage message put') as c:
-        c.argument('content', type=unicode_string, help='Message content, up to 64KB in size.')
+        c.argument('content', type=str, help='Message content, up to 64KB in size.')
         c.extra('time_to_live', type=int,
                 help='Specify the time-to-live interval for the message, in seconds. '
                      'The time-to-live may be any positive number or -1 for infinity. '
@@ -2285,7 +2284,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
                      'a maximum of 32. By default, a single message is peeked from the queue with this operation.')
 
     with self.argument_context('storage message update') as c:
-        c.argument('content', type=unicode_string, help='Message content, up to 64KB in size.')
+        c.argument('content', type=str, help='Message content, up to 64KB in size.')
         c.extra('visibility_timeout', type=int,
                 help='If not specified, the default value is 0. Specify the new visibility timeout value, in seconds, '
                      'relative to server time. The new value must be larger than or equal to 0, and cannot be larger '

--- a/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
@@ -76,7 +76,7 @@ class AzCopy:
             _urlretrieve(file_url, install_location)
             os.chmod(install_location,
                      os.stat(install_location).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
-        except IOError as err:
+        except OSError as err:
             raise CLIError('Connection error while attempting to download azcopy {}. You could also install the '
                            'specified azcopy version to {} manually. ({})'.format(AZCOPY_VERSION, install_dir, err))
 

--- a/src/azure-cli/azure/cli/command_modules/synapse/manual/operations/artifacts.py
+++ b/src/azure-cli/azure/cli/command_modules/synapse/manual/operations/artifacts.py
@@ -349,7 +349,7 @@ def write_to_file(notebook, path):
         notebook_result['cells'] = notebook_properties['cells']
         with open(path, 'w') as f:
             json.dump(notebook_result, f, indent=4)
-    except IOError:
+    except OSError:
         raise CLIError('Unable to export to file: {}'.format(path))
 
 

--- a/src/azure-cli/azure/cli/command_modules/synapse/manual/operations/kustopool.py
+++ b/src/azure-cli/azure/cli/command_modules/synapse/manual/operations/kustopool.py
@@ -220,5 +220,5 @@ def write_to_file(kql_script, path):
             query = kql_script.properties.content.query
         with open(path, 'w') as f:
             f.write(query)
-    except IOError:
+    except OSError:
         raise CLIError('Unable to export to file: {}'.format(path))

--- a/src/azure-cli/azure/cli/command_modules/vm/_image_builder.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_image_builder.py
@@ -13,10 +13,7 @@ from enum import Enum
 
 import requests
 
-try:
-    from urllib.parse import urlparse
-except ImportError:
-    from urlparse import urlparse  # pylint: disable=import-error
+from urllib.parse import urlparse
 
 from knack.util import CLIError
 from knack.log import get_logger

--- a/src/azure-cli/azure/cli/command_modules/vm/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_validators.py
@@ -7,10 +7,7 @@
 
 import os
 
-try:
-    from urllib.parse import urlparse
-except ImportError:
-    from urlparse import urlparse  # pylint: disable=import-error
+from urllib.parse import urlparse
 
 from knack.log import get_logger
 from knack.util import CLIError

--- a/src/azure-cli/azure/cli/command_modules/vm/_vm_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_vm_utils.py
@@ -10,10 +10,7 @@ import importlib
 
 from azure.cli.core.commands.arm import ArmTemplateBuilder
 
-try:
-    from urllib.parse import urlparse
-except ImportError:
-    from urlparse import urlparse  # pylint: disable=import-error
+from urllib.parse import urlparse
 
 from knack.log import get_logger
 from knack.util import CLIError

--- a/src/azure-cli/azure/cli/command_modules/vm/azure_stack/_image_builder.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/azure_stack/_image_builder.py
@@ -11,12 +11,9 @@ import json
 import traceback
 from enum import Enum
 
-import requests
+from urllib.parse import urlparse
 
-try:
-    from urllib.parse import urlparse
-except ImportError:
-    from urlparse import urlparse  # pylint: disable=import-error
+import requests
 
 from knack.util import CLIError
 from knack.log import get_logger

--- a/src/azure-cli/azure/cli/command_modules/vm/azure_stack/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/azure_stack/_validators.py
@@ -7,10 +7,7 @@
 
 import os
 
-try:
-    from urllib.parse import urlparse
-except ImportError:
-    from urlparse import urlparse  # pylint: disable=import-error
+from urllib.parse import urlparse
 
 from knack.log import get_logger
 from knack.util import CLIError

--- a/src/azure-cli/azure/cli/command_modules/vm/azure_stack/_vm_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/azure_stack/_vm_utils.py
@@ -8,12 +8,9 @@ import json
 import os
 import re
 
-from azure.cli.core.commands.arm import ArmTemplateBuilder
+from urllib.parse import urlparse
 
-try:
-    from urllib.parse import urlparse
-except ImportError:
-    from urlparse import urlparse  # pylint: disable=import-error
+from azure.cli.core.commands.arm import ArmTemplateBuilder
 
 from knack.log import get_logger
 from knack.util import CLIError

--- a/tools/automation/utilities/pypi.py
+++ b/tools/automation/utilities/pypi.py
@@ -3,10 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-try:
-    import xmlrpclib
-except ImportError:
-    import xmlrpc.client as xmlrpclib  # pylint: disable=import-error
+import xmlrpc.client as xmlrpclib
 
 
 def is_available_on_pypi(module_name, module_version):


### PR DESCRIPTION
**Description**

Removed a bit of Python 2.7 code that I found by searching for `ImportError` and `Python 2.7`.

There are still quite a fair pieces of Python 2.7 compatibility around. `sys.version_info`  is a good place to start.

Note that I also saw a fair chunk of https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow in the code

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).