### PR TITLE
{ACR} Add connection pooling with ACR registries.

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
@@ -10,6 +10,7 @@ from json import loads
 from enum import Enum
 from base64 import b64encode
 import requests
+from requests import Session
 from requests import RequestException
 from requests.utils import to_native_string
 from msrest.http_logger import log_request, log_response
@@ -34,6 +35,7 @@ from ._errors import CONNECTIVITY_TOOMANYREQUESTS_ERROR
 
 
 logger = get_logger(__name__)
+session = requests.Session()
 
 
 EMPTY_GUID = '00000000-0000-0000-0000-000000000000'
@@ -593,7 +595,7 @@ def request_data_from_registry(http_method,
             if file_payload:
                 with open(file_payload, 'rb') as data_payload:
                     logger.debug(add_timestamp("Sending a HTTP {} request to {}".format(http_method, url)))
-                    response = requests.request(
+                    response = session.request(
                         method=http_method,
                         url=url,
                         headers=headers,
@@ -604,7 +606,7 @@ def request_data_from_registry(http_method,
                     )
             else:
                 logger.debug(add_timestamp("Sending a HTTP {} request to {}".format(http_method, url)))
-                response = requests.request(
+                response = session.request(
                     method=http_method,
                     url=url,
                     headers=headers,


### PR DESCRIPTION
**Related command**
az acr repository list

**Description**
I have a registry of 60000 (sixty thousands) images. Listing them usually takes ~10 minutes on my internet connection. Largely because listing happens in pages by 100 entries per page. So az cli does ~600 requests to list all images. Each request used it's own connection.
With this change a request to the same registry will reuse an existing connection (if any) or open a new one.
It should not break things as I make no initial configuration for a session so no parameters are reused. But I'm happy to fix my code if this naïve approach doesn't work.

**Testing Guide**
az acr repository list --name some_very_large_repository

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
