### PR TITLE
[Core] Add `truststore` library so System certificates are trusted automatically

### DIFF
--- a/src/azure-cli-core/azure/cli/core/ssl_context_adaptor.py
+++ b/src/azure-cli-core/azure/cli/core/ssl_context_adaptor.py
@@ -1,0 +1,10 @@
+import requests.adapters
+import ssl
+import truststore
+
+class SSLContextAdapter(requests.adapters.HTTPAdapter):
+    def init_poolmanager(self, *args, **kwargs):
+        ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+
+        kwargs['ssl_context'] = ctx
+        return super(SSLContextAdapter, self).init_poolmanager(*args, **kwargs)

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -906,6 +906,7 @@ def send_raw_request(cli_ctx, method, url, headers=None, uri_parameters=None,  #
     import uuid
     from requests import Session, Request
     from requests.structures import CaseInsensitiveDict
+    from azure.cli.core.ssl_context_adaptor import SSLContextAdapter
 
     result = CaseInsensitiveDict()
     for s in headers or []:
@@ -1027,6 +1028,7 @@ def send_raw_request(cli_ctx, method, url, headers=None, uri_parameters=None,  #
 
     # https://requests.readthedocs.io/en/latest/user/advanced/#prepared-requests
     s = Session()
+    s.mount(url, SSLContextAdapter())
     req = Request(method=method, url=url, headers=headers, params=uri_parameters, data=body)
     prepped = s.prepare_request(req)
 

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -127,6 +127,7 @@ semver==2.13.0
 six==1.16.0
 sshtunnel==0.1.5
 tabulate==0.8.9
+truststore==0.10.0
 urllib3==1.26.19
 wcwidth==0.1.7
 websocket-client==1.3.1

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -128,6 +128,7 @@ semver==2.13.0
 six==1.16.0
 sshtunnel==0.1.5
 tabulate==0.8.9
+truststore==0.10.0
 urllib3==1.26.19
 wcwidth==0.1.7
 websocket-client==1.3.1

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -129,6 +129,7 @@ semver==2.13.0
 six==1.16.0
 sshtunnel==0.1.5
 tabulate==0.8.9
+truststore==0.10.0
 urllib3==1.26.19
 wcwidth==0.1.7
 websocket-client==1.3.1


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
core

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Fixes https://github.com/azure/azure-cli/issues/28050
Fixes https://github.com/azure/azure-cli/issues/26456
Fixes https://github.com/Azure/azure-cli/issues/29948

**Testing Guide**
<!--Example commands with explanations.-->

Run az commands when behind a MitM proxy with the certificates in a trusted OS store and without setting the `REQUESTS_CA_BUNDLE` environment value

e.g. I've been using:

```
az rest --uri $STORAGE_ACCOUNT
```

Before:
```
HTTPSConnectionPool(host='***.web.core.windows.net', port=443): Max retries exceeded with url: / (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get issuer certificate (_ssl.c:1000)')))
Certificate verification failed. This typically happens when using Azure CLI behind a proxy that intercepts traffic with a self-signed certificate. Please add this certificate to the trusted CA bundle. More info: https://docs.microsoft.com/cli/azure/use-cli-effectively#work-behind-a-proxy.
```

After:

```
The requested content does not exist.(<!DOCTYPE html><html><head><title>WebContentNotFound</title></head><body><h1>The requested content does not exist.</h1><p><ul><li>HttpStatusCode: 404</li><li>ErrorCode: WebContentNotFound</li><li>RequestId : 8465eefc-801e-00b6-01fa-464419000000</li><li>TimeStamp : 2024-12-05T09:47:28.0584286Z</li></ul></p></body></html>)
```

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Core] Add `truststore` library so System certificates are trusted automatically

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
