### PR TITLE
{App Service} Call `get_token()` with `scopes`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -3446,9 +3446,11 @@ def _get_site_credential(cli_ctx, resource_group_name, name, slot=None):
 
 def get_bearer_token(cli_ctx):
     from azure.cli.core._profile import Profile
+    from azure.cli.core.auth.util import resource_to_scopes
     profile = Profile(cli_ctx=cli_ctx)
     credential, _, _ = profile.get_login_credentials()
-    bearer_token = credential.get_token().token
+    scopes = resource_to_scopes(cli_ctx.cloud.endpoints.active_directory_resource_id)
+    bearer_token = credential.get_token(*scopes).token
     return bearer_token
 
 


### PR DESCRIPTION
**Related command**
`az webapp deploy`

**Description**<!--Mandatory-->
Calling `get_token()` without `scopes` is no longer supported (https://github.com/Azure/azure-cli/pull/29690). After Track 1 SDK authentication removal (https://github.com/Azure/azure-cli/pull/29631), these tests fails

```
FAILED src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py::AppServiceLogTest::test_download_win_web_log
FAILED src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py::WebappZipDeployScenarioTest::test_deploy_zip
FAILED src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py::WebappDeploymentLogsScenarioTest::test_webapp_list_deployment_logs
FAILED src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py::WebappDeploymentLogsScenarioTest::test_webapp_show_deployment_logs
FAILED src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py::WebappOneDeployScenarioTest::test_one_deploy_arm
FAILED src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py::WebappOneDeployScenarioTest::test_one_deploy_scm
FAILED src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py::TrackRuntimeStatusTest::test_webapp_deployment_source_disable_tracking_runtimestatus
FAILED src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py::TrackRuntimeStatusTest::test_webapp_deployment_source_track_runtimestatus_buildfailed
FAILED src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py::TrackRuntimeStatusTest::test_webapp_deployment_source_track_runtimestatus_runtimefailed
FAILED src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py::TrackRuntimeStatusTest::test_webapp_deployment_source_track_runtimestatus_runtimesucessful
FAILED src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py::TrackRuntimeStatusTest::test_webapp_track_runtimestatus_buildfailed
FAILED src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py::TrackRuntimeStatusTest::test_webapp_track_runtimestatus_runtimefailed
FAILED src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py::TrackRuntimeStatusTest::test_webapp_track_runtimestatus_runtimesucessful
```

https://dev.azure.com/azclitools/public/_build/results?buildId=219257&view=logs&j=3791f883-8843-5e94-fc79-c8ca993c0a42&t=fc099b28-42bc-5603-6ee8-d61b88ef47c8

```py
self = <azure.cli.testsdk.patches.patch_retrieve_token_for_user.<locals>.get_user_credential_mock.<locals>.UserCredentialMock object at 0x7f7307d80fe0>
scopes = (), kwargs = {}

    def get_token(self, *scopes, **kwargs):  # pylint: disable=unused-argument
        # Old Track 2 SDKs are no longer supported. ***/pull/29690
>       assert len(scopes) == 1, "'scopes' must contain only one element."
E       AssertionError: 'scopes' must contain only one element.

src/azure-cli-testsdk/azure/cli/testsdk/patches.py:73: AssertionError
```

The access token is used to call `scm_url` (such as `https://webapp-win-log000002.scm.azurewebsites.net`), but the token's audience is ARM (`https://management.core.windows.net/`). This seems incorrect.
