### PR TITLE
[Storage] Fix #28554: `az storage blob service-properties update`: Support cases where `--static-website false` and index and 404 documents were already set

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/operations/blob.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/blob.py
@@ -329,12 +329,15 @@ def set_service_properties_track2(client, parameters, delete_retention=None, del
 
     if hasattr(parameters, 'static_website'):
         kwargs['static_website'] = parameters.static_website
-    if static_website is not None:
-        parameters.static_website.enabled = static_website
     if index_document is not None:
         parameters.static_website.index_document = index_document
     if error_document_404_path is not None:
         parameters.static_website.error_document404_path = error_document_404_path
+    if static_website is not None:
+        parameters.static_website.enabled = static_website
+        if not static_website:
+            parameters.static_website.index_document = None
+            parameters.static_website.error_document404_path = None
     if hasattr(parameters, 'hour_metrics'):
         kwargs['hour_metrics'] = parameters.hour_metrics
     if hasattr(parameters, 'logging'):

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/recordings/test_storage_blob_update_service_properties.yaml
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/recordings/test_storage_blob_update_service_properties.yaml
@@ -13,21 +13,21 @@ interactions:
       ParameterSetName:
       - -n -g --kind
       User-Agent:
-      - AZURECLI/2.61.0 azsdk-python-core/1.28.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
+      - AZURECLI/2.67.0 (PIP) azsdk-python-core/1.31.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_storage_blob_update_service_properties","date":"2024-06-19T11:00:03Z","module":"storage"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_storage_blob_update_service_properties","date":"2024-12-12T08:46:21Z","module":"storage","Creator":"zhiyihuang@microsoft.com","DateCreated":"2024-12-12T08:46:25Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '382'
+      - '456'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 19 Jun 2024 11:00:05 GMT
+      - Thu, 12 Dec 2024 08:46:27 GMT
       expires:
       - '-1'
       pragma:
@@ -59,7 +59,7 @@ interactions:
       ParameterSetName:
       - -n -g --kind
       User-Agent:
-      - AZURECLI/2.61.0 azsdk-python-core/1.28.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
+      - AZURECLI/2.67.0 (PIP) azsdk-python-core/1.31.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/checkNameAvailability?api-version=2023-05-01
   response:
@@ -73,7 +73,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 19 Jun 2024 11:00:07 GMT
+      - Thu, 12 Dec 2024 08:46:29 GMT
       expires:
       - '-1'
       pragma:
@@ -85,7 +85,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=54826b22-38d6-4fb2-bad9-b7b93a3e9c5a,objectId=a7250e3a-0e5e-48e2-9a34-45f1f5e1a91e/eastus2euap/a37be6c5-b67a-4d2d-b7cb-d06d7a2f9bd1
+      - tenantId=54826b22-38d6-4fb2-bad9-b7b93a3e9c5a,objectId=a7250e3a-0e5e-48e2-9a34-45f1f5e1a91e/eastus2euap/6eed7690-2d21-4aee-8ae0-b8d359ef25a8
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '3749'
     status:
@@ -110,7 +110,7 @@ interactions:
       ParameterSetName:
       - -n -g --kind
       User-Agent:
-      - AZURECLI/2.61.0 azsdk-python-core/1.28.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
+      - AZURECLI/2.67.0 (PIP) azsdk-python-core/1.31.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/account000002?api-version=2023-05-01
   response:
@@ -124,11 +124,11 @@ interactions:
       content-type:
       - text/plain; charset=utf-8
       date:
-      - Wed, 19 Jun 2024 11:00:12 GMT
+      - Thu, 12 Dec 2024 08:46:38 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/westus/asyncoperations/f980f4bf-81ea-4b34-95c8-b2d8e745c4ce?monitor=true&api-version=2023-05-01&t=638543916127823783&c=MIIHhjCCBm6gAwIBAgITHgTCiypfPNI5jYkgXAAABMKLKjANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDYwHhcNMjQwNjE4MDYzNzI1WhcNMjQwOTE2MDYzNzI1WjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOOPdootJ8ZHa_lIRnNgux_WGL-bBveeXB5WdIBDDXKVLj4z-swKD2kX6qrgtkbcS6BXYTp_x_OTOICI3sUrHtlH0GYLhtSpG3T20AjJNepXqd9uxENw44mO-KXdKZrI-pExqv2uDrYE2KVRARlfbQS6gULKhgCp_kvCORyykB-iA2gYhVn8zpVCh9q90OBMk43wu6gBdryJlNWZ8ZqpG0O9PHE0uW3m00sszKqKNjfe0ZuU-kJ1Mgcaye50NptZlqA6zG2Z7bF9OYN2XygIaLliHtskMXkpQh_1h1ITB7IVnt1xMWb0ULLrDs1dGggFpynHaGhKCP8y5_uC9Yj26VkCAwEAAaOCBHMwggRvMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwIwCgYIKwYBBQUHAwEwPAYJKwYBBAGCNxUHBC8wLQYlKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFgh8fIENbYcQIBZAIBBjCCAcsGCCsGAQUFBwEBBIIBvTCCAbkwYwYIKwYBBQUHMAKGV2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2lpbmZyYS9DZXJ0cy9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDEuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwyLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMy5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDQuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwHQYDVR0OBBYEFMFBxiX3CkKjr6OeqYNtCETZzpEDMA4GA1UdDwEB_wQEAwIFoDCCASYGA1UdHwSCAR0wggEZMIIBFaCCARGgggENhj9odHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ1JML0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcmyGMWh0dHA6Ly9jcmwxLmFtZS5nYmwvY3JsL0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcmyGMWh0dHA6Ly9jcmwyLmFtZS5nYmwvY3JsL0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcmyGMWh0dHA6Ly9jcmwzLmFtZS5nYmwvY3JsL0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcmyGMWh0dHA6Ly9jcmw0LmFtZS5nYmwvY3JsL0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcmwwgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDATAMBgorBgEEAYI3ewQBMB8GA1UdIwQYMBaAFPFGaMbxw_ArLX2LauGy-b41_NFBMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcDATANBgkqhkiG9w0BAQsFAAOCAQEAekgyV4K1wYICKvlQHidFDcgrRckc64c9TPiybo-vQ3GXYmaZmCpTGXgWLKuvRvIEcx-fqM3AaLDEl9dbizOPqGSlLR6J2R8p9eKEjL0uuRgSL3KlMlDmNLBnpd1Oeo6Ylyqngvx7wVAjfCEWloh4LJfvTdpa9wNqrHpPNVnc8yURDT4Dw1ZITlNTObml1BO9wbWkj4CLSHP8GlyN_sQZqfWjF4V5emF2rQA7xGLPJ7U2_UNDXkuZaDaHfrPpq3DL9pOWAh8yqrIY5Wht0bHUcqnds5gNMZtCwMAGdpvyjpVQ-O77QOfOY9VLFC-Sw19zoEpTnV9oN3j2Tn7YFKS-2g&s=ZXyoFYg5gj_IVSuy-iIO10QYItOk11xVdbvCkfwjTTmRDKizvqFEaSbx4uA0h6ZRVVUlBVtqwAQfbYy-ZlofC9_7mmWCtY497ZjbKPB-AdBaoGYSnBlgVk3CdAsCXlRa2_fGQj3EgRK3RXc4PFpyfONYAZx3QEOQ0kjcRmBSEPZw2shMkXJyeM6qbsjCHbR0HhhvbS2wtAiCQp0C62juLr3bpdLdQMrM42n8WqmR1WzTucX8OdyF0wFdJGr-0AN6wfJnf3C6cpJ0we5UARYnJA_H4HAtiq61p-ZlDoxczyEBxye1RVB7jCCyQbCilIOLTpP0lK133OFGO-B1ZHFkEg&h=-A-jxFfR8dEGbqrejKfVfeX21WaNjYyyvdGt3392MdY
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/westus/asyncoperations/ac467393-3fed-49a2-8a74-8cf0a6639806?monitor=true&api-version=2023-05-01&t=638695899990166017&c=MIIHpDCCBoygAwIBAgITfwR9aF61vN1fmBzWPwAEBH1oXjANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjQxMTI0MTE0NzIzWhcNMjUwMjIyMTE0NzIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALuLjvgBki3J2F02eLI0Ue_mnx-xpdgkQLmLDR_vHDzb5j-t90CpaEDQKPwPNvv28Bccb1Uo3G3MoI0Q79jgICmZpYGxdkMZoM6GX3jMNRZAbDtlzUaKW7wyBI4zFYtESxrolzHuINTdWsOeGAXH6PJ2YgDiYiq4Zns8FsngUwkfv42Ft7zomij9yvSP5nuVFivqBrYjd2UNK3BfaD4x1Ng5lEarTerVa9ZPsEkmx-tS-cKZ-wcEwiBwe0bxyk_KjKRUwnV0_aDYBEI2Qgs_pIA2vpm51p1xRONn0HnFV1fzk3CEhAMaNHwb-3aRxwAGveUN2KjJh-H4TColLKvqlhkCAwEAAaOCBJEwggSNMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwIwCgYIKwYBBQUHAwEwPAYJKwYBBAGCNxUHBC8wLQYlKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFgh8fIENbYcQIBZAIBBjCCAdoGCCsGAQUFBwEBBIIBzDCCAcgwZgYIKwYBBQUHMAKGWmh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2lpbmZyYS9DZXJ0cy9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDEuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwyLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMy5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDQuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwHQYDVR0OBBYEFB397v0dagsUEpPTIi-zaCGx8TjWMA4GA1UdDwEB_wQEAwIFoDCCATUGA1UdHwSCASwwggEoMIIBJKCCASCgggEchkJodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ1JML0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcmyGNGh0dHA6Ly9jcmwxLmFtZS5nYmwvY3JsL0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcmyGNGh0dHA6Ly9jcmwyLmFtZS5nYmwvY3JsL0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcmyGNGh0dHA6Ly9jcmwzLmFtZS5nYmwvY3JsL0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcmyGNGh0dHA6Ly9jcmw0LmFtZS5nYmwvY3JsL0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcmwwgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDATAMBgorBgEEAYI3ewQCMB8GA1UdIwQYMBaAFK55wmtdJYgTBvYHCcOXfHuXjx1VMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcDATANBgkqhkiG9w0BAQsFAAOCAQEAUnTi3rvLq3zXPwQbR0EQf11BD9WwNZ00WlmUlFoZo9zjK5B-5PoPHivE-UtqdGf_rRIONyhoH5k-AssCFx0exCUfEHnygyXktLffJjo-85mmeWHsGbQ-pTHUq6JsDwSUv-Rh5yYlvU6BU4FZrPYfCss5cpJQi3OTegnUy-hjPl1bK_lQtN-B7JIYuMfkeUHnoICcXT9DCAu6S0yuzQtLNH_OGiTP_sV7gLRgsmtBmLDwAWIHew4hH6WZrLvCQ4jiUpQ5KAUsKFzlLI30PTCSnEg43HpLjgNtHNsbzwxznYMUsjy4kFrqOWlHQCcuOg_HfGKnmZ5ErVHZBVisDC5SuQ&s=kjUszk6pNzaIaVu6C_5Zl6oVhZcSVBajH1c6xgTk60OwDVflLUvPvKXujIURrXIV15J2unbb3gPX0E4cqQ3xX4_c_8seMzRzyJnsEtv3n_mLDIsyjZ9JOe4H8VXVwVa8iuEk2h5Igwo4N5BHOlQegqmRgwi1xLRfJiC_2OMzZzrFThql1Bw1mN0luMLaz3w_DELbt7_dvKReVJVnFqAbpPZw9fuk3JMOd1ptIUJE65jemes0id83OEMcHmDAjndM86_-PjIideYzNZhKeOsj3WxrdlpbfqrJrMIFn3ZAx5tQZf18Mx7d6BoklY3_v71lobAErWMhH_HZkO3ocZJeAw&h=mqyWJcOwhjiVQNZhsZL7oFxImoGonUZjlSIi52bNHHc
       pragma:
       - no-cache
       server:
@@ -138,7 +138,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=54826b22-38d6-4fb2-bad9-b7b93a3e9c5a,objectId=a7250e3a-0e5e-48e2-9a34-45f1f5e1a91e/eastus2euap/d04836dc-5f30-44ae-a1c0-31468783cd22
+      - tenantId=54826b22-38d6-4fb2-bad9-b7b93a3e9c5a,objectId=a7250e3a-0e5e-48e2-9a34-45f1f5e1a91e/eastus2euap/1e7223da-45ee-4c28-8088-3d339fba4444
       x-ms-ratelimit-remaining-subscription-global-writes:
       - '2999'
       x-ms-ratelimit-remaining-subscription-writes:
@@ -160,27 +160,25 @@ interactions:
       ParameterSetName:
       - -n -g --kind
       User-Agent:
-      - AZURECLI/2.61.0 azsdk-python-core/1.28.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
+      - AZURECLI/2.67.0 (PIP) azsdk-python-core/1.31.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/westus/asyncoperations/f980f4bf-81ea-4b34-95c8-b2d8e745c4ce?monitor=true&api-version=2023-05-01&t=638543916127823783&c=MIIHhjCCBm6gAwIBAgITHgTCiypfPNI5jYkgXAAABMKLKjANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDYwHhcNMjQwNjE4MDYzNzI1WhcNMjQwOTE2MDYzNzI1WjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOOPdootJ8ZHa_lIRnNgux_WGL-bBveeXB5WdIBDDXKVLj4z-swKD2kX6qrgtkbcS6BXYTp_x_OTOICI3sUrHtlH0GYLhtSpG3T20AjJNepXqd9uxENw44mO-KXdKZrI-pExqv2uDrYE2KVRARlfbQS6gULKhgCp_kvCORyykB-iA2gYhVn8zpVCh9q90OBMk43wu6gBdryJlNWZ8ZqpG0O9PHE0uW3m00sszKqKNjfe0ZuU-kJ1Mgcaye50NptZlqA6zG2Z7bF9OYN2XygIaLliHtskMXkpQh_1h1ITB7IVnt1xMWb0ULLrDs1dGggFpynHaGhKCP8y5_uC9Yj26VkCAwEAAaOCBHMwggRvMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwIwCgYIKwYBBQUHAwEwPAYJKwYBBAGCNxUHBC8wLQYlKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFgh8fIENbYcQIBZAIBBjCCAcsGCCsGAQUFBwEBBIIBvTCCAbkwYwYIKwYBBQUHMAKGV2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2lpbmZyYS9DZXJ0cy9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDEuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwyLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMy5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDQuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwHQYDVR0OBBYEFMFBxiX3CkKjr6OeqYNtCETZzpEDMA4GA1UdDwEB_wQEAwIFoDCCASYGA1UdHwSCAR0wggEZMIIBFaCCARGgggENhj9odHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ1JML0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcmyGMWh0dHA6Ly9jcmwxLmFtZS5nYmwvY3JsL0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcmyGMWh0dHA6Ly9jcmwyLmFtZS5nYmwvY3JsL0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcmyGMWh0dHA6Ly9jcmwzLmFtZS5nYmwvY3JsL0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcmyGMWh0dHA6Ly9jcmw0LmFtZS5nYmwvY3JsL0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcmwwgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDATAMBgorBgEEAYI3ewQBMB8GA1UdIwQYMBaAFPFGaMbxw_ArLX2LauGy-b41_NFBMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcDATANBgkqhkiG9w0BAQsFAAOCAQEAekgyV4K1wYICKvlQHidFDcgrRckc64c9TPiybo-vQ3GXYmaZmCpTGXgWLKuvRvIEcx-fqM3AaLDEl9dbizOPqGSlLR6J2R8p9eKEjL0uuRgSL3KlMlDmNLBnpd1Oeo6Ylyqngvx7wVAjfCEWloh4LJfvTdpa9wNqrHpPNVnc8yURDT4Dw1ZITlNTObml1BO9wbWkj4CLSHP8GlyN_sQZqfWjF4V5emF2rQA7xGLPJ7U2_UNDXkuZaDaHfrPpq3DL9pOWAh8yqrIY5Wht0bHUcqnds5gNMZtCwMAGdpvyjpVQ-O77QOfOY9VLFC-Sw19zoEpTnV9oN3j2Tn7YFKS-2g&s=ZXyoFYg5gj_IVSuy-iIO10QYItOk11xVdbvCkfwjTTmRDKizvqFEaSbx4uA0h6ZRVVUlBVtqwAQfbYy-ZlofC9_7mmWCtY497ZjbKPB-AdBaoGYSnBlgVk3CdAsCXlRa2_fGQj3EgRK3RXc4PFpyfONYAZx3QEOQ0kjcRmBSEPZw2shMkXJyeM6qbsjCHbR0HhhvbS2wtAiCQp0C62juLr3bpdLdQMrM42n8WqmR1WzTucX8OdyF0wFdJGr-0AN6wfJnf3C6cpJ0we5UARYnJA_H4HAtiq61p-ZlDoxczyEBxye1RVB7jCCyQbCilIOLTpP0lK133OFGO-B1ZHFkEg&h=-A-jxFfR8dEGbqrejKfVfeX21WaNjYyyvdGt3392MdY
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/westus/asyncoperations/ac467393-3fed-49a2-8a74-8cf0a6639806?monitor=true&api-version=2023-05-01&t=638695899990166017&c=MIIHpDCCBoygAwIBAgITfwR9aF61vN1fmBzWPwAEBH1oXjANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjQxMTI0MTE0NzIzWhcNMjUwMjIyMTE0NzIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALuLjvgBki3J2F02eLI0Ue_mnx-xpdgkQLmLDR_vHDzb5j-t90CpaEDQKPwPNvv28Bccb1Uo3G3MoI0Q79jgICmZpYGxdkMZoM6GX3jMNRZAbDtlzUaKW7wyBI4zFYtESxrolzHuINTdWsOeGAXH6PJ2YgDiYiq4Zns8FsngUwkfv42Ft7zomij9yvSP5nuVFivqBrYjd2UNK3BfaD4x1Ng5lEarTerVa9ZPsEkmx-tS-cKZ-wcEwiBwe0bxyk_KjKRUwnV0_aDYBEI2Qgs_pIA2vpm51p1xRONn0HnFV1fzk3CEhAMaNHwb-3aRxwAGveUN2KjJh-H4TColLKvqlhkCAwEAAaOCBJEwggSNMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwIwCgYIKwYBBQUHAwEwPAYJKwYBBAGCNxUHBC8wLQYlKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFgh8fIENbYcQIBZAIBBjCCAdoGCCsGAQUFBwEBBIIBzDCCAcgwZgYIKwYBBQUHMAKGWmh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2lpbmZyYS9DZXJ0cy9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDEuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwyLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMy5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDQuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwHQYDVR0OBBYEFB397v0dagsUEpPTIi-zaCGx8TjWMA4GA1UdDwEB_wQEAwIFoDCCATUGA1UdHwSCASwwggEoMIIBJKCCASCgggEchkJodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ1JML0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcmyGNGh0dHA6Ly9jcmwxLmFtZS5nYmwvY3JsL0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcmyGNGh0dHA6Ly9jcmwyLmFtZS5nYmwvY3JsL0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcmyGNGh0dHA6Ly9jcmwzLmFtZS5nYmwvY3JsL0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcmyGNGh0dHA6Ly9jcmw0LmFtZS5nYmwvY3JsL0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcmwwgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDATAMBgorBgEEAYI3ewQCMB8GA1UdIwQYMBaAFK55wmtdJYgTBvYHCcOXfHuXjx1VMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcDATANBgkqhkiG9w0BAQsFAAOCAQEAUnTi3rvLq3zXPwQbR0EQf11BD9WwNZ00WlmUlFoZo9zjK5B-5PoPHivE-UtqdGf_rRIONyhoH5k-AssCFx0exCUfEHnygyXktLffJjo-85mmeWHsGbQ-pTHUq6JsDwSUv-Rh5yYlvU6BU4FZrPYfCss5cpJQi3OTegnUy-hjPl1bK_lQtN-B7JIYuMfkeUHnoICcXT9DCAu6S0yuzQtLNH_OGiTP_sV7gLRgsmtBmLDwAWIHew4hH6WZrLvCQ4jiUpQ5KAUsKFzlLI30PTCSnEg43HpLjgNtHNsbzwxznYMUsjy4kFrqOWlHQCcuOg_HfGKnmZ5ErVHZBVisDC5SuQ&s=kjUszk6pNzaIaVu6C_5Zl6oVhZcSVBajH1c6xgTk60OwDVflLUvPvKXujIURrXIV15J2unbb3gPX0E4cqQ3xX4_c_8seMzRzyJnsEtv3n_mLDIsyjZ9JOe4H8VXVwVa8iuEk2h5Igwo4N5BHOlQegqmRgwi1xLRfJiC_2OMzZzrFThql1Bw1mN0luMLaz3w_DELbt7_dvKReVJVnFqAbpPZw9fuk3JMOd1ptIUJE65jemes0id83OEMcHmDAjndM86_-PjIideYzNZhKeOsj3WxrdlpbfqrJrMIFn3ZAx5tQZf18Mx7d6BoklY3_v71lobAErWMhH_HZkO3ocZJeAw&h=mqyWJcOwhjiVQNZhsZL7oFxImoGonUZjlSIi52bNHHc
   response:
     body:
       string: ''
     headers:
       cache-control:
       - no-cache
-      connection:
-      - close
       content-length:
       - '0'
       content-type:
       - text/plain; charset=utf-8
       date:
-      - Wed, 19 Jun 2024 11:00:12 GMT
+      - Thu, 12 Dec 2024 08:46:38 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/westus/asyncoperations/f980f4bf-81ea-4b34-95c8-b2d8e745c4ce?monitor=true&api-version=2023-05-01&t=638543916131886267&c=MIIHhjCCBm6gAwIBAgITHgTCiypfPNI5jYkgXAAABMKLKjANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDYwHhcNMjQwNjE4MDYzNzI1WhcNMjQwOTE2MDYzNzI1WjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOOPdootJ8ZHa_lIRnNgux_WGL-bBveeXB5WdIBDDXKVLj4z-swKD2kX6qrgtkbcS6BXYTp_x_OTOICI3sUrHtlH0GYLhtSpG3T20AjJNepXqd9uxENw44mO-KXdKZrI-pExqv2uDrYE2KVRARlfbQS6gULKhgCp_kvCORyykB-iA2gYhVn8zpVCh9q90OBMk43wu6gBdryJlNWZ8ZqpG0O9PHE0uW3m00sszKqKNjfe0ZuU-kJ1Mgcaye50NptZlqA6zG2Z7bF9OYN2XygIaLliHtskMXkpQh_1h1ITB7IVnt1xMWb0ULLrDs1dGggFpynHaGhKCP8y5_uC9Yj26VkCAwEAAaOCBHMwggRvMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwIwCgYIKwYBBQUHAwEwPAYJKwYBBAGCNxUHBC8wLQYlKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFgh8fIENbYcQIBZAIBBjCCAcsGCCsGAQUFBwEBBIIBvTCCAbkwYwYIKwYBBQUHMAKGV2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2lpbmZyYS9DZXJ0cy9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDEuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwyLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMy5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDQuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwHQYDVR0OBBYEFMFBxiX3CkKjr6OeqYNtCETZzpEDMA4GA1UdDwEB_wQEAwIFoDCCASYGA1UdHwSCAR0wggEZMIIBFaCCARGgggENhj9odHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ1JML0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcmyGMWh0dHA6Ly9jcmwxLmFtZS5nYmwvY3JsL0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcmyGMWh0dHA6Ly9jcmwyLmFtZS5nYmwvY3JsL0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcmyGMWh0dHA6Ly9jcmwzLmFtZS5nYmwvY3JsL0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcmyGMWh0dHA6Ly9jcmw0LmFtZS5nYmwvY3JsL0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcmwwgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDATAMBgorBgEEAYI3ewQBMB8GA1UdIwQYMBaAFPFGaMbxw_ArLX2LauGy-b41_NFBMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcDATANBgkqhkiG9w0BAQsFAAOCAQEAekgyV4K1wYICKvlQHidFDcgrRckc64c9TPiybo-vQ3GXYmaZmCpTGXgWLKuvRvIEcx-fqM3AaLDEl9dbizOPqGSlLR6J2R8p9eKEjL0uuRgSL3KlMlDmNLBnpd1Oeo6Ylyqngvx7wVAjfCEWloh4LJfvTdpa9wNqrHpPNVnc8yURDT4Dw1ZITlNTObml1BO9wbWkj4CLSHP8GlyN_sQZqfWjF4V5emF2rQA7xGLPJ7U2_UNDXkuZaDaHfrPpq3DL9pOWAh8yqrIY5Wht0bHUcqnds5gNMZtCwMAGdpvyjpVQ-O77QOfOY9VLFC-Sw19zoEpTnV9oN3j2Tn7YFKS-2g&s=AgprpVIKZc1dsN-oMG4pnNgmz9RGgwEwqdyGBHIxgGkbNuRknjDvFXJKnTpvjvfYfBE8uQNhRvCY6I4_YeyN3HDjM597D_uOGT4w_0-TLKyGnzWoJ4yaDOju92uAVqSDk_OckLIKkMj0BYU2ZPbvX_m5b3_YeAEf94klyl_9_YnRHpIHbl8RDdZpUAB2hKGXdY3Y12PWOEbCLnxwbFlwVcXmI0rvldDlujCsA2W4F6UwRBE5GTwTKz5fNekKj-f-mKDM2QvkxHnhNRl45AJ1CRUgqG7Bo0igK6wDZbtaNEFNmczkkaWC32zKDtvXWHSV1_iI68XzJUvi7Dht2gJk4w&h=wFMPI8wKtrpZUeiD1uA2-_3UK-W5RFrSYovIr8rGVhI
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/westus/asyncoperations/ac467393-3fed-49a2-8a74-8cf0a6639806?monitor=true&api-version=2023-05-01&t=638695899994228532&c=MIIHpDCCBoygAwIBAgITfwR9aF61vN1fmBzWPwAEBH1oXjANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjQxMTI0MTE0NzIzWhcNMjUwMjIyMTE0NzIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALuLjvgBki3J2F02eLI0Ue_mnx-xpdgkQLmLDR_vHDzb5j-t90CpaEDQKPwPNvv28Bccb1Uo3G3MoI0Q79jgICmZpYGxdkMZoM6GX3jMNRZAbDtlzUaKW7wyBI4zFYtESxrolzHuINTdWsOeGAXH6PJ2YgDiYiq4Zns8FsngUwkfv42Ft7zomij9yvSP5nuVFivqBrYjd2UNK3BfaD4x1Ng5lEarTerVa9ZPsEkmx-tS-cKZ-wcEwiBwe0bxyk_KjKRUwnV0_aDYBEI2Qgs_pIA2vpm51p1xRONn0HnFV1fzk3CEhAMaNHwb-3aRxwAGveUN2KjJh-H4TColLKvqlhkCAwEAAaOCBJEwggSNMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwIwCgYIKwYBBQUHAwEwPAYJKwYBBAGCNxUHBC8wLQYlKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFgh8fIENbYcQIBZAIBBjCCAdoGCCsGAQUFBwEBBIIBzDCCAcgwZgYIKwYBBQUHMAKGWmh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2lpbmZyYS9DZXJ0cy9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDEuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwyLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMy5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDQuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwHQYDVR0OBBYEFB397v0dagsUEpPTIi-zaCGx8TjWMA4GA1UdDwEB_wQEAwIFoDCCATUGA1UdHwSCASwwggEoMIIBJKCCASCgggEchkJodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ1JML0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcmyGNGh0dHA6Ly9jcmwxLmFtZS5nYmwvY3JsL0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcmyGNGh0dHA6Ly9jcmwyLmFtZS5nYmwvY3JsL0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcmyGNGh0dHA6Ly9jcmwzLmFtZS5nYmwvY3JsL0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcmyGNGh0dHA6Ly9jcmw0LmFtZS5nYmwvY3JsL0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcmwwgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDATAMBgorBgEEAYI3ewQCMB8GA1UdIwQYMBaAFK55wmtdJYgTBvYHCcOXfHuXjx1VMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcDATANBgkqhkiG9w0BAQsFAAOCAQEAUnTi3rvLq3zXPwQbR0EQf11BD9WwNZ00WlmUlFoZo9zjK5B-5PoPHivE-UtqdGf_rRIONyhoH5k-AssCFx0exCUfEHnygyXktLffJjo-85mmeWHsGbQ-pTHUq6JsDwSUv-Rh5yYlvU6BU4FZrPYfCss5cpJQi3OTegnUy-hjPl1bK_lQtN-B7JIYuMfkeUHnoICcXT9DCAu6S0yuzQtLNH_OGiTP_sV7gLRgsmtBmLDwAWIHew4hH6WZrLvCQ4jiUpQ5KAUsKFzlLI30PTCSnEg43HpLjgNtHNsbzwxznYMUsjy4kFrqOWlHQCcuOg_HfGKnmZ5ErVHZBVisDC5SuQ&s=WuUnGlO960H8-PKP2YaEJntyoZpKSx4psGRM-8P1KGCtWx73uw_C4sVjqpR0Oj4kKXKMiUE3I5kjvWMhFuP0cR-utJJCSVdLpArvWglb0U22PrROYMOK1r5DMo96wgnyQo2d5QDIBRGZavHeYXh2wdgXlzuGrOZoWwAD-GvxLLEE8dmVOwxcndiXfz15MXHP6txFxaRTddfFBXZdE21rgqWczsxBSNUwu4pM_IJbupOl3ojSnG7YJMgeCVpKlT_C_gdsTIWKenfTflQdWYzXXXk9himNUQ53bx_KVdACKq-a_bOjNfd4hK00ci8ba3X1nM3CS_5KhLP4FeHdUjyokQ&h=N2JK3Zh9QWPnFrGmYQX7pedKLtdwlARyRwB0Sol8sNg
       pragma:
       - no-cache
       server:
@@ -190,9 +188,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=54826b22-38d6-4fb2-bad9-b7b93a3e9c5a,objectId=a7250e3a-0e5e-48e2-9a34-45f1f5e1a91e/eastus2euap/2f7bfdba-ac7d-4264-b34b-fe9f05a79c10
+      - tenantId=54826b22-38d6-4fb2-bad9-b7b93a3e9c5a,objectId=a7250e3a-0e5e-48e2-9a34-45f1f5e1a91e/eastus2euap/56d5c439-89c3-41e9-af5f-222b453edcd3
       x-ms-ratelimit-remaining-subscription-global-reads:
-      - '3749'
+      - '3748'
     status:
       code: 202
       message: Accepted
@@ -210,12 +208,12 @@ interactions:
       ParameterSetName:
       - -n -g --kind
       User-Agent:
-      - AZURECLI/2.61.0 azsdk-python-core/1.28.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
+      - AZURECLI/2.67.0 (PIP) azsdk-python-core/1.31.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/westus/asyncoperations/f980f4bf-81ea-4b34-95c8-b2d8e745c4ce?monitor=true&api-version=2023-05-01&t=638543916131886267&c=MIIHhjCCBm6gAwIBAgITHgTCiypfPNI5jYkgXAAABMKLKjANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDYwHhcNMjQwNjE4MDYzNzI1WhcNMjQwOTE2MDYzNzI1WjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOOPdootJ8ZHa_lIRnNgux_WGL-bBveeXB5WdIBDDXKVLj4z-swKD2kX6qrgtkbcS6BXYTp_x_OTOICI3sUrHtlH0GYLhtSpG3T20AjJNepXqd9uxENw44mO-KXdKZrI-pExqv2uDrYE2KVRARlfbQS6gULKhgCp_kvCORyykB-iA2gYhVn8zpVCh9q90OBMk43wu6gBdryJlNWZ8ZqpG0O9PHE0uW3m00sszKqKNjfe0ZuU-kJ1Mgcaye50NptZlqA6zG2Z7bF9OYN2XygIaLliHtskMXkpQh_1h1ITB7IVnt1xMWb0ULLrDs1dGggFpynHaGhKCP8y5_uC9Yj26VkCAwEAAaOCBHMwggRvMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwIwCgYIKwYBBQUHAwEwPAYJKwYBBAGCNxUHBC8wLQYlKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFgh8fIENbYcQIBZAIBBjCCAcsGCCsGAQUFBwEBBIIBvTCCAbkwYwYIKwYBBQUHMAKGV2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2lpbmZyYS9DZXJ0cy9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDEuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwyLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMy5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDQuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwHQYDVR0OBBYEFMFBxiX3CkKjr6OeqYNtCETZzpEDMA4GA1UdDwEB_wQEAwIFoDCCASYGA1UdHwSCAR0wggEZMIIBFaCCARGgggENhj9odHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ1JML0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcmyGMWh0dHA6Ly9jcmwxLmFtZS5nYmwvY3JsL0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcmyGMWh0dHA6Ly9jcmwyLmFtZS5nYmwvY3JsL0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcmyGMWh0dHA6Ly9jcmwzLmFtZS5nYmwvY3JsL0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcmyGMWh0dHA6Ly9jcmw0LmFtZS5nYmwvY3JsL0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcmwwgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDATAMBgorBgEEAYI3ewQBMB8GA1UdIwQYMBaAFPFGaMbxw_ArLX2LauGy-b41_NFBMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcDATANBgkqhkiG9w0BAQsFAAOCAQEAekgyV4K1wYICKvlQHidFDcgrRckc64c9TPiybo-vQ3GXYmaZmCpTGXgWLKuvRvIEcx-fqM3AaLDEl9dbizOPqGSlLR6J2R8p9eKEjL0uuRgSL3KlMlDmNLBnpd1Oeo6Ylyqngvx7wVAjfCEWloh4LJfvTdpa9wNqrHpPNVnc8yURDT4Dw1ZITlNTObml1BO9wbWkj4CLSHP8GlyN_sQZqfWjF4V5emF2rQA7xGLPJ7U2_UNDXkuZaDaHfrPpq3DL9pOWAh8yqrIY5Wht0bHUcqnds5gNMZtCwMAGdpvyjpVQ-O77QOfOY9VLFC-Sw19zoEpTnV9oN3j2Tn7YFKS-2g&s=AgprpVIKZc1dsN-oMG4pnNgmz9RGgwEwqdyGBHIxgGkbNuRknjDvFXJKnTpvjvfYfBE8uQNhRvCY6I4_YeyN3HDjM597D_uOGT4w_0-TLKyGnzWoJ4yaDOju92uAVqSDk_OckLIKkMj0BYU2ZPbvX_m5b3_YeAEf94klyl_9_YnRHpIHbl8RDdZpUAB2hKGXdY3Y12PWOEbCLnxwbFlwVcXmI0rvldDlujCsA2W4F6UwRBE5GTwTKz5fNekKj-f-mKDM2QvkxHnhNRl45AJ1CRUgqG7Bo0igK6wDZbtaNEFNmczkkaWC32zKDtvXWHSV1_iI68XzJUvi7Dht2gJk4w&h=wFMPI8wKtrpZUeiD1uA2-_3UK-W5RFrSYovIr8rGVhI
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/westus/asyncoperations/ac467393-3fed-49a2-8a74-8cf0a6639806?monitor=true&api-version=2023-05-01&t=638695899994228532&c=MIIHpDCCBoygAwIBAgITfwR9aF61vN1fmBzWPwAEBH1oXjANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjQxMTI0MTE0NzIzWhcNMjUwMjIyMTE0NzIzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALuLjvgBki3J2F02eLI0Ue_mnx-xpdgkQLmLDR_vHDzb5j-t90CpaEDQKPwPNvv28Bccb1Uo3G3MoI0Q79jgICmZpYGxdkMZoM6GX3jMNRZAbDtlzUaKW7wyBI4zFYtESxrolzHuINTdWsOeGAXH6PJ2YgDiYiq4Zns8FsngUwkfv42Ft7zomij9yvSP5nuVFivqBrYjd2UNK3BfaD4x1Ng5lEarTerVa9ZPsEkmx-tS-cKZ-wcEwiBwe0bxyk_KjKRUwnV0_aDYBEI2Qgs_pIA2vpm51p1xRONn0HnFV1fzk3CEhAMaNHwb-3aRxwAGveUN2KjJh-H4TColLKvqlhkCAwEAAaOCBJEwggSNMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwIwCgYIKwYBBQUHAwEwPAYJKwYBBAGCNxUHBC8wLQYlKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFgh8fIENbYcQIBZAIBBjCCAdoGCCsGAQUFBwEBBIIBzDCCAcgwZgYIKwYBBQUHMAKGWmh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2lpbmZyYS9DZXJ0cy9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDEuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwyLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMy5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDQuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwHQYDVR0OBBYEFB397v0dagsUEpPTIi-zaCGx8TjWMA4GA1UdDwEB_wQEAwIFoDCCATUGA1UdHwSCASwwggEoMIIBJKCCASCgggEchkJodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ1JML0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcmyGNGh0dHA6Ly9jcmwxLmFtZS5nYmwvY3JsL0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcmyGNGh0dHA6Ly9jcmwyLmFtZS5nYmwvY3JsL0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcmyGNGh0dHA6Ly9jcmwzLmFtZS5nYmwvY3JsL0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcmyGNGh0dHA6Ly9jcmw0LmFtZS5nYmwvY3JsL0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcmwwgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDATAMBgorBgEEAYI3ewQCMB8GA1UdIwQYMBaAFK55wmtdJYgTBvYHCcOXfHuXjx1VMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcDATANBgkqhkiG9w0BAQsFAAOCAQEAUnTi3rvLq3zXPwQbR0EQf11BD9WwNZ00WlmUlFoZo9zjK5B-5PoPHivE-UtqdGf_rRIONyhoH5k-AssCFx0exCUfEHnygyXktLffJjo-85mmeWHsGbQ-pTHUq6JsDwSUv-Rh5yYlvU6BU4FZrPYfCss5cpJQi3OTegnUy-hjPl1bK_lQtN-B7JIYuMfkeUHnoICcXT9DCAu6S0yuzQtLNH_OGiTP_sV7gLRgsmtBmLDwAWIHew4hH6WZrLvCQ4jiUpQ5KAUsKFzlLI30PTCSnEg43HpLjgNtHNsbzwxznYMUsjy4kFrqOWlHQCcuOg_HfGKnmZ5ErVHZBVisDC5SuQ&s=WuUnGlO960H8-PKP2YaEJntyoZpKSx4psGRM-8P1KGCtWx73uw_C4sVjqpR0Oj4kKXKMiUE3I5kjvWMhFuP0cR-utJJCSVdLpArvWglb0U22PrROYMOK1r5DMo96wgnyQo2d5QDIBRGZavHeYXh2wdgXlzuGrOZoWwAD-GvxLLEE8dmVOwxcndiXfz15MXHP6txFxaRTddfFBXZdE21rgqWczsxBSNUwu4pM_IJbupOl3ojSnG7YJMgeCVpKlT_C_gdsTIWKenfTflQdWYzXXXk9himNUQ53bx_KVdACKq-a_bOjNfd4hK00ci8ba3X1nM3CS_5KhLP4FeHdUjyokQ&h=N2JK3Zh9QWPnFrGmYQX7pedKLtdwlARyRwB0Sol8sNg
   response:
     body:
-      string: '{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/account000002","name":"account000002","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{},"properties":{"keyCreationTime":{"key1":"2024-06-19T11:00:08.8544257Z","key2":"2024-06-19T11:00:08.8544257Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2024-06-19T11:00:10.3231181Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2024-06-19T11:00:10.3231181Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2024-06-19T11:00:08.7605904Z","primaryEndpoints":{"dfs":"https://account000002.dfs.core.windows.net/","web":"https://account000002.z22.web.core.windows.net/","blob":"https://account000002.blob.core.windows.net/","queue":"https://account000002.queue.core.windows.net/","table":"https://account000002.table.core.windows.net/","file":"https://account000002.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available","secondaryLocation":"eastus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://account000002-secondary.dfs.core.windows.net/","web":"https://account000002-secondary.z22.web.core.windows.net/","blob":"https://account000002-secondary.blob.core.windows.net/","queue":"https://account000002-secondary.queue.core.windows.net/","table":"https://account000002-secondary.table.core.windows.net/"}}}'
+      string: '{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/account000002","name":"account000002","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{},"properties":{"keyCreationTime":{"key1":"2024-12-12T08:46:34.8230391Z","key2":"2024-12-12T08:46:34.8230391Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"ipv6Rules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2024-12-12T08:46:36.7917391Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2024-12-12T08:46:36.7917391Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2024-12-12T08:46:34.6979853Z","primaryEndpoints":{"dfs":"https://account000002.dfs.core.windows.net/","web":"https://account000002.z22.web.core.windows.net/","blob":"https://account000002.blob.core.windows.net/","queue":"https://account000002.queue.core.windows.net/","table":"https://account000002.table.core.windows.net/","file":"https://account000002.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available","secondaryLocation":"eastus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://account000002-secondary.dfs.core.windows.net/","web":"https://account000002-secondary.z22.web.core.windows.net/","blob":"https://account000002-secondary.blob.core.windows.net/","queue":"https://account000002-secondary.queue.core.windows.net/","table":"https://account000002-secondary.table.core.windows.net/"}}}'
     headers:
       cache-control:
       - no-cache
@@ -224,7 +222,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 19 Jun 2024 11:00:31 GMT
+      - Thu, 12 Dec 2024 08:46:56 GMT
       expires:
       - '-1'
       pragma:
@@ -236,7 +234,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=54826b22-38d6-4fb2-bad9-b7b93a3e9c5a,objectId=a7250e3a-0e5e-48e2-9a34-45f1f5e1a91e/eastus2euap/52fd3b22-1aa5-40ef-961a-485ab756b97d
+      - tenantId=54826b22-38d6-4fb2-bad9-b7b93a3e9c5a,objectId=a7250e3a-0e5e-48e2-9a34-45f1f5e1a91e/eastus2euap/bf22f17f-9734-472a-b983-41bf5ce18193
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '3749'
     status:
@@ -258,12 +256,12 @@ interactions:
       ParameterSetName:
       - -n -g --query -o
       User-Agent:
-      - AZURECLI/2.61.0 azsdk-python-core/1.28.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
+      - AZURECLI/2.67.0 (PIP) azsdk-python-core/1.31.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/account000002/listKeys?api-version=2023-05-01&$expand=kerb
   response:
     body:
-      string: '{"keys":[{"creationTime":"2024-06-19T11:00:08.8544257Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2024-06-19T11:00:08.8544257Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
+      string: '{"keys":[{"creationTime":"2024-12-12T08:46:34.8230391Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2024-12-12T08:46:34.8230391Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
     headers:
       cache-control:
       - no-cache
@@ -272,7 +270,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 19 Jun 2024 11:00:33 GMT
+      - Thu, 12 Dec 2024 08:46:58 GMT
       expires:
       - '-1'
       pragma:
@@ -284,9 +282,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=54826b22-38d6-4fb2-bad9-b7b93a3e9c5a,objectId=a7250e3a-0e5e-48e2-9a34-45f1f5e1a91e/eastus2euap/72580b39-b024-46f8-9d33-3ccb15d76175
+      - tenantId=54826b22-38d6-4fb2-bad9-b7b93a3e9c5a,objectId=a7250e3a-0e5e-48e2-9a34-45f1f5e1a91e/eastus2euap/a46af3a1-4ccd-432d-9f7d-2b173bc1ae2b
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11989'
+      - '11997'
     status:
       code: 200
       message: OK
@@ -304,9 +302,9 @@ interactions:
       ParameterSetName:
       - --account-name --account-key
       User-Agent:
-      - AZURECLI/2.61.0 azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
+      - AZURECLI/2.67.0 (PIP) azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
       x-ms-date:
-      - Wed, 19 Jun 2024 11:00:33 GMT
+      - Thu, 12 Dec 2024 08:46:59 GMT
       x-ms-version:
       - '2022-11-02'
     method: GET
@@ -319,7 +317,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Wed, 19 Jun 2024 11:00:34 GMT
+      - Thu, 12 Dec 2024 08:47:00 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -343,9 +341,9 @@ interactions:
       ParameterSetName:
       - --static-website --index-document --404-document --account-name --account-key
       User-Agent:
-      - AZURECLI/2.61.0 azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
+      - AZURECLI/2.67.0 (PIP) azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
       x-ms-date:
-      - Wed, 19 Jun 2024 11:00:34 GMT
+      - Thu, 12 Dec 2024 08:47:00 GMT
       x-ms-version:
       - '2022-11-02'
     method: GET
@@ -358,7 +356,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Wed, 19 Jun 2024 11:00:34 GMT
+      - Thu, 12 Dec 2024 08:47:01 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -389,9 +387,9 @@ interactions:
       ParameterSetName:
       - --static-website --index-document --404-document --account-name --account-key
       User-Agent:
-      - AZURECLI/2.61.0 azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
+      - AZURECLI/2.67.0 (PIP) azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
       x-ms-date:
-      - Wed, 19 Jun 2024 11:00:35 GMT
+      - Thu, 12 Dec 2024 08:47:01 GMT
       x-ms-version:
       - '2022-11-02'
     method: PUT
@@ -403,7 +401,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 19 Jun 2024 11:00:36 GMT
+      - Thu, 12 Dec 2024 08:47:02 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
@@ -425,9 +423,9 @@ interactions:
       ParameterSetName:
       - --static-website --index-document --404-document --account-name --account-key
       User-Agent:
-      - AZURECLI/2.61.0 azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
+      - AZURECLI/2.67.0 (PIP) azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
       x-ms-date:
-      - Wed, 19 Jun 2024 11:00:36 GMT
+      - Thu, 12 Dec 2024 08:47:02 GMT
       x-ms-version:
       - '2022-11-02'
     method: GET
@@ -440,7 +438,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Wed, 19 Jun 2024 11:00:36 GMT
+      - Thu, 12 Dec 2024 08:47:02 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -464,9 +462,9 @@ interactions:
       ParameterSetName:
       - --delete-retention --delete-retention-period --account-name --account-key
       User-Agent:
-      - AZURECLI/2.61.0 azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
+      - AZURECLI/2.67.0 (PIP) azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
       x-ms-date:
-      - Wed, 19 Jun 2024 11:00:37 GMT
+      - Thu, 12 Dec 2024 08:47:03 GMT
       x-ms-version:
       - '2022-11-02'
     method: GET
@@ -479,7 +477,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Wed, 19 Jun 2024 11:00:37 GMT
+      - Thu, 12 Dec 2024 08:47:03 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -510,9 +508,9 @@ interactions:
       ParameterSetName:
       - --delete-retention --delete-retention-period --account-name --account-key
       User-Agent:
-      - AZURECLI/2.61.0 azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
+      - AZURECLI/2.67.0 (PIP) azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
       x-ms-date:
-      - Wed, 19 Jun 2024 11:00:38 GMT
+      - Thu, 12 Dec 2024 08:47:04 GMT
       x-ms-version:
       - '2022-11-02'
     method: PUT
@@ -524,7 +522,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 19 Jun 2024 11:00:39 GMT
+      - Thu, 12 Dec 2024 08:47:04 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
@@ -546,9 +544,9 @@ interactions:
       ParameterSetName:
       - --delete-retention --delete-retention-period --account-name --account-key
       User-Agent:
-      - AZURECLI/2.61.0 azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
+      - AZURECLI/2.67.0 (PIP) azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
       x-ms-date:
-      - Wed, 19 Jun 2024 11:00:39 GMT
+      - Thu, 12 Dec 2024 08:47:05 GMT
       x-ms-version:
       - '2022-11-02'
     method: GET
@@ -561,7 +559,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Wed, 19 Jun 2024 11:00:39 GMT
+      - Thu, 12 Dec 2024 08:47:04 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -585,9 +583,9 @@ interactions:
       ParameterSetName:
       - --set --account-name --account-key
       User-Agent:
-      - AZURECLI/2.61.0 azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
+      - AZURECLI/2.67.0 (PIP) azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
       x-ms-date:
-      - Wed, 19 Jun 2024 11:00:40 GMT
+      - Thu, 12 Dec 2024 08:47:06 GMT
       x-ms-version:
       - '2022-11-02'
     method: GET
@@ -600,7 +598,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Wed, 19 Jun 2024 11:00:41 GMT
+      - Thu, 12 Dec 2024 08:47:06 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -631,9 +629,9 @@ interactions:
       ParameterSetName:
       - --set --account-name --account-key
       User-Agent:
-      - AZURECLI/2.61.0 azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
+      - AZURECLI/2.67.0 (PIP) azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
       x-ms-date:
-      - Wed, 19 Jun 2024 11:00:41 GMT
+      - Thu, 12 Dec 2024 08:47:07 GMT
       x-ms-version:
       - '2022-11-02'
     method: PUT
@@ -645,7 +643,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 19 Jun 2024 11:00:41 GMT
+      - Thu, 12 Dec 2024 08:47:08 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
@@ -667,9 +665,9 @@ interactions:
       ParameterSetName:
       - --set --account-name --account-key
       User-Agent:
-      - AZURECLI/2.61.0 azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
+      - AZURECLI/2.67.0 (PIP) azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
       x-ms-date:
-      - Wed, 19 Jun 2024 11:00:43 GMT
+      - Thu, 12 Dec 2024 08:47:08 GMT
       x-ms-version:
       - '2022-11-02'
     method: GET
@@ -682,7 +680,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Wed, 19 Jun 2024 11:00:42 GMT
+      - Thu, 12 Dec 2024 08:47:08 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -706,9 +704,9 @@ interactions:
       ParameterSetName:
       - --set --account-name --account-key
       User-Agent:
-      - AZURECLI/2.61.0 azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
+      - AZURECLI/2.67.0 (PIP) azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
       x-ms-date:
-      - Wed, 19 Jun 2024 11:00:43 GMT
+      - Thu, 12 Dec 2024 08:47:09 GMT
       x-ms-version:
       - '2022-11-02'
     method: GET
@@ -721,7 +719,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Wed, 19 Jun 2024 11:00:43 GMT
+      - Thu, 12 Dec 2024 08:47:09 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -752,9 +750,9 @@ interactions:
       ParameterSetName:
       - --set --account-name --account-key
       User-Agent:
-      - AZURECLI/2.61.0 azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
+      - AZURECLI/2.67.0 (PIP) azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
       x-ms-date:
-      - Wed, 19 Jun 2024 11:00:44 GMT
+      - Thu, 12 Dec 2024 08:47:10 GMT
       x-ms-version:
       - '2022-11-02'
     method: PUT
@@ -766,7 +764,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 19 Jun 2024 11:00:44 GMT
+      - Thu, 12 Dec 2024 08:47:10 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
@@ -788,9 +786,9 @@ interactions:
       ParameterSetName:
       - --set --account-name --account-key
       User-Agent:
-      - AZURECLI/2.61.0 azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
+      - AZURECLI/2.67.0 (PIP) azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
       x-ms-date:
-      - Wed, 19 Jun 2024 11:00:45 GMT
+      - Thu, 12 Dec 2024 08:47:11 GMT
       x-ms-version:
       - '2022-11-02'
     method: GET
@@ -803,7 +801,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Wed, 19 Jun 2024 11:00:44 GMT
+      - Thu, 12 Dec 2024 08:47:10 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -827,9 +825,9 @@ interactions:
       ParameterSetName:
       - --set --account-name --account-key
       User-Agent:
-      - AZURECLI/2.61.0 azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
+      - AZURECLI/2.67.0 (PIP) azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
       x-ms-date:
-      - Wed, 19 Jun 2024 11:00:45 GMT
+      - Thu, 12 Dec 2024 08:47:12 GMT
       x-ms-version:
       - '2022-11-02'
     method: GET
@@ -842,7 +840,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Wed, 19 Jun 2024 11:00:46 GMT
+      - Thu, 12 Dec 2024 08:47:12 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -873,9 +871,9 @@ interactions:
       ParameterSetName:
       - --set --account-name --account-key
       User-Agent:
-      - AZURECLI/2.61.0 azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
+      - AZURECLI/2.67.0 (PIP) azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
       x-ms-date:
-      - Wed, 19 Jun 2024 11:00:46 GMT
+      - Thu, 12 Dec 2024 08:47:13 GMT
       x-ms-version:
       - '2022-11-02'
     method: PUT
@@ -887,7 +885,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 19 Jun 2024 11:00:48 GMT
+      - Thu, 12 Dec 2024 08:47:13 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
@@ -909,9 +907,9 @@ interactions:
       ParameterSetName:
       - --set --account-name --account-key
       User-Agent:
-      - AZURECLI/2.61.0 azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
+      - AZURECLI/2.67.0 (PIP) azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
       x-ms-date:
-      - Wed, 19 Jun 2024 11:00:48 GMT
+      - Thu, 12 Dec 2024 08:47:14 GMT
       x-ms-version:
       - '2022-11-02'
     method: GET
@@ -924,7 +922,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Wed, 19 Jun 2024 11:00:48 GMT
+      - Thu, 12 Dec 2024 08:47:13 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -948,9 +946,9 @@ interactions:
       ParameterSetName:
       - --account-name --account-key
       User-Agent:
-      - AZURECLI/2.61.0 azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
+      - AZURECLI/2.67.0 (PIP) azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
       x-ms-date:
-      - Wed, 19 Jun 2024 11:00:48 GMT
+      - Thu, 12 Dec 2024 08:47:14 GMT
       x-ms-version:
       - '2022-11-02'
     method: GET
@@ -963,7 +961,249 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Wed, 19 Jun 2024 11:00:48 GMT
+      - Thu, 12 Dec 2024 08:47:15 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding:
+      - chunked
+      x-ms-version:
+      - '2022-11-02'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage blob service-properties update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --index-document --404-document --account-name --account-key
+      User-Agent:
+      - AZURECLI/2.67.0 (PIP) azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
+      x-ms-date:
+      - Thu, 12 Dec 2024 08:47:15 GMT
+      x-ms-version:
+      - '2022-11-02'
+    method: GET
+    uri: https://account000002.blob.core.windows.net/?restype=service&comp=properties
+  response:
+    body:
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>true</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors
+        /><DeleteRetentionPolicy><Enabled>true</Enabled><Days>1</Days><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy><StaticWebsite><Enabled>true</Enabled><IndexDocument>index.html</IndexDocument><ErrorDocument404Path>error.html</ErrorDocument404Path></StaticWebsite></StorageServiceProperties>"
+    headers:
+      content-type:
+      - application/xml
+      date:
+      - Thu, 12 Dec 2024 08:47:15 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding:
+      - chunked
+      x-ms-version:
+      - '2022-11-02'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <StorageServiceProperties><Logging><Version>1.0</Version><Delete>true</Delete><Read>false</Read><Write>false</Write><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors
+      /><DeleteRetentionPolicy><Enabled>true</Enabled><Days>1</Days></DeleteRetentionPolicy><StaticWebsite><Enabled>true</Enabled><IndexDocument>index1.html</IndexDocument><ErrorDocument404Path>error2.html</ErrorDocument404Path></StaticWebsite></StorageServiceProperties>'
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage blob service-properties update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '806'
+      Content-Type:
+      - application/xml
+      ParameterSetName:
+      - --index-document --404-document --account-name --account-key
+      User-Agent:
+      - AZURECLI/2.67.0 (PIP) azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
+      x-ms-date:
+      - Thu, 12 Dec 2024 08:47:16 GMT
+      x-ms-version:
+      - '2022-11-02'
+    method: PUT
+    uri: https://account000002.blob.core.windows.net/?restype=service&comp=properties
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Thu, 12 Dec 2024 08:47:17 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version:
+      - '2022-11-02'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage blob service-properties update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --index-document --404-document --account-name --account-key
+      User-Agent:
+      - AZURECLI/2.67.0 (PIP) azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
+      x-ms-date:
+      - Thu, 12 Dec 2024 08:47:18 GMT
+      x-ms-version:
+      - '2022-11-02'
+    method: GET
+    uri: https://account000002.blob.core.windows.net/?restype=service&comp=properties
+  response:
+    body:
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>true</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors
+        /><DeleteRetentionPolicy><Enabled>true</Enabled><Days>1</Days><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy><StaticWebsite><Enabled>true</Enabled><IndexDocument>index1.html</IndexDocument><ErrorDocument404Path>error2.html</ErrorDocument404Path></StaticWebsite></StorageServiceProperties>"
+    headers:
+      content-type:
+      - application/xml
+      date:
+      - Thu, 12 Dec 2024 08:47:18 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding:
+      - chunked
+      x-ms-version:
+      - '2022-11-02'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage blob service-properties update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --static-website --account-name --account-key
+      User-Agent:
+      - AZURECLI/2.67.0 (PIP) azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
+      x-ms-date:
+      - Thu, 12 Dec 2024 08:47:18 GMT
+      x-ms-version:
+      - '2022-11-02'
+    method: GET
+    uri: https://account000002.blob.core.windows.net/?restype=service&comp=properties
+  response:
+    body:
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>true</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors
+        /><DeleteRetentionPolicy><Enabled>true</Enabled><Days>1</Days><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy><StaticWebsite><Enabled>true</Enabled><IndexDocument>index1.html</IndexDocument><ErrorDocument404Path>error2.html</ErrorDocument404Path></StaticWebsite></StorageServiceProperties>"
+    headers:
+      content-type:
+      - application/xml
+      date:
+      - Thu, 12 Dec 2024 08:47:18 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding:
+      - chunked
+      x-ms-version:
+      - '2022-11-02'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <StorageServiceProperties><Logging><Version>1.0</Version><Delete>true</Delete><Read>false</Read><Write>false</Write><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors
+      /><DeleteRetentionPolicy><Enabled>true</Enabled><Days>1</Days></DeleteRetentionPolicy><StaticWebsite><Enabled>false</Enabled></StaticWebsite></StorageServiceProperties>'
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage blob service-properties update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '709'
+      Content-Type:
+      - application/xml
+      ParameterSetName:
+      - --static-website --account-name --account-key
+      User-Agent:
+      - AZURECLI/2.67.0 (PIP) azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
+      x-ms-date:
+      - Thu, 12 Dec 2024 08:47:19 GMT
+      x-ms-version:
+      - '2022-11-02'
+    method: PUT
+    uri: https://account000002.blob.core.windows.net/?restype=service&comp=properties
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Thu, 12 Dec 2024 08:47:19 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version:
+      - '2022-11-02'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage blob service-properties update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --static-website --account-name --account-key
+      User-Agent:
+      - AZURECLI/2.67.0 (PIP) azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
+      x-ms-date:
+      - Thu, 12 Dec 2024 08:47:20 GMT
+      x-ms-version:
+      - '2022-11-02'
+    method: GET
+    uri: https://account000002.blob.core.windows.net/?restype=service&comp=properties
+  response:
+    body:
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>true</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors
+        /><DeleteRetentionPolicy><Enabled>true</Enabled><Days>1</Days><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy><StaticWebsite><Enabled>false</Enabled></StaticWebsite></StorageServiceProperties>"
+    headers:
+      content-type:
+      - application/xml
+      date:
+      - Thu, 12 Dec 2024 08:47:19 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -987,9 +1227,9 @@ interactions:
       ParameterSetName:
       - --days --account-name --account-key
       User-Agent:
-      - AZURECLI/2.61.0 azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
+      - AZURECLI/2.67.0 (PIP) azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
       x-ms-date:
-      - Wed, 19 Jun 2024 11:00:50 GMT
+      - Thu, 12 Dec 2024 08:47:21 GMT
       x-ms-version:
       - '2022-11-02'
     method: GET
@@ -997,12 +1237,12 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>true</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors
-        /><DeleteRetentionPolicy><Enabled>true</Enabled><Days>1</Days><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy><StaticWebsite><Enabled>true</Enabled><IndexDocument>index.html</IndexDocument><ErrorDocument404Path>error.html</ErrorDocument404Path></StaticWebsite></StorageServiceProperties>"
+        /><DeleteRetentionPolicy><Enabled>true</Enabled><Days>1</Days><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy><StaticWebsite><Enabled>false</Enabled></StaticWebsite></StorageServiceProperties>"
     headers:
       content-type:
       - application/xml
       date:
-      - Wed, 19 Jun 2024 11:00:50 GMT
+      - Thu, 12 Dec 2024 08:47:21 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -1032,9 +1272,9 @@ interactions:
       ParameterSetName:
       - --days --account-name --account-key
       User-Agent:
-      - AZURECLI/2.61.0 azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
+      - AZURECLI/2.67.0 (PIP) azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
       x-ms-date:
-      - Wed, 19 Jun 2024 11:00:51 GMT
+      - Thu, 12 Dec 2024 08:47:22 GMT
       x-ms-version:
       - '2022-11-02'
     method: PUT
@@ -1046,7 +1286,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 19 Jun 2024 11:00:51 GMT
+      - Thu, 12 Dec 2024 08:47:21 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
@@ -1068,9 +1308,9 @@ interactions:
       ParameterSetName:
       - --days --account-name --account-key
       User-Agent:
-      - AZURECLI/2.61.0 azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
+      - AZURECLI/2.67.0 (PIP) azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
       x-ms-date:
-      - Wed, 19 Jun 2024 11:00:51 GMT
+      - Thu, 12 Dec 2024 08:47:22 GMT
       x-ms-version:
       - '2022-11-02'
     method: GET
@@ -1078,12 +1318,12 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>true</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors
-        /><DeleteRetentionPolicy><Enabled>true</Enabled><Days>2</Days><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy><StaticWebsite><Enabled>true</Enabled><IndexDocument>index.html</IndexDocument><ErrorDocument404Path>error.html</ErrorDocument404Path></StaticWebsite></StorageServiceProperties>"
+        /><DeleteRetentionPolicy><Enabled>true</Enabled><Days>2</Days><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy><StaticWebsite><Enabled>false</Enabled></StaticWebsite></StorageServiceProperties>"
     headers:
       content-type:
       - application/xml
       date:
-      - Wed, 19 Jun 2024 11:00:51 GMT
+      - Thu, 12 Dec 2024 08:47:22 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -1107,9 +1347,9 @@ interactions:
       ParameterSetName:
       - --account-name --account-key
       User-Agent:
-      - AZURECLI/2.61.0 azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
+      - AZURECLI/2.67.0 (PIP) azsdk-python-storage-blob/12.16.0 Python/3.9.13 (Windows-10-10.0.19045-SP0)
       x-ms-date:
-      - Wed, 19 Jun 2024 11:00:52 GMT
+      - Thu, 12 Dec 2024 08:47:23 GMT
       x-ms-version:
       - '2022-11-02'
     method: GET
@@ -1117,12 +1357,12 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>true</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors
-        /><DeleteRetentionPolicy><Enabled>true</Enabled><Days>2</Days><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy><StaticWebsite><Enabled>true</Enabled><IndexDocument>index.html</IndexDocument><ErrorDocument404Path>error.html</ErrorDocument404Path></StaticWebsite></StorageServiceProperties>"
+        /><DeleteRetentionPolicy><Enabled>true</Enabled><Days>2</Days><AllowPermanentDelete>false</AllowPermanentDelete></DeleteRetentionPolicy><StaticWebsite><Enabled>false</Enabled></StaticWebsite></StorageServiceProperties>"
     headers:
       content-type:
       - application/xml
       date:
-      - Wed, 19 Jun 2024 11:00:52 GMT
+      - Thu, 12 Dec 2024 08:47:23 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_blob_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_blob_scenarios.py
@@ -473,6 +473,18 @@ class StorageBlobUploadTests(StorageScenarioMixin, ScenarioTest):
                                 JMESPathCheck('minuteMetrics.enabled', True),
                                 JMESPathCheck('minuteMetrics.includeApis', True),
                                 JMESPathCheck('logging.delete', True))
+
+        self.storage_cmd('storage blob service-properties update --index-document index1.html '
+                         '--404-document error2.html', account_info) \
+            .assert_with_checks(JMESPathCheck('staticWebsite.enabled', True),
+                                JMESPathCheck('staticWebsite.indexDocument', 'index1.html'),
+                                JMESPathCheck('staticWebsite.errorDocument_404Path', 'error2.html'))
+
+        self.storage_cmd('storage blob service-properties update --static-website false', account_info) \
+            .assert_with_checks(JMESPathCheck('staticWebsite.enabled', False),
+                                JMESPathCheck('staticWebsite.indexDocument', None),
+                                JMESPathCheck('staticWebsite.errorDocument_404Path', None))
+
         self.storage_cmd('storage blob service-properties delete-policy update --days 2', account_info)
         self.storage_cmd('storage blob service-properties delete-policy show', account_info) \
             .assert_with_checks(JMESPathCheck('days', 2))


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
`az storage blob service-properties update`:  Support cases where `--static-website false` but there is existing index-document or 404-document, matching portal behavior to clear index-document and 404-document
Fix #28554 
**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Storage] Fix #28554: `az storage blob service-properties update`: Support cases where `--static-website false` and index and 404 documents were already set

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
