### PR TITLE
{RDBMS} `az postgres flexible-server firewall-rule`: Update validations and message for fire wall rule commands

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_common.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_common.py
@@ -86,6 +86,8 @@ def firewall_rule_create_func(cmd, client, resource_group_name, server_name, fir
         end_ip_address = start_ip_address
     elif start_ip_address is None and end_ip_address is not None:
         start_ip_address = end_ip_address
+    elif start_ip_address is None and end_ip_address is None:
+        raise CLIError("Incorrect Usage : Need to pass in value for either \'--start-ip-address\' or \'--end-ip-address\'.")
 
     if firewall_rule_name is None:
         now = datetime.now()

--- a/src/azure-cli/azure/cli/command_modules/rdbms/validators.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/validators.py
@@ -841,7 +841,7 @@ def validate_public_access_server(cmd, client, resource_group_name, server_name)
 
     server = server_operations_client.get(resource_group_name, server_name)
     if server.network.public_network_access == 'Disabled':
-        raise ValidationError("Firewall rule operations cannot be requested for a private access enabled server.")
+        raise ValidationError("Firewall rule operations cannot be requested for a server that doesn't have public access enabled.")
 
 
 def _validate_identity(cmd, namespace, identity):

--- a/src/azure-cli/azure/cli/command_modules/rdbms/validators.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/validators.py
@@ -841,7 +841,8 @@ def validate_public_access_server(cmd, client, resource_group_name, server_name)
 
     server = server_operations_client.get(resource_group_name, server_name)
     if server.network.public_network_access == 'Disabled':
-        raise ValidationError("Firewall rule operations cannot be requested for a server that doesn't have public access enabled.")
+        raise ValidationError("Firewall rule operations cannot be requested for "
+                              "a server that doesn't have public access enabled.")
 
 
 def _validate_identity(cmd, namespace, identity):


### PR DESCRIPTION
**Related command**
az postgres flexible-server firewall-rule

**Description**<!--Mandatory-->
az postgres flexible-server firewall-rule create needs to validate that either --start-ip-address or --end-ip-address are passed. Otherwise, it constructs a request with an empty body that returns an InternalServerError.''

Change the text of this error, to the following:
 
Firewall rule operations cannot be requested for a server that doesn't have public access enabled.


**Testing Guide**
Manual
Validate stat or end has to be passed
![image](https://github.com/user-attachments/assets/39841b3c-57d2-48ee-9fc0-cc514fc63be5)

Update error text
![image](https://github.com/user-attachments/assets/c6d6581b-554c-407f-a2fc-07b40c51fc66)


**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
