### PR TITLE
{Packaging} Remove empty `__pycache__` folder in zip package

### DIFF
--- a/build_scripts/windows/scripts/build.cmd
+++ b/build_scripts/windows/scripts/build.cmd
@@ -205,7 +205,7 @@ for /f %%f in ('dir /b /s *.pyc') do (
 )
 popd
 
-REM Remove __pycache__
+REM Remove empty __pycache__ directories because .pyc files are already moved to parent directories
 echo remove pycache
 for /d /r %BUILDING_DIR%\Lib\site-packages\ %%d in (__pycache__) do (
     if exist %%d rmdir /s /q "%%d"

--- a/build_scripts/windows/scripts/build.cmd
+++ b/build_scripts/windows/scripts/build.cmd
@@ -207,7 +207,7 @@ popd
 
 REM Remove __pycache__
 echo remove pycache
-for /d /r %BUILDING_DIR%\Lib\site-packages\pip %%d in (__pycache__) do (
+for /d /r %BUILDING_DIR%\Lib\site-packages\ %%d in (__pycache__) do (
     if exist %%d rmdir /s /q "%%d"
 )
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
There are 2072 empty `__pycache__` folders in 2.69.0 zip package. For example: `Lib/site-packages/__pycache__`. (The only non-empty folder is `Scripts\__pycache__`)
```
fd --type directory --type empty __pycache__ | wc
   2072    2072  167666
```

In `build.cmd`, we only remove `__pycache__` files in `pip` folder. The empty `__pycache__` folders are never been removed. Since msi package ingores emtpy folder by default, this issue does not happen in msi.

> Because folders created by the installer are deleted when they become empty, you must author an entry into the CreateFolder table to install a component that consists of an empty folder. 
-- https://learn.microsoft.com/en-us/windows/win32/msi/createfolder-table?redirectedfrom=MSDN 


**Testing Guide**
<!--Example commands with explanations.-->
2.69.0 zip package:
![image](https://github.com/user-attachments/assets/3080ce5a-c8bf-468e-b93e-7db68fac97ae)

new package:
![image](https://github.com/user-attachments/assets/c4f7acd4-d0ff-467f-aeca-bff091c117ef)

The files number is the same, but the folder count decreased by 2072.