### PR TITLE
[AppService] `az functionapp list-flexconsumption-locations`]: Check if flex region is enabled for subscription

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands.py
@@ -787,7 +787,7 @@ class FunctionappDapr(LiveScenarioTest):
 class FunctionAppFlex(LiveScenarioTest):
     def test_functionapp_list_flexconsumption_locations(self):
         locations = self.cmd('functionapp list-flexconsumption-locations').get_output_in_json()
-        self.assertTrue(len(locations) == 13)
+        self.assertTrue(len(locations) == 12)
 
     def test_functionapp_list_flexconsumption_locations_zone_redundant(self):
         locations = self.cmd('functionapp list-flexconsumption-locations --zone-redundant').get_output_in_json()


### PR DESCRIPTION
**Related command**
`az functionapp list-flexconsumption-locations`

**Description**<!--Mandatory-->
We need to check if the subscription has the flex region enabled before listing the flex consumption location.

**Testing Guide**
Run `az functionapp list-flexconsumption-locations` and ensure that the regions listed are those that are allow listed for your subscription. 

**History Notes**

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
