### PR TITLE
[App Service] `az webapp deploy`: Add `--pull-identity` parameter to enable MSI authentication for pull based deployments

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -815,8 +815,8 @@ subscription than the app service environment, please use the resource ID for --
         c.argument('reset', help='Reset Java apps to the default parking page if set to true with no type specified.', arg_type=get_three_state_flag())
         c.argument('timeout', type=int, help='Timeout for the deployment operation in milliseconds. Ignored when using "--src-url" since synchronous deployments are not yet supported when using "--src-url"')
         c.argument('slot', help="The name of the slot. Default to the productions slot if not specified.")
-        c.argument('track_status', help="If true, web app startup status during deployment will be tracked for linux web apps.",
-                   arg_type=get_three_state_flag())
+        c.argument('track_status', help="If true, web app startup status during deployment will be tracked for linux web apps.", arg_type=get_three_state_flag())
+        c.argument('pull_identity', help="AAD identity used for pull based deployments. 'system' will use the app's system assigned identy. An user assigned identity can be used by providing the client ID. Only available for Windows WebApps. Support for Linux WebApps coming soon.")
         c.argument('enable_kudu_warmup', help="If true, kudu will be warmed up before performing deployment for a linux webapp.",
                    arg_type=get_three_state_flag())
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_one_deploy_pull_with_MSI.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_one_deploy_pull_with_MSI.yaml
@@ -1,0 +1,1389 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - appservice plan create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --sku
+      User-Agent:
+      - AZURECLI/2.69.0 azsdk-python-core/1.31.0 Python/3.10.11 (Windows-10-10.0.26100-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_webapp_OneDeploy000001?api-version=2022-09-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001","name":"cli_test_webapp_OneDeploy000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","test":"test_one_deploy_pull_with_MSI","date":"2025-02-26T00:08:46Z","module":"appservice"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '405'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 26 Feb 2025 00:08:49 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 673948E5EDE6461E94A63F988FE487C6 Ref B: CO6AA3150218039 Ref C: 2025-02-26T00:08:49Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "westeurope", "sku": {"name": "S1", "tier": "STANDARD", "capacity":
+      1}, "properties": {"perSiteScaling": false, "isXenon": false, "zoneRedundant":
+      false}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - appservice plan create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '167'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -n --sku
+      User-Agent:
+      - AZURECLI/2.69.0 azsdk-python-core/1.31.0 Python/3.10.11 (Windows-10-10.0.26100-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/serverfarms/webapp-oneDeploy-plan000003?api-version=2023-01-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/serverfarms/webapp-oneDeploy-plan000003","name":"webapp-oneDeploy-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"westeurope","properties":{"serverFarmId":109253,"name":"webapp-oneDeploy-plan000003","sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1},"workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"cli_test_webapp_OneDeploy000001-WestEuropewebspace","subscription":"d4913c61-6ff7-4316-8390-bdf6dce3fc0c","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":0,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        Europe","perSiteScaling":false,"elasticScaleEnabled":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"cli_test_webapp_OneDeploy000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-377_109253","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"kubeEnvironmentProfile":null,"zoneRedundant":false,"migrateToVMSS":null,"vnetConnectionsUsed":null,"vnetConnectionsMax":null,"createdTime":"2025-02-26T00:08:57.57"},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1686'
+      content-type:
+      - application/json
+      date:
+      - Wed, 26 Feb 2025 00:09:00 GMT
+      etag:
+      - '"1DB87E2A1B03540"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '12000'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '800'
+      x-msedge-ref:
+      - 'Ref A: DF3E4601CEE64B77B26D7E1C498CCF8A Ref B: CO6AA3150219049 Ref C: 2025-02-26T00:08:49Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --plan
+      User-Agent:
+      - AZURECLI/2.69.0 azsdk-python-core/1.31.0 Python/3.10.11 (Windows-10-10.0.26100-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/serverfarms/webapp-oneDeploy-plan000003?api-version=2023-01-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/serverfarms/webapp-oneDeploy-plan000003","name":"webapp-oneDeploy-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
+        Europe","properties":{"serverFarmId":109253,"name":"webapp-oneDeploy-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"cli_test_webapp_OneDeploy000001-WestEuropewebspace","subscription":"d4913c61-6ff7-4316-8390-bdf6dce3fc0c","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        Europe","perSiteScaling":false,"elasticScaleEnabled":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"cli_test_webapp_OneDeploy000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-377_109253","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"kubeEnvironmentProfile":null,"zoneRedundant":false,"migrateToVMSS":null,"vnetConnectionsUsed":0,"vnetConnectionsMax":2,"createdTime":"2025-02-26T00:08:57.57"},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1606'
+      content-type:
+      - application/json
+      date:
+      - Wed, 26 Feb 2025 00:09:01 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 1A834BB724194132892A30F60F8CE5AE Ref B: CO6AA3150217053 Ref C: 2025-02-26T00:09:01Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "webapp-oneDeploy-test000002", "type": "Site"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '55'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -n --plan
+      User-Agent:
+      - AZURECLI/2.69.0 azsdk-python-core/1.31.0 Python/3.10.11 (Windows-10-10.0.26100-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/checknameavailability?api-version=2023-12-01
+  response:
+    body:
+      string: '{"nameAvailable":true,"reason":"","message":""}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '47'
+      content-type:
+      - application/json
+      date:
+      - Wed, 26 Feb 2025 00:09:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 6BD0A8A41C534A179D28C1A86FCABB4A Ref B: CO6AA3150219047 Ref C: 2025-02-26T00:09:02Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --plan
+      User-Agent:
+      - AZURECLI/2.69.0 azsdk-python-core/1.31.0 Python/3.10.11 (Windows-10-10.0.26100-SP0)
+    method: GET
+    uri: https://management.azure.com/providers/Microsoft.Web/webAppStacks?api-version=2023-01-01
+  response:
+    body:
+      string: '{"value":[{"id":null,"name":"dotnet","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":".NET","value":"dotnet","preferredOs":"windows","majorVersions":[{"displayText":".NET
+        9 (STS)","value":"dotnet9","minorVersions":[{"displayText":".NET 9 (STS)","value":"9","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v9.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"9.x"}},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|9.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"9.x"},"supportedFeatures":{"disableSsh":true}}}}]},{"displayText":".NET
+        8 (LTS)","value":"dotnet8","minorVersions":[{"displayText":".NET 8 (LTS)","value":"8","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v8.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.x"}},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|8.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.x"},"supportedFeatures":{"disableSsh":true}}}}]},{"displayText":".NET
+        7 (STS)","value":"dotnet7","minorVersions":[{"displayText":".NET 7 (STS)","value":"7","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v7.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.x"},"endOfLifeDate":"2024-05-14T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|7.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.x"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2024-05-14T00:00:00Z"}}}]},{"displayText":".NET
+        6","value":"dotnet6","minorVersions":[{"displayText":".NET 6 (LTS)","value":"6","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v6.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"6.0.x"}},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|6.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"6.0.x"},"supportedFeatures":{"disableSsh":true}}}}]},{"displayText":".NET
+        5","value":"dotnet5","minorVersions":[{"displayText":".NET 5","value":"5","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v5.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"5.0.x"},"endOfLifeDate":"2022-05-08T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|5.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"5.0.x"},"endOfLifeDate":"2022-05-08T00:00:00Z"}}}]},{"displayText":".NET
+        Core 3","value":"dotnetcore3","minorVersions":[{"displayText":".NET Core 3.1
+        (LTS)","value":"3.1","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"3.1","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.1.301"},"isDeprecated":true,"endOfLifeDate":"2022-12-03T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|3.1","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.1.301"},"isDeprecated":true,"endOfLifeDate":"2022-12-03T00:00:00Z"}}},{"displayText":".NET
+        Core 3.0","value":"3.0","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"3.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.0.103"},"endOfLifeDate":"2020-03-03T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|3.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.0.103"},"endOfLifeDate":"2020-03-03T00:00:00Z"}}}]},{"displayText":".NET
+        Core 2","value":"dotnetcore2","minorVersions":[{"displayText":".NET Core 2.2","value":"2.2","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"2.2","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"2.2.207"},"endOfLifeDate":"2019-12-23T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|2.2","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"2.2.207"},"endOfLifeDate":"2019-12-23T00:00:00Z"}}},{"displayText":".NET
+        Core 2.1 (LTS)","value":"2.1","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"2.1","remoteDebuggingSupported":false,"isDeprecated":true,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"2.1.807"},"endOfLifeDate":"2021-07-21T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|2.1","remoteDebuggingSupported":false,"isDeprecated":true,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"2.1.807"},"endOfLifeDate":"2021-07-21T00:00:00Z"}}},{"displayText":".NET
+        Core 2.0","value":"2.0","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"2.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"2.1.202"},"endOfLifeDate":"2018-10-01T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|2.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"2.1.202"},"endOfLifeDate":"2018-10-01T00:00:00Z"}}}]},{"displayText":".NET
+        Core 1","value":"dotnetcore1","minorVersions":[{"displayText":".NET Core 1.1","value":"1.1","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.1","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"1.1.14"},"endOfLifeDate":"2019-06-27T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|1.1","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"1.1.14"},"endOfLifeDate":"2019-06-27T00:00:00Z"}}},{"displayText":".NET
+        Core 1.0","value":"1.0","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"1.1.14"},"endOfLifeDate":"2019-06-27T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|1.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"1.1.14"},"endOfLifeDate":"2019-06-27T00:00:00Z"}}}]},{"displayText":"ASP.NET
+        V4","value":"aspdotnetv4","minorVersions":[{"displayText":"ASP.NET V4.8","value":"v4.8","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v4.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.1"}}}}]},{"displayText":"ASP.NET
+        V3","value":"aspdotnetv3","minorVersions":[{"displayText":"ASP.NET V3.5","value":"v3.5","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v2.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"2.1"}}}}]}]}},{"id":null,"name":"node","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"Node","value":"node","preferredOs":"linux","majorVersions":[{"displayText":"Node
+        LTS","value":"lts","minorVersions":[{"displayText":"Node LTS","value":"lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|lts","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true}}}}]},{"displayText":"Node
+        22","value":"22","minorVersions":[{"displayText":"Node 22 LTS","value":"22-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|22-lts","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"22.x"},"supportedFeatures":{"disableSsh":true}}}}]},{"displayText":"Node
+        20","value":"20","minorVersions":[{"displayText":"Node 20 LTS","value":"20-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|20-lts","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"20.x"},"supportedFeatures":{"disableSsh":true}},"windowsRuntimeSettings":{"runtimeVersion":"~20","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"20.x"}}}}]},{"displayText":"Node
+        18","value":"18","minorVersions":[{"displayText":"Node 18 LTS","value":"18-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|18-lts","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"18.x"},"supportedFeatures":{"disableSsh":true}},"windowsRuntimeSettings":{"runtimeVersion":"~18","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"18.x"}}}}]},{"displayText":"Node
+        16","value":"16","minorVersions":[{"displayText":"Node 16 LTS","value":"16-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|16-lts","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"16.x"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2023-09-11T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"~16","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"16.x"},"endOfLifeDate":"2023-09-11T00:00:00Z"}}}]},{"displayText":"Node
+        14","value":"14","minorVersions":[{"displayText":"Node 14 LTS","value":"14-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|14-lts","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"14.x"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2023-04-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"~14","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"14.x"},"endOfLifeDate":"2023-04-30T00:00:00Z"}}}]},{"displayText":"Node
+        12","value":"12","minorVersions":[{"displayText":"Node 12 LTS","value":"12-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|12-lts","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"12.x"},"endOfLifeDate":"2022-04-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"12.13.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2022-04-01T00:00:00Z"}}},{"displayText":"Node
+        12.9","value":"12.9","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|12.9","isDeprecated":true,"remoteDebuggingSupported":true,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"12.x"},"endOfLifeDate":"2022-04-01T00:00:00Z"}}}]},{"displayText":"Node
+        10","value":"10","minorVersions":[{"displayText":"Node 10 LTS","value":"10-LTS","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|10-lts","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"10.x"},"endOfLifeDate":"2021-04-01T00:00:00Z"}}},{"displayText":"Node
+        10.16","value":"10.16","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|10.16","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"10.x"},"endOfLifeDate":"2021-04-01T00:00:00Z"}}},{"displayText":"Node
+        10.15","value":"10.15","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"10.15.2","isDeprecated":true,"isPreview":true,"isHidden":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"10.x"},"endOfLifeDate":"2021-04-01T00:00:00Z"}}},{"displayText":"Node
+        10.14","value":"10.14","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|10.14","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"10.x"},"endOfLifeDate":"2021-04-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"10.14.1","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"10.x"},"endOfLifeDate":"2021-04-01T00:00:00Z"}}},{"displayText":"Node
+        10.12","value":"10.12","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|10.12","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"10.x"},"endOfLifeDate":"2021-04-01T00:00:00Z"}}},{"displayText":"Node
+        10.10","value":"10.10","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|10.10","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"10.x"},"endOfLifeDate":"2021-04-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"10.0.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"10.x"},"endOfLifeDate":"2021-04-01T00:00:00Z"}}},{"displayText":"Node
+        10.6","value":"10.6","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|10.6","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"10.x"},"endOfLifeDate":"2021-04-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"10.6.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2021-04-01T00:00:00Z"}}},{"displayText":"Node
+        10.1","value":"10.1","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|10.1","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"10.x"},"endOfLifeDate":"2021-04-01T00:00:00Z"}}}]},{"displayText":"Node
+        9","value":"9","minorVersions":[{"displayText":"Node 9.4","value":"9.4","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|9.4","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2019-06-30T00:00:00Z"}}}]},{"displayText":"Node
+        8","value":"8","minorVersions":[{"displayText":"Node 8 LTS","value":"8-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|8-lts","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2019-12-31T00:00:00Z"}}},{"displayText":"Node
+        8.12","value":"8.12","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|8.12","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2019-12-31T00:00:00Z"}}},{"displayText":"Node
+        8.11","value":"8.11","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|8.11","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2019-12-31T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"8.11","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2019-12-31T00:00:00Z"}}},{"displayText":"Node
+        8.10","value":"8.10","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"8.10","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2019-12-31T00:00:00Z"}}},{"displayText":"Node
+        8.9","value":"8.9","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|8.9","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2019-12-31T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"8.9","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2019-12-31T00:00:00Z"}}},{"displayText":"Node
+        8.8","value":"8.8","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|8.8","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2019-12-31T00:00:00Z"}}},{"displayText":"Node
+        8.5","value":"8.5","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"8.5","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2019-12-31T00:00:00Z"}}},{"displayText":"Node
+        8.4","value":"8.4","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"8.4","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2019-12-31T00:00:00Z"}}},{"displayText":"Node
+        8.2","value":"8.2","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|8.2","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2019-12-31T00:00:00Z"}}},{"displayText":"Node
+        8.1","value":"8.1","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|8.1","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2019-12-31T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"8.1.4","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2019-12-31T00:00:00Z"}}},{"displayText":"Node
+        8.0","value":"8.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|8.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2019-12-31T00:00:00Z"}}}]},{"displayText":"Node
+        7","value":"7","minorVersions":[{"displayText":"Node 7.10","value":"7.10","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"7.10.1","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2017-06-30T00:00:00Z"}}}]},{"displayText":"Node
+        6","value":"6","minorVersions":[{"displayText":"Node 6 LTS","value":"6-LTS","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|6-lts","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2019-04-30T00:00:00Z"}}},{"displayText":"Node
+        6.12","value":"6.12","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"6.12","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2019-04-30T00:00:00Z"}}},{"displayText":"Node
+        6.11","value":"6.11","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|6.11","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2019-04-30T00:00:00Z"}}},{"displayText":"Node
+        6.10","value":"6.10","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|6.10","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2019-04-30T00:00:00Z"}}},{"displayText":"Node
+        6.9","value":"6.9","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|6.9","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2019-04-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"6.9.5","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2019-04-30T00:00:00Z"}}},{"displayText":"Node
+        6.6","value":"6.6","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|6.6","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2019-04-30T00:00:00Z"}}},{"displayText":"Node
+        6.5","value":"6.5","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"6.5.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2019-04-30T00:00:00Z"}}},{"displayText":"Node
+        6.2","value":"6.2","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|6.2","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2019-04-30T00:00:00Z"}}}]},{"displayText":"Node
+        4","value":"4","minorVersions":[{"displayText":"Node 4.8","value":"4.8","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|4.8","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2018-04-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"4.8","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2018-04-30T00:00:00Z"}}},{"displayText":"Node
+        4.5","value":"4.5","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|4.5","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2018-04-30T00:00:00Z"}}},{"displayText":"Node
+        4.4","value":"4.4","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|4.4","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2018-04-30T00:00:00Z"}}}]}]}},{"id":null,"name":"python","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"Python","value":"python","preferredOs":"linux","majorVersions":[{"displayText":"Python
+        3","value":"3","minorVersions":[{"displayText":"Python 3.12","value":"3.12","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.12","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.12"},"supportedFeatures":{"disableSsh":true}}}},{"displayText":"Python
+        3.11","value":"3.11","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.11","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.11"},"supportedFeatures":{"disableSsh":true},"isHidden":false}}},{"displayText":"Python
+        3.10","value":"3.10","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.10","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.10"},"supportedFeatures":{"disableSsh":true},"isHidden":false,"isEarlyAccess":false}}},{"displayText":"Python
+        3.9","value":"3.9","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.9","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.9"},"supportedFeatures":{"disableSsh":true},"isHidden":false}}},{"displayText":"Python
+        3.8","value":"3.8","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.8","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.8"},"supportedFeatures":{"disableSsh":true}}}},{"displayText":"Python
+        3.7","value":"3.7","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.7","remoteDebuggingSupported":false,"isDeprecated":true,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.7"},"supportedFeatures":{"disableSsh":true}}}},{"displayText":"Python
+        3.6","value":"3.6","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.6","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.6"}},"windowsRuntimeSettings":{"runtimeVersion":"3.4.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.6"}}}}]},{"displayText":"Python
+        2","value":"2","minorVersions":[{"displayText":"Python 2.7","value":"2.7","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|2.7","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"2.7"},"endOfLifeDate":"2020-02-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"2.7.3","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"2.7"},"endOfLifeDate":"2020-02-01T00:00:00Z"}}}]}]}},{"id":null,"name":"php","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"PHP","value":"php","preferredOs":"linux","majorVersions":[{"displayText":"PHP
+        8","value":"8","minorVersions":[{"displayText":"PHP 8.3","value":"8.3","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|8.3","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.3"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2026-11-23T00:00:00Z"}}},{"displayText":"PHP
+        8.2","value":"8.2","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|8.2","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.2"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2025-12-08T00:00:00Z"}}},{"displayText":"PHP
+        8.1","value":"8.1","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|8.1","isHidden":false,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.1"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2023-11-26T00:00:00Z"}}},{"displayText":"PHP
+        8.0","value":"8.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|8.0","isHidden":false,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.0"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2023-11-26T00:00:00Z"}}}]},{"displayText":"PHP
+        7","value":"7","minorVersions":[{"displayText":"PHP 7.4","value":"7.4","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"7.4","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.4","notSupportedInCreates":true},"isDeprecated":true,"endOfLifeDate":"2022-11-30T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"PHP|7.4","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.4","notSupportedInCreates":true},"isDeprecated":true,"endOfLifeDate":"2022-11-30T00:00:00Z"}}},{"displayText":"PHP
+        7.3","value":"7.3","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|7.3","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.3","notSupportedInCreates":true},"endOfLifeDate":"2021-12-06T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"7.3","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.3","notSupportedInCreates":true},"endOfLifeDate":"2021-12-06T00:00:00Z"}}},{"displayText":"PHP
+        7.2","value":"7.2","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|7.2","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2020-11-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"7.2","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2020-11-30T00:00:00Z"}}},{"displayText":"PHP
+        7.1","value":"7.1","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"7.1","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2020-02-01T00:00:00Z"}}},{"displayText":"7.0","value":"7.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|7.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2020-02-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"7.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2020-02-01T00:00:00Z"}}}]},{"displayText":"PHP
+        5","value":"5","minorVersions":[{"displayText":"PHP 5.6","value":"5.6","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|5.6","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2021-02-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"5.6","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2021-02-01T00:00:00Z"}}}]}]}},{"id":null,"name":"ruby","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"Ruby","value":"ruby","preferredOs":"linux","majorVersions":[{"displayText":"Ruby
+        2","value":"2","minorVersions":[{"displayText":"Ruby 2.7","value":"2.7","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.7","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2023-03-31T00:00:00Z"}}},{"displayText":"Ruby
+        2.7.3","value":"2.7.3","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.7.3","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"isHidden":true,"endOfLifeDate":"2023-03-31T00:00:00Z"}}},{"displayText":"Ruby
+        2.6","value":"2.6","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.6","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2022-03-31T00:00:00Z"}}},{"displayText":"Ruby
+        2.6.2","value":"2.6.2","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.6.2","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2022-03-31T00:00:00Z"}}},{"displayText":"Ruby
+        2.5","value":"2.5","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.5","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2021-03-31T00:00:00Z"}}},{"displayText":"Ruby
+        2.5.5","value":"2.5.5","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.5.5","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2021-03-31T00:00:00Z"}}},{"displayText":"Ruby
+        2.4","value":"2.4","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.4","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2020-04-01T00:00:00Z"}}},{"displayText":"Ruby
+        2.4.5","value":"2.4.5","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.4.5","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2020-04-01T00:00:00Z"}}},{"displayText":"Ruby
+        2.3","value":"2.3","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.3","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2019-03-31T00:00:00Z"}}},{"displayText":"Ruby
+        2.3.8","value":"2.3.8","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.3.8","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2019-03-31T00:00:00Z"}}},{"displayText":"Ruby
+        2.3.3","value":"2.3.3","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.3.3","remoteDebuggingSupported":false,"isDeprecated":true,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2019-03-31T00:00:00Z"}}}]}]}},{"id":null,"name":"java","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"Java","value":"java","preferredOs":"linux","majorVersions":[{"displayText":"Java
+        21","value":"21","minorVersions":[{"displayText":"Java 21","value":"21.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"21","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"}}},{"displayText":"Java
+        21.0.4","value":"21.0.4","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"}}},{"displayText":"Java
+        21.0.3","value":"21.0.3","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"}}},{"displayText":"Java
+        21.0.1","value":"21.0.1","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"21.0.1","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"}}}]},{"displayText":"Java
+        17","value":"17","minorVersions":[{"displayText":"Java 17","value":"17.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        17.0.12","value":"17.0.12","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        17.0.11","value":"17.0.11","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        17.0.9","value":"17.0.9","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.9","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        17.0.4","value":"17.0.4","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.4","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        17.0.3","value":"17.0.3","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.3","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        17.0.2","value":"17.0.2","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.2","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        17.0.1","value":"17.0.1","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.1","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}}]},{"displayText":"Java
+        11","value":"11","minorVersions":[{"displayText":"Java 11","value":"11.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.24","value":"11.0.21","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.23","value":"11.0.21","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.21","value":"11.0.21","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.21","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.16","value":"11.0.16","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.16","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.15","value":"11.0.15","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.15","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.14","value":"11.0.14","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.14","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.13","value":"11.0.13","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.13","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.12","value":"11.0.12","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.12","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.11","value":"11.0.11","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.11","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.9","value":"11.0.9","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.9","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.8","value":"11.0.8","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"11.0.8","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.7","value":"11.0.7","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.7","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.6","value":"11.0.6","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.6","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.5","value":"11.0.5","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.5_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.3","value":"11.0.3","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"11.0.3_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.2","value":"11.0.2","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"11.0.2_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}}]},{"displayText":"Java
+        8","value":"8","minorVersions":[{"displayText":"Java 8","value":"8.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"1.8","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_422","value":"8.0.422","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_392","value":"8.0.392","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_392","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_345","value":"8.0.345","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_345","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_332","value":"8.0.332","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_332","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_322","value":"8.0.322","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_322","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_312","value":"8.0.312","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_312","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_302","value":"8.0.302","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_302","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_292","value":"8.0.292","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_292","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_282","value":"8.0.282","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_282","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_275","value":"8.0.275","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_265","value":"8.0.265","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_265","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_252","value":"8.0.252","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_252","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_242","value":"8.0.242","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_242","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_232","value":"8.0.232","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_232_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_212","value":"8.0.212","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_212_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_202","value":"8.0.202","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_202_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_202 (Oracle)","value":"8.0.202 (Oracle)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_202","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"}}}},{"displayText":"Java
+        1.8.0_181","value":"8.0.181","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_181_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_181 (Oracle)","value":"8.0.181 (Oracle)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_181","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"}}}},{"displayText":"Java
+        1.8.0_172","value":"8.0.172","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_172_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_172 (Oracle)","value":"8.0.172 (Oracle)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_172","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"}}}},{"displayText":"Java
+        1.8.0_144","value":"8.0.144","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_144","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_111 (Oracle)","value":"8.0.111 (Oracle)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_111","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"}}}},{"displayText":"Java
+        1.8.0_102","value":"8.0.102","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_102","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_92","value":"8.0.92","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_92","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_73 (Oracle)","value":"8.0.73 (Oracle)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_73","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"}}}},{"displayText":"Java
+        1.8.0_60 (Oracle)","value":"8.0.60 (Oracle)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_60","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"}}}},{"displayText":"Java
+        1.8.0_25 (Oracle)","value":"8.0.25 (Oracle)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_25","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"}}}}]},{"displayText":"Java
+        7","value":"7","minorVersions":[{"displayText":"Java 7","value":"7.0","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.7","isAutoUpdate":true,"isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2023-07-01T00:00:00Z"}}},{"displayText":"Java
+        1.7.0_292","value":"7.0.292","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.7.0_292","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2023-07-01T00:00:00Z"}}},{"displayText":"Java
+        1.7.0_272","value":"7.0.272","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.7.0_272","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2023-07-01T00:00:00Z"}}},{"displayText":"Java
+        1.7.0_262","value":"7.0.262","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.7.0_262","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2023-07-01T00:00:00Z"}}},{"displayText":"Java
+        1.7.0_242","value":"7.0.242","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.7.0_242_ZULU","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2023-07-01T00:00:00Z"}}},{"displayText":"Java
+        1.7.0_222","value":"7.0.222","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.7.0_222_ZULU","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2023-07-01T00:00:00Z"}}},{"displayText":"Java
+        1.7.0_191","value":"7.0.191","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.7.0_191_ZULU","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2023-07-01T00:00:00Z"}}},{"displayText":"Java
+        1.7.0_80 (Oracle)","value":"7.0.80 (Oracle)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.7.0_80","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false}}}},{"displayText":"Java
+        1.7.0_71 (Oracle)","value":"7.0.71 (Oracle)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.7.0_71","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false}}}},{"displayText":"Java
+        1.7.0_51 (Oracle)","value":"7.0.51 (Oracle)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.7.0_51","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false}}}}]}]}},{"id":null,"name":"javacontainers","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"Java
+        Containers","value":"javacontainers","majorVersions":[{"displayText":"Java
+        SE (Embedded Web Server)","value":"javase","minorVersions":[{"displayText":"Java
+        SE (Embedded Web Server)","value":"SE","stackSettings":{"windowsContainerSettings":{"javaContainer":"JAVA","javaContainerVersion":"SE","isAutoUpdate":true},"linuxContainerSettings":{"java21Runtime":"JAVA|21-java21","java17Runtime":"JAVA|17-java17","java11Runtime":"JAVA|11-java11","java8Runtime":"JAVA|8-jre8","isAutoUpdate":true}}},{"displayText":"Java
+        SE 21.0.4","value":"21.0.4","stackSettings":{"linuxContainerSettings":{"java21Runtime":"JAVA|21.0.4"}}},{"displayText":"Java
+        SE 21.0.3","value":"21.0.3","stackSettings":{"linuxContainerSettings":{"java21Runtime":"JAVA|21.0.3"}}},{"displayText":"Java
+        SE 21.0.1","value":"21.0.1","stackSettings":{"linuxContainerSettings":{"java21Runtime":"JAVA|21.0.1"}}},{"displayText":"Java
+        SE 17.0.12","value":"17.0.12","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.12"}}},{"displayText":"Java
+        SE 17.0.11","value":"17.0.11","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.11"}}},{"displayText":"Java
+        SE 17.0.9","value":"17.0.9","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.9"}}},{"displayText":"Java
+        SE 17.0.4","value":"17.0.4","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.4"}}},{"displayText":"Java
+        SE 17.0.3","value":"17.0.3","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.3"}}},{"displayText":"Java
+        SE 17.0.2","value":"17.0.2","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.2"}}},{"displayText":"Java
+        SE 17.0.1","value":"17.0.1","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.1"}}},{"displayText":"Java
+        SE 11.0.24","value":"11.0.24","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.24"}}},{"displayText":"Java
+        SE 11.0.23","value":"11.0.23","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.23"}}},{"displayText":"Java
+        SE 11.0.21","value":"11.0.21","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.21"}}},{"displayText":"Java
+        SE 11.0.16","value":"11.0.16","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.16"}}},{"displayText":"Java
+        SE 11.0.15","value":"11.0.15","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.15"}}},{"displayText":"Java
+        SE 11.0.14","value":"11.0.14","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.14"}}},{"displayText":"Java
+        SE 11.0.13","value":"11.0.13","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.13"}}},{"displayText":"Java
+        SE 11.0.12","value":"11.0.12","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.12"}}},{"displayText":"Java
+        SE 11.0.11","value":"11.0.11","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.11"}}},{"displayText":"Java
+        SE 11.0.9","value":"11.0.9","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.9"}}},{"displayText":"Java
+        SE 11.0.7","value":"11.0.7","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.7"}}},{"displayText":"Java
+        SE 11.0.6","value":"11.0.6","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.6"}}},{"displayText":"Java
+        SE 11.0.5","value":"11.0.5","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.5"}}},{"displayText":"Java
+        SE 8u422","value":"1.8.422","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u422"}}},{"displayText":"Java
+        SE 8u412","value":"1.8.412","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u412"}}},{"displayText":"Java
+        SE 8u392","value":"1.8.392","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u392"}}},{"displayText":"Java
+        SE 8u345","value":"1.8.345","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u345"}}},{"displayText":"Java
+        SE 8u332","value":"1.8.332","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u332"}}},{"displayText":"Java
+        SE 8u322","value":"1.8.322","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u322"}}},{"displayText":"Java
+        SE 8u312","value":"1.8.312","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u312"}}},{"displayText":"Java
+        SE 8u302","value":"1.8.302","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u302"}}},{"displayText":"Java
+        SE 8u292","value":"1.8.292","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u292"}}},{"displayText":"Java
+        SE 8u275","value":"1.8.275","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u275"}}},{"displayText":"Java
+        SE 8u252","value":"1.8.252","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u252"}}},{"displayText":"Java
+        SE 8u242","value":"1.8.242","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u242"}}},{"displayText":"Java
+        SE 8u232","value":"1.8.232","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u232"}}}]},{"displayText":"Red
+        Hat JBoss EAP 8","value":"jbosseap8.0","minorVersions":[{"displayText":"Red
+        Hat JBoss EAP 8","value":"8","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8-java11","java17Runtime":"JBOSSEAP|8-java17","isAutoUpdate":true}}},{"displayText":"Red
+        Hat JBoss EAP 8.0 update 2.1","value":"8.0.2.1","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.2.1-java11","java17Runtime":"JBOSSEAP|8.0.2.1-java17"}}},{"displayText":"Red
+        Hat JBoss EAP 8.0 update 1","value":"8.0.1","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.1-java11","java17Runtime":"JBOSSEAP|8.0.1-java17"}}}]},{"displayText":"Red
+        Hat JBoss EAP 8 BYO License","value":"jbosseap8.0_byol","minorVersions":[{"displayText":"Red
+        Hat JBoss EAP 8 BYO License","value":"8","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8-java11_byol","java17Runtime":"JBOSSEAP|8-java17_byol","isAutoUpdate":true}}},{"displayText":"Red
+        Hat JBoss EAP 8 update 1 BYO License","value":"8.0.1","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.1-java11_byol","java17Runtime":"JBOSSEAP|8.0.1-java17_byol"}}},{"displayText":"Red
+        Hat JBoss EAP 8.0 update 2.1 BYO License","value":"8.0.2","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.2-java11_byol","java17Runtime":"JBOSSEAP|8.0.2-java17_byol"}}}]},{"displayText":"Red
+        Hat JBoss EAP 7","value":"jbosseap","minorVersions":[{"displayText":"Red Hat
+        JBoss EAP 7","value":"7","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7-java8","java11Runtime":"JBOSSEAP|7-java11","java17Runtime":"JBOSSEAP|7-java17","isAutoUpdate":true}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.18","value":"7.4.18","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.18-java8","java11Runtime":"JBOSSEAP|7.4.18-java11","java17Runtime":"JBOSSEAP|7.4.18-java17"}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.17","value":"7.4.17","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.17-java8","java11Runtime":"JBOSSEAP|7.4.17-java11","java17Runtime":"JBOSSEAP|7.4.17-java17"}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.16","value":"7.4.16","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.16-java8","java11Runtime":"JBOSSEAP|7.4.16-java11","java17Runtime":"JBOSSEAP|7.4.16-java17"}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.13","value":"7.4.13","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.13-java8","java11Runtime":"JBOSSEAP|7.4.13-java11","java17Runtime":"JBOSSEAP|7.4.13-java17"}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.7","value":"7.4.7","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.7-java8","java11Runtime":"JBOSSEAP|7.4.7-java11","java17Runtime":"JBOSSEAP|7.4.7-java17"}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.5","value":"7.4.5","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.5-java8","java11Runtime":"JBOSSEAP|7.4.5-java11","java17Runtime":"JBOSSEAP|7.4.5-java17"}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.2","value":"7.4.2","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.2-java8","java11Runtime":"JBOSSEAP|7.4.2-java11"}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.1","value":"7.4.1","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.1-java8","java11Runtime":"JBOSSEAP|7.4.1-java11"}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.0","value":"7.4.0","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.0-java8","java11Runtime":"JBOSSEAP|7.4.0-java11"}}},{"displayText":"Red
+        Hat JBoss EAP 7.3.10","value":"7.3.10","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.3.10-java8","java11Runtime":"JBOSSEAP|7.3.10-java11"}}},{"displayText":"Red
+        Hat JBoss EAP 7.3.9","value":"7.3.9","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.3.9-java8","java11Runtime":"JBOSSEAP|7.3.9-java11"}}},{"displayText":"Red
+        Hat JBoss EAP 7.3","value":"7.3","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.3-java8","java11Runtime":"JBOSSEAP|7.3-java11","isAutoUpdate":true,"isHidden":true}}},{"displayText":"Red
+        Hat JBoss EAP 7.4","value":"7.4","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4-java8","java11Runtime":"JBOSSEAP|7.4-java11","isAutoUpdate":true,"isHidden":true}}},{"displayText":"JBoss
+        EAP 7.2","value":"7.2.0","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.2-java8","isDeprecated":true}}}]},{"displayText":"Red
+        Hat JBoss EAP 7 BYO License","value":"jbosseap7_byol","minorVersions":[{"displayText":"Red
+        Hat JBoss EAP 7 BYO License","value":"7","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7-java8_byol","java11Runtime":"JBOSSEAP|7-java11_byol","java17Runtime":"JBOSSEAP|7-java17_byol","isAutoUpdate":true}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.13 BYO License","value":"7.4.13","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.13-java8_byol","java11Runtime":"JBOSSEAP|7.4.13-java11_byol","java17Runtime":"JBOSSEAP|7.4.13-java17_byol"}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.7 BYO License","value":"7.4.7","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.7-java8_byol","java11Runtime":"JBOSSEAP|7.4.7-java11_byol","java17Runtime":"JBOSSEAP|7.4.7-java17_byol"}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.5 BYO License","value":"7.4.5","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.5-java8_byol","java11Runtime":"JBOSSEAP|7.4.5-java11_byol","java17Runtime":"JBOSSEAP|7.4.5-java17_byol"}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.2 BYO License","value":"7.4.2","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.2-java8_byol","java11Runtime":"JBOSSEAP|7.4.2-java11_byol"}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.1 BYO License","value":"7.4.1","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.1-java8_byol","java11Runtime":"JBOSSEAP|7.4.1-java11_byol"}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.0 BYO License","value":"7.4.0","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.0-java8_byol","java11Runtime":"JBOSSEAP|7.4.0-java11_byol"}}},{"displayText":"Red
+        Hat JBoss EAP 7.3.10 BYO License","value":"7.3.10","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.3.10-java8_byol","java11Runtime":"JBOSSEAP|7.3.10-java11_byol"}}},{"displayText":"Red
+        Hat JBoss EAP 7.3.9 BYO License","value":"7.3.9","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.3.9-java8_byol","java11Runtime":"JBOSSEAP|7.3.9-java11_byol"}}}]},{"displayText":"Apache
+        Tomcat 10.1","value":"tomcat10.1","minorVersions":[{"displayText":"Apache
+        Tomcat 10.1","value":"10.1","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1","isAutoUpdate":true},"linuxContainerSettings":{"java21Runtime":"TOMCAT|10.1-java21","java17Runtime":"TOMCAT|10.1-java17","java11Runtime":"TOMCAT|10.1-java11","isAutoUpdate":true}}},{"displayText":"Apache
+        Tomcat 10.1.28","value":"10.1.28","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.28","isHidden":true},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.28-java11","java17Runtime":"TOMCAT|10.1.28-java17","java21Runtime":"TOMCAT|10.1.28-java21"}}},{"displayText":"Apache
+        Tomcat 10.1.25","value":"10.1.25","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.25","isHidden":true},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.25-java11","java17Runtime":"TOMCAT|10.1.25-java17","java21Runtime":"TOMCAT|10.1.25-java21"}}},{"displayText":"Apache
+        Tomcat 10.1.23","value":"10.1.23","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.23","isHidden":true},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.23-java11","java17Runtime":"TOMCAT|10.1.23-java17","java21Runtime":"TOMCAT|10.1.23-java21"}}},{"displayText":"Apache
+        Tomcat 10.1.16","value":"10.1.16","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.16"},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.16-java11","java17Runtime":"TOMCAT|10.1.16-java17","java21Runtime":"TOMCAT|10.1.16-java21"}}}]},{"displayText":"Apache
+        Tomcat 10.0","value":"tomcat10.0","minorVersions":[{"displayText":"Apache
+        Tomcat 10.0","value":"10.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0","isAutoUpdate":true,"endOfLifeDate":"2022-10-31T00:00:00Z"},"linuxContainerSettings":{"java17Runtime":"TOMCAT|10.0-java17","java11Runtime":"TOMCAT|10.0-java11","java8Runtime":"TOMCAT|10.0-jre8","isAutoUpdate":true,"endOfLifeDate":"2022-10-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 10.0.27","value":"10.0.27","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0.27"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|10.0.27-java8","java11Runtime":"TOMCAT|10.0.27-java11","java17Runtime":"TOMCAT|10.0.27-java17","endOfLifeDate":"2022-10-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 10.0.23","value":"10.0.23","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0.23","endOfLifeDate":"2022-10-31T00:00:00Z"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|10.0.23-java8","java11Runtime":"TOMCAT|10.0.23-java11","java17Runtime":"TOMCAT|10.0.23-java17","endOfLifeDate":"2022-10-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 10.0.21","value":"10.0.21","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0.21","endOfLifeDate":"2022-10-31T00:00:00Z"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|10.0.21-java8","java11Runtime":"TOMCAT|10.0.21-java11","java17Runtime":"TOMCAT|10.0.21-java17","endOfLifeDate":"2022-10-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 10.0.20","value":"10.0.20","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0.20","endOfLifeDate":"2022-10-31T00:00:00Z"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|10.0.20-java8","java11Runtime":"TOMCAT|10.0.20-java11","java17Runtime":"TOMCAT|10.0.20-java17","endOfLifeDate":"2022-10-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 10.0.12","value":"10.0.12","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0.12","endOfLifeDate":"2022-10-31T00:00:00Z"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|10.0.12-java8","java11Runtime":"TOMCAT|10.0.12-java11","java17Runtime":"TOMCAT|10.0.12-java17","endOfLifeDate":"2022-10-31T00:00:00Z"}}}]},{"displayText":"Apache
+        Tomcat 9.0","value":"tomcat9.0","minorVersions":[{"displayText":"Apache Tomcat
+        9.0","value":"9.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0","isAutoUpdate":true},"linuxContainerSettings":{"java21Runtime":"TOMCAT|9.0-java21","java17Runtime":"TOMCAT|9.0-java17","java11Runtime":"TOMCAT|9.0-java11","java8Runtime":"TOMCAT|9.0-jre8","isAutoUpdate":true}}},{"displayText":"Apache
+        Tomcat 9.0.93","value":"9.0.93","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.93","isHidden":true},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.93-java8","java11Runtime":"TOMCAT|9.0.93-java11","java17Runtime":"TOMCAT|9.0.93-java17","java21Runtime":"TOMCAT|9.0.93-java21"}}},{"displayText":"Apache
+        Tomcat 9.0.90","value":"9.0.90","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.90","isHidden":true},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.90-java8","java11Runtime":"TOMCAT|9.0.90-java11","java17Runtime":"TOMCAT|9.0.90-java17","java21Runtime":"TOMCAT|9.0.90-java21"}}},{"displayText":"Apache
+        Tomcat 9.0.88","value":"9.0.88","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.88","isHidden":true},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.88-java8","java11Runtime":"TOMCAT|9.0.88-java11","java17Runtime":"TOMCAT|9.0.88-java17","java21Runtime":"TOMCAT|9.0.88-java21"}}},{"displayText":"Apache
+        Tomcat 9.0.83","value":"9.0.83","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.83"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.83-java8","java11Runtime":"TOMCAT|9.0.83-java11","java17Runtime":"TOMCAT|9.0.83-java17","java21Runtime":"TOMCAT|9.0.83-java21"}}},{"displayText":"Apache
+        Tomcat 9.0.65","value":"9.0.65","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.65"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.65-java8","java11Runtime":"TOMCAT|9.0.65-java11","java17Runtime":"TOMCAT|9.0.65-java17"}}},{"displayText":"Apache
+        Tomcat 9.0.63","value":"9.0.63","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.63"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.63-java8","java11Runtime":"TOMCAT|9.0.63-java11","java17Runtime":"TOMCAT|9.0.63-java17"}}},{"displayText":"Apache
+        Tomcat 9.0.62","value":"9.0.62","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.62"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.62-java8","java11Runtime":"TOMCAT|9.0.62-java11","java17Runtime":"TOMCAT|9.0.62-java17"}}},{"displayText":"Apache
+        Tomcat 9.0.54","value":"9.0.54","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.54"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.54-java8","java11Runtime":"TOMCAT|9.0.54-java11","java17Runtime":"TOMCAT|9.0.54-java17"}}},{"displayText":"Apache
+        Tomcat 9.0.52","value":"9.0.52","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.52"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.52-java8","java11Runtime":"TOMCAT|9.0.52-java11"}}},{"displayText":"Apache
+        Tomcat 9.0.46","value":"9.0.46","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.46"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.46-java8","java11Runtime":"TOMCAT|9.0.46-java11"}}},{"displayText":"Apache
+        Tomcat 9.0.41","value":"9.0.41","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.41-java8","java11Runtime":"TOMCAT|9.0.41-java11"}}},{"displayText":"Apache
+        Tomcat 9.0.38","value":"9.0.38","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.38"}}},{"displayText":"Apache
+        Tomcat 9.0.37","value":"9.0.37","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.37"},"linuxContainerSettings":{"java11Runtime":"TOMCAT|9.0.37-java11","java8Runtime":"TOMCAT|9.0.37-java8"}}},{"displayText":"Apache
+        Tomcat 9.0.33","value":"9.0.33","stackSettings":{"linuxContainerSettings":{"java11Runtime":"TOMCAT|9.0.33-java11","java8Runtime":"TOMCAT|9.0.33-java8"}}},{"displayText":"Apache
+        Tomcat 9.0.31","value":"9.0.31","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.31"}}},{"displayText":"Apache
+        Tomcat 9.0.27","value":"9.0.27","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.27"}}},{"displayText":"Apache
+        Tomcat 9.0.21","value":"9.0.21","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.21"}}},{"displayText":"Apache
+        Tomcat 9.0.20","value":"9.0.20","stackSettings":{"linuxContainerSettings":{"java11Runtime":"TOMCAT|9.0.20-java11","java8Runtime":"TOMCAT|9.0.20-java8"}}},{"displayText":"Apache
+        Tomcat 9.0.14","value":"9.0.14","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.14"}}},{"displayText":"Apache
+        Tomcat 9.0.12","value":"9.0.12","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.12"}}},{"displayText":"Apache
+        Tomcat 9.0.8","value":"9.0.8","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.8"}}},{"displayText":"Apache
+        Tomcat 9.0.0","value":"9.0.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.0"}}}]},{"displayText":"Apache
+        Tomcat 8.5","value":"tomcat8.5","minorVersions":[{"displayText":"Apache Tomcat
+        8.5","value":"8.5","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5","isAutoUpdate":true,"endOfLifeDate":"2024-03-31T00:00:00Z"},"linuxContainerSettings":{"java11Runtime":"TOMCAT|8.5-java11","java8Runtime":"TOMCAT|8.5-jre8","isAutoUpdate":true,"endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.100","value":"8.5.100","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.100-java8","java11Runtime":"TOMCAT|8.5.100-java11","endOfLifeDate":"2024-03-31T00:00:00Z"},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.100","endOfLifeDate":"2024-03-31T00:00:00Z","isHidden":true}}},{"displayText":"Apache
+        Tomcat 8.5.96","value":"8.5.96","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.96-java8","java11Runtime":"TOMCAT|8.5.96-java11","endOfLifeDate":"2024-03-31T00:00:00Z"},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.96","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.82","value":"8.5.82","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.82-java8","java11Runtime":"TOMCAT|8.5.82-java11","endOfLifeDate":"2024-03-31T00:00:00Z"},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.82","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.79","value":"8.5.79","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.79-java8","java11Runtime":"TOMCAT|8.5.79-java11","endOfLifeDate":"2024-03-31T00:00:00Z"},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.79","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.78","value":"8.5.78","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.78-java8","java11Runtime":"TOMCAT|8.5.78-java11","endOfLifeDate":"2024-03-31T00:00:00Z"},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.78","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.72","value":"8.5.72","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.72-java8","java11Runtime":"TOMCAT|8.5.72-java11","endOfLifeDate":"2024-03-31T00:00:00Z"},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.72","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.69","value":"8.5.69","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.69-java8","java11Runtime":"TOMCAT|8.5.69-java11","endOfLifeDate":"2024-03-31T00:00:00Z"},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.69","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.66","value":"8.5.66","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.66-java8","java11Runtime":"TOMCAT|8.5.66-java11","endOfLifeDate":"2024-03-31T00:00:00Z"},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.66","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.61","value":"8.5.61","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.61-java8","java11Runtime":"TOMCAT|8.5.61-java11","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.58","value":"8.5.58","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.58","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.57","value":"8.5.57","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.57","endOfLifeDate":"2024-03-31T00:00:00Z"},"linuxContainerSettings":{"java11Runtime":"TOMCAT|8.5.57-java11","java8Runtime":"TOMCAT|8.5.57-java8","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.53","value":"8.5.53","stackSettings":{"linuxContainerSettings":{"java11Runtime":"TOMCAT|8.5.53-java11","java8Runtime":"TOMCAT|8.5.53-java8","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.51","value":"8.5.51","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.51","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.47","value":"8.5.47","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.47","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.42","value":"8.5.42","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.42","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.41","value":"8.5.41","stackSettings":{"linuxContainerSettings":{"java11Runtime":"TOMCAT|8.5.41-java11","java8Runtime":"TOMCAT|8.5.41-java8","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.37","value":"8.5.37","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.37","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.34","value":"8.5.34","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.34","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.31","value":"8.5.31","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.31","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.20","value":"8.5.20","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.20","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
+        Tomcat 8.5.6","value":"8.5.6","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.6","endOfLifeDate":"2024-03-31T00:00:00Z"}}}]},{"displayText":"Apache
+        Tomcat 8.0","value":"tomcat8.0","minorVersions":[{"displayText":"Apache Tomcat
+        8.0","value":"8.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.0","isAutoUpdate":true,"isDeprecated":true}}},{"displayText":"Apache
+        Tomcat 8.0.53","value":"8.0.53","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.0.53","isDeprecated":true}}},{"displayText":"Apache
+        Tomcat 8.0.46","value":"8.0.46","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.0.46","isDeprecated":true}}},{"displayText":"Apache
+        Tomcat 8.0.23","value":"8.0.23","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.0.23","isDeprecated":true}}}]},{"displayText":"Apache
+        Tomcat 7.0","value":"tomcat7.0","minorVersions":[{"displayText":"Apache Tomcat
+        7.0","value":"7.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0","isAutoUpdate":true,"isDeprecated":true}}},{"displayText":"Apache
+        Tomcat 7.0.94","value":"7.0.94","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0.94","isDeprecated":true}}},{"displayText":"Apache
+        Tomcat 7.0.81","value":"7.0.81","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0.81","isDeprecated":true}}},{"displayText":"Apache
+        Tomcat 7.0.62","value":"7.0.62","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0.62","isDeprecated":true}}},{"displayText":"Apache
+        Tomcat 7.0.50","value":"7.0.50","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0.50","isDeprecated":true}}}]},{"displayText":"Jetty
+        9.3","value":"jetty9.3","minorVersions":[{"displayText":"Jetty 9.3","value":"9.3","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.3","isAutoUpdate":true,"isDeprecated":true}}},{"displayText":"Jetty
+        9.3.25","value":"9.3.25","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.3.25","isDeprecated":true}}},{"displayText":"Jetty
+        9.3.13","value":"9.3.13","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.3.13","isDeprecated":true}}}]},{"displayText":"Jetty
+        9.1","value":"jetty9.1","minorVersions":[{"displayText":"Jetty 9.1","value":"9.1","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.1","isAutoUpdate":true,"isDeprecated":true}}},{"displayText":"Jetty
+        9.1.0","value":"9.1.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.1.0","isDeprecated":true}}}]},{"displayText":"WildFly
+        14","value":"wildfly14","minorVersions":[{"displayText":"WildFly 14","value":"14","stackSettings":{"linuxContainerSettings":{"java8Runtime":"WILDFLY|14-jre8","isDeprecated":true,"isAutoUpdate":true}}},{"displayText":"WildFly
+        14.0.1","value":"14.0.1","stackSettings":{"linuxContainerSettings":{"isDeprecated":true,"java8Runtime":"WILDFLY|14.0.1-java8"}}}]}]}},{"id":null,"name":"staticsite","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"HTML
+        (Static Content)","value":"staticsite","preferredOs":"linux","majorVersions":[{"displayText":"HTML
+        (Static Content)","value":"1","minorVersions":[{"displayText":"HTML (Static
+        Content)","value":"1.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"STATICSITE|1.0","isHidden":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false}}}}]}]}},{"id":null,"name":"go","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"Go","value":"go","preferredOs":"linux","majorVersions":[{"displayText":"Go
+        1","value":"go1","minorVersions":[{"displayText":"Go 1.19 (Experimental)","value":"go1.19","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"GO|1.19","remoteDebuggingSupported":false,"isDeprecated":true,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true},"supportedFeatures":{"disableSsh":true},"isHidden":false,"isEarlyAccess":false}}},{"displayText":"Go
+        1.18 (Experimental)","value":"go1.18","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"GO|1.18","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"supportedFeatures":{"disableSsh":true},"isHidden":false,"isEarlyAccess":false,"isDeprecated":true}}}]}]}}],"nextLink":null,"id":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '98228'
+      content-type:
+      - application/json
+      date:
+      - Wed, 26 Feb 2025 00:09:02 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-msedge-ref:
+      - 'Ref A: A67F40CAB7A64E569AF24181A85EFA2E Ref B: CO6AA3150220023 Ref C: 2025-02-26T00:09:03Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "West Europe", "properties": {"serverFarmId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/serverfarms/webapp-oneDeploy-plan000003",
+      "reserved": false, "isXenon": false, "hyperV": false, "siteConfig": {"netFrameworkVersion":
+      "v4.6", "appSettings": [{"name": "WEBSITE_NODE_DEFAULT_VERSION", "value": "~16"}],
+      "alwaysOn": true, "localMySqlEnabled": false, "http20Enabled": true}, "scmSiteAlsoStopped":
+      false, "httpsOnly": false}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '519'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -n --plan
+      User-Agent:
+      - AZURECLI/2.69.0 azsdk-python-core/1.31.0 Python/3.10.11 (Windows-10-10.0.26100-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/sites/webapp-oneDeploy-test000002?api-version=2023-01-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/sites/webapp-oneDeploy-test000002","name":"webapp-oneDeploy-test000002","type":"Microsoft.Web/sites","kind":"app","location":"West
+        Europe","properties":{"name":"webapp-oneDeploy-test000002","state":"Running","hostNames":["webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net"],"webSpace":"cli_test_webapp_OneDeploy000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-377.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli_test_webapp_OneDeploy000001-WestEuropewebspace/sites/webapp-oneDeploy-test000002","repositorySiteName":"webapp-oneDeploy-test000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net","webapp-onedeploy-testnvsjal2z3kjjy6qbasf.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-onedeploy-testnvsjal2z3kjjy6qbasf.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/serverfarms/webapp-oneDeploy-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2025-02-26T00:09:05.9566667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"vnetRouteAllEnabled":false,"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"vnetImagePullEnabled":false,"vnetContentShareEnabled":false,"outboundVnetRouting":{"allTraffic":false,"applicationTraffic":false,"contentShareTraffic":false,"imagePullTraffic":false,"backupRestoreTraffic":false},"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"","windowsFxVersion":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"elasticWebAppScaleLimit":0,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false},"functionAppConfig":null,"daprConfig":null,"deploymentId":"webapp-oneDeploy-test000002","slotName":null,"trafficManagerHostNames":null,"sku":"Standard","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientAffinityProxyEnabled":false,"blockPathTraversal":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"ipMode":"IPv4","vnetBackupRestoreEnabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"054064C16B6181EF9569664570EEAC17379D4660547C2C9947A7CD1B2AD083AF","kind":"app","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"20.50.2.27","possibleInboundIpAddresses":"20.50.2.27","ftpUsername":"webapp-oneDeploy-test000002\\$webapp-oneDeploy-test000002","ftpsHostName":"ftps://waws-prod-am2-377.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"20.73.237.47,20.71.73.98,20.73.237.54,20.73.237.61,20.73.237.63,20.73.237.72,108.141.14.172,20.50.2.27","possibleOutboundIpAddresses":"20.73.237.47,20.71.73.98,20.73.237.54,20.73.237.61,20.73.237.63,20.73.237.72,108.141.14.172,20.73.237.79,20.71.73.109,20.73.237.85,20.73.237.101,20.71.78.167,20.73.237.116,20.73.237.123,20.73.237.135,20.73.237.136,20.73.237.151,20.73.237.161,20.73.237.162,20.73.236.209,20.73.237.194,20.71.74.96,20.73.237.221,20.73.237.226,20.73.237.235,20.73.237.251,20.67.123.6,20.67.123.237,20.73.147.51,20.73.147.205,20.73.150.79,20.50.2.27","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-377","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli_test_webapp_OneDeploy000001","defaultHostName":"webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"publicNetworkAccess":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs,AppServiceAuthenticationLogs","inFlightFeatures":null,"storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"defaultHostNameScope":"Global","privateLinkIdentifiers":null,"sshEnabled":null}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '7927'
+      content-type:
+      - application/json
+      date:
+      - Wed, 26 Feb 2025 00:09:28 GMT
+      etag:
+      - '"1DB87E2A68E57AB"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-msedge-ref:
+      - 'Ref A: 86EFFFEE28634D5CBFE1CB4304CA9572 Ref B: CO6AA3150217053 Ref C: 2025-02-26T00:09:03Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"format": "WebDeploy"}'
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -n --plan
+      User-Agent:
+      - AZURECLI/2.69.0 azsdk-python-core/1.31.0 Python/3.10.11 (Windows-10-10.0.26100-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/sites/webapp-oneDeploy-test000002/publishxml?api-version=2023-01-01
+  response:
+    body:
+      string: <publishData><publishProfile profileName="webapp-oneDeploy-test000002
+        - Web Deploy" publishMethod="MSDeploy" publishUrl="webapp-onedeploy-testnvsjal2z3kjjy6qbasf.scm.azurewebsites.net:443"
+        msdeploySite="webapp-oneDeploy-test000002" userName="REDACTED" userPWD="REDACTED"
+        destinationAppUrl="http://webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net"
+        SQLServerDBConnectionString="REDACTED" mySQLDBConnectionString="" hostingProviderForumLink=""
+        controlPanelLink="https://portal.azure.com" webSystem="WebSites"><databases
+        /></publishProfile><publishProfile profileName="webapp-oneDeploy-test000002
+        - FTP" publishMethod="FTP" publishUrl="ftps://waws-prod-am2-377.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="REDACTED" userPWD="REDACTED" destinationAppUrl="http://webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net"
+        SQLServerDBConnectionString="REDACTED" mySQLDBConnectionString="" hostingProviderForumLink=""
+        controlPanelLink="https://portal.azure.com" webSystem="WebSites"><databases
+        /></publishProfile><publishProfile profileName="webapp-oneDeploy-test000002
+        - Zip Deploy" publishMethod="ZipDeploy" publishUrl="webapp-onedeploy-testnvsjal2z3kjjy6qbasf.scm.azurewebsites.net:443"
+        userName="REDACTED" userPWD="REDACTED" destinationAppUrl="http://webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net"
+        SQLServerDBConnectionString="REDACTED" mySQLDBConnectionString="" hostingProviderForumLink=""
+        controlPanelLink="https://portal.azure.com" webSystem="WebSites"><databases
+        /></publishProfile></publishData>
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1552'
+      content-type:
+      - application/xml
+      date:
+      - Wed, 26 Feb 2025 00:09:28 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-msedge-ref:
+      - 'Ref A: 891AD397FDCB4EC5BF7F9ABE36BE7F97 Ref B: CO6AA3150218035 Ref C: 2025-02-26T00:09:28Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp identity assign
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.69.0 azsdk-python-core/1.31.0 Python/3.10.11 (Windows-10-10.0.26100-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/sites/webapp-oneDeploy-test000002?api-version=2023-01-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/sites/webapp-oneDeploy-test000002","name":"webapp-oneDeploy-test000002","type":"Microsoft.Web/sites","kind":"app","location":"West
+        Europe","properties":{"name":"webapp-oneDeploy-test000002","state":"Running","hostNames":["webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net"],"webSpace":"cli_test_webapp_OneDeploy000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-377.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli_test_webapp_OneDeploy000001-WestEuropewebspace/sites/webapp-oneDeploy-test000002","repositorySiteName":"webapp-oneDeploy-test000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net","webapp-onedeploy-testnvsjal2z3kjjy6qbasf.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-onedeploy-testnvsjal2z3kjjy6qbasf.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/serverfarms/webapp-oneDeploy-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2025-02-26T00:09:27.72","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"vnetRouteAllEnabled":false,"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"vnetImagePullEnabled":false,"vnetContentShareEnabled":false,"outboundVnetRouting":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"","windowsFxVersion":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":true,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":null,"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":true,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":0,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false},"functionAppConfig":null,"daprConfig":null,"deploymentId":"webapp-oneDeploy-test000002","slotName":null,"trafficManagerHostNames":null,"sku":"Standard","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientAffinityProxyEnabled":false,"blockPathTraversal":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"ipMode":"IPv4","vnetBackupRestoreEnabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"054064C16B6181EF9569664570EEAC17379D4660547C2C9947A7CD1B2AD083AF","kind":"app","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"20.50.2.27","possibleInboundIpAddresses":"20.50.2.27","ftpUsername":"webapp-oneDeploy-test000002\\$webapp-oneDeploy-test000002","ftpsHostName":"ftps://waws-prod-am2-377.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"20.73.237.47,20.71.73.98,20.73.237.54,20.73.237.61,20.73.237.63,20.73.237.72,108.141.14.172,20.50.2.27","possibleOutboundIpAddresses":"20.73.237.47,20.71.73.98,20.73.237.54,20.73.237.61,20.73.237.63,20.73.237.72,108.141.14.172,20.73.237.79,20.71.73.109,20.73.237.85,20.73.237.101,20.71.78.167,20.73.237.116,20.73.237.123,20.73.237.135,20.73.237.136,20.73.237.151,20.73.237.161,20.73.237.162,20.73.236.209,20.73.237.194,20.71.74.96,20.73.237.221,20.73.237.226,20.73.237.235,20.73.237.251,20.67.123.6,20.67.123.237,20.73.147.51,20.73.147.205,20.73.150.79,20.50.2.27","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-377","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli_test_webapp_OneDeploy000001","defaultHostName":"webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"publicNetworkAccess":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs,AppServiceAuthenticationLogs","inFlightFeatures":["SiteContainers"],"storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"defaultHostNameScope":"Global","privateLinkIdentifiers":null,"sshEnabled":null}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '7591'
+      content-type:
+      - application/json
+      date:
+      - Wed, 26 Feb 2025 00:09:29 GMT
+      etag:
+      - '"1DB87E2B33F7280"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 5D4E9A4B21EB4ED8BE7F0980B54BFBD9 Ref B: CO6AA3150218023 Ref C: 2025-02-26T00:09:28Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"kind": "app", "location": "West Europe", "identity": {"type": "SystemAssigned"},
+      "properties": {"enabled": true, "hostNameSslStates": [{"name": "webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net",
+      "sslState": "Disabled", "hostType": "Standard"}, {"name": "webapp-onedeploy-testnvsjal2z3kjjy6qbasf.scm.azurewebsites.net",
+      "sslState": "Disabled", "hostType": "Repository"}], "serverFarmId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/serverfarms/webapp-oneDeploy-plan000003",
+      "reserved": false, "isXenon": false, "hyperV": false, "vnetRouteAllEnabled":
+      false, "vnetImagePullEnabled": false, "vnetContentShareEnabled": false, "siteConfig":
+      {"numberOfWorkers": 1, "linuxFxVersion": "", "acrUseManagedIdentityCreds": false,
+      "alwaysOn": true, "http20Enabled": true, "functionAppScaleLimit": 0, "minimumElasticInstanceCount":
+      0}, "scmSiteAlsoStopped": false, "clientAffinityEnabled": true, "clientCertEnabled":
+      false, "clientCertMode": "Required", "endToEndEncryptionEnabled": false, "hostNamesDisabled":
+      false, "customDomainVerificationId": "054064C16B6181EF9569664570EEAC17379D4660547C2C9947A7CD1B2AD083AF",
+      "containerSize": 0, "dailyMemoryTimeQuota": 0, "httpsOnly": false, "redundancyMode":
+      "None", "storageAccountRequired": false, "keyVaultReferenceIdentity": "SystemAssigned"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp identity assign
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1368'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.69.0 azsdk-python-core/1.31.0 Python/3.10.11 (Windows-10-10.0.26100-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/sites/webapp-oneDeploy-test000002?api-version=2023-01-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/sites/webapp-oneDeploy-test000002","name":"webapp-oneDeploy-test000002","type":"Microsoft.Web/sites","kind":"app","location":"West
+        Europe","properties":{"name":"webapp-oneDeploy-test000002","state":"Running","hostNames":["webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net"],"webSpace":"cli_test_webapp_OneDeploy000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-377.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli_test_webapp_OneDeploy000001-WestEuropewebspace/sites/webapp-oneDeploy-test000002","repositorySiteName":"webapp-oneDeploy-test000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net","webapp-onedeploy-testnvsjal2z3kjjy6qbasf.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-onedeploy-testnvsjal2z3kjjy6qbasf.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/serverfarms/webapp-oneDeploy-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2025-02-26T00:09:33.68","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"vnetRouteAllEnabled":false,"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"vnetImagePullEnabled":false,"vnetContentShareEnabled":false,"outboundVnetRouting":{"allTraffic":false,"applicationTraffic":false,"contentShareTraffic":false,"imagePullTraffic":false,"backupRestoreTraffic":false},"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"","windowsFxVersion":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":true,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":true,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"elasticWebAppScaleLimit":0,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":1,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false},"functionAppConfig":null,"daprConfig":null,"deploymentId":"webapp-oneDeploy-test000002","slotName":null,"trafficManagerHostNames":null,"sku":"Standard","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientAffinityProxyEnabled":false,"blockPathTraversal":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"ipMode":"IPv4","vnetBackupRestoreEnabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"054064C16B6181EF9569664570EEAC17379D4660547C2C9947A7CD1B2AD083AF","kind":"app","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"20.50.2.27","possibleInboundIpAddresses":"20.50.2.27","ftpUsername":"webapp-oneDeploy-test000002\\$webapp-oneDeploy-test000002","ftpsHostName":"ftps://waws-prod-am2-377.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"20.73.237.47,20.71.73.98,20.73.237.54,20.73.237.61,20.73.237.63,20.73.237.72,108.141.14.172,20.50.2.27","possibleOutboundIpAddresses":"20.73.237.47,20.71.73.98,20.73.237.54,20.73.237.61,20.73.237.63,20.73.237.72,108.141.14.172,20.73.237.79,20.71.73.109,20.73.237.85,20.73.237.101,20.71.78.167,20.73.237.116,20.73.237.123,20.73.237.135,20.73.237.136,20.73.237.151,20.73.237.161,20.73.237.162,20.73.236.209,20.73.237.194,20.71.74.96,20.73.237.221,20.73.237.226,20.73.237.235,20.73.237.251,20.67.123.6,20.67.123.237,20.73.147.51,20.73.147.205,20.73.150.79,20.50.2.27","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-377","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli_test_webapp_OneDeploy000001","defaultHostName":"webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"publicNetworkAccess":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs,AppServiceAuthenticationLogs","inFlightFeatures":null,"storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"defaultHostNameScope":"Global","privateLinkIdentifiers":null,"sshEnabled":null},"identity":{"type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","principalId":"f9919d5a-65ac-4fef-82c4-328ee97da93f"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '8060'
+      content-type:
+      - application/json
+      date:
+      - Wed, 26 Feb 2025 00:09:33 GMT
+      etag:
+      - '"1DB87E2B33F7280"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-msedge-ref:
+      - 'Ref A: 3A8EDDD7A817452F87CF5A603B85DDFF Ref B: CO6AA3150220009 Ref C: 2025-02-26T00:09:29Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp deploy
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --src-url --type --pull-identity
+      User-Agent:
+      - AZURECLI/2.69.0 azsdk-python-core/1.31.0 Python/3.10.11 (Windows-10-10.0.26100-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/sites/webapp-oneDeploy-test000002?api-version=2023-01-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/sites/webapp-oneDeploy-test000002","name":"webapp-oneDeploy-test000002","type":"Microsoft.Web/sites","kind":"app","location":"West
+        Europe","properties":{"name":"webapp-oneDeploy-test000002","state":"Running","hostNames":["webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net"],"webSpace":"cli_test_webapp_OneDeploy000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-377.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli_test_webapp_OneDeploy000001-WestEuropewebspace/sites/webapp-oneDeploy-test000002","repositorySiteName":"webapp-oneDeploy-test000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net","webapp-onedeploy-testnvsjal2z3kjjy6qbasf.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-onedeploy-testnvsjal2z3kjjy6qbasf.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/serverfarms/webapp-oneDeploy-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2025-02-26T00:09:33.68","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"vnetRouteAllEnabled":false,"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"vnetImagePullEnabled":false,"vnetContentShareEnabled":false,"outboundVnetRouting":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"","windowsFxVersion":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":true,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":null,"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":true,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":0,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":1,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false},"functionAppConfig":null,"daprConfig":null,"deploymentId":"webapp-oneDeploy-test000002","slotName":null,"trafficManagerHostNames":null,"sku":"Standard","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientAffinityProxyEnabled":false,"blockPathTraversal":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"ipMode":"IPv4","vnetBackupRestoreEnabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"054064C16B6181EF9569664570EEAC17379D4660547C2C9947A7CD1B2AD083AF","kind":"app","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"20.50.2.27","possibleInboundIpAddresses":"20.50.2.27","ftpUsername":"webapp-oneDeploy-test000002\\$webapp-oneDeploy-test000002","ftpsHostName":"ftps://waws-prod-am2-377.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"20.73.237.47,20.71.73.98,20.73.237.54,20.73.237.61,20.73.237.63,20.73.237.72,108.141.14.172,20.50.2.27","possibleOutboundIpAddresses":"20.73.237.47,20.71.73.98,20.73.237.54,20.73.237.61,20.73.237.63,20.73.237.72,108.141.14.172,20.73.237.79,20.71.73.109,20.73.237.85,20.73.237.101,20.71.78.167,20.73.237.116,20.73.237.123,20.73.237.135,20.73.237.136,20.73.237.151,20.73.237.161,20.73.237.162,20.73.236.209,20.73.237.194,20.71.74.96,20.73.237.221,20.73.237.226,20.73.237.235,20.73.237.251,20.67.123.6,20.67.123.237,20.73.147.51,20.73.147.205,20.73.150.79,20.50.2.27","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-377","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli_test_webapp_OneDeploy000001","defaultHostName":"webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"publicNetworkAccess":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs,AppServiceAuthenticationLogs","inFlightFeatures":["SiteContainers"],"storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"defaultHostNameScope":"Global","privateLinkIdentifiers":null,"sshEnabled":null},"identity":{"type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","principalId":"f9919d5a-65ac-4fef-82c4-328ee97da93f"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '7731'
+      content-type:
+      - application/json
+      date:
+      - Wed, 26 Feb 2025 00:09:34 GMT
+      etag:
+      - '"1DB87E2B6CCDF00"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 672516E320C7405F962935E4FB0733BF Ref B: CO6AA3150218039 Ref C: 2025-02-26T00:09:34Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp deploy
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --src-url --type --pull-identity
+      User-Agent:
+      - AZURECLI/2.69.0 azsdk-python-core/1.31.0 Python/3.10.11 (Windows-10-10.0.26100-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/sites/webapp-oneDeploy-test000002?api-version=2023-01-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/sites/webapp-oneDeploy-test000002","name":"webapp-oneDeploy-test000002","type":"Microsoft.Web/sites","kind":"app","location":"West
+        Europe","properties":{"name":"webapp-oneDeploy-test000002","state":"Running","hostNames":["webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net"],"webSpace":"cli_test_webapp_OneDeploy000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-377.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli_test_webapp_OneDeploy000001-WestEuropewebspace/sites/webapp-oneDeploy-test000002","repositorySiteName":"webapp-oneDeploy-test000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net","webapp-onedeploy-testnvsjal2z3kjjy6qbasf.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-onedeploy-testnvsjal2z3kjjy6qbasf.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/serverfarms/webapp-oneDeploy-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2025-02-26T00:09:33.68","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"vnetRouteAllEnabled":false,"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"vnetImagePullEnabled":false,"vnetContentShareEnabled":false,"outboundVnetRouting":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"","windowsFxVersion":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":true,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":null,"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":true,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":0,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":1,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false},"functionAppConfig":null,"daprConfig":null,"deploymentId":"webapp-oneDeploy-test000002","slotName":null,"trafficManagerHostNames":null,"sku":"Standard","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientAffinityProxyEnabled":false,"blockPathTraversal":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"ipMode":"IPv4","vnetBackupRestoreEnabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"054064C16B6181EF9569664570EEAC17379D4660547C2C9947A7CD1B2AD083AF","kind":"app","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"20.50.2.27","possibleInboundIpAddresses":"20.50.2.27","ftpUsername":"webapp-oneDeploy-test000002\\$webapp-oneDeploy-test000002","ftpsHostName":"ftps://waws-prod-am2-377.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"20.73.237.47,20.71.73.98,20.73.237.54,20.73.237.61,20.73.237.63,20.73.237.72,108.141.14.172,20.50.2.27","possibleOutboundIpAddresses":"20.73.237.47,20.71.73.98,20.73.237.54,20.73.237.61,20.73.237.63,20.73.237.72,108.141.14.172,20.73.237.79,20.71.73.109,20.73.237.85,20.73.237.101,20.71.78.167,20.73.237.116,20.73.237.123,20.73.237.135,20.73.237.136,20.73.237.151,20.73.237.161,20.73.237.162,20.73.236.209,20.73.237.194,20.71.74.96,20.73.237.221,20.73.237.226,20.73.237.235,20.73.237.251,20.67.123.6,20.67.123.237,20.73.147.51,20.73.147.205,20.73.150.79,20.50.2.27","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-377","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli_test_webapp_OneDeploy000001","defaultHostName":"webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"publicNetworkAccess":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs,AppServiceAuthenticationLogs","inFlightFeatures":["SiteContainers"],"storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"defaultHostNameScope":"Global","privateLinkIdentifiers":null,"sshEnabled":null},"identity":{"type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","principalId":"f9919d5a-65ac-4fef-82c4-328ee97da93f"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '7731'
+      content-type:
+      - application/json
+      date:
+      - Wed, 26 Feb 2025 00:09:35 GMT
+      etag:
+      - '"1DB87E2B6CCDF00"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: E7772CCBEA4D4A8BB686C69E4AFFC8DC Ref B: CO6AA3150217023 Ref C: 2025-02-26T00:09:35Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp deploy
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --src-url --type --pull-identity
+      User-Agent:
+      - AZURECLI/2.69.0 azsdk-python-core/1.31.0 Python/3.10.11 (Windows-10-10.0.26100-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/sites/webapp-oneDeploy-test000002?api-version=2023-01-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/sites/webapp-oneDeploy-test000002","name":"webapp-oneDeploy-test000002","type":"Microsoft.Web/sites","kind":"app","location":"West
+        Europe","properties":{"name":"webapp-oneDeploy-test000002","state":"Running","hostNames":["webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net"],"webSpace":"cli_test_webapp_OneDeploy000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-377.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli_test_webapp_OneDeploy000001-WestEuropewebspace/sites/webapp-oneDeploy-test000002","repositorySiteName":"webapp-oneDeploy-test000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net","webapp-onedeploy-testnvsjal2z3kjjy6qbasf.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-onedeploy-testnvsjal2z3kjjy6qbasf.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/serverfarms/webapp-oneDeploy-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2025-02-26T00:09:33.68","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"vnetRouteAllEnabled":false,"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"vnetImagePullEnabled":false,"vnetContentShareEnabled":false,"outboundVnetRouting":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"","windowsFxVersion":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":true,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":null,"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":true,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":0,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":1,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false},"functionAppConfig":null,"daprConfig":null,"deploymentId":"webapp-oneDeploy-test000002","slotName":null,"trafficManagerHostNames":null,"sku":"Standard","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientAffinityProxyEnabled":false,"blockPathTraversal":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"ipMode":"IPv4","vnetBackupRestoreEnabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"054064C16B6181EF9569664570EEAC17379D4660547C2C9947A7CD1B2AD083AF","kind":"app","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"20.50.2.27","possibleInboundIpAddresses":"20.50.2.27","ftpUsername":"webapp-oneDeploy-test000002\\$webapp-oneDeploy-test000002","ftpsHostName":"ftps://waws-prod-am2-377.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"20.73.237.47,20.71.73.98,20.73.237.54,20.73.237.61,20.73.237.63,20.73.237.72,108.141.14.172,20.50.2.27","possibleOutboundIpAddresses":"20.73.237.47,20.71.73.98,20.73.237.54,20.73.237.61,20.73.237.63,20.73.237.72,108.141.14.172,20.73.237.79,20.71.73.109,20.73.237.85,20.73.237.101,20.71.78.167,20.73.237.116,20.73.237.123,20.73.237.135,20.73.237.136,20.73.237.151,20.73.237.161,20.73.237.162,20.73.236.209,20.73.237.194,20.71.74.96,20.73.237.221,20.73.237.226,20.73.237.235,20.73.237.251,20.67.123.6,20.67.123.237,20.73.147.51,20.73.147.205,20.73.150.79,20.50.2.27","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-377","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli_test_webapp_OneDeploy000001","defaultHostName":"webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"publicNetworkAccess":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs,AppServiceAuthenticationLogs","inFlightFeatures":["SiteContainers"],"storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"defaultHostNameScope":"Global","privateLinkIdentifiers":null,"sshEnabled":null},"identity":{"type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","principalId":"f9919d5a-65ac-4fef-82c4-328ee97da93f"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '7731'
+      content-type:
+      - application/json
+      date:
+      - Wed, 26 Feb 2025 00:09:36 GMT
+      etag:
+      - '"1DB87E2B6CCDF00"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: DA5E310C3D6047EA8C5B8A09DF207663 Ref B: CO6AA3150220053 Ref C: 2025-02-26T00:09:36Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp deploy
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --src-url --type --pull-identity
+      User-Agent:
+      - python/3.10.11 (Windows-10-10.0.26100-SP0) AZURECLI/2.69.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/sites/webapp-oneDeploy-test000002?api-version=2023-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/sites/webapp-oneDeploy-test000002","name":"webapp-oneDeploy-test000002","type":"Microsoft.Web/sites","kind":"app","location":"West
+        Europe","properties":{"name":"webapp-oneDeploy-test000002","state":"Running","hostNames":["webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net"],"webSpace":"cli_test_webapp_OneDeploy000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-377.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli_test_webapp_OneDeploy000001-WestEuropewebspace/sites/webapp-oneDeploy-test000002","repositorySiteName":"webapp-oneDeploy-test000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net","webapp-onedeploy-testnvsjal2z3kjjy6qbasf.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-onedeploy-testnvsjal2z3kjjy6qbasf.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/serverfarms/webapp-oneDeploy-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2025-02-26T00:09:33.68","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"vnetRouteAllEnabled":false,"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"vnetImagePullEnabled":false,"vnetContentShareEnabled":false,"outboundVnetRouting":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"","windowsFxVersion":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":true,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":null,"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":true,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":0,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":1,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false},"functionAppConfig":null,"daprConfig":null,"deploymentId":"webapp-oneDeploy-test000002","slotName":null,"trafficManagerHostNames":null,"sku":"Standard","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientAffinityProxyEnabled":false,"blockPathTraversal":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"ipMode":"IPv4","vnetBackupRestoreEnabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"054064C16B6181EF9569664570EEAC17379D4660547C2C9947A7CD1B2AD083AF","kind":"app","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"20.50.2.27","possibleInboundIpAddresses":"20.50.2.27","ftpUsername":"webapp-oneDeploy-test000002\\$webapp-oneDeploy-test000002","ftpsHostName":"ftps://waws-prod-am2-377.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"20.73.237.47,20.71.73.98,20.73.237.54,20.73.237.61,20.73.237.63,20.73.237.72,108.141.14.172,20.50.2.27","possibleOutboundIpAddresses":"20.73.237.47,20.71.73.98,20.73.237.54,20.73.237.61,20.73.237.63,20.73.237.72,108.141.14.172,20.73.237.79,20.71.73.109,20.73.237.85,20.73.237.101,20.71.78.167,20.73.237.116,20.73.237.123,20.73.237.135,20.73.237.136,20.73.237.151,20.73.237.161,20.73.237.162,20.73.236.209,20.73.237.194,20.71.74.96,20.73.237.221,20.73.237.226,20.73.237.235,20.73.237.251,20.67.123.6,20.67.123.237,20.73.147.51,20.73.147.205,20.73.150.79,20.50.2.27","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-377","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli_test_webapp_OneDeploy000001","defaultHostName":"webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"publicNetworkAccess":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs,AppServiceAuthenticationLogs","inFlightFeatures":["SiteContainers"],"storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"defaultHostNameScope":"Global","privateLinkIdentifiers":null,"sshEnabled":null},"identity":{"type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","principalId":"f9919d5a-65ac-4fef-82c4-328ee97da93f"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '7731'
+      content-type:
+      - application/json
+      date:
+      - Wed, 26 Feb 2025 00:09:38 GMT
+      etag:
+      - '"1DB87E2B6CCDF00"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: D7200C2A6C964A269F3759AE77A5D293 Ref B: CO6AA3150219011 Ref C: 2025-02-26T00:09:36Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp deploy
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --src-url --type --pull-identity
+      User-Agent:
+      - AZURECLI/2.69.0 azsdk-python-core/1.31.0 Python/3.10.11 (Windows-10-10.0.26100-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/sites/webapp-oneDeploy-test000002/basicPublishingCredentialsPolicies/scm?api-version=2023-01-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/sites/webapp-oneDeploy-test000002/basicPublishingCredentialsPolicies/scm","name":"scm","type":"Microsoft.Web/sites/basicPublishingCredentialsPolicies","location":"West
+        Europe","properties":{"allow":false}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '335'
+      content-type:
+      - application/json
+      date:
+      - Wed, 26 Feb 2025 00:09:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 3697E6539F8B43D4904F24F24FCCA789 Ref B: CO6AA3150219023 Ref C: 2025-02-26T00:09:38Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"packageUri": "https://tomcat.apache.org/tomcat-7.0-doc/appdev/sample/sample.war",
+      "pullIdentity": "system"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '109'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - AZURECLI/2.69.0
+    method: POST
+    uri: https://webapp-onedeploy-testnvsjal2z3kjjy6qbasf.scm.azurewebsites.net/api/publish?type=zip
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Wed, 26 Feb 2025 00:09:59 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      set-cookie:
+      - ARRAffinity=bd1c1462d6f510dac115a128ce96d2fecf18207376913da1139719ff17ff988e;Path=/;HttpOnly;Secure;Domain=webapp-onedeploy-testnvsjal2z3kjjy6qbasf.scm.azurewebsites.net
+      - ARRAffinitySameSite=bd1c1462d6f510dac115a128ce96d2fecf18207376913da1139719ff17ff988e;Path=/;HttpOnly;SameSite=None;Secure;Domain=webapp-onedeploy-testnvsjal2z3kjjy6qbasf.scm.azurewebsites.net
+      x-aspnet-version:
+      - 4.0.30319
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp deploy
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --src-url --type --pull-identity
+      User-Agent:
+      - AZURECLI/2.69.0 azsdk-python-core/1.31.0 Python/3.10.11 (Windows-10-10.0.26100-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/sites/webapp-oneDeploy-test000002?api-version=2023-01-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/sites/webapp-oneDeploy-test000002","name":"webapp-oneDeploy-test000002","type":"Microsoft.Web/sites","kind":"app","location":"West
+        Europe","properties":{"name":"webapp-oneDeploy-test000002","state":"Running","hostNames":["webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net"],"webSpace":"cli_test_webapp_OneDeploy000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-377.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli_test_webapp_OneDeploy000001-WestEuropewebspace/sites/webapp-oneDeploy-test000002","repositorySiteName":"webapp-oneDeploy-test000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net","webapp-onedeploy-testnvsjal2z3kjjy6qbasf.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-onedeploy-testnvsjal2z3kjjy6qbasf.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/serverfarms/webapp-oneDeploy-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2025-02-26T00:09:33.68","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"vnetRouteAllEnabled":false,"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"vnetImagePullEnabled":false,"vnetContentShareEnabled":false,"outboundVnetRouting":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"","windowsFxVersion":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":true,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":null,"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":true,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":0,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":1,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false},"functionAppConfig":null,"daprConfig":null,"deploymentId":"webapp-oneDeploy-test000002","slotName":null,"trafficManagerHostNames":null,"sku":"Standard","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientAffinityProxyEnabled":false,"blockPathTraversal":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"ipMode":"IPv4","vnetBackupRestoreEnabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"054064C16B6181EF9569664570EEAC17379D4660547C2C9947A7CD1B2AD083AF","kind":"app","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"20.50.2.27","possibleInboundIpAddresses":"20.50.2.27","ftpUsername":"webapp-oneDeploy-test000002\\$webapp-oneDeploy-test000002","ftpsHostName":"ftps://waws-prod-am2-377.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"20.73.237.47,20.71.73.98,20.73.237.54,20.73.237.61,20.73.237.63,20.73.237.72,108.141.14.172,20.50.2.27","possibleOutboundIpAddresses":"20.73.237.47,20.71.73.98,20.73.237.54,20.73.237.61,20.73.237.63,20.73.237.72,108.141.14.172,20.73.237.79,20.71.73.109,20.73.237.85,20.73.237.101,20.71.78.167,20.73.237.116,20.73.237.123,20.73.237.135,20.73.237.136,20.73.237.151,20.73.237.161,20.73.237.162,20.73.236.209,20.73.237.194,20.71.74.96,20.73.237.221,20.73.237.226,20.73.237.235,20.73.237.251,20.67.123.6,20.67.123.237,20.73.147.51,20.73.147.205,20.73.150.79,20.50.2.27","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-377","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli_test_webapp_OneDeploy000001","defaultHostName":"webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"publicNetworkAccess":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs,AppServiceAuthenticationLogs","inFlightFeatures":["SiteContainers"],"storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"defaultHostNameScope":"Global","privateLinkIdentifiers":null,"sshEnabled":null},"identity":{"type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","principalId":"f9919d5a-65ac-4fef-82c4-328ee97da93f"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '7731'
+      content-type:
+      - application/json
+      date:
+      - Wed, 26 Feb 2025 00:09:59 GMT
+      etag:
+      - '"1DB87E2B6CCDF00"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 4F0F630D940846A2A8733087D8541B40 Ref B: CO6AA3150220031 Ref C: 2025-02-26T00:09:59Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp deploy
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --src-url --type --pull-identity
+      User-Agent:
+      - python/3.10.11 (Windows-10-10.0.26100-SP0) AZURECLI/2.69.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/sites/webapp-oneDeploy-test000002?api-version=2023-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/sites/webapp-oneDeploy-test000002","name":"webapp-oneDeploy-test000002","type":"Microsoft.Web/sites","kind":"app","location":"West
+        Europe","properties":{"name":"webapp-oneDeploy-test000002","state":"Running","hostNames":["webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net"],"webSpace":"cli_test_webapp_OneDeploy000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-377.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli_test_webapp_OneDeploy000001-WestEuropewebspace/sites/webapp-oneDeploy-test000002","repositorySiteName":"webapp-oneDeploy-test000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net","webapp-onedeploy-testnvsjal2z3kjjy6qbasf.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-onedeploy-testnvsjal2z3kjjy6qbasf.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/serverfarms/webapp-oneDeploy-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2025-02-26T00:09:33.68","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"vnetRouteAllEnabled":false,"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"vnetImagePullEnabled":false,"vnetContentShareEnabled":false,"outboundVnetRouting":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"","windowsFxVersion":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":true,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":null,"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":true,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":0,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":1,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false},"functionAppConfig":null,"daprConfig":null,"deploymentId":"webapp-oneDeploy-test000002","slotName":null,"trafficManagerHostNames":null,"sku":"Standard","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientAffinityProxyEnabled":false,"blockPathTraversal":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"ipMode":"IPv4","vnetBackupRestoreEnabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"054064C16B6181EF9569664570EEAC17379D4660547C2C9947A7CD1B2AD083AF","kind":"app","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"20.50.2.27","possibleInboundIpAddresses":"20.50.2.27","ftpUsername":"webapp-oneDeploy-test000002\\$webapp-oneDeploy-test000002","ftpsHostName":"ftps://waws-prod-am2-377.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"20.73.237.47,20.71.73.98,20.73.237.54,20.73.237.61,20.73.237.63,20.73.237.72,108.141.14.172,20.50.2.27","possibleOutboundIpAddresses":"20.73.237.47,20.71.73.98,20.73.237.54,20.73.237.61,20.73.237.63,20.73.237.72,108.141.14.172,20.73.237.79,20.71.73.109,20.73.237.85,20.73.237.101,20.71.78.167,20.73.237.116,20.73.237.123,20.73.237.135,20.73.237.136,20.73.237.151,20.73.237.161,20.73.237.162,20.73.236.209,20.73.237.194,20.71.74.96,20.73.237.221,20.73.237.226,20.73.237.235,20.73.237.251,20.67.123.6,20.67.123.237,20.73.147.51,20.73.147.205,20.73.150.79,20.50.2.27","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-377","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli_test_webapp_OneDeploy000001","defaultHostName":"webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"publicNetworkAccess":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs,AppServiceAuthenticationLogs","inFlightFeatures":["SiteContainers"],"storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"defaultHostNameScope":"Global","privateLinkIdentifiers":null,"sshEnabled":null},"identity":{"type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","principalId":"f9919d5a-65ac-4fef-82c4-328ee97da93f"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '7731'
+      content-type:
+      - application/json
+      date:
+      - Wed, 26 Feb 2025 00:10:01 GMT
+      etag:
+      - '"1DB87E2B6CCDF00"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 8D0E259D9A184D5FB747ECDA87533BDA Ref B: CO6AA3150219033 Ref C: 2025-02-26T00:10:00Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp deploy
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --src-url --type --pull-identity
+      User-Agent:
+      - AZURECLI/2.69.0 azsdk-python-core/1.31.0 Python/3.10.11 (Windows-10-10.0.26100-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/sites/webapp-oneDeploy-test000002/basicPublishingCredentialsPolicies/scm?api-version=2023-01-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/sites/webapp-oneDeploy-test000002/basicPublishingCredentialsPolicies/scm","name":"scm","type":"Microsoft.Web/sites/basicPublishingCredentialsPolicies","location":"West
+        Europe","properties":{"allow":false}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '335'
+      content-type:
+      - application/json
+      date:
+      - Wed, 26 Feb 2025 00:10:02 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 7C6DF7ABE5224BDB984AE81D416D8C09 Ref B: CO6AA3150220021 Ref C: 2025-02-26T00:10:01Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.69.0
+    method: GET
+    uri: https://webapp-onedeploy-testnvsjal2z3kjjy6qbasf.scm.azurewebsites.net/api/deployments/mock-deployment
+  response:
+    body:
+      string: '{"id":"919ee3e0b87245b2a7575f5bc01dfd4f","status":4,"status_text":"","author_email":"N/A","author":"N/A","deployer":"OneDeploy","message":"OneDeploy","progress":"","received_time":"2025-02-26T00:09:54.024323Z","start_time":"2025-02-26T00:09:54.2769786Z","end_time":"2025-02-26T00:09:59.1809969Z","last_success_end_time":"2025-02-26T00:09:59.1809969Z","complete":true,"active":true,"is_temp":false,"is_readonly":true,"url":"https://webapp-onedeploy-testnvsjal2z3kjjy6qbasf.scm.azurewebsites.net/api/deployments/latest","log_url":"https://webapp-onedeploy-testnvsjal2z3kjjy6qbasf.scm.azurewebsites.net/api/deployments/latest/log","site_name":"webapp-oneDeploy-test000002","provisioningState":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '702'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 26 Feb 2025 00:10:07 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      set-cookie:
+      - ARRAffinity=bd1c1462d6f510dac115a128ce96d2fecf18207376913da1139719ff17ff988e;Path=/;HttpOnly;Secure;Domain=webapp-onedeploy-testnvsjal2z3kjjy6qbasf.scm.azurewebsites.net
+      - ARRAffinitySameSite=bd1c1462d6f510dac115a128ce96d2fecf18207376913da1139719ff17ff988e;Path=/;HttpOnly;SameSite=None;Secure;Domain=webapp-onedeploy-testnvsjal2z3kjjy6qbasf.scm.azurewebsites.net
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp deploy
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --src-url --type --pull-identity
+      User-Agent:
+      - AZURECLI/2.69.0 azsdk-python-core/1.31.0 Python/3.10.11 (Windows-10-10.0.26100-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/sites/webapp-oneDeploy-test000002?api-version=2023-01-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/sites/webapp-oneDeploy-test000002","name":"webapp-oneDeploy-test000002","type":"Microsoft.Web/sites","kind":"app","location":"West
+        Europe","properties":{"name":"webapp-oneDeploy-test000002","state":"Running","hostNames":["webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net"],"webSpace":"cli_test_webapp_OneDeploy000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-377.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli_test_webapp_OneDeploy000001-WestEuropewebspace/sites/webapp-oneDeploy-test000002","repositorySiteName":"webapp-oneDeploy-test000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net","webapp-onedeploy-testnvsjal2z3kjjy6qbasf.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-onedeploy-testnvsjal2z3kjjy6qbasf.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_OneDeploy000001/providers/Microsoft.Web/serverfarms/webapp-oneDeploy-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2025-02-26T00:09:33.68","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"vnetRouteAllEnabled":false,"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"vnetImagePullEnabled":false,"vnetContentShareEnabled":false,"outboundVnetRouting":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"","windowsFxVersion":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":true,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":null,"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":true,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":0,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":1,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false},"functionAppConfig":null,"daprConfig":null,"deploymentId":"webapp-oneDeploy-test000002","slotName":null,"trafficManagerHostNames":null,"sku":"Standard","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientAffinityProxyEnabled":false,"blockPathTraversal":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"ipMode":"IPv4","vnetBackupRestoreEnabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"054064C16B6181EF9569664570EEAC17379D4660547C2C9947A7CD1B2AD083AF","kind":"app","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"20.50.2.27","possibleInboundIpAddresses":"20.50.2.27","ftpUsername":"webapp-oneDeploy-test000002\\$webapp-oneDeploy-test000002","ftpsHostName":"ftps://waws-prod-am2-377.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"20.73.237.47,20.71.73.98,20.73.237.54,20.73.237.61,20.73.237.63,20.73.237.72,108.141.14.172,20.50.2.27","possibleOutboundIpAddresses":"20.73.237.47,20.71.73.98,20.73.237.54,20.73.237.61,20.73.237.63,20.73.237.72,108.141.14.172,20.73.237.79,20.71.73.109,20.73.237.85,20.73.237.101,20.71.78.167,20.73.237.116,20.73.237.123,20.73.237.135,20.73.237.136,20.73.237.151,20.73.237.161,20.73.237.162,20.73.236.209,20.73.237.194,20.71.74.96,20.73.237.221,20.73.237.226,20.73.237.235,20.73.237.251,20.67.123.6,20.67.123.237,20.73.147.51,20.73.147.205,20.73.150.79,20.50.2.27","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-377","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli_test_webapp_OneDeploy000001","defaultHostName":"webapp-onedeploy-testnvsjal2z3kjjy6qbasf.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"publicNetworkAccess":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs,AppServiceAuthenticationLogs","inFlightFeatures":["SiteContainers"],"storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"defaultHostNameScope":"Global","privateLinkIdentifiers":null,"sshEnabled":null},"identity":{"type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","principalId":"f9919d5a-65ac-4fef-82c4-328ee97da93f"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '7731'
+      content-type:
+      - application/json
+      date:
+      - Wed, 26 Feb 2025 00:10:08 GMT
+      etag:
+      - '"1DB87E2B6CCDF00"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 5EA3615E120F45DC904A9AE9E9AE7497 Ref B: CO6AA3150217047 Ref C: 2025-02-26T00:10:07Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
@@ -2855,7 +2855,7 @@ class WebappLocalContextScenarioTest(LocalContextScenarioTest):
             self.cmd('webapp delete')
 
         self.cmd('webapp delete -n {webapp_name}')
-        self.cmd('appservice plan delete -n {plan_name} -y')
+        selfj.cmd('appservice plan delete -n {plan_name} -y')
 
 
 class WebappOneDeployScenarioTest(ScenarioTest):
@@ -2877,18 +2877,20 @@ class WebappOneDeployScenarioTest(ScenarioTest):
             JMESPathCheck('properties.status', 'RuntimeSuccessful'),
         ])
 
-    @unittest.skip("Flaky test")
-    @ResourceGroupPreparer(name_prefix='cli_test_webapp_OneDeploy', location=LINUX_ASP_LOCATION_WEBAPP)
-    def test_one_deploy_arm(self, resource_group):
+    @ResourceGroupPreparer(name_prefix='cli_test_webapp_OneDeploy', location=WINDOWS_ASP_LOCATION_WEBAPP)
+    def test_one_deploy_pull_with_MSI(self, resource_group):
         webapp_name = self.create_random_name('webapp-oneDeploy-test', 40)
         plan_name = self.create_random_name('webapp-oneDeploy-plan', 40)
         war_url = "https://tomcat.apache.org/tomcat-7.0-doc/appdev/sample/sample.war"
         self.cmd(
-            'appservice plan create -g {} -n {} --sku S1 --is-linux'.format(resource_group, plan_name))
+            'appservice plan create -g {} -n {} --sku S1'.format(resource_group, plan_name))
         self.cmd(
-            'webapp create -g {} -n {} --plan {} -r "TOMCAT|9.0-java11"'.format(resource_group, webapp_name, plan_name))
+            'webapp create -g {} -n {} --plan {}'.format(resource_group, webapp_name, plan_name))
+        self.cmd(
+            'webapp identity assign -g {} -n {}'.format(resource_group, webapp_name)
+        )
         
-        self.cmd(f'webapp deploy -g {resource_group} -n {webapp_name} --src-url {war_url} --type war').assert_with_checks([
+        self.cmd(f'webapp deploy -g {resource_group} -n {webapp_name} --src-url {war_url} --type zip --pull-identity system').assert_with_checks([
             JMESPathCheck('deployer', 'OneDeploy'),
             JMESPathCheck('message', 'OneDeploy'),
         ])


### PR DESCRIPTION
**Related command**
az webapp deploy

**Description**<!--Mandatory-->
Adding --pull-identity argument to allow for MSI based authentication when performing a pull based deployment. 

`pullIdentity` can have 3 states;
- `null`: MSI will not be used. This matches the existing behavior (SAS or public access)
- `system`: Authenticates using system assigned identity
- `{client-Id}`: Authenticates using provided user assigned identity

**Testing Guide**
`az webapp deploy -g {resource-group-name] -n {app-name} --src-url {package-url} --pull-identity system --type zip`: Deploys a zip file from `{package-url}` using the system assigned identity of the web app to authenticate against the storage account.
`az webapp deploy -g {resource-group-name] -n {app-name} --src-url {package-url} --pull-identity {client-id} --type zip`: Deploys a zip file from `{package-url}` using the user assigned identity with id `{client-id}` to authenticate against the storage account
`az webapp deploy -g {resource-group-name] -n {app-name} --src-url {package-url} --type zip`: Behavior is unchanged. Deployment will pull with anonymous access or SAS token

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
