### PR TITLE
{RDBMS} Add warnings that selecting PG version 12 will no longer be supported in `az postgres flexible-server upgrade` 

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_common.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_common.py
@@ -296,6 +296,11 @@ def flexible_server_version_upgrade(cmd, client, resource_group_name, server_nam
     current_version = int(instance.version.split('.')[0])
     if current_version >= int(version):
         raise CLIError("The version to upgrade to must be greater than the current version.")
+    if version == '12':
+        logger.warning("Support for PostgreSQL 12 has officially ended. As a result, "
+                        "the option to select version 12 will be removed in the near future. "
+                        "We recommend selecting PostgreSQL 13 or a later version for "
+                        "all future operations.")
 
     replica_operations_client = cf_postgres_flexible_replica(cmd.cli_ctx, '_')
     version_mapped = version

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_common.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_common.py
@@ -298,9 +298,9 @@ def flexible_server_version_upgrade(cmd, client, resource_group_name, server_nam
         raise CLIError("The version to upgrade to must be greater than the current version.")
     if version == '12':
         logger.warning("Support for PostgreSQL 12 has officially ended. As a result, "
-                        "the option to select version 12 will be removed in the near future. "
-                        "We recommend selecting PostgreSQL 13 or a later version for "
-                        "all future operations.")
+                       "the option to select version 12 will be removed in the near future. "
+                       "We recommend selecting PostgreSQL 13 or a later version for "
+                       "all future operations.")
 
     replica_operations_client = cf_postgres_flexible_replica(cmd.cli_ctx, '_')
     version_mapped = version


### PR DESCRIPTION
**Related command**
`az postgres flexible-server upgrade` 

**Description**<!--Mandatory-->
PG 12 is no longer being supported by community, ability to select version will be blocked during provisioning and migration version upgrade.

**Testing Guide**
Manually
postgres' 'flexible-server' 'upgrade' '-g' 'nasc-runner' '--name' 'nasc-pg11-delete' '--version' '12'                  
WARNING: Unable to load extension 'rdbms-connect: local variable 'command_loader' referenced before assignment'. Use --debug for more information.
Upgrading major version in server nasc-pg11-delete is irreversible. The action you're about to take can't be undone. Going further will initiate major version upgrade to the selected version on this server. (y/n): y
**WARNING: Support for PostgreSQL 12 has officially ended. As a result, the option to select version 12 will be removed in the near future. We recommend selecting PostgreSQL 13 or a later version for all future operations.**

**History Notes**
{RDBMS} `az postgres flexible-server upgrade`: Add warnings that selecting PG version 12 will no longer be supported
