### PR TITLE
{Containerapp} Use `get_mgmt_service_client` to create `ServiceLinkerManagementClient`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/containerapp/_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/containerapp/_utils.py
@@ -412,12 +412,8 @@ def parse_secret_flags(secret_list):
 
 
 def get_linker_client(cmd):
-    resource = cmd.cli_ctx.cloud.endpoints.active_directory_resource_id
-    profile = Profile(cli_ctx=cmd.cli_ctx)
-    credential, subscription_id, _ = profile.get_login_credentials(
-        subscription_id=get_subscription_id(cmd.cli_ctx), resource=resource)
-    linker_client = ServiceLinkerManagementClient(credential)
-    return linker_client
+    from azure.cli.core.commands.client_factory import get_mgmt_service_client
+    return get_mgmt_service_client(cmd.cli_ctx, ServiceLinkerManagementClient)
 
 
 def validate_binding_name(binding_name):


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
Mgmt-plane SDK client should be created by `get_mgmt_service_client`, not manually created.
