### PR TITLE
{AMS} Remove unnecessary `resource` argument

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/ams/operations/sp.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/operations/sp.py
@@ -42,8 +42,7 @@ def reset_sp_credentials_for_mediaservice(cmd, client, account_name, resource_gr
     sp_oid = aad_sp['id']  # pylint: disable=unsubscriptable-object
 
     profile = Profile(cli_ctx=cmd.cli_ctx)
-    _, _, tenant_id = profile.get_login_credentials(
-        resource=cmd.cli_ctx.cloud.endpoints.active_directory_graph_resource_id)
+    _, _, tenant_id = profile.get_login_credentials()
 
     subscription_id = get_subscription_id(cmd.cli_ctx)
 
@@ -84,8 +83,7 @@ def create_or_update_assign_sp_to_mediaservice(cmd, client, account_name, resour
     app_object_id = aad_application['id']
 
     profile = Profile(cli_ctx=cmd.cli_ctx)
-    _, _, tenant_id = profile.get_login_credentials(
-        resource=cmd.cli_ctx.cloud.endpoints.active_directory_graph_resource_id)
+    _, _, tenant_id = profile.get_login_credentials()
     created_password = add_sp_password(graph_client, entity_name_string='password', app_id=app_object_id,
                                        password_display_name=password_display_name, years=years)
 
@@ -104,8 +102,7 @@ def create_or_update_assign_sp_to_mediaservice(cmd, client, account_name, resour
 def _update_sp(cmd, graph_client, aad_sp, ams, account_name, resource_group_name, display_name,
                new_sp_name, role, years, sp_password, xml):
     profile = Profile(cli_ctx=cmd.cli_ctx)
-    _, _, tenant_id = profile.get_login_credentials(
-        resource=cmd.cli_ctx.cloud.endpoints.active_directory_graph_resource_id)
+    _, _, tenant_id = profile.get_login_credentials()
     sp_oid = aad_sp['id']
     app_id = aad_sp['appId']
     app_object_id = _get_application_object_id(graph_client, app_id)


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
Track 1 SDK authentication will be dropped by https://github.com/Azure/azure-cli/pull/29631.

Actually, the returned credential is discarded, so no access token is retrieved.
