### PR TITLE
[Container] `az container exec`: Fix exception when stdin is not a tty

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/container/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/container/custom.py
@@ -1003,10 +1003,16 @@ def _start_exec_pipe_windows(web_socket_uri, password):
 
 def _start_exec_pipe_linux(web_socket_uri, password):
     stdin_fd = sys.stdin.fileno()
-    old_tty = termios.tcgetattr(stdin_fd)
+    try:
+        old_tty = termios.tcgetattr(stdin_fd)
+        has_tty = True
+    except termios.error:
+        old_tty = None
+        has_tty = False
     old_winch_handler = signal.getsignal(signal.SIGWINCH)
-    tty.setraw(stdin_fd)
-    tty.setcbreak(stdin_fd)
+    if has_tty:
+        tty.setraw(stdin_fd)
+        tty.setcbreak(stdin_fd)
     buff = bytearray()
     lock = threading.Lock()
 
@@ -1018,7 +1024,8 @@ def _start_exec_pipe_linux(web_socket_uri, password):
         flushKeyboard.start()
     ws = websocket.WebSocketApp(web_socket_uri, on_open=_on_ws_open_linux, on_message=_on_ws_msg)
     ws.run_forever()
-    termios.tcsetattr(stdin_fd, termios.TCSADRAIN, old_tty)
+    if has_tty:
+        termios.tcsetattr(stdin_fd, termios.TCSADRAIN, old_tty)
     signal.signal(signal.SIGWINCH, old_winch_handler)
 
 


### PR DESCRIPTION
Reproduction steps:

```bash
az container exec \
  --container-name "container" \
  -g "$RESOURCE_GROUP" \
  -n "$ACI_NAME" \
  --exec-command "echo Hello" > ./stdout < /dev/null 2>./stderr
```

Expected behavior:

./stdout should contain "Hello"

Actual behavior:

Command crashes without running the command. Error:

     ERROR: The command failed with an unexpected error. Here is the traceback:
     ERROR: (25, 'Inappropriate ioctl for device')
     Traceback (most recent call last):
     File "/opt/az/lib/python3.12/site-packages/knack/cli.py", line 233, in invoke
     cmd_result = self.invocation.execute(args)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     File "/opt/az/lib/python3.12/site-packages/azure/cli/core/commands/__init__.py", line 666, in execute
     raise ex
     File "/opt/az/lib/python3.12/site-packages/azure/cli/core/commands/__init__.py", line 733, in _run_jobs_serially
     results.append(self._run_job(expanded_arg, cmd_copy))
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     File "/opt/az/lib/python3.12/site-packages/azure/cli/core/commands/__init__.py", line 703, in _run_job
     result = cmd_copy(params)
               ^^^^^^^^^^^^^^^^
     File "/opt/az/lib/python3.12/site-packages/azure/cli/core/commands/__init__.py", line 336, in __call__
     return self.handler(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     File "/opt/az/lib/python3.12/site-packages/azure/cli/core/commands/command_operation.py", line 121, in handler
     return op(**command_args)
               ^^^^^^^^^^^^^^^^^^
     File "/opt/az/lib/python3.12/site-packages/azure/cli/command_modules/container/custom.py", line 970, in container_exec
     _start_exec_pipe_linux(execContainerResponse.web_socket_uri, execContainerResponse.password)
     File "/opt/az/lib/python3.12/site-packages/azure/cli/command_modules/container/custom.py", line 1006, in _start_exec_pipe_linux
     old_tty = termios.tcgetattr(stdin_fd)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
     termios.error: (25, 'Inappropriate ioctl for device')
     To check existing issues, please visit: https://github.com/Azure/azure-cli/issues

This makes the "exec" command unusable in e.g. CI environments.

Tested that all of the following works:
* Running `az container exec` normally, starting bash, starting `vi` and it takes the correct terminal size.
* Running `az container exec` in our CI now works
* The provided reproduction command now no longer crashes.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
