### PR TITLE
{CI} Fix file name space when iterating git diffs for secret scan task

### DIFF
--- a/.githooks/pre-commit.sh
+++ b/.githooks/pre-commit.sh
@@ -20,7 +20,7 @@ else
     against=$(git hash-object -t tree /dev/null)
 fi
 has_secrets=0
-for FILE in `git diff --cached --name-only --diff-filter=AM $against` ; do
+for FILE in "`git diff --cached --name-only --diff-filter=AM $against`" ; do
     # Check if the file contains secrets
     detected=$(azdev scan -f "$FILE" | python -c "import sys, json; print(json.load(sys.stdin)['secrets_detected'])")
     if [ "$detected" = "True" ]; then

--- a/.githooks/pre-commit.sh
+++ b/.githooks/pre-commit.sh
@@ -20,6 +20,9 @@ else
     against=$(git hash-object -t tree /dev/null)
 fi
 has_secrets=0
+
+IFS_OLD=${IFS}
+IFS=$'\n'
 for FILE in "`git diff --cached --name-only --diff-filter=AM $against`" ; do
     # Check if the file contains secrets
     detected=$(azdev scan -f "$FILE" | python -c "import sys, json; print(json.load(sys.stdin)['secrets_detected'])")
@@ -28,6 +31,7 @@ for FILE in "`git diff --cached --name-only --diff-filter=AM $against`" ; do
       has_secrets=1
     fi
 done
+IFS=${IFS_OLD}
 
 if [ $has_secrets -eq 1 ]; then
     printf "\033[0;31mSecret detected. If you want to skip that, run add '--no-verify' in the end of 'git commit' command.\033[0m\n"

--- a/.githooks/pre-commit.sh
+++ b/.githooks/pre-commit.sh
@@ -23,7 +23,7 @@ has_secrets=0
 
 IFS_OLD=${IFS}
 IFS=$'\n'
-for FILE in "`git diff --cached --name-only --diff-filter=AM $against`" ; do
+for FILE in `git diff --cached --name-only --diff-filter=AM $against` ; do
     # Check if the file contains secrets
     detected=$(azdev scan -f "$FILE" | python -c "import sys, json; print(json.load(sys.stdin)['secrets_detected'])")
     if [ "$detected" = "True" ]; then

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1137,7 +1137,8 @@ jobs:
         . env/bin/activate
         git fetch origin --depth=1 $(System.PullRequest.TargetBranch)
         declare -A secret_files
-        for FILE in `git diff --name-only --diff-filter=AM origin/$(System.PullRequest.TargetBranch)` ; do
+        for FILE in "`git diff --name-only --diff-filter=AM origin/$(System.PullRequest.TargetBranch)`" ; do
+          echo $FILE
           detected=$(azdev scan -f "$FILE" | python -c "import sys, json; print(json.load(sys.stdin)['secrets_detected'])")
           if [ $detected == 'True' ]; then
             printf "\033[0;31mDetected secrets from %s, You can run 'azdev mask' to remove secrets.\033[0m\n" "$FILE"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1139,7 +1139,7 @@ jobs:
         declare -A secret_files
         IFS_OLD=${IFS}
         IFS=$'\n'
-        for FILE in "`git diff --name-only --diff-filter=AM origin/$(System.PullRequest.TargetBranch)`" ; do
+        for FILE in `git diff --name-only --diff-filter=AM origin/$(System.PullRequest.TargetBranch)` ; do
           echo $FILE
           detected=$(azdev scan -f "$FILE" | python -c "import sys, json; print(json.load(sys.stdin)['secrets_detected'])")
           if [ $detected == 'True' ]; then

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1137,6 +1137,8 @@ jobs:
         . env/bin/activate
         git fetch origin --depth=1 $(System.PullRequest.TargetBranch)
         declare -A secret_files
+        IFS_OLD=${IFS}
+        IFS=$'\n'
         for FILE in "`git diff --name-only --diff-filter=AM origin/$(System.PullRequest.TargetBranch)`" ; do
           echo $FILE
           detected=$(azdev scan -f "$FILE" | python -c "import sys, json; print(json.load(sys.stdin)['secrets_detected'])")
@@ -1145,6 +1147,7 @@ jobs:
             secret_files+=$FILE
           fi
         done
+        IFS=${IFS_OLD}
         if [ "${#secret_files[@]}" -gt 0 ]; then
           exit 1
         fi


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
A supplementary for #30422 
While using for loop to iterate all git diff files, we need to change the `$IFS` from default to `$'\n'` only so that file name with space won't be split.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
