### PR TITLE
{Misc} Don't compare booleans and None with ==

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_logicapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_logicapp_commands.py
@@ -278,7 +278,7 @@ class LogicAppDeployTest(LiveScenarioTest):
 
 class LogicAppPlanTest(ScenarioTest):
     def _create_app_service_plan(self, sku, resource_group, plan_name=None, expect_failure=False):
-        if plan_name == None:
+        if plan_name is None:
             plan = self.create_random_name('plan', 24)
         else:
             plan = plan_name

--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/tests/latest/test_cosmosdb_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/tests/latest/test_cosmosdb_commands.py
@@ -2791,26 +2791,26 @@ class CosmosDBTests(ScenarioTest):
         locations_list = self.cmd('az cosmosdb locations list').get_output_in_json()
         assert len(locations_list) > 0
         for location_val in locations_list:
-            assert location_val['id'] != None
-            assert location_val['name'] != None
-            assert location_val['type'] != None
-            assert location_val['properties']['backupStorageRedundancies'] != None
-            assert location_val['properties']['isResidencyRestricted'] != None
-            assert location_val['properties']['supportsAvailabilityZone'] != None
-            assert location_val['properties']['isSubscriptionRegionAccessAllowedForRegular'] != None
-            assert location_val['properties']['isSubscriptionRegionAccessAllowedForAz'] != None
-            assert location_val['properties']['status'] != None
+            assert location_val['id'] is not None
+            assert location_val['name'] is not None
+            assert location_val['type'] is not None
+            assert location_val['properties']['backupStorageRedundancies'] is not None
+            assert location_val['properties']['isResidencyRestricted'] is not None
+            assert location_val['properties']['supportsAvailabilityZone'] is not None
+            assert location_val['properties']['isSubscriptionRegionAccessAllowedForRegular'] is not None
+            assert location_val['properties']['isSubscriptionRegionAccessAllowedForAz'] is not None
+            assert location_val['properties']['status'] is not None
 
         locations_show = self.cmd('az cosmosdb locations show --location {loc}').get_output_in_json()
-        assert locations_show['id'] != None
-        assert locations_show['name'] != None
-        assert locations_show['type'] != None
-        assert locations_show['properties']['backupStorageRedundancies'] != None
-        assert locations_show['properties']['isResidencyRestricted'] != None
-        assert locations_show['properties']['supportsAvailabilityZone'] != None
-        assert locations_show['properties']['isSubscriptionRegionAccessAllowedForRegular'] != None
-        assert locations_show['properties']['isSubscriptionRegionAccessAllowedForAz'] != None
-        assert locations_show['properties']['status'] != None
+        assert locations_show['id'] is not None
+        assert locations_show['name'] is not None
+        assert locations_show['type'] is not None
+        assert locations_show['properties']['backupStorageRedundancies'] is not None
+        assert locations_show['properties']['isResidencyRestricted'] is not None
+        assert locations_show['properties']['supportsAvailabilityZone'] is not None
+        assert locations_show['properties']['isSubscriptionRegionAccessAllowedForRegular'] is not None
+        assert locations_show['properties']['isSubscriptionRegionAccessAllowedForAz'] is not None
+        assert locations_show['properties']['status'] is not None
     
     @ResourceGroupPreparer(name_prefix='cli_test_cosmosdb_service', location='eastus2')
     def test_cosmosdb_service(self, resource_group):
@@ -2998,7 +2998,7 @@ class CosmosDBTests(ScenarioTest):
 
         container_show = self.cmd('az cosmosdb sql container show -g {rg} -a {acc} -d {db_name} -n {ctn_name}').get_output_in_json()
         assert container_show["name"] == ctn_name
-        assert container_show["resource"]["defaultTtl"] == None
+        assert container_show["resource"]["defaultTtl"] is None
 
         self.cmd('az cosmosdb sql database delete -g {rg} -a {acc} -n {db_name} --yes')
         database_list = self.cmd('az cosmosdb sql database list -g {rg} -a {acc}').get_output_in_json()

--- a/src/azure-cli/azure/cli/command_modules/security/tests/latest/test_security_automations_scenario.py
+++ b/src/azure-cli/azure/cli/command_modules/security/tests/latest/test_security_automations_scenario.py
@@ -23,7 +23,7 @@ class SecurityCenterSecurityAutomationsTests(ScenarioTest):
 
         # Create Automation rule set
         security_automation_rule_set = self.cmd("az security automation-rule-set create").get_output_in_json()
-        assert security_automation_rule_set["rules"] == None
+        assert security_automation_rule_set["rules"] is None
 
         # Create Automation source
         security_automation_source = self.cmd("az security automation-source create --event-source 'Assessments'").get_output_in_json()


### PR DESCRIPTION
**Description**

This is not how these comparisons are made in Python. 

Fixed using

```sh
ruff check --select "E711" --fix --unsafe-fixes
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).