### PR TITLE
{Misc} Remove misc Python 2.7 fallbacks.

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_commands_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_commands_mock.py
@@ -1391,7 +1391,7 @@ class AcrMockCommandsTests(unittest.TestCase):
 
         mock_get_access_credentials.return_value = 'testregistry.azurecr.io', EMPTY_GUID, 'password'
 
-        builtins_open = '__builtin__.open' if sys.version_info[0] < 3 else 'builtins.open'
+        builtins_open = 'builtins.open'
 
         # Push a chart
         with mock.patch(builtins_open) as mock_open:

--- a/src/azure-cli/azure/cli/command_modules/ams/tests/latest/test_ams_streaming_endpoint_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/tests/latest/test_ams_streaming_endpoint_scenarios.py
@@ -4,7 +4,6 @@
 # --------------------------------------------------------------------------------------------
 
 import os
-import sys
 
 from azure.cli.core.util import CLIError
 from azure.cli.testsdk import ScenarioTest, ResourceGroupPreparer, StorageAccountPreparer
@@ -383,8 +382,6 @@ class AmsStreamingEndpointsTests(ScenarioTest):
     @ResourceGroupPreparer()
     @StorageAccountPreparer(parameter_name='storage_account_for_create')
     def test_ams_streaming_endpoint_stop_async(self, storage_account_for_create):
-        if sys.version_info.major == 2:  # azure-cli/issues/9386
-            return
         amsname = self.create_random_name(prefix='ams', length=12)
         streaming_endpoint_name = self.create_random_name(prefix="strep", length=12)
 

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_commands.py
@@ -2016,7 +2016,7 @@ class AppConfigJsonContentTypeScenarioTest(ScenarioTest):
         entry_feature = 'Beta'
         internal_feature_key = FeatureFlagConstants.FEATURE_FLAG_PREFIX + entry_feature
         default_description = ""
-        default_conditions = "{{u\'client_filters\': []}}" if sys.version_info[0] < 3 else "{{\'client_filters\': []}}"
+        default_conditions = "{{\'client_filters\': []}}"
         default_locked = False
         default_state = "off"
         self.kwargs.update({
@@ -2201,7 +2201,7 @@ class AppConfigFeatureScenarioTest(ScenarioTest):
         internal_feature_key = FeatureFlagConstants.FEATURE_FLAG_PREFIX + entry_feature
         entry_label = 'v1'
         default_description = ""
-        default_conditions = "{{u\'client_filters\': []}}" if sys.version_info[0] < 3 else "{{\'client_filters\': []}}"
+        default_conditions = "{{\'client_filters\': []}}"
         default_locked = False
         default_state = "off"
 
@@ -2513,7 +2513,7 @@ class AppConfigFeatureScenarioTest(ScenarioTest):
         feature_key = FeatureFlagConstants.FEATURE_FLAG_PREFIX + feature_prefix + feature_name
         entry_label = 'v1'
         default_description = ""
-        default_conditions = "{{u\'client_filters\': []}}" if sys.version_info[0] < 3 else "{{\'client_filters\': []}}"
+        default_conditions = "{{\'client_filters\': []}}"
         default_locked = False
         default_state = "off"
 
@@ -2618,7 +2618,7 @@ class AppConfigFeatureFilterScenarioTest(ScenarioTest):
         internal_feature_key = FeatureFlagConstants.FEATURE_FLAG_PREFIX + entry_feature
         entry_label = 'Standard'
         default_description = ""
-        default_conditions = "{{u\'client_filters\': []}}" if sys.version_info[0] < 3 else "{{\'client_filters\': []}}"
+        default_conditions = "{{\'client_filters\': []}}"
         default_locked = False
         default_state = "off"
 
@@ -2986,7 +2986,7 @@ class AppConfigAadAuthLiveScenarioTest(ScenarioTest):
         entry_feature = 'Beta'
         internal_feature_key = FeatureFlagConstants.FEATURE_FLAG_PREFIX + entry_feature
         default_description = ""
-        default_conditions = "{{u\'client_filters\': []}}" if sys.version_info[0] < 3 else "{{\'client_filters\': []}}"
+        default_conditions = "{{\'client_filters\': []}}"
         default_locked = False
         default_state = "off"
         self.kwargs.update({

--- a/src/azure-cli/azure/cli/command_modules/botservice/bot_json_formatter.py
+++ b/src/azure-cli/azure/cli/command_modules/botservice/bot_json_formatter.py
@@ -5,7 +5,6 @@
 
 import base64
 from collections import Counter
-import sys
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.backends import default_backend
 from azure.cli.core._profile import Profile
@@ -107,10 +106,7 @@ class BotJsonFormatter:  # pylint:disable=too-few-public-methods
         """
         services = bot_file_data['services']
 
-        if sys.version_info.major >= 3:
-            decrypt = BotJsonFormatter.__decrypt_py3
-        else:
-            decrypt = BotJsonFormatter.__decrypt_py2
+        decrypt = BotJsonFormatter.__decrypt
 
         if password_only:
             # Get all endpoints that have potentially valid appPassword values
@@ -171,7 +167,7 @@ class BotJsonFormatter:  # pylint:disable=too-few-public-methods
         return services
 
     @staticmethod
-    def __decrypt_py3(secret, encrypted_value, logger):
+    def __decrypt(secret, encrypted_value, logger):
         # If the string length is 0 or no secret was passed in, return the empty string.
         if not encrypted_value or not secret:
             return encrypted_value
@@ -198,34 +194,4 @@ class BotJsonFormatter:  # pylint:disable=too-few-public-methods
         decrypted_bytes = decryptor.update(base64.standard_b64decode(str.encode(encrypted_text))) + decryptor.finalize()
 
         decrypted_string = decrypted_bytes.decode('utf-8')
-        return ''.join([char for char in decrypted_string if ord(char) > 31])
-
-    @staticmethod
-    def __decrypt_py2(secret, encrypted_value, logger):
-        # If the string length is 0 or no secret was passed in, return the empty string.
-        if not encrypted_value or not secret:
-            return encrypted_value
-
-        parts = encrypted_value.split("!")
-        if len(parts) != 2:
-            logger.warn('Encrypted value "%s" not in standard encrypted format, decryption skipped.' % encrypted_value)
-            return encrypted_value
-
-        iv_text = parts[0]
-        encrypted_text = parts[1]
-        iv_bytes = base64.standard_b64decode(iv_text)
-        secret_bytes = base64.standard_b64decode(secret)
-
-        if len(iv_bytes) != 16:
-            logger.warn('Initialization Vector for "%s" not valid, decryption skipped.' % encrypted_value)
-            return encrypted_value
-        if len(secret_bytes) != 32:
-            logger.warn('Passed in secret length is invalid, decryption skipped.')
-            return encrypted_value
-
-        cipher = Cipher(algorithms.AES(secret_bytes), modes.CBC(iv_bytes), backend=default_backend())
-        decryptor = cipher.decryptor()
-        decrypted_bytes = decryptor.update(base64.standard_b64decode(encrypted_text)) + decryptor.finalize()
-
-        decrypted_string = decrypted_bytes.encode('utf-8')
         return ''.join([char for char in decrypted_string if ord(char) > 31])

--- a/src/azure-cli/azure/cli/command_modules/botservice/bot_publish_prep.py
+++ b/src/azure-cli/azure/cli/command_modules/botservice/bot_publish_prep.py
@@ -4,7 +4,6 @@
 # --------------------------------------------------------------------------------------------
 
 import os
-import sys
 import zipfile
 import requests
 
@@ -99,12 +98,8 @@ class BotPublishPrep:
         :return: zipfile.ZipFile instance
         """
         response = requests.get('https://icscratch.blob.core.windows.net/bot-packages/node_v4_publish.zip')
-        if sys.version_info.major >= 3:
-            import io
-            return zipfile.ZipFile(io.BytesIO(response.content))
-        # If Python version is 2.X, use StringIO instead.
-        import StringIO  # pylint: disable=import-error
-        return zipfile.ZipFile(StringIO.StringIO(response.content))
+        import io
+        return zipfile.ZipFile(io.BytesIO(response.content))
 
     @staticmethod
     def __extract_specific_file_from_zip(logger, zip_file, web_config_exists, iisnode_yml_exists):

--- a/src/azure-cli/azure/cli/command_modules/monitor/grammar/autoscale/AutoscaleConditionParser.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/grammar/autoscale/AutoscaleConditionParser.py
@@ -8,10 +8,7 @@
 from antlr4 import *
 from io import StringIO
 import sys
-if sys.version_info[1] > 5:
-	from typing import TextIO
-else:
-	from typing.io import TextIO
+from typing import TextIO
 
 def serializedATN():
     return [
@@ -1096,8 +1093,3 @@ class AutoscaleConditionParser ( Parser ):
         finally:
             self.exitRule()
         return localctx
-
-
-
-
-

--- a/src/azure-cli/azure/cli/command_modules/monitor/grammar/metric_alert/MetricAlertConditionParser.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/grammar/metric_alert/MetricAlertConditionParser.py
@@ -6,12 +6,8 @@
 # encoding: utf-8
 # pylint: disable=all
 from antlr4 import *
-from io import StringIO
 import sys
-if sys.version_info[1] > 5:
-	from typing import TextIO
-else:
-	from typing.io import TextIO
+from typing import TextIO
 
 def serializedATN():
     return [

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -12,7 +12,6 @@ import json
 import os
 import re
 import ssl
-import sys
 import uuid
 import base64
 

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -341,9 +341,6 @@ def _is_bicepparam_file_provided(parameters):
 
 
 def _ssl_context():
-    if sys.version_info < (3, 4):
-        return ssl.SSLContext(ssl.PROTOCOL_TLSv1)
-
     return ssl.create_default_context()
 
 


### PR DESCRIPTION
**Description**

Some of this was also done in #30368 

I see this function in various places. I've edited one instance that didn't have the `in_cloud_console()` check. I left the ones that match this untouched:

```python
def _ssl_context():
    if sys.version_info < (3, 4) or (in_cloud_console() and platform.system() == 'Windows'):
        try:
            # added in python 2.7.13 and 3.6
            return ssl.SSLContext(ssl.PROTOCOL_TLS)
        except AttributeError:
            return ssl.SSLContext(ssl.PROTOCOL_TLSv1)

    return ssl.create_default_context()
```

There's a commented out test in `test_ams_streaming_endpoint_scenarios.py`

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
