### PR TITLE
[Profile] `az login`: Add `--client-id`, `--object-id` and `--resource-id` for authenticating with user-assigned managed identity

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/profile/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/__init__.py
@@ -75,6 +75,12 @@ class ProfileCommandsLoader(AzCommandsLoader):
             # Managed identity
             c.argument('identity', options_list=('-i', '--identity'), action='store_true',
                        help="Log in using managed identity", arg_group='Managed Identity')
+            c.argument('client_id',
+                       help="Client ID of the user-assigned managed identity", arg_group='Managed Identity')
+            c.argument('object_id',
+                       help="Object ID of the user-assigned managed identity", arg_group='Managed Identity')
+            c.argument('resource_id',
+                       help="Resource ID of the user-assigned managed identity", arg_group='Managed Identity')
 
         with self.argument_context('logout') as c:
             c.argument('username', help='account user, if missing, logout the current active account')

--- a/src/azure-cli/azure/cli/command_modules/profile/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/_help.py
@@ -43,8 +43,10 @@ examples:
       text: az login --service-principal --username APP_ID --certificate /path/to/cert.pem --tenant TENANT_ID
     - name: Log in with a system-assigned managed identity.
       text: az login --identity
-    - name: Log in with a user-assigned managed identity. You must specify the client ID, object ID or resource ID of the user-assigned managed identity with --username.
-      text: az login --identity --username 00000000-0000-0000-0000-000000000000
+    - name: Log in with a user-assigned managed identity's client ID.
+      text: az login --identity --client-id 00000000-0000-0000-0000-000000000000
+    - name: Log in with a user-assigned managed identity's resource ID.
+      text: az login --identity --resource-id /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MyResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/MyIdentity
 """
 
 helps['account'] = """

--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -114,14 +114,14 @@ def account_clear(cmd):
     profile.logout_all()
 
 
-# pylint: disable=inconsistent-return-statements, too-many-branches
+# pylint: disable=too-many-branches, too-many-locals
 def login(cmd, username=None, password=None, tenant=None, scopes=None, allow_no_subscriptions=False,
           # Device code flow
           use_device_code=False,
           # Service principal
           service_principal=None, certificate=None, use_cert_sn_issuer=None, client_assertion=None,
           # Managed identity
-          identity=False):
+          identity=False, client_id=None, object_id=None, resource_id=None):
     """Log in to access Azure subscriptions"""
 
     # quick argument usage check
@@ -143,7 +143,9 @@ def login(cmd, username=None, password=None, tenant=None, scopes=None, allow_no_
     if identity:
         if in_cloud_console():
             return profile.login_in_cloud_shell()
-        return profile.login_with_managed_identity(username, allow_no_subscriptions)
+        return profile.login_with_managed_identity(
+            identity_id=username, client_id=client_id, object_id=object_id, resource_id=resource_id,
+            allow_no_subscriptions=allow_no_subscriptions)
     if in_cloud_console():  # tell users they might not need login
         logger.warning(_CLOUD_CONSOLE_LOGIN_WARNING)
 

--- a/src/azure-cli/azure/cli/command_modules/profile/tests/latest/test_profile_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/tests/latest/test_profile_custom.py
@@ -88,15 +88,15 @@ class ProfileCommandTest(unittest.TestCase):
         get_raw_token_mock.assert_called_with(mock.ANY, None, None, None, tenant_id)
 
     @mock.patch('azure.cli.command_modules.profile.custom.Profile', autospec=True)
-    def test_get_login(self, profile_mock):
+    def test_login_with_mi(self, profile_mock):
         invoked = []
 
-        def test_login(msi_port, identity_id=None):
+        def login_with_managed_identity_mock(*args, **kwargs):
             invoked.append(True)
 
         # mock the instance
         profile_instance = mock.MagicMock()
-        profile_instance.login_with_managed_identity = test_login
+        profile_instance.login_with_managed_identity = login_with_managed_identity_mock
         # mock the constructor
         profile_mock.return_value = profile_instance
 


### PR DESCRIPTION
**Related command**
`az login --identity`

**Description**<!--Mandatory-->
Close https://github.com/Azure/azure-cli/issues/29480

`az login` currently reuses `--username` for 3 types of IDs. This has several disadvantages:

1. It is inefficient, as it uses a trial-and-error approach to detect the ID type.
2. It pollutes managed identity's server telemetry as it makes failed calls on purpose.
3. It is confusing, as username is a concept related to user flow, such as auth code flow, device code flow and username password (ROPC) flow.
4. It may have security risk of sending data (may contain PII) to unexpected places.

With the recent initiative of moving to password-free authentication methods, managed identity authentication is becoming more important. 

**Testing Guide**
```sh
# New way to log in with client ID
az login --identity --client-id 00000000-0000-0000-0000-000000000000

# New way to log in with object ID
az login --identity --object-id 00000000-0000-0000-0000-000000000000

# New way to log in with resource ID
az login --identity --resource-id /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/testrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testmi

# Old way to log in with any ID
az login --identity --username 00000000-0000-0000-0000-000000000000

# System-assigned managed identity is not changed
az login --identity
```

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Profile] `az login`: Passing the managed identity ID with `--username` is deprecated and will be removed in a future release. Please use `--client-id`, `--object-id` or `--resource-id` instead