### PR TITLE
{Packaging} Accelerate command execution in Docker image with warm start

### DIFF
--- a/azure-linux.dockerfile
+++ b/azure-linux.dockerfile
@@ -11,7 +11,7 @@ FROM $IMAGE
 RUN --mount=type=bind,target=/azure-cli.rpm,source=./docker-temp/azure-cli.rpm \
     tdnf install ca-certificates jq /azure-cli.rpm -y && \
     # Run az version to generate the commandIndex.json and speed up the following az commands
-    az version && cd ~/.azure && ls | grep -v commandIndex.json | xargs rm -rf && \
+    az version && cd ~/.azure && ls | grep --invert-match commandIndex.json | xargs rm -rf && \
     tdnf clean all && rm -rf /var/cache/tdnf
 
 # See https://github.com/Azure/azure-cli/issues/29828 for background on this

--- a/azure-linux.dockerfile
+++ b/azure-linux.dockerfile
@@ -8,7 +8,8 @@ FROM $IMAGE
 
 # ca-certificates: Azure Linux base image does not contain Mozilla CA certificates, install it to prevent CERTIFICATE_VERIFY_FAILED errors, see https://github.com/Azure/azure-cli/issues/26026
 # jq: It's widely used for parsing JSON output in Azure CLI and has a small size. See https://github.com/Azure/azure-cli/issues/29830
-RUN --mount=type=bind,target=/azure-cli.rpm,source=./docker-temp/azure-cli.rpm tdnf install ca-certificates jq /azure-cli.rpm -y && tdnf clean all && rm -rf /var/cache/tdnf
+# Run az version to generate the command index and speed up the following az commands
+RUN --mount=type=bind,target=/azure-cli.rpm,source=./docker-temp/azure-cli.rpm tdnf install ca-certificates jq /azure-cli.rpm -y && az version && tdnf clean all && rm -rf /var/cache/tdnf
 
 # See https://github.com/Azure/azure-cli/issues/29828 for background on this
 ENV AZ_BICEP_GLOBALIZATION_INVARIANT=1

--- a/azure-linux.dockerfile
+++ b/azure-linux.dockerfile
@@ -8,8 +8,11 @@ FROM $IMAGE
 
 # ca-certificates: Azure Linux base image does not contain Mozilla CA certificates, install it to prevent CERTIFICATE_VERIFY_FAILED errors, see https://github.com/Azure/azure-cli/issues/26026
 # jq: It's widely used for parsing JSON output in Azure CLI and has a small size. See https://github.com/Azure/azure-cli/issues/29830
-# Run az version to generate the command index and speed up the following az commands
-RUN --mount=type=bind,target=/azure-cli.rpm,source=./docker-temp/azure-cli.rpm tdnf install ca-certificates jq /azure-cli.rpm -y && az version && tdnf clean all && rm -rf /var/cache/tdnf
+RUN --mount=type=bind,target=/azure-cli.rpm,source=./docker-temp/azure-cli.rpm \
+    tdnf install ca-certificates jq /azure-cli.rpm -y && \
+    # Run az version to generate the commandIndex.json and speed up the following az commands
+    az version && cd ~/.azure && ls | grep -v commandIndex.json | xargs rm -rf && \
+    tdnf clean all && rm -rf /var/cache/tdnf
 
 # See https://github.com/Azure/azure-cli/issues/29828 for background on this
 ENV AZ_BICEP_GLOBALIZATION_INVARIANT=1


### PR DESCRIPTION
**Description**<!--Mandatory-->
Call `az version` during docker build to generate command index. This should accelerate the first command execution speed. 

It adds these files in `~/.azure`, and only `commandIndex.json` is kept in the image.
```
root [ ~/.azure ]# ls  ~/.azure
az.json  az.sess  az_survey.json  azureProfile.json  commandIndex.json  commands  config  logs  telemetry  versionCheck.json
```

This reminds me of https://github.com/Azure/azure-cli/issues/19183, where the user complains that the first invocation is slow.

-------------

CLI also tries to get latest version from GitHub and save `versionCheck.json` in fresh installation, which takes 2s on my machine. I believe it's also not necessary. Source code: https://github.com/Azure/azure-cli/blob/a29d2e78ac30942b98427627e4f2c4a598bc1eeb/src/azure-cli-core/azure/cli/core/__init__.py#L85

When releasing new docker image, the main branch version is not changed yet, so the `versionCheck.json` is outdated. I don't want to cache an outdated file. https://github.com/Azure/azure-cli/pull/30671 fixes this issue.



**Testing Guide**

```bash
docker run --rm -it test bash -c 'time az account -h'
real    0m2.245s
user    0m0.370s
sys     0m0.037s

docker run --rm -it mcr.microsoft.com/azure-cli:2.68.0-azurelinux3.0 bash -c 'time az account -h'
real    0m4.208s
user    0m2.082s
sys     0m0.252s
```