### PR TITLE
{Misc} Fix UP022. Use capture_output for subprocess.run.

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
@@ -339,8 +339,7 @@ def _get_bicep_env_vars(custom_env=None):
 def _run_command(bicep_installation_path, args, custom_env=None):
     process = subprocess.run(
         [rf"{bicep_installation_path}"] + args,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         env=_get_bicep_env_vars(custom_env))
 
     try:

--- a/src/azure-cli/azure/cli/command_modules/security/_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/security/_utils.py
@@ -16,7 +16,7 @@ def run_cli_cmd(cmd, retry=0):
     import json
     import subprocess
 
-    output = subprocess.run(cmd, shell=True, check=False, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+    output = subprocess.run(cmd, shell=True, check=False, capture_output=True)
     if output.returncode != 0:
         if retry:
             run_cli_cmd(cmd, retry - 1)


### PR DESCRIPTION
**Description**

From the documentation:

> If capture_output is true, stdout and stderr will be captured. When used, the internal Popen object is automatically created with stdout and stderr both set to PIPE. The stdout and stderr arguments may not be supplied at the same time as capture_output. If you wish to capture and combine both streams into one, set stdout to PIPE and stderr to STDOUT, instead of using capture_output.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).