### PR TITLE
[Storage] Fix #29929: `az storage copy`: Fix when wildcard `*` is in `--source-file-path`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_validators.py
@@ -2025,8 +2025,14 @@ def get_url_with_sas(cmd, namespace, url=None, container=None, blob=None, share=
         client = cf_blob_service(cmd.cli_ctx, kwargs)
         if blob is None:
             blob = ''
-        from .operations.blob import create_blob_url
-        url = create_blob_url(client, container, blob, snapshot=None)
+        if '*' in container or '*' in blob:
+            url = client.url
+            if not url.endswith('/'):
+                url = url + '/'
+            url = url + container + '/' + blob
+        else:
+            from .operations.blob import create_blob_url
+            url = create_blob_url(client, container, blob, snapshot=None)
         service = 'blob'
     elif share:
         if hasattr(namespace, 'enable_file_backup_request_intent'):

--- a/src/azure-cli/azure/cli/command_modules/storage/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_validators.py
@@ -2033,10 +2033,14 @@ def get_url_with_sas(cmd, namespace, url=None, container=None, blob=None, share=
             kwargs.update({'enable_file_backup_request_intent': namespace.enable_file_backup_request_intent})
         client = cf_share_service(cmd.cli_ctx, kwargs)
         client = client.get_share_client(share)
-        dir_name, file_name = os.path.split(file_path) if file_path else (None, '')
-        dir_name = None if dir_name in ('', '.') else dir_name
-        from .operations.file import create_file_url
-        url = create_file_url(client, directory_name=dir_name, file_name=file_name)
+        # if wildcard '*' in file path, skip manually parsing the url
+        if file_path and '*' in file_path:
+            url = client.url + '/' + file_path
+        else:
+            dir_name, file_name = os.path.split(file_path) if file_path else (None, '')
+            dir_name = None if dir_name in ('', '.') else dir_name
+            from .operations.file import create_file_url
+            url = create_file_url(client, directory_name=dir_name, file_name=file_name)
         service = 'file'
     elif not any([url, container, share]):  # In account level, only blob service is supported
         service = 'blob'

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/fileshare.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/fileshare.py
@@ -101,7 +101,7 @@ def _get_client(client, kwargs):
         directory_path = directory_path.replace('./', '', 1)
     dir_client = client.get_directory_client(directory_path=directory_path)
     file_name = kwargs.pop("file_name", None)
-    if file_name:
+    if file_name and file_name != '*':
         total_path = directory_path + '/' + file_name if directory_path else file_name
         dir_client = client.get_directory_client(directory_path=total_path)
         exists = False

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/fileshare.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/fileshare.py
@@ -101,7 +101,7 @@ def _get_client(client, kwargs):
         directory_path = directory_path.replace('./', '', 1)
     dir_client = client.get_directory_client(directory_path=directory_path)
     file_name = kwargs.pop("file_name", None)
-    if file_name and file_name != '*':
+    if file_name:
         total_path = directory_path + '/' + file_name if directory_path else file_name
         dir_client = client.get_directory_client(directory_path=total_path)
         exists = False


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix when wildcard `*` is in `--source-file-path`
Fix #29929 

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Storage] Fix #29929: `az storage copy`: Fix when wildcard `*` is in `--source-file-path`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
