### PR TITLE
{ACR} Fix #30041: `az acr`:  Fix the "multiple values for keyword argument" error when the acr commands running on SAW

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
@@ -196,7 +196,7 @@ def _get_aad_token_after_challenge(cli_ctx,
     }
 
     logger.debug(add_timestamp("Sending a HTTP Post request to {}".format(authhost)))
-    response = requests.post(authhost, urlencode(content), headers=headers,
+    response = requests.post(url=authhost, data=urlencode(content), headers=headers,
                              verify=not should_disable_connection_verify())
 
     if response.status_code not in [200]:

--- a/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
@@ -297,7 +297,7 @@ def _get_token_with_username_and_password(login_server,
     }
 
     logger.debug(add_timestamp("Sending a HTTP Post request to {}".format(authhost)))
-    response = requests.post(authhost, urlencode(content), headers=headers,
+    response = requests.post(url=authhost, data=urlencode(content), headers=headers,
                              verify=not should_disable_connection_verify())
 
     if response.status_code != 200:

--- a/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
@@ -160,7 +160,7 @@ def _get_aad_token_after_challenge(cli_ctx,
     }
 
     logger.debug(add_timestamp("Sending a HTTP Post request to {}".format(authhost)))
-    response = requests.post(authhost, urlencode(content), headers=headers,
+    response = requests.post(url=authhost, data=urlencode(content), headers=headers,
                              verify=not should_disable_connection_verify())
 
     if response.status_code == 429:


### PR DESCRIPTION
**Related command**
az acr login 

**Description**<!--Mandatory-->
Fix login issue on SAW https://github.com/Azure/azure-cli/issues/30041 due to a special package used to replace the standard python requests package. Since the standard python package cannot be used on SAW for security reasons, CLI team replaced requests with windows-http. The different positional argument sequence between requests and windows-http caused this issue to occur on SAW. I had a discussion with Hang Lei and the quickest way to resolve this is to use keyword arguments instead of positional arguments. We will have to wait until the next CLI release to SAW for the issue to be resolved. 

**Testing Guide**

az acr login -n myregistry

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
