### PR TITLE
[ARM] `az bicep`: Fix installation check for concurrent usages

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
@@ -122,8 +122,7 @@ def ensure_bicep_installation(cli_ctx, release_tag=None, target_platform=None, s
             return
 
     installation_dir = os.path.dirname(installation_path)
-    if not os.path.exists(installation_dir):
-        os.makedirs(installation_dir)
+    os.makedirs(installation_dir, exist_ok=True)
 
     try:
         release_tag = release_tag if release_tag else get_bicep_latest_release_tag()


### PR DESCRIPTION
**Related command**
`az bicep`

**Description**<!--Mandatory-->
If `az bicep` is called by multiple processes or threads the code has a race condition. By simply allowing for the directory to exist, the same behavior as before is achieved without failing in concurrent usages.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
