### PR TITLE
{cli} Changes for adding an optional field for Filtering to Azure Cli commands for flowlogs resource creation and updation

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/watcher/flow_log/_delete.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/watcher/flow_log/_delete.py
@@ -22,9 +22,9 @@ class Delete(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2022-01-01",
+        "version": "2024-03-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/networkwatchers/{}/flowlogs/{}", "2022-01-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/networkwatchers/{}/flowlogs/{}", "2024-03-01"],
         ]
     }
 
@@ -85,7 +85,7 @@ class Delete(AAZCommand):
                 return self.client.build_lro_polling(
                     self.ctx.args.no_wait,
                     session,
-                    None,
+                    self.on_200_201,
                     self.on_error,
                     lro_options={"final-state-via": "location"},
                     path_format_arguments=self.url_parameters,
@@ -95,6 +95,15 @@ class Delete(AAZCommand):
                     self.ctx.args.no_wait,
                     session,
                     self.on_204,
+                    self.on_error,
+                    lro_options={"final-state-via": "location"},
+                    path_format_arguments=self.url_parameters,
+                )
+            if session.http_response.status_code in [200, 201]:
+                return self.client.build_lro_polling(
+                    self.ctx.args.no_wait,
+                    session,
+                    self.on_200_201,
                     self.on_error,
                     lro_options={"final-state-via": "location"},
                     path_format_arguments=self.url_parameters,
@@ -143,13 +152,16 @@ class Delete(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2022-01-01",
+                    "api-version", "2024-03-01",
                     required=True,
                 ),
             }
             return parameters
 
         def on_204(self, session):
+            pass
+
+        def on_200_201(self, session):
             pass
 
 

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/watcher/flow_log/_list.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/watcher/flow_log/_list.py
@@ -28,6 +28,8 @@ class List(AAZCommand):
         ]
     }
 
+    AZ_SUPPORT_PAGINATION = True
+
     def _handler(self, command_args):
         super()._handler(command_args)
         return self.build_paging(self._execute_operations, self._output)

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/watcher/flow_log/_show.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/watcher/flow_log/_show.py
@@ -25,9 +25,9 @@ class Show(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2022-01-01",
+        "version": "2024-03-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/networkwatchers/{}/flowlogs/{}", "2022-01-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/networkwatchers/{}/flowlogs/{}", "2024-03-01"],
         ]
     }
 
@@ -133,7 +133,7 @@ class Show(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2022-01-01",
+                    "api-version", "2024-03-01",
                     required=True,
                 ),
             }
@@ -184,6 +184,9 @@ class Show(AAZCommand):
 
             properties = cls._schema_on_200.properties
             properties.enabled = AAZBoolType()
+            properties.enabled_filtering_criteria = AAZStrType(
+                serialized_name="enabledFilteringCriteria",
+            )
             properties.flow_analytics_configuration = AAZObjectType(
                 serialized_name="flowAnalyticsConfiguration",
             )

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/watcher/flow_log/_update.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/watcher/flow_log/_update.py
@@ -40,9 +40,9 @@ class Update(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2023-11-01",
+        "version": "2024-03-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/networkwatchers/{}/flowlogs/{}", "2023-11-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/networkwatchers/{}/flowlogs/{}", "2024-03-01"],
         ]
     }
 
@@ -83,9 +83,6 @@ class Update(AAZCommand):
         _args_schema.location = AAZResourceLocationArg(
             help="Location to identify the exclusive Network Watcher under a region. Only one Network Watcher can be existed per subscription and region.",
             nullable=True,
-            fmt=AAZResourceLocationArgFormat(
-                resource_group_arg="resource_group",
-            ),
         )
         _args_schema.enabled = AAZBoolArg(
             options=["--enabled"],
@@ -156,6 +153,12 @@ class Update(AAZCommand):
         # define Arg Group "Properties"
 
         _args_schema = cls._args_schema
+        _args_schema.filtering_criteria = AAZStrArg(
+            options=["--filtering-criteria"],
+            arg_group="Properties",
+            help="Update condition to filter flowlogs based on SrcIP, SrcPort, DstIP, DstPort, Protocol, Encryption, Direction and Action. If not specified, all flowlogs will be logged.",
+            nullable=True,
+        )
         _args_schema.flow_analytics_configuration = AAZObjectArg(
             options=["--flow-analytics-configuration"],
             arg_group="Properties",
@@ -296,7 +299,7 @@ class Update(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2023-11-01",
+                    "api-version", "2024-03-01",
                     required=True,
                 ),
             }
@@ -399,7 +402,7 @@ class Update(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2023-11-01",
+                    "api-version", "2024-03-01",
                     required=True,
                 ),
             }
@@ -457,7 +460,7 @@ class Update(AAZCommand):
                 value=instance,
                 typ=AAZObjectType
             )
-            _builder.set_prop("identity", AAZObjectType, ".identity")
+            _builder.set_prop("identity", AAZIdentityObjectType, ".identity")
             _builder.set_prop("location", AAZStrType, ".location")
             _builder.set_prop("properties", AAZObjectType, typ_kwargs={"flags": {"client_flatten": True}})
             _builder.set_prop("tags", AAZDictType, ".tags")
@@ -474,6 +477,7 @@ class Update(AAZCommand):
             properties = _builder.get(".properties")
             if properties is not None:
                 properties.set_prop("enabled", AAZBoolType, ".enabled")
+                properties.set_prop("enabledFilteringCriteria", AAZStrType, ".filtering_criteria")
                 properties.set_prop("flowAnalyticsConfiguration", AAZObjectType, ".flow_analytics_configuration")
                 properties.set_prop("format", AAZObjectType)
                 properties.set_prop("retentionPolicy", AAZObjectType, ".retention_policy")
@@ -542,7 +546,7 @@ class _UpdateHelper:
             flags={"read_only": True},
         )
         flow_log_read.id = AAZStrType()
-        flow_log_read.identity = AAZObjectType()
+        flow_log_read.identity = AAZIdentityObjectType()
         flow_log_read.location = AAZStrType()
         flow_log_read.name = AAZStrType(
             flags={"read_only": True},
@@ -584,6 +588,9 @@ class _UpdateHelper:
 
         properties = _schema_flow_log_read.properties
         properties.enabled = AAZBoolType()
+        properties.enabled_filtering_criteria = AAZStrType(
+            serialized_name="enabledFilteringCriteria",
+        )
         properties.flow_analytics_configuration = AAZObjectType(
             serialized_name="flowAnalyticsConfiguration",
         )

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/watcher/flow_log/_wait.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/watcher/flow_log/_wait.py
@@ -20,7 +20,7 @@ class Wait(AAZWaitCommand):
 
     _aaz_info = {
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/networkwatchers/{}/flowlogs/{}", "2022-01-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/networkwatchers/{}/flowlogs/{}", "2024-03-01"],
         ]
     }
 
@@ -126,7 +126,7 @@ class Wait(AAZWaitCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2022-01-01",
+                    "api-version", "2024-03-01",
                     required=True,
                 ),
             }
@@ -177,6 +177,9 @@ class Wait(AAZWaitCommand):
 
             properties = cls._schema_on_200.properties
             properties.enabled = AAZBoolType()
+            properties.enabled_filtering_criteria = AAZStrType(
+                serialized_name="enabledFilteringCriteria",
+            )
             properties.flow_analytics_configuration = AAZObjectType(
                 serialized_name="flowAnalyticsConfiguration",
             )


### PR DESCRIPTION
**Related commands**

```
az network watcher flow-log create --location eastus2euap --resource-group riddhi_rg3 --name vnet-eastus2euap-flowlog --vnet vnet-eastus2euap --storage-account riddhisa3  --filtering-criteria "dstip=20.252.145.59 || DstPort=443"

az network watcher flow-log show --location eastus2euap --name vnet-eastus2euap-flowlog

```

**Description**<!--Mandatory-->
This PR introduces a new optional field, "filtering-criteria," for the creation and update of the Flowlogs resource. Necessary validations for this field have already been implemented in NRP. Unit tests for this feature have been added as part of this PR.

Additionally, screenshots of the testing performed, beyond unit tests, are included below.



**Testing Guide**
Help command shows the new field and its proper explanation:

![image](https://github.com/user-attachments/assets/6afe95f7-86c6-4562-86f5-569349e52701)

`az network watcher flow-log create --location eastus2euap --resource-group riddhi_rg3 --name vnet-eastus2euap-flowlog --vnet vnet-eastus2euap --storage-account riddhisa3  --filtering-criteria "dstip=20.252.145.59 || DstPort=443"`

![image](https://github.com/user-attachments/assets/c8eacd0d-cc7a-4901-aa6c-bb6a8c8421ae)

`az network watcher flow-log show --location eastus2euap --name vnet-eastus2euap-flowlog
`
![image](https://github.com/user-attachments/assets/cea634ad-40a5-48e2-9dc6-98a1b1d734ca)

Validations for filtering field happens in NRP
Expected error when the condition is not in the expected format of key value pairs combined with relational operators.
![image](https://github.com/user-attachments/assets/8b3ad7aa-2639-4605-a107-a287cecabaeb)

The length of the value passed to filtering-criteria should not exceed 1000.

![image](https://github.com/user-attachments/assets/6906d74e-af04-4571-b68e-e0bdc3413ec3)




**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
