### PR TITLE
{Misc} Remove various Python 2.7 ImportError

### DIFF
--- a/scripts/curl_install_pypi/install.py
+++ b/scripts/curl_install_pypi/install.py
@@ -23,19 +23,7 @@ import tempfile
 import shutil
 import subprocess
 import hashlib
-try:
-    # Attempt to load python 3 module
-    from urllib.request import urlopen
-except ImportError:
-    # Import python 2 version
-    from urllib2 import urlopen
-
-try:
-    # Rename raw_input to input to support Python 2
-    input = raw_input
-except NameError:
-    # Python 3 doesn't have raw_input
-    pass
+from urllib.request import urlopen
 
 AZ_DISPATCH_TEMPLATE = """#!/usr/bin/env bash
 {install_dir}/bin/python -m azure.cli "$@"

--- a/src/azure-cli-core/azure/cli/core/aaz/_operation.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_operation.py
@@ -11,7 +11,7 @@ import json
 from azure.core.exceptions import ClientAuthenticationError, ResourceExistsError, ResourceNotFoundError, \
     HttpResponseError
 from azure.cli.core.azclierror import InvalidArgumentValueError
-from urllib.parse import parse_qs, urljoin, urlparse
+from urllib.parse import parse_qs, urljoin, urlparse, quote
 
 from ._arg_browser import AAZArgBrowser
 from ._base import AAZUndefined, AAZBaseValue, AAZBaseType, has_value

--- a/src/azure-cli-core/azure/cli/core/aaz/_operation.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_operation.py
@@ -5,13 +5,12 @@
 
 # pylint: disable=too-few-public-methods, protected-access, too-many-nested-blocks, too-many-branches
 
-from urllib.parse import quote
+from urllib.parse import parse_qs, urljoin, urlparse, quote
 import json
 
 from azure.core.exceptions import ClientAuthenticationError, ResourceExistsError, ResourceNotFoundError, \
     HttpResponseError
 from azure.cli.core.azclierror import InvalidArgumentValueError
-from urllib.parse import parse_qs, urljoin, urlparse, quote
 
 from ._arg_browser import AAZArgBrowser
 from ._base import AAZUndefined, AAZBaseValue, AAZBaseType, has_value

--- a/src/azure-cli-core/azure/cli/core/aaz/_operation.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_operation.py
@@ -5,6 +5,7 @@
 
 # pylint: disable=too-few-public-methods, protected-access, too-many-nested-blocks, too-many-branches
 
+from urllib.parse import quote
 import json
 
 from azure.core.exceptions import ClientAuthenticationError, ResourceExistsError, ResourceNotFoundError, \
@@ -18,11 +19,6 @@ from ._content_builder import AAZContentBuilder
 from ._field_type import AAZSimpleType, AAZObjectType, AAZBaseDictType, AAZListType
 from ._field_value import AAZList, AAZObject, AAZBaseDictValue
 from .exceptions import AAZInvalidValueError
-
-try:
-    from urllib import quote  # type: ignore
-except ImportError:
-    from urllib.parse import quote  # type: ignore
 
 
 class AAZOperation:

--- a/src/azure-cli-core/azure/cli/core/keys.py
+++ b/src/azure-cli-core/azure/cli/core/keys.py
@@ -16,11 +16,7 @@ def is_valid_ssh_rsa_public_key(openssh_pubkey):
     # http://stackoverflow.com/questions/2494450/ssh-rsa-public-key-validation-using-a-regular-expression # pylint: disable=line-too-long
     # A "good enough" check is to see if the key starts with the correct header.
     import struct
-    try:
-        from base64 import decodebytes as base64_decode
-    except ImportError:
-        # deprecated and redirected to decodebytes in Python 3
-        from base64 import decodestring as base64_decode
+    from base64 import decodestring as base64_decode
 
     parts = openssh_pubkey.split()
     if len(parts) < 2:

--- a/src/azure-cli-core/azure/cli/core/keys.py
+++ b/src/azure-cli-core/azure/cli/core/keys.py
@@ -16,7 +16,7 @@ def is_valid_ssh_rsa_public_key(openssh_pubkey):
     # http://stackoverflow.com/questions/2494450/ssh-rsa-public-key-validation-using-a-regular-expression # pylint: disable=line-too-long
     # A "good enough" check is to see if the key starts with the correct header.
     import struct
-    from base64 import decodestring as base64_decode
+    from base64 import decodebytes as base64_decode
 
     parts = openssh_pubkey.split()
     if len(parts) < 2:

--- a/src/azure-cli-telemetry/azure/cli/telemetry/__init__.py
+++ b/src/azure-cli-telemetry/azure/cli/telemetry/__init__.py
@@ -37,10 +37,9 @@ def _start(config_dir, cache_dir):
         startupinfo.wShowWindow = subprocess.SW_HIDE
         kwargs['startupinfo'] = startupinfo
     else:
-        if sys.version_info >= (3, 3):
-            kwargs['stdin'] = subprocess.DEVNULL
-            kwargs['stdout'] = subprocess.DEVNULL
-            kwargs['stderr'] = subprocess.STDOUT
+        kwargs['stdin'] = subprocess.DEVNULL
+        kwargs['stdout'] = subprocess.DEVNULL
+        kwargs['stderr'] = subprocess.STDOUT
 
     process = subprocess.Popen(**kwargs)
     logger.info('Return from creating process %s', process.pid)

--- a/src/azure-cli-telemetry/azure/cli/telemetry/components/telemetry_client.py
+++ b/src/azure-cli-telemetry/azure/cli/telemetry/components/telemetry_client.py
@@ -6,17 +6,11 @@
 import json
 import datetime
 
+import urllib.request as http_client_t
+from urllib.error import HTTPError
+
 from applicationinsights import TelemetryClient
 from applicationinsights.channel import SynchronousSender, SynchronousQueue, TelemetryChannel
-
-try:
-    # Python 2.x
-    import urllib2 as http_client_t
-    from urllib2 import HTTPError
-except ImportError:
-    # Python 3.x
-    import urllib.request as http_client_t
-    from urllib.error import HTTPError
 
 
 class CliTelemetryClient:

--- a/src/azure-cli-telemetry/azure/cli/telemetry/tests/test_telemetry_client.py
+++ b/src/azure-cli-telemetry/azure/cli/telemetry/tests/test_telemetry_client.py
@@ -8,18 +8,13 @@ from unittest import mock
 import os
 import unittest
 
+import urllib.request as http_client_t
+from urllib.error import HTTPError
+
 from applicationinsights.channel import SynchronousSender
 
-try:
-    # Python 2.x
-    import urllib2 as http_client_t
-    from urllib2 import HTTPError
-except ImportError:
-    # Python 3.x
-    import urllib.request as http_client_t
-    from urllib.error import HTTPError
 
-from azure.cli.telemetry.components.telemetry_client import (CliTelemetryClient, _NoRetrySender, http_client_t)
+from azure.cli.telemetry.components.telemetry_client import CliTelemetryClient, _NoRetrySender
 
 TEST_RESOURCE_FOLDER = os.path.join(os.path.dirname(__file__), 'resources')
 

--- a/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
@@ -3,10 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-try:
-    from urllib.parse import urlencode, urlparse, urlunparse
-except ImportError:
-    from urllib import urlencode
+from urllib.parse import urlencode, urlparse, urlunparse
 
 import time
 from json import loads

--- a/src/azure-cli/azure/cli/command_modules/acr/manifest.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/manifest.py
@@ -5,10 +5,7 @@
 
 from datetime import datetime, timedelta
 
-try:
-    from urllib.parse import unquote
-except ImportError:
-    from urllib import unquote
+from urllib.parse import unquote
 
 from knack.log import get_logger
 from azure.cli.core.util import user_confirmation

--- a/src/azure-cli/azure/cli/command_modules/acr/repository.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/repository.py
@@ -3,10 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-try:
-    from urllib.parse import unquote
-except ImportError:
-    from urllib import unquote
+from urllib.parse import unquote
 
 from knack.util import CLIError
 from knack.log import get_logger

--- a/src/azure-cli/azure/cli/command_modules/acr/tests/hybrid_2020_09_01/test_acr_commands_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/tests/hybrid_2020_09_01/test_acr_commands_mock.py
@@ -3,10 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-try:
-    from urllib.parse import urlencode
-except ImportError:
-    from urllib import urlencode
+from urllib.parse import urlencode
 import json
 import unittest
 from unittest import mock

--- a/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_commands_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_commands_mock.py
@@ -3,10 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-try:
-    from urllib.parse import urlencode
-except ImportError:
-    from urllib import urlencode
+from urllib.parse import urlencode
 import json
 import unittest
 from unittest import mock

--- a/src/azure-cli/azure/cli/command_modules/botservice/kudu_client.py
+++ b/src/azure-cli/azure/cli/command_modules/botservice/kudu_client.py
@@ -11,12 +11,7 @@ import zipfile
 import requests
 import urllib3
 
-try:
-    # Try importing Python 3 urllib.parse
-    from urllib.parse import quote
-except ImportError:
-    # If urllib.parse was not imported, use Python 2 module urlparse
-    from urllib import quote  # pylint: disable=import-error
+from urllib.parse import quote
 
 from knack.util import CLIError
 from azure.cli.command_modules.botservice.http_response_validator import HttpResponseValidator

--- a/src/azure-cli/azure/cli/command_modules/botservice/web_app_operations.py
+++ b/src/azure-cli/azure/cli/command_modules/botservice/web_app_operations.py
@@ -3,16 +3,11 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+from urllib.parse import urlsplit
+
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.mgmt.web import WebSiteManagementClient
 from azure.mgmt.web.models import HostType
-
-try:
-    # Try importing Python 3 urllib.parse
-    from urllib.parse import urlsplit
-except ImportError:
-    # If urllib.parse was not imported, use Python 2 module urlparse
-    from urlparse import urlsplit  # pylint: disable=import-error
 
 
 class WebAppOperations:

--- a/src/azure-cli/azure/cli/command_modules/iot/sas_token_auth.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/sas_token_auth.py
@@ -7,10 +7,7 @@ from base64 import b64encode, b64decode
 from hashlib import sha256
 from hmac import HMAC
 from time import time
-try:
-    from urllib import (urlencode, quote)
-except ImportError:
-    from urllib.parse import (urlencode, quote)  # pylint: disable=import-error
+from urllib.parse import urlencode, quote
 from msrest.authentication import Authentication
 
 

--- a/src/azure-cli/azure/cli/command_modules/lab/validators.py
+++ b/src/azure-cli/azure/cli/command_modules/lab/validators.py
@@ -499,11 +499,7 @@ def _is_valid_ssh_rsa_public_key(openssh_pubkey):
     # http://stackoverflow.com/questions/2494450/ssh-rsa-public-key-validation-using-a-regular-expression
     # A "good enough" check is to see if the key starts with the correct header.
     import struct
-    try:
-        from base64 import decodebytes as base64_decode
-    except ImportError:
-        # deprecated and redirected to decodebytes in Python 3
-        from base64 import decodestring as base64_decode
+    from base64 import decodebytes as base64_decode
     parts = openssh_pubkey.split()
     if len(parts) < 2:
         return False

--- a/src/azure-cli/azure/cli/command_modules/resource/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_validators.py
@@ -6,13 +6,11 @@
 import os
 import re
 import argparse
+from urllib.parse import urlparse, urlsplit
+
 from azure.cli.core.azclierror import ArgumentUsageError
 
 from knack.util import CLIError
-try:
-    from urllib.parse import urlparse, urlsplit
-except ImportError:
-    from urlparse import urlparse, urlsplit  # pylint: disable=import-error
 
 MSI_LOCAL_ID = '[system]'
 

--- a/src/azure-cli/azure/cli/command_modules/servicefabric/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/servicefabric/custom.py
@@ -8,14 +8,11 @@
 import os
 import time
 
+from urllib.parse import urlparse
+
 from OpenSSL import crypto
 from cryptography.hazmat.primitives.serialization import pkcs12
 from cryptography.hazmat.primitives import hashes
-
-try:
-    from urllib.parse import urlparse
-except ImportError:
-    from urlparse import urlparse  # pylint: disable=import-error
 
 from azure.cli.core.util import CLIError, get_file_json, b64_to_hex, sdk_no_wait
 from azure.cli.core.commands import LongRunningOperation

--- a/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
@@ -3,12 +3,10 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-
 import os
 import platform
 import subprocess
 import datetime
-import sys
 import zipfile
 import stat
 from urllib.parse import urlparse
@@ -224,12 +222,7 @@ def _urlretrieve(url, install_location):
     req = urlopen(url)
     compressedFile = io.BytesIO(req.read())
     if url.endswith('zip'):
-        if sys.version_info.major >= 3:
-            zip_file = zipfile.ZipFile(compressedFile)
-        else:
-            # If Python version is 2.X, use StringIO instead.
-            import StringIO  # pylint: disable=import-error
-            zip_file = zipfile.ZipFile(StringIO.StringIO(req.read()))
+        zip_file = zipfile.ZipFile(compressedFile)
         for fileName in zip_file.namelist():
             if fileName.endswith('azcopy') or fileName.endswith('azcopy.exe'):
                 with open(install_location, 'wb') as f:

--- a/src/azure-cli/azure/cli/command_modules/vm/_image_builder.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_image_builder.py
@@ -13,10 +13,7 @@ from enum import Enum
 
 import requests
 
-try:
-    from urllib.parse import urlparse
-except ImportError:
-    from urlparse import urlparse  # pylint: disable=import-error
+from urllib.parse import urlparse
 
 from knack.util import CLIError
 from knack.log import get_logger

--- a/src/azure-cli/azure/cli/command_modules/vm/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_validators.py
@@ -7,10 +7,7 @@
 
 import os
 
-try:
-    from urllib.parse import urlparse
-except ImportError:
-    from urlparse import urlparse  # pylint: disable=import-error
+from urllib.parse import urlparse
 
 from knack.log import get_logger
 from knack.util import CLIError

--- a/src/azure-cli/azure/cli/command_modules/vm/_vm_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_vm_utils.py
@@ -8,12 +8,9 @@ import os
 import re
 import importlib
 
-from azure.cli.core.commands.arm import ArmTemplateBuilder
+from urllib.parse import urlparse
 
-try:
-    from urllib.parse import urlparse
-except ImportError:
-    from urlparse import urlparse  # pylint: disable=import-error
+from azure.cli.core.commands.arm import ArmTemplateBuilder
 
 from knack.log import get_logger
 from knack.util import CLIError

--- a/src/azure-cli/azure/cli/command_modules/vm/azure_stack/_image_builder.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/azure_stack/_image_builder.py
@@ -11,12 +11,9 @@ import json
 import traceback
 from enum import Enum
 
-import requests
+from urllib.parse import urlparse
 
-try:
-    from urllib.parse import urlparse
-except ImportError:
-    from urlparse import urlparse  # pylint: disable=import-error
+import requests
 
 from knack.util import CLIError
 from knack.log import get_logger

--- a/src/azure-cli/azure/cli/command_modules/vm/azure_stack/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/azure_stack/_validators.py
@@ -7,10 +7,7 @@
 
 import os
 
-try:
-    from urllib.parse import urlparse
-except ImportError:
-    from urlparse import urlparse  # pylint: disable=import-error
+from urllib.parse import urlparse
 
 from knack.log import get_logger
 from knack.util import CLIError

--- a/src/azure-cli/azure/cli/command_modules/vm/azure_stack/_vm_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/azure_stack/_vm_utils.py
@@ -10,10 +10,7 @@ import re
 
 from azure.cli.core.commands.arm import ArmTemplateBuilder
 
-try:
-    from urllib.parse import urlparse
-except ImportError:
-    from urlparse import urlparse  # pylint: disable=import-error
+from urllib.parse import urlparse
 
 from knack.log import get_logger
 from knack.util import CLIError

--- a/tools/automation/utilities/pypi.py
+++ b/tools/automation/utilities/pypi.py
@@ -3,10 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-try:
-    import xmlrpclib
-except ImportError:
-    import xmlrpc.client as xmlrpclib  # pylint: disable=import-error
+import xmlrpc.client as xmlrpclib  # pylint: disable=import-error
 
 
 def is_available_on_pypi(module_name, module_version):


### PR DESCRIPTION
**Description**

Taken from #30368

Remove the various Python 2.7 import fallbacks. This was mostly limited to `urllib`. 

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
