### PR TITLE
{CI} Use CFS in LTS release

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ trigger:
     include:
     - '*'
     exclude:
-    - 'release'
+    - 'release*'
 
 pr:
   branches:
@@ -210,7 +210,7 @@ jobs:
       artifactName: metadata
 
   - task: PipAuthenticate@1
-    condition: eq(variables['Build.SourceBranch'], 'refs/heads/release')
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/release')
     displayName: 'Pip Authenticate'
     inputs:
       artifactFeeds: $(AZURE_ARTIFACTS_FEEDS)
@@ -254,7 +254,7 @@ jobs:
         artifactName: metadata
 
     - task: PipAuthenticate@1
-      condition: eq(variables['Build.SourceBranch'], 'refs/heads/release')
+      condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/release')
       displayName: 'Pip Authenticate'
       inputs:
         artifactFeeds: $(AZURE_ARTIFACTS_FEEDS)
@@ -444,7 +444,7 @@ jobs:
       versionSpec: 3.12
 
   - task: PipAuthenticate@1
-    condition: eq(variables['Build.SourceBranch'], 'refs/heads/release')
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/release')
     displayName: 'Pip Authenticate'
     inputs:
       artifactFeeds: $(AZURE_ARTIFACTS_FEEDS)
@@ -732,7 +732,7 @@ jobs:
     displayName: Install Docker
 
   - task: PipAuthenticate@1
-    condition: eq(variables['Build.SourceBranch'], 'refs/heads/release')
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/release')
     displayName: 'Pip Authenticate'
     inputs:
       artifactFeeds: $(AZURE_ARTIFACTS_FEEDS)
@@ -828,7 +828,7 @@ jobs:
   - bash: ./scripts/ci/install_docker.sh
     displayName: Install Docker
   - task: PipAuthenticate@1
-    condition: eq(variables['Build.SourceBranch'], 'refs/heads/release')
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/release')
     displayName: 'Pip Authenticate'
     inputs:
       artifactFeeds: $(AZURE_ARTIFACTS_FEEDS)
@@ -950,7 +950,7 @@ jobs:
   - bash: ./scripts/ci/install_docker.sh
     displayName: Install Docker
   - task: PipAuthenticate@1
-    condition: eq(variables['Build.SourceBranch'], 'refs/heads/release')
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/release')
     displayName: 'Pip Authenticate'
     inputs:
       artifactFeeds: $(AZURE_ARTIFACTS_FEEDS)


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Supplement of https://github.com/Azure/azure-cli/pull/29866. Use CFS in the LTS release, such as `release-lts-2.66`.