### PR TITLE
{Misc} Don't use aliased io.open

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_archive_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_archive_utils.py
@@ -7,7 +7,6 @@ import tarfile
 import os
 import re
 import codecs
-from io import open
 import requests
 from knack.log import get_logger
 from knack.util import CLIError

--- a/src/azure-cli/azure/cli/command_modules/appconfig/_kv_helpers.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/_kv_helpers.py
@@ -5,7 +5,6 @@
 
 # pylint: disable=line-too-long,too-many-nested-blocks,too-many-lines,too-many-return-statements
 
-import io
 import json
 from itertools import chain
 from json import JSONDecodeError
@@ -91,7 +90,7 @@ def __read_with_appropriate_encoding(file_path, format_):
     detected_encoding = __check_file_encoding(file_path)
 
     try:
-        with io.open(file_path, 'r', encoding=default_encoding) as config_file:
+        with open(file_path, 'r', encoding=default_encoding) as config_file:
             if format_ == 'json':
                 config_data = json.load(config_file)
                 # Only accept json objects
@@ -110,7 +109,7 @@ def __read_with_appropriate_encoding(file_path, format_):
         if detected_encoding == default_encoding:
             raise
 
-        with io.open(file_path, 'r', encoding=detected_encoding) as config_file:
+        with open(file_path, 'r', encoding=detected_encoding) as config_file:
             if format_ == 'json':
                 config_data = json.load(config_file)
 

--- a/src/azure-cli/azure/cli/command_modules/containerapp/_archive_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/containerapp/_archive_utils.py
@@ -8,7 +8,6 @@ import tarfile
 import os
 import re
 import codecs
-from io import open
 import requests
 from knack.log import get_logger
 from azure.core.exceptions import HttpResponseError


### PR DESCRIPTION
**Description**

Taken out from #30368 

Motivation in:
https://docs.astral.sh/ruff/rules/open-alias/

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
