### PR TITLE
{dls} Set `scopes` when creating `AzureDLFileSystem`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/dls/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/dls/_client_factory.py
@@ -25,9 +25,11 @@ def cf_dls_account_trusted_provider(cli_ctx, _):
 def cf_dls_filesystem(cli_ctx, account_name):
     from azure.datalake.store import core
     from azure.cli.core._profile import Profile
+    from azure.cli.core.auth.util import resource_to_scopes
 
     cred, _, _ = Profile(cli_ctx=cli_ctx).get_login_credentials()
     return core.AzureDLFileSystem(
         token_credential=cred,
         store_name=account_name,
-        url_suffix=cli_ctx.cloud.suffixes.azure_datalake_store_file_system_endpoint)
+        url_suffix=cli_ctx.cloud.suffixes.azure_datalake_store_file_system_endpoint,
+        scopes=resource_to_scopes(cli_ctx.cloud.endpoints.active_directory_data_lake_resource_id)[0])


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
The Track 2 migration for `azure-datalake-store` SDK (https://github.com/Azure/azure-cli/pull/30770) is incomplete - it doesn't set `scopes` when creating `AzureDLFileSystem`.

