### PR TITLE
[Network] Fix #30535: `az network lb address-pool address add`: Address level may not have virtual network property

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/operations/load_balancer.py
+++ b/src/azure-cli/azure/cli/command_modules/network/operations/load_balancer.py
@@ -637,11 +637,6 @@ class LBAddressPoolAddressAdd(_LBAddressPoolAddressAdd):
             subnet = f"{virtual_network}/subnets/{subnet}"
             args.subnet = subnet
 
-        if not virtual_network and not subnet:
-            raise ArgumentUsageError(
-                "vnet or subnet is required."
-            )
-
     def _output(self, *args, **kwargs):
         result = self.deserialize_output(self.ctx.vars.instance, client_flatten=True)
         return result


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
fix: https://github.com/Azure/azure-cli/issues/30535

![image](https://github.com/user-attachments/assets/82bc3f43-afff-4f7e-9eb7-0dd52a242a5d)
The Vnet is added to the backend pool, so when customers try to pass in the Vnet via this command we get an NRP error. When no Vnet is applied we hit an error saying "Vnet or subnet is required" <- this limit should be removed.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
