### PR TITLE
{Batch} Set `audience` when creating `LogsQueryClient`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_client_factory.py
@@ -130,10 +130,10 @@ def cf_log_analytics_data_plane(cli_ctx, _):
     from azure.monitor.query import LogsQueryClient
     from azure.cli.core._profile import Profile
     profile = Profile(cli_ctx=cli_ctx)
-    cred, _, _ = profile.get_login_credentials(
-        resource=cli_ctx.cloud.endpoints.log_analytics_resource_id)
+    cred, _, _ = profile.get_login_credentials()
     api_version = 'v1'
-    return LogsQueryClient(cred, endpoint=cli_ctx.cloud.endpoints.log_analytics_resource_id + '/' + api_version)
+    return LogsQueryClient(cred, endpoint=cli_ctx.cloud.endpoints.log_analytics_resource_id + '/' + api_version,
+                           audience=cli_ctx.cloud.endpoints.log_analytics_resource_id)
 
 
 def cf_disk_encryption_set(cli_ctx, _):

--- a/src/azure-cli/azure/cli/command_modules/vm/azure_stack/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/azure_stack/_client_factory.py
@@ -130,10 +130,10 @@ def cf_log_analytics_data_plane(cli_ctx, _):
     from azure.monitor.query import LogsQueryClient
     from azure.cli.core._profile import Profile
     profile = Profile(cli_ctx=cli_ctx)
-    cred, _, _ = profile.get_login_credentials(
-        resource=cli_ctx.cloud.endpoints.log_analytics_resource_id)
+    cred, _, _ = profile.get_login_credentials()
     api_version = 'v1'
-    return LogsQueryClient(cred, endpoint=cli_ctx.cloud.endpoints.log_analytics_resource_id + '/' + api_version)
+    return LogsQueryClient(cred, endpoint=cli_ctx.cloud.endpoints.log_analytics_resource_id + '/' + api_version,
+                           audience=cli_ctx.cloud.endpoints.log_analytics_resource_id)
 
 
 def cf_disk_encryption_set(cli_ctx, _):


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
The migration to `azure-monitor-query` SDK (https://github.com/Azure/azure-cli/pull/30501) is incomplete - it doesn't set `audience` when creating `LogsQueryClient`.