### PR TITLE
{RDBMS} `az postgres flexible-server create`: Fix the comparator for sorting sku name so it also sort the core number too when displaying the error message

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/validators.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/validators.py
@@ -453,13 +453,24 @@ def _pg_tier_validator(tier, sku_info):
 
 
 def compare_sku_names(sku_1, sku_2):
-    regex_pattern = r"_v(\d)"
+    regex_pattern = r"\D+(?P<core_number>\d+)\D+(?P<version>\d*)"
 
     sku_1_match = re.search(regex_pattern, sku_1)
     sku_2_match = re.search(regex_pattern, sku_2)
 
-    return (int(sku_2_match.group(1)) if sku_2_match else 0) - \
-        (int(sku_1_match.group(1)) if sku_1_match else 0)
+    # the case where version number is different, sort by the version number first
+    if sku_1_match.group('version') and int(sku_2_match.group('version')) > int(sku_1_match.group('version')):
+        return 1
+    if sku_1_match.group('version') and int(sku_2_match.group('version')) < int(sku_1_match.group('version')):
+        return -1
+
+    # the case where version number is the same, we want to sort by the core number
+    if int(sku_2_match.group('core_number')) > int(sku_1_match.group('core_number')):
+        return 1
+    if int(sku_2_match.group('core_number')) < int(sku_1_match.group('core_number')):
+        return -1
+
+    return 0
 
 
 def _pg_sku_name_validator(sku_name, sku_info, tier, instance):


### PR DESCRIPTION
**Related command**
az postgres flexible-server create

**Description**<!--Mandatory-->
Fix the comparator for sorting sku name so it also sort the core number too when displaying the error message

**Testing Guide**
![image (2)](https://github.com/user-attachments/assets/02e186d4-3490-4fc3-aa19-f73616285034)

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

{RDBMS} `az postgres flexible-server create`: Fix the comparator for sorting sku name so it also sort the core number too when displaying the error message

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
