### PR TITLE
{ACR} Hotfix: Revert polling change

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/agentpool.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/agentpool.py
@@ -90,7 +90,7 @@ def acr_agentpool_delete(cmd,
     try:
         response = client.begin_delete(resource_group_name=resource_group_name,
                                        registry_name=registry_name,
-                                       agent_pool_name=agent_pool_name).result()
+                                       agent_pool_name=agent_pool_name)
 
         if no_wait:
             logger.warning("Started to delete the agent pool '%s': %s", agent_pool_name, response.status())

--- a/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_agentpool_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_agentpool_commands.py
@@ -3,11 +3,12 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from azure.cli.testsdk import ScenarioTest, StorageAccountPreparer, ResourceGroupPreparer, record_only
+from azure.cli.testsdk import ScenarioTest, StorageAccountPreparer, ResourceGroupPreparer, record_only, live_only
 
 
 class AcrAgentPoolCommandsTests(ScenarioTest):
 
+    @live_only()  # This test requires live Azure resources
     @ResourceGroupPreparer()
     def test_acr_agentpool(self, resource_group):
         # Agentpool prerequisites for agentpool testing


### PR DESCRIPTION
**Related command**
az acr agentpool delete

**Description**<!--Mandatory-->
Revert some changes from this PR https://github.com/Azure/azure-cli/pull/30195 since we found an regression. Found an issue with self.cmd not detecting a command failure in this case. https://github.com/Azure/azure-cli/issues/30478

**Testing Guide**
acr agentpool delete -n {agents_name} -r {registry_name} -y

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).