### PR TITLE
{CI} Install specific version in script

### DIFF
--- a/scripts/release/debian/verify_debian_in_docker.sh
+++ b/scripts/release/debian/verify_debian_in_docker.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# This script should be run in a docker to verify installing deb package from the apt repository.
+# This script should be run in a docker to verify installing azure-cli in Ubuntu and Debian
 
 apt update -y
 apt install curl -y
@@ -9,6 +9,11 @@ counter=4
 while [ $counter -gt 0 ]
 do
     curl -sL https://aka.ms/InstallAzureCLIDeb | bash
+    apt-get remove azure-cli -y
+    AZ_DIST=$(lsb_release -cs)
+    # apt-get install azure-cli=2.67.0-1~noble
+    apt-get install azure-cli=${CLI_VERSION}-1~${AZ_DIST} -y
+
     ACTUAL_VERSION=$(az version | sed -n 's|"azure-cli": "\(.*\)",|\1|p' | sed 's|[[:space:]]||g')
     echo "actual version:${ACTUAL_VERSION}"
     echo "expected version:${CLI_VERSION}"

--- a/scripts/release/rpm/verify_rpm_in_docker.sh
+++ b/scripts/release/rpm/verify_rpm_in_docker.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# This script should be run in a docker to verify installing rpm package from the yum repository.
+# This script should be run in a docker to verify installing azure-cli in CentOS, RHEL and Azure Linux
 
 if [ "$IMPORT_KEY" == "true" ]; then
     rpm --import https://packages.microsoft.com/keys/microsoft.asc
@@ -12,7 +12,15 @@ fi
 counter=4
 
 while [ $counter -gt 0 ]; do
-    $DNF_COMMAND install azure-cli -y
+    $DNF_COMMAND clean all
+
+    if [ "$DNF_COMMAND" == "dnf" ]; then
+        # dnf install azure-cli-2.67.0-1.el9
+        $DNF_COMMAND install azure-cli-${CLI_VERSION}-1$(rpm --eval %{?dist}) -y
+    else
+        # tdnf install azure-cli=2.67.0
+        $DNF_COMMAND install azure-cli==${CLI_VERSION} -y
+    fi
     ACTUAL_VERSION=$(az version | sed -n 's|"azure-cli": "\(.*\)",|\1|p' | sed 's|[[:space:]]||g')
     echo "actual version:${ACTUAL_VERSION}"
     echo "expected version:${CLI_VERSION}"


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

We need to install a specific version to verify the LTS version. Update the script to install `CLI_VERSION` instead of the latest one.

**Testing Guide**
<!--Example commands with explanations.-->

`docker run -e CLI_VERSION=2.66.0 -v ./verify_debian_in_docker.sh:/verify_debian_in_docker.sh ubuntu:24.04 bash ./verify_debian_in_docker.sh`

`docker run -e CLI_VERSION=2.66.0 -v ./verify_debian_in_docker.sh:/verify_debian_in_docker.sh debian:12 bash ./verify_debian_in_docker.sh`

`docker run -e CLI_VERSION=2.66.0 -e IMPORT_KEY=false -e DNF_COMMAND=tdnf -v ./verify_rpm_in_docker.sh:/verify_rpm_in_docker.sh mcr.microsoft.com/cbl-mariner/base/core:2.0  bash ./verify_rpm_in_docker.sh`

`docker run -e CLI_VERSION=2.66.0 -e IMPORT_KEY=false -e DNF_COMMAND=tdnf -v ./verify_rpm_in_docker.sh:/verify_rpm_in_docker.sh mcr.microsoft.com/azurelinux/base/core:3.0  bash ./verify_rpm_in_docker.sh`

`docker run -e CLI_VERSION=2.66.0 -e IMPORT_KEY=true -e RPM_URL=https://packages.microsoft.com/config/rhel/9.0/packages-microsoft-prod.rpm -e DNF_COMMAND=dnf -v ./verify_rpm_in_docker.sh:/verify_rpm_in_docker.sh registry.access.redhat.com/ubi9/ubi:9.0.0  bash ./verify_rpm_in_docker.sh`


