### PR TITLE
[Core] `aaz`: Support simple type parsed from string value

### DIFF
--- a/src/azure-cli-core/azure/cli/core/aaz/_field_type.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_field_type.py
@@ -51,8 +51,7 @@ class AAZSimpleType(AAZBaseType):
                 raise AAZInvalidValueError('Expect {}, got {} ({})'.format(self.DataType, data, type(data)))
             if not isinstance(json_data, self.DataType):
                 raise AAZInvalidValueError('Expect {}, got {} ({})'.format(self.DataType, data, type(data)))
-            else:
-                data = json_data
+            data = json_data
 
         return data
 

--- a/src/azure-cli-core/azure/cli/core/aaz/_field_type.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_field_type.py
@@ -5,6 +5,8 @@
 import abc
 
 from collections import OrderedDict
+
+from azure.cli.core.util import shell_safe_json_parse
 from ._base import AAZBaseType, AAZValuePatch, AAZUndefined
 from ._field_value import AAZObject, AAZDict, AAZFreeFormDict, AAZList, AAZSimpleValue, \
     AAZIdentityObject
@@ -43,7 +45,14 @@ class AAZSimpleType(AAZBaseType):
 
         assert self.DataType is not None
         if not isinstance(data, self.DataType):
-            raise AAZInvalidValueError('Expect {}, got {} ({})'.format(self.DataType, data, type(data)))
+            try:
+                json_data = shell_safe_json_parse(data)
+            except:  # pylint:disable=bare-except
+                raise AAZInvalidValueError('Expect {}, got {} ({})'.format(self.DataType, data, type(data)))
+            if not isinstance(json_data, self.DataType):
+                raise AAZInvalidValueError('Expect {}, got {} ({})'.format(self.DataType, data, type(data)))
+            else:
+                data = json_data
 
         return data
 
@@ -87,7 +96,19 @@ class AAZFloatType(AAZSimpleType):
             data = float(data)
 
         if not isinstance(data, self.DataType):
-            raise AAZInvalidValueError('Expect {}, got {} ({})'.format(self.DataType, data, type(data)))
+            try:
+                json_data = shell_safe_json_parse(data)
+            except:  # pylint:disable=bare-except
+                raise AAZInvalidValueError('Expect {}, got {} ({})'.format(self.DataType, data, type(data)))
+            if isinstance(json_data, int):
+                # transform int to float
+                if float(json_data) != json_data:
+                    raise AAZValuePrecisionLossError(json_data, float(json_data))
+                json_data = float(json_data)
+            if not isinstance(json_data, self.DataType):
+                raise AAZInvalidValueError('Expect {}, got {} ({})'.format(self.DataType, data, type(data)))
+            else:
+                data = json_data
 
         return data
 

--- a/src/azure-cli-core/azure/cli/core/aaz/_field_type.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_field_type.py
@@ -107,8 +107,7 @@ class AAZFloatType(AAZSimpleType):
                 json_data = float(json_data)
             if not isinstance(json_data, self.DataType):
                 raise AAZInvalidValueError('Expect {}, got {} ({})'.format(self.DataType, data, type(data)))
-            else:
-                data = json_data
+            data = json_data
 
         return data
 

--- a/src/azure-cli-core/azure/cli/core/tests/test_aaz_field.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_aaz_field.py
@@ -37,6 +37,17 @@ class TestAAZField(unittest.TestCase):
 
         with self.assertRaises(AAZInvalidValueError):
             v.properties.count = "a"
+        
+        with self.assertRaises(AAZInvalidValueError):
+            v.properties.count = "1a"
+        
+        with self.assertRaises(AAZInvalidValueError):
+            v.properties.count = "1.1"
+
+        # support string input with json parsing
+        v.properties.count = "12"
+        assert v.properties.count == 12
+        assert v.properties.count._data == 12
 
         # test string type
         model_schema.properties.name = AAZStrType()
@@ -70,6 +81,17 @@ class TestAAZField(unittest.TestCase):
         assert not v.properties.enable
         assert v.properties.enable is not False
 
+        with self.assertRaises(AAZInvalidValueError):
+            v.properties.enable = 1
+
+        # support string input with json parsing
+        v.properties.enable = "false"
+        v.properties.enable = "true"
+        assert v.properties.enable == True
+        assert not (v.properties.enable != True)
+        assert v.properties.enable
+        assert v.properties.enable is not True  # cannot us is
+
         # test float type
         model_schema.properties.height = AAZFloatType()
         v.properties.height = 10.0
@@ -86,6 +108,17 @@ class TestAAZField(unittest.TestCase):
         v.properties.height = 10  # test assign int
         assert str(v.properties.height) == "10.0"
 
+        with self.assertRaises(AAZInvalidValueError):
+            v.properties.height = "1a"
+        
+        v.properties.height = "12.1"
+        assert v.properties.height == 12.1
+        assert v.properties.height._data == 12.1
+
+        v.properties.height = "12"
+        assert v.properties.height == 12
+        assert v.properties.height._data == 12
+
         # test assign properties by dict
         v.properties = {
             "count": 100,
@@ -99,6 +132,21 @@ class TestAAZField(unittest.TestCase):
         assert v.properties.count._data == 100
         assert v.properties.enable._data == True
         assert v.properties.height._data == 111
+
+        # test assign properties by dict with all string value
+        v.properties = {
+            "count": "101",
+            "name": "abcd",
+            "enable": "False",
+            "height": "121"
+        }
+
+        assert not v.properties._is_patch
+        assert v.properties.name._data == "abcd"
+        assert v.properties.count._data == 101
+        assert v.properties.enable._data == False
+        assert v.properties.height._data == 121
+
 
     def test_aaz_dict_type(self):
         from azure.cli.core.aaz._field_type import AAZObjectType, AAZDictType, AAZStrType


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

The python SDK support to transform string to simple types such as int, bool, float. This PR added those support in aaz dev commands as well to backward compatible with the existing SDK command migration.

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
