### PR TITLE
{Core} Bump MSAL to 1.31.2b1

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -53,7 +53,7 @@ DEPENDENCIES = [
     'jmespath',
     'knack~=0.11.0',
     'msal-extensions==1.2.0',
-    'msal[broker]==1.31.1',
+    'msal[broker]==1.31.2b1',
     'msrestazure~=0.6.4',
     'packaging>=20.9',
     'pkginfo>=1.5.0.1',

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -104,7 +104,7 @@ jmespath==0.9.5
 jsondiff==2.0.0
 knack==0.11.0
 msal-extensions==1.2.0
-msal[broker]==1.31.1
+msal[broker]==1.31.2b1
 msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -105,7 +105,7 @@ jmespath==0.9.5
 jsondiff==2.0.0
 knack==0.11.0
 msal-extensions==1.2.0
-msal[broker]==1.31.1
+msal[broker]==1.31.2b1
 msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -104,7 +104,7 @@ jmespath==0.9.5
 jsondiff==2.0.0
 knack==0.11.0
 msal-extensions==1.2.0
-msal[broker]==1.31.1
+msal[broker]==1.31.2b1
 msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2


### PR DESCRIPTION
**Related command**
`az account get-access-token`

**Description**<!--Mandatory-->
Bump MSAL to 1.31.2b1 to adopt https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/785 which fixes https://github.com/AzureAD/microsoft-authentication-library-for-python/issues/784.

After migrating Cloud Shell authentication to MSAL (https://github.com/Azure/azure-cli/pull/29637), in Cloud Shell, `az account get-access-token` fails if `--resource` is a GUID:

```
$ az account get-access-token --resource 6dae42f8-4368-4678-94ff-3960e28e3630
A Cloud Shell credential problem occurred. When you report the issue with the error below, please mention the hostname 'SandboxHost-638736411959985933'
Audience 6dae42f8-4368-4678-94ff-3960e28e3630/.default is not a supported MSI token audience.
```

This PR fixes this issue. 

**Testing Guide**
In Cloud Shell, run

```sh
# ARM
az account get-access-token --scope https://management.azure.com//.default --debug
az account get-access-token --resource https://management.azure.com/ --debug

# AKS
az account get-access-token --scope https://aks-aad-server.azure.com/.default
az account get-access-token --resource https://aks-aad-server.azure.com
az account get-access-token --scope 6dae42f8-4368-4678-94ff-3960e28e3630/.default
az account get-access-token --resource 6dae42f8-4368-4678-94ff-3960e28e3630
```

The AKS Microsoft Entra server application ID `6dae42f8-4368-4678-94ff-3960e28e3630` is officially documented: https://learn.microsoft.com/en-us/azure/aks/kubelogin-authentication#how-to-use-kubelogin-with-aks
