### PR TITLE
[RDBMS] `az postgres flexible-server private-endpoint-connection / private-link-resource / server-logs / virtual-endpoint list`: Fix linter issue and not exposing IDs parameter on the list command

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
@@ -823,7 +823,10 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
             argument_context_string = '{} flexible-server virtual-endpoint {}'.format(command_group, scope)
             with self.argument_context(argument_context_string) as c:
                 c.argument('resource_group_name', arg_type=resource_group_name_type)
-                c.argument('server_name', options_list=['--server-name', '-s'], arg_type=server_name_arg_type)
+                if scope == 'list':
+                    c.argument('server_name', options_list=['--server-name', '-s'], id_part=None, arg_type=server_name_arg_type)
+                else:
+                    c.argument('server_name', options_list=['--server-name', '-s'], arg_type=server_name_arg_type)
                 c.argument('virtual_endpoint_name', options_list=['--name', '-n'], arg_type=virtual_endpoint_arg_type, validator=virtual_endpoint_name_validator)
 
         with self.argument_context('{} flexible-server long-term-retention list'.format(command_group)) as c:
@@ -990,7 +993,10 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
             argument_context_string = '{} flexible-server server-logs {}'.format(command_group, scope)
             with self.argument_context(argument_context_string) as c:
                 c.argument('resource_group_name', arg_type=resource_group_name_type)
-                c.argument('server_name', id_part='name', options_list=['--server-name', '-s'], arg_type=server_name_arg_type)
+                if scope == "list":
+                    c.argument('server_name', options_list=['--server-name', '-s'], id_part=None, arg_type=server_name_arg_type)
+                else:
+                    c.argument('server_name', id_part='name', options_list=['--server-name', '-s'], arg_type=server_name_arg_type)
 
         with self.argument_context('{} flexible-server server-logs download'.format(command_group)) as c:
             c.argument('file_name', options_list=['--name', '-n'], nargs='+', help='Space-separated list of log filenames on the server to download.')
@@ -1004,7 +1010,7 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
             with self.argument_context('{} flexible-server private-endpoint-connection {}'.format(command_group, scope)) as c:
                 c.argument('resource_group_name', arg_type=resource_group_name_type)
                 if scope == "list":
-                    c.argument('server_name', options_list=['--server-name', '-s'], id_part='name', arg_type=server_name_arg_type, required=False)
+                    c.argument('server_name', options_list=['--server-name', '-s'], id_part=None, arg_type=server_name_arg_type, required=False)
                 else:
                     c.argument('server_name', options_list=['--server-name', '-s'], id_part='name', arg_type=server_name_arg_type, required=False,
                                help='Name of the Server. Required if --id is not specified')
@@ -1020,7 +1026,10 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
         for scope in ['list', 'show']:
             with self.argument_context('{} flexible-server private-link-resource {}'.format(command_group, scope)) as c:
                 c.argument('resource_group_name', arg_type=resource_group_name_type)
-                c.argument('server_name', options_list=['--server-name', '-s'], id_part='name', arg_type=server_name_arg_type, required=False)
+                if scope == 'list':
+                    c.argument('server_name', options_list=['--server-name', '-s'], id_part=None, arg_type=server_name_arg_type, required=False)
+                else:
+                    c.argument('server_name', options_list=['--server-name', '-s'], id_part='name', arg_type=server_name_arg_type, required=False)
 
         # GTID
         if command_group == 'mysql':


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
- az postgres flexible-server private-endpoint-connection list
- az postgres flexible-server private-link-resource list
- az postgres flexible-server server-logs list
- az postgres flexible-server virtual-endpoint list

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix linter issue and not exposing IDs parameter on the list command

**Testing Guide**
<!--Example commands with explanations.-->
Local testing

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[RDBMS] BREAKING CHANGE: `az postgres flexible-server private-endpoint-connection / private-link-resource / server-logs / virtual-endpoint list`: Fix linter issue and not exposing IDs parameter on the list command

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
