### PR TITLE
{Batch} Set `credential_scopes` when creating `BatchClient`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/batch/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/batch/_client_factory.py
@@ -51,8 +51,7 @@ def batch_data_client_factory(cli_ctx, kwargs):
     if not token_credential and not account_key:
         from azure.cli.core._profile import Profile
         profile = Profile(cli_ctx=cli_ctx)
-        resource = cli_ctx.cloud.endpoints.batch_resource_id
-        token_credential, _, _ = profile.get_login_credentials(resource=resource)
+        token_credential, _, _ = profile.get_login_credentials()
 
     if account_key:
         from azure.core.credentials import AzureNamedKeyCredential
@@ -64,4 +63,6 @@ def batch_data_client_factory(cli_ctx, kwargs):
             account_endpoint.startswith('http://')):
         account_endpoint = 'https://' + account_endpoint
 
-    return BatchClient(credential=credential, endpoint=account_endpoint.rstrip('/'))
+    from azure.cli.core.auth.util import resource_to_scopes
+    return BatchClient(credential=credential, endpoint=account_endpoint.rstrip('/'),
+                       credential_scopes=resource_to_scopes(cli_ctx.cloud.endpoints.batch_resource_id))

--- a/src/azure-cli/azure/cli/command_modules/batch/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/batch/_validators.py
@@ -332,8 +332,7 @@ def validate_client_parameters(cmd, namespace):
         # check to see if we are using the default credentials
         from azure.cli.core._profile import Profile
         profile = Profile(cli_ctx=cmd.cli_ctx)
-        resource = cmd.cli_ctx.cloud.endpoints.batch_resource_id
-        token_credential, _, _ = profile.get_login_credentials(resource=resource)
+        token_credential, _, _ = profile.get_login_credentials()
 
         # if not we query for the account key
         if token_credential is None:


### PR DESCRIPTION
**Related command**
`az batch`

**Description**<!--Mandatory-->
The Track 2 migration for `azure-batch` SDK (https://github.com/Azure/azure-cli/pull/30501) is incomplete - it doesn't set `credential_scopes` when creating `BatchClient`.

This will cause failure in sovereign clouds as different clouds have different `batch_resource_id`:

https://github.com/Azure/azure-cli/blob/58145231ac574303e8f64e38044cc0a39ca90013/src/azure-cli-core/azure/cli/core/cloud.py#L365

https://github.com/Azure/azure-cli/blob/58145231ac574303e8f64e38044cc0a39ca90013/src/azure-cli-core/azure/cli/core/cloud.py#L402

https://github.com/Azure/azure-cli/blob/58145231ac574303e8f64e38044cc0a39ca90013/src/azure-cli-core/azure/cli/core/cloud.py#L433

https://github.com/Azure/azure-cli/blob/58145231ac574303e8f64e38044cc0a39ca90013/src/azure-cli-core/azure/cli/core/cloud.py#L465
