### PR TITLE
{CI} Enable component detection in release branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,8 @@ variables:
 - template: ${{ variables.Pipeline.Workspace }}/.azure-pipelines/templates/variables.yml
 - name: Codeql.Enabled
   value: false
+- name: ComponentDetection.ForceScan
+  value: True
 
 parameters:
 - name: architectures

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ variables:
 - name: Codeql.Enabled
   value: false
 - name: ComponentDetection.ForceScan
-  value: True
+  value: eq(variables['Build.SourceBranch'], 'refs/heads/release')
 
 parameters:
 - name: architectures


### PR DESCRIPTION
CG only runs in default branch by default.
Set ComponentDetection.ForceScan to enable CG in release branch.

> ComponentDetection.ForceScan - When enabled, the auto-injected build task will execute a scan in your build no matter if the branch is not in scope (e.g. non-default branch)
---https://docs.opensource.microsoft.com/tools/cg/component-detection/variables/

```
##[info]Looking for pipeline information in Product Catalog...
##[info]Evaluating Branch...
##[info]SourceBranch: refs/heads/release
##[info]DefaultBranch: refs/heads/dev
##[info]Result: Skipping scan. Reason: Pipeline is not in-scope for automatic open source vulnerability scans and not default branch.
```
--------

It also skips running when CFS is not enabled, that's why CG is not running in dev branch.

> If the pip report is not detecting any components in your build, please ensure the following.
> 
> You are using a private feed for PIP, set by the PIP_INDEX_URL variable, or the Pip Authenticate build task
---https://docs.opensource.microsoft.com/tools/cg/component-detection/tsg/pipreport/

```
Skipping pip report due to invalid PIP_INDEX_URL.

PipReport: Found PipReportOverrideBehavior environment variable set to Skip. Skipping pip detection for 'D:\a\_work\1\s\requirements.txt'.
```


