### PR TITLE
{Misc.} `az --version`: Show config directory location

### DIFF
--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -363,6 +363,7 @@ def _get_local_versions():
 
 def get_az_version_string(use_cache=False):  # pylint: disable=too-many-statements
     from azure.cli.core.extension import get_extensions, EXTENSIONS_DIR, DEV_EXTENSION_SOURCES, EXTENSIONS_SYS_DIR
+    from azure.cli.core._environment import get_config_dir
     import io
     output = io.StringIO()
     versions = _get_local_versions()
@@ -410,6 +411,7 @@ def get_az_version_string(use_cache=False):  # pylint: disable=too-many-statemen
     _print()
 
     _print("Python location '{}'".format(os.path.abspath(sys.executable)))
+    _print("Config directory '{}'".format(get_config_dir()))
     _print("Extensions directory '{}'".format(EXTENSIONS_DIR))
     if os.path.isdir(EXTENSIONS_SYS_DIR) and os.listdir(EXTENSIONS_SYS_DIR):
         _print("Extensions system directory '{}'".format(EXTENSIONS_SYS_DIR))


### PR DESCRIPTION
**Related command**
`az --version`

**Description**<!--Mandatory-->
Show the config directory location actually used by Azure CLI in the output of `az --version`.

The default config directory is `$HOME/.azure` and can be overridden with `AZURE_CONFIG_DIR`: https://learn.microsoft.com/en-us/cli/azure/azure-cli-configuration#cli-configuration-file

Currently, it is not very convenient to get the config directory location: https://github.com/actions/runner-images/pull/11173#discussion_r1916144221. It is only shown in the `--debug` log.

**Testing Guide**
```
> az --version
azure-cli                         2.68.0

core                              2.68.0
telemetry                          1.1.0

Extensions:
ssh                                2.0.6

Dependencies:
msal                              1.31.0
azure-mgmt-resource               23.1.1

Python location 'D:\cli\py312\Scripts\python.exe'
Config directory 'C:\Users\xxx\.azure'
Extensions directory 'C:\Users\xxx\.azure\cliextensions'

Python (Windows) 3.12.8 (tags/v3.12.8:2dc476b, Dec  3 2024, 19:30:04) [MSC v.1942 64 bit (AMD64)]

Legal docs and information: aka.ms/AzureCliLegal
```
