### PR TITLE
{doc} Remove invalid command group ref in `service_name.json`

### DIFF
--- a/src/azure-cli/service_name.json
+++ b/src/azure-cli/service_name.json
@@ -190,11 +190,6 @@
     "URL": "https://learn.microsoft.com/azure/azure-resource-manager/templates/template-tutorial-deployment-script"
   },
   {
-    "Command": "az deploymentmanager",
-    "AzureServiceName": "Resource Manager",
-    "URL": "https://learn.microsoft.com/azure/azure-resource-manager/templates/deployment-manager-overview"
-  },
-  {
     "Command": "az stack",
     "AzureServiceName": "Resource Manager",
     "URL": "https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/deployment-stacks"
@@ -368,11 +363,6 @@
     "Command": "az network",
     "AzureServiceName": "Networking",
     "URL": "https://azure.microsoft.com/product-categories/networking"
-  },
-  {
-    "Command": "az openshift",
-    "AzureServiceName": "Red Hat OpenShift",
-    "URL": "https://learn.microsoft.com/azure/openshift"
   },
   {
     "Command": "az pipelines",


### PR DESCRIPTION
The following Azure CLI reference groups are no longer being published but still exist in the `service_name.json` file. This is creating build warnings in MicrosoftDocs/azure-docs-cli.

![image](https://github.com/user-attachments/assets/004f2da6-4df1-4e0a-87f6-6cf055748646)