### PR TITLE
[Core] BREAKING CHANGE: Change get_config_dir to honor XDG spec

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_environment.py
+++ b/src/azure-cli-core/azure/cli/core/_environment.py
@@ -10,4 +10,20 @@ _ENV_AZ_BICEP_GLOBALIZATION_INVARIANT = 'AZ_BICEP_GLOBALIZATION_INVARIANT'
 
 def get_config_dir():
     import os
-    return os.getenv('AZURE_CONFIG_DIR', None) or os.path.expanduser(os.path.join('~', '.azure'))
+    def sanitize(*d):
+        return os.path.expanduser(os.path.expandvars(os.path.join(*d)))
+    
+    # Directory set in env has precedence
+    if env := os.getenv('AZURE_CONFIG_DIR'):
+        return sanitize(env)
+    
+    # Honor XDG variables
+    if env := os.getenv('XDG_CONFIG_HOME'):
+        return sanitize(env, 'azure')
+    
+    # Or the default fallover directory conform the XDG Base Directory Specification
+    if os.path.isdir(sanitize('~', '.config')):
+        return sanitize('~', '.config', 'azure')
+    
+    # If all others fail, return a dot-dir in the user's home directory.
+    return sanitize('~', '.azure')


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
This commit modifies the `get_config_dir` function to honor the XDG Base Directory Specification in accordance with https://specifications.freedesktop.org/basedir-spec/latest/, and falls back to a dot-dir in the user's home directory if the relevant environment variables and home directories do not exist.

**Testing Guide**
<!--Example commands with explanations.-->
On running the az cli, it should now refer to '${XDG_CONFIG_HOME}/azure', or '${HOME}/.config/azure'.
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
