### PR TITLE
{Core} Stop using legacy `base64.decodebytes`

### DIFF
--- a/src/azure-cli-core/azure/cli/core/keys.py
+++ b/src/azure-cli-core/azure/cli/core/keys.py
@@ -16,7 +16,7 @@ def is_valid_ssh_rsa_public_key(openssh_pubkey):
     # http://stackoverflow.com/questions/2494450/ssh-rsa-public-key-validation-using-a-regular-expression # pylint: disable=line-too-long
     # A "good enough" check is to see if the key starts with the correct header.
     import struct
-    from base64 import decodebytes as base64_decode
+    import base64
 
     parts = openssh_pubkey.split()
     if len(parts) < 2:
@@ -24,7 +24,7 @@ def is_valid_ssh_rsa_public_key(openssh_pubkey):
     key_type = parts[0]
     key_string = parts[1]
 
-    data = base64_decode(key_string.encode())  # pylint:disable=deprecated-method
+    data = base64.b64decode(key_string)
     int_len = 4
     str_len = struct.unpack('>I', data[:int_len])[0]  # this should return 7
     return data[int_len:int_len + str_len] == key_type.encode()

--- a/src/azure-cli/azure/cli/command_modules/lab/validators.py
+++ b/src/azure-cli/azure/cli/command_modules/lab/validators.py
@@ -499,14 +499,14 @@ def _is_valid_ssh_rsa_public_key(openssh_pubkey):
     # http://stackoverflow.com/questions/2494450/ssh-rsa-public-key-validation-using-a-regular-expression
     # A "good enough" check is to see if the key starts with the correct header.
     import struct
-    from base64 import decodebytes as base64_decode
+    import base64
     parts = openssh_pubkey.split()
     if len(parts) < 2:
         return False
     key_type = parts[0]
     key_string = parts[1]
 
-    data = base64_decode(key_string.encode())  # pylint:disable=deprecated-method
+    data = base64.b64decode(key_string)
     int_len = 4
     str_len = struct.unpack('>I', data[:int_len])[0]  # this should return 7
     return data[int_len:int_len + str_len] == key_type.encode()


### PR DESCRIPTION
**Related command**
`az vm create`
`az aks create`

**Description**<!--Mandatory-->
Created from https://github.com/Azure/azure-cli/pull/30451#discussion_r1868915243
Stop using legacy `base64.decodebytes`.

https://docs.python.org/3/library/base64.html

![image](https://github.com/user-attachments/assets/48479068-8555-491b-a08a-fce694648171)
