### PR TITLE
{App Service} Fix #25882: `az webapp up`: AttributeError: module 'os' has no attribute 'join' in `test_webapp_up_dotnet6_e2e`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_up_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_up_commands.py
@@ -477,7 +477,7 @@ class WebAppUpE2ETests(ScenarioTest):
         # the zip contains more than one projects, it is assumed that the user is in this directory
         # when he makes the webapp up.
         up_working_dir = temp_dir
-        os.chdir(os.join(up_working_dir, "WebApplication1"))
+        os.chdir(os.path.join(up_working_dir, "dotnet6-webapi-with-dependencies-up"))
 
         # test dryrun operation
         result = self.cmd('webapp up -n {} --dryrun --os-type Linux'


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az webapp up

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fixes #25882 

**Testing Guide**
<!--Example commands with explanations.-->
azdev test test_webapp_up_dotnet6_e2e --live

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
