### PR TITLE
{RDBMS} `az postgres flexible-server backup delete`: change user confirmation so it refers to server name instead of resource group

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
@@ -1438,7 +1438,7 @@ def backup_delete_func(client, resource_group_name, server_name, backup_name, ye
 
     if not yes:
         user_confirmation(
-            "Are you sure you want to delete the backup '{0}' in resource group '{1}'".format(backup_name, resource_group_name), yes=yes)
+            "Are you sure you want to delete the backup '{0}' in server '{1}'".format(backup_name, server_name), yes=yes)
 
     return client.begin_delete(
         resource_group_name,


### PR DESCRIPTION
**Related command**
az postgres flexible-server backup delete

**Description**<!--Mandatory-->
Change user confirmation so it refers to server name instead of resource group

**Testing Guide**
Manual testing

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

{RDBMS} `az postgres flexible-server backup delete`: change user confirmation so it refers to server name instead of resource group

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
