### PR TITLE
{Misc.} Remove unused function

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/azure_stack/_util.py
+++ b/src/azure-cli/azure/cli/command_modules/network/azure_stack/_util.py
@@ -3,41 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-import sys
-from knack.util import CLIError
-from azure.cli.core.util import sdk_no_wait
-
-from ._client_factory import network_client_factory
-from .custom import lb_get
 from azure.cli.core.azclierror import UnrecognizedArgumentError
-
-
-# workaround for : https://github.com/Azure/azure-cli/issues/17071
-def delete_lb_resource_property_entry(resource, prop):
-    """ Factory method for creating delete functions. """
-
-    def delete_func(cmd, resource_group_name, resource_name, item_name, no_wait=False):  # pylint: disable=unused-argument
-        client = getattr(network_client_factory(cmd.cli_ctx), resource)
-        item = lb_get(client, resource_group_name, resource_name)
-
-        if item.__getattribute__(prop) is not None:
-            keep_items = [x for x in item.__getattribute__(prop) if x.name.lower() != item_name.lower()]
-        else:
-            keep_items = None
-
-        with cmd.update_context(item) as c:
-            c.set_param(prop, keep_items)
-        if no_wait:
-            sdk_no_wait(no_wait, client.begin_create_or_update, resource_group_name, resource_name, item)
-        else:
-            result = sdk_no_wait(no_wait, client.begin_create_or_update,
-                                 resource_group_name, resource_name, item).result()
-            if next((x for x in getattr(result, prop) or [] if x.name.lower() == item_name.lower()), None):
-                raise CLIError("Failed to delete '{}' on '{}'".format(item_name, resource_name))
-
-    func_name = 'delete_lb_resource_property_entry_{}_{}'.format(resource, prop)
-    setattr(sys.modules[__name__], func_name, delete_func)
-    return func_name
 
 
 def _list_to_dict(enum_list):


### PR DESCRIPTION
This code doesn't comply with the linter rules: https://github.com/Azure/azure-cli/pull/30365/files#r1861670755

Remove it as it's not used.