### PR TITLE
{Synapse} Set `credential_scopes` when creating clients

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/synapse/manual/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/synapse/manual/_client_factory.py
@@ -105,17 +105,18 @@ def cf_kusto_pool(cli_ctx, *_):
 def synapse_spark_factory(cli_ctx, workspace_name, sparkpool_name):
     from azure.synapse.spark import SparkClient
     from azure.cli.core._profile import Profile
+    # Uncomment this line after SparkClient is fixed. See https://github.com/Azure/azure-cli/pull/30788
+    # from azure.cli.core.auth.util import resource_to_scopes
     from azure.cli.core.commands.client_factory import get_subscription_id
     subscription_id = get_subscription_id(cli_ctx)
     profile = Profile(cli_ctx=cli_ctx)
-    cred, _, _ = profile.get_login_credentials(
-        resource=cli_ctx.cloud.endpoints.synapse_analytics_resource_id,
-        subscription_id=subscription_id
-    )
+    cred, _, _ = profile.get_login_credentials(subscription_id=subscription_id)
     return SparkClient(
         credential=cred,
         endpoint='{}{}{}'.format("https://", workspace_name, cli_ctx.cloud.suffixes.synapse_analytics_endpoint),
-        spark_pool_name=sparkpool_name
+        spark_pool_name=sparkpool_name,
+        # Uncomment this line after SparkClient is fixed
+        # credential_scopes=resource_to_scopes(cli_ctx.cloud.endpoints.synapse_analytics_resource_id)
     )
 
 
@@ -130,16 +131,15 @@ def cf_synapse_spark_session(cli_ctx, workspace_name, sparkpool_name):
 def synapse_accesscontrol_factory(cli_ctx, workspace_name):
     from azure.synapse.accesscontrol import AccessControlClient
     from azure.cli.core._profile import Profile
+    from azure.cli.core.auth.util import resource_to_scopes
     from azure.cli.core.commands.client_factory import get_subscription_id
     subscription_id = get_subscription_id(cli_ctx)
     profile = Profile(cli_ctx=cli_ctx)
-    cred, _, _ = profile.get_login_credentials(
-        resource=cli_ctx.cloud.endpoints.synapse_analytics_resource_id,
-        subscription_id=subscription_id
-    )
+    cred, _, _ = profile.get_login_credentials(subscription_id=subscription_id)
     return AccessControlClient(
         credential=cred,
-        endpoint='{}{}{}'.format("https://", workspace_name, cli_ctx.cloud.suffixes.synapse_analytics_endpoint)
+        endpoint='{}{}{}'.format("https://", workspace_name, cli_ctx.cloud.suffixes.synapse_analytics_endpoint),
+        credential_scopes=resource_to_scopes(cli_ctx.cloud.endpoints.synapse_analytics_resource_id)
     )
 
 
@@ -160,16 +160,15 @@ def cf_graph_client_factory(cli_ctx, **_):
 def cf_synapse_client_artifacts_factory(cli_ctx, workspace_name):
     from azure.synapse.artifacts import ArtifactsClient
     from azure.cli.core._profile import Profile
+    from azure.cli.core.auth.util import resource_to_scopes
     from azure.cli.core.commands.client_factory import get_subscription_id
     subscription_id = get_subscription_id(cli_ctx)
     profile = Profile(cli_ctx=cli_ctx)
-    cred, _, _ = profile.get_login_credentials(
-        resource=cli_ctx.cloud.endpoints.synapse_analytics_resource_id,
-        subscription_id=subscription_id
-    )
+    cred, _, _ = profile.get_login_credentials(subscription_id=subscription_id)
     return ArtifactsClient(
         credential=cred,
-        endpoint='{}{}{}'.format("https://", workspace_name, cli_ctx.cloud.suffixes.synapse_analytics_endpoint)
+        endpoint='{}{}{}'.format("https://", workspace_name, cli_ctx.cloud.suffixes.synapse_analytics_endpoint),
+        credential_scopes=resource_to_scopes(cli_ctx.cloud.endpoints.synapse_analytics_resource_id)
     )
 
 
@@ -216,16 +215,15 @@ def cf_synapse_library(cli_ctx, workspace_name):
 def cf_synapse_client_managedprivateendpoints_factory(cli_ctx, workspace_name):
     from azure.synapse.managedprivateendpoints import VnetClient
     from azure.cli.core._profile import Profile
+    from azure.cli.core.auth.util import resource_to_scopes
     from azure.cli.core.commands.client_factory import get_subscription_id
     subscription_id = get_subscription_id(cli_ctx)
     profile = Profile(cli_ctx=cli_ctx)
-    cred, _, _ = profile.get_login_credentials(
-        resource=cli_ctx.cloud.endpoints.synapse_analytics_resource_id,
-        subscription_id=subscription_id
-    )
+    cred, _, _ = profile.get_login_credentials(subscription_id=subscription_id)
     return VnetClient(
         credential=cred,
-        endpoint='{}{}{}'.format("https://", workspace_name, cli_ctx.cloud.suffixes.synapse_analytics_endpoint)
+        endpoint='{}{}{}'.format("https://", workspace_name, cli_ctx.cloud.suffixes.synapse_analytics_endpoint),
+        credential_scopes=resource_to_scopes(cli_ctx.cloud.endpoints.synapse_analytics_resource_id)
     )
 
 


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
`credential_scopes` is not set when creating `azure.synapse` clients.

This will cause failure in sovereign clouds as different clouds have different `synapse_analytics_resource_id`:

https://github.com/Azure/azure-cli/blob/58145231ac574303e8f64e38044cc0a39ca90013/src/azure-cli-core/azure/cli/core/cloud.py#L378

https://github.com/Azure/azure-cli/blob/58145231ac574303e8f64e38044cc0a39ca90013/src/azure-cli-core/azure/cli/core/cloud.py#L414

https://github.com/Azure/azure-cli/blob/58145231ac574303e8f64e38044cc0a39ca90013/src/azure-cli-core/azure/cli/core/cloud.py#L445

