### PR TITLE
[AppService] `az webapp list-runtimes`: Remove the JBoss '_byol' entries from the output for webapps with Linux OS

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -4134,7 +4134,7 @@ class _StackRuntimeHelper(_AbstractStackRuntimeHelper):
                     (linux_container_settings.java11_runtime, "11", linux_container_settings.is_auto_update),
                     (linux_container_settings.java8_runtime, "8", linux_container_settings.is_auto_update)]
                 # Remove the JBoss'_byol' entries from the output
-                runtimes = [(r, v, au) for (r, v, au) in runtimes if r is not None and not(r.endswith("_byol"))]    # pylint: disable=line-too-long
+                runtimes = [(r, v, au) for (r, v, au) in runtimes if r is not None and not r.endswith("_byol")]    # pylint: disable=line-too-long
                 for runtime_name, version, auto_update in [(r, v, au) for (r, v, au) in runtimes if r is not None]:
                     runtime = self.Runtime(display_name=runtime_name,
                                            configs={"linux_fx_version": runtime_name},

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -4133,6 +4133,8 @@ class _StackRuntimeHelper(_AbstractStackRuntimeHelper):
                     (linux_container_settings.additional_properties.get("java17Runtime"), "17", linux_container_settings.is_auto_update),    # pylint: disable=line-too-long
                     (linux_container_settings.java11_runtime, "11", linux_container_settings.is_auto_update),
                     (linux_container_settings.java8_runtime, "8", linux_container_settings.is_auto_update)]
+                # Remove the JBoss'_byol' entries from the output
+                runtimes = [(r, v, au) for (r, v, au) in runtimes if r is not None and not(r.endswith("_byol"))]    # pylint: disable=line-too-long
                 for runtime_name, version, auto_update in [(r, v, au) for (r, v, au) in runtimes if r is not None]:
                     runtime = self.Runtime(display_name=runtime_name,
                                            configs={"linux_fx_version": runtime_name},


### PR DESCRIPTION
**Related command**

`az webapp list-runtimes`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

App Service Linux uses internal variants of the JBoss EAP runtimes with a `_byol` suffix in their name and those should be removed from the output to avoid confusion.

**Testing Guide**

Running `az webapp list-runtimes --os linux` should not contain any entries which had `_byol` in their runtime name.

Before:
```
> az webapp list-runtimes --os linux
[
...(omitted)...
  "JBOSSEAP:8-java17",
  "JBOSSEAP:8-java11",
  "JBOSSEAP:8-java17_byol",
  "JBOSSEAP:8-java11_byol",
  "JBOSSEAP:7-java17",
  "JBOSSEAP:7-java11",
  "JBOSSEAP:7-java8",
  "JBOSSEAP:7-java17_byol",
  "JBOSSEAP:7-java11_byol",
  "JBOSSEAP:7-java8_byol",
...(omitted)...
```

After:
```
az webapp list-runtimes --os linux
[
...(omitted)...
  "JBOSSEAP:8-java17",
  "JBOSSEAP:8-java11",
  "JBOSSEAP:7-java17",
  "JBOSSEAP:7-java11",
  "JBOSSEAP:7-java8",
...(omitted)...
```


**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
