### PR TITLE
{Core} Add deviceId in CLI telemetry to share with VS code

### DIFF
--- a/src/azure-cli-core/azure/cli/core/telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry.py
@@ -158,6 +158,7 @@ class TelemetrySession:  # pylint: disable=too-many-instance-attributes
             'Context.Default.VS.Core.Distro.Id': _get_distro_id(),  # eg. 'centos'
             'Context.Default.VS.Core.Distro.Version': _get_distro_version(),  # eg. '8.4.2105'
             'Context.Dafault.VS.Core.Istty': str(sys.stdin.isatty()),
+            'Context.Default.VS.Core.User.DeviceId': _get_device_id(),
             'Context.Default.VS.Core.User.Id': _get_installation_id(),
             'Context.Default.VS.Core.User.IsMicrosoftInternal': 'False',
             'Context.Default.VS.Core.User.IsOptedIn': 'True',
@@ -569,6 +570,13 @@ def _get_secrets_warning_config():
 def _get_core_version():
     from azure.cli.core import __version__ as core_version
     return core_version
+
+
+@decorators.suppress_all_exceptions(fallback_return=None)
+def _get_device_id():
+    # This is a shared id with VS code telemetry
+    from deviceid import get_device_id
+    return get_device_id()
 
 
 @decorators.suppress_all_exceptions(fallback_return=None)

--- a/src/azure-cli-core/azure/cli/core/telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry.py
@@ -158,7 +158,7 @@ class TelemetrySession:  # pylint: disable=too-many-instance-attributes
             'Context.Default.VS.Core.Distro.Id': _get_distro_id(),  # eg. 'centos'
             'Context.Default.VS.Core.Distro.Version': _get_distro_version(),  # eg. '8.4.2105'
             'Context.Dafault.VS.Core.Istty': str(sys.stdin.isatty()),
-            'Context.Default.VS.Core.User.DeviceId': _get_device_id(),
+            'Context.Default.VS.Core.DevDeviceId': _get_device_id(),
             'Context.Default.VS.Core.User.Id': _get_installation_id(),
             'Context.Default.VS.Core.User.IsMicrosoftInternal': 'False',
             'Context.Default.VS.Core.User.IsOptedIn': 'True',

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -52,6 +52,7 @@ DEPENDENCIES = [
     'humanfriendly~=10.0',
     'jmespath',
     'knack~=0.11.0',
+    'microsoft-security-utilities-secret-masker~=1.0.0b2',
     'msal-extensions==1.2.0',
     'msal[broker]==1.31.2b1',
     'msrestazure~=0.6.4',
@@ -61,8 +62,8 @@ DEPENDENCIES = [
     'psutil>=5.9; sys_platform != "cygwin"',
     'PyJWT>=2.1.0',
     'pyopenssl>=17.1.0',  # https://github.com/pyca/pyopenssl/pull/612
+    'py-deviceid',
     'requests[socks]',
-    'microsoft-security-utilities-secret-masker~=1.0.0b2',
 ]
 
 with open('README.rst', 'r', encoding='utf-8') as f:


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
We want a shared deviceId in the telemetry to join CLI telemetry and VS code telemetry. VS code provides https://pypi.org/project/py-deviceid/ lib to generate the same device id for each device which can be used by VS code and CLI (or any other client tools)

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
