### PR TITLE
{CI} New issue template for reference doc's feedback

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/docs_feedback.yml
@@ -30,16 +30,24 @@ body:
   validations:
     required: true
 - type: textarea
+  id: referencecommand
+  validations:
+    required: true
+  attributes:
+    label: Reference command name
+    description: >-
+      Enter the reference command name. Example: `az vm create`. Do not include parameters in this section.
+- type: textarea
   id: userfeedback
   validations:
     required: true
   attributes:
     label: Feedback
     description: >-
-      If possible, please provide extended details that will add context and help the team update
-      the documentation. Additional details may not be useful for typos, grammar, formatting, etc.
-      For technical or factual errors, please include code snippets and output from the `--debug`
-      parameter. For information on troubleshooting Azure CLI commands, see https://learn.microsoft.com/cli/azure/use-azure-cli-successfully-troubleshooting
+      Please provide extended details that will add context and help the team update
+      Azure CLI reference documentation. For technical or factual errors, include code
+      snippets and output from the `--debug` parameter. For examples on using `--debug`,
+      see https://learn.microsoft.com/cli/azure/use-azure-cli-successfully-troubleshooting#the---debug-parameter.
 - type: markdown
   attributes:
     value: Article information

--- a/.github/ISSUE_TEMPLATE/docs_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/docs_feedback.yml
@@ -1,0 +1,69 @@
+name: ✒️ Reference documentation issue or question
+description: Report reference documentation related issue
+title: '[Reference feedback]: '
+labels: [needs-triage]
+
+body:
+- type: markdown
+  attributes:
+    value: >
+      Azure CLI documentation includes 3 categories:
+
+      - Conceptual doc about Azure CLI: https://docs.microsoft.com/en-us/CLI/azure 
+           
+      - Engineering doc on Github repo (Core): https://github.com/Azure/azure-CLI
+
+      - Engineering doc on Github repo (Extensions): https://github.com/Azure/azure-CLI-extensions
+- type: markdown
+  attributes:
+    value: Select the issue type, and describe the issue in the text box below. Add as much detail as needed to help us resolve the issue.
+- type: dropdown
+  id: issue-type
+  attributes:
+    label: Type of issue
+    options:
+      - Other (describe below)
+      - Code doesn't work
+      - Missing information
+      - Outdated article
+      - Typo
+  validations:
+    required: true
+- type: textarea
+  id: userfeedback
+  validations:
+    required: true
+  attributes:
+    label: Feedback
+    description: >-
+      If possible, please provide extended details that will add context and help the team update
+      the documentation. Additional details may not be useful for typos, grammar, formatting, etc.
+      For technical or factual errors, please include code snippets and output from the `--debug`
+      parameter. For information on troubleshooting Azure CLI commands, see https://learn.microsoft.com/cli/azure/use-azure-cli-successfully-troubleshooting
+- type: markdown
+  attributes:
+    value: Article information
+- type: markdown
+  attributes:
+    value: "*If the following fields are automatically filled in for you, please don't modify them*"
+- type: input
+  id: pageUrl
+  attributes:
+    label: Page URL
+- type: input
+  id: contentSourceUrl
+  attributes:
+    label: Content source URL
+- type: input
+  id: author
+  attributes:
+    label: Author
+    description: GitHub Id of the author
+- type: input
+  id: documentVersionIndependentId
+  attributes:
+    label: Document Id
+- type: markdown
+  attributes:
+    value: >
+      The Azure CLI team is listening, please let us know how we are doing: https://learn.microsoft.com/cli/azure/command-line-tools-survey-guidance.


### PR DESCRIPTION
This PR replaces [#30083](https://github.com/Azure/azure-cli/pull/30083)
*****************************************************
We need an additional GitHub issue template in azure-cli for customer feedback that is recieved on autogenerated reference docs. This template aligns with the Azure PowerShell template found here: https://github.com/Azure/azure-powershell/blob/main/.github/ISSUE_TEMPLATE/4-AZ-DOC-BUG.yml.

Anytime a customer uses the docs or product feedback links in MicrosoftDocs/azure-docs-cli WHEN IN AN AUTOGENERATED REFERENCE DOC, they will be taken to this new template. This will keep MicrosoftDocs/azure-docs-cli GitHub issues about conceptual content, and reference feedback is channeled correctly to the engineering teams.

**MicrosoftDocs/azure-docs-cli [PR 4788](https://github.com/MicrosoftDocs/azure-docs-cli/pull/4788/files#diff-25e6592e0a824906d8ada0a84573256efbdaba49bee6833df043caaa2ca91129) is waiting on this PR to merge.**