### PR TITLE
[RDBMS] `az postgres flexible-server geo-restore`: add optional `--restore-time` parameter

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
@@ -687,6 +687,7 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
                 c.argument('public_access', options_list=['--public-access'], arg_type=get_enum_type(['Enabled', 'Disabled']),
                            help='Determines the public access. ')
             elif command_group == 'postgres':
+                c.argument('restore_point_in_time', arg_type=restore_point_in_time_arg_type)
                 c.argument('geo_redundant_backup', default='Disabled', arg_type=geo_redundant_backup_arg_type)
                 c.argument('byok_key', arg_type=key_arg_type)
                 c.argument('byok_identity', arg_type=identity_arg_type)

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
@@ -615,7 +615,7 @@ def flexible_replica_create(cmd, client, resource_group_name, source_server, rep
 def flexible_server_georestore(cmd, client, resource_group_name, server_name, source_server, location, zone=None,
                                vnet=None, vnet_address_prefix=None, subnet=None, subnet_address_prefix=None,
                                private_dns_zone_arguments=None, geo_redundant_backup=None, no_wait=False, yes=False,
-                               byok_identity=None, byok_key=None, backup_byok_identity=None, backup_byok_key=None):
+                               byok_identity=None, byok_key=None, backup_byok_identity=None, backup_byok_key=None, restore_point_in_time=None):
     validate_resource_group(resource_group_name)
 
     server_name = server_name.lower()
@@ -631,6 +631,8 @@ def flexible_server_georestore(cmd, client, resource_group_name, server_name, so
             raise CLIError('The provided source-server {} is invalid.'.format(source_server))
     else:
         source_server_id = source_server
+
+    restore_point_in_time = validate_and_format_restore_point_in_time(restore_point_in_time)
 
     try:
         id_parts = parse_resource_id(source_server_id)
@@ -659,7 +661,7 @@ def flexible_server_georestore(cmd, client, resource_group_name, server_name, so
     storage = postgresql_flexibleservers.models.Storage(type=None)
 
     parameters = postgresql_flexibleservers.models.Server(
-        point_in_time_utc=get_current_time(),
+        point_in_time_utc=restore_point_in_time,
         location=location,
         source_server_resource_id=source_server_id,
         create_mode="GeoRestore",

--- a/src/azure-cli/azure/cli/command_modules/rdbms/validators.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/validators.py
@@ -808,7 +808,7 @@ def validate_and_format_restore_point_in_time(restore_time):
         return parser.parse(restore_time)
     except:
         raise ValidationError("The restore point in time value has incorrect date format. "
-                              "Please use ISO format e.g., 2021-10-22T00:08:23+00:00.")
+                              "Please use ISO format e.g., 2024-10-22T00:08:23+00:00.")
 
 
 def is_citus_cluster(cmd, resource_group_name, server_name):


### PR DESCRIPTION
**Related command**
az postgres flexible-server geo-restore

**Description**<!--Mandatory-->
Add optional `--restore-time` parameter. From [_params.py](https://github.com/Azure/azure-cli/blob/fc511f6a1ef7ade727b42d836a76539c6e737322/src/azure-cli/azure/cli/command_modules/rdbms/_params.py#L475-L479), the default value is `get_current_time()`, which is the exact value we're passing without the argument. Therefore, this is not a breaking change.

**Testing Guide**
Manual testing

**History Notes**

[RDBMS] `az postgres flexible-server geo-restore`: add `--restore-time` parameter

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
