### PR TITLE
{RDBMS} `az postgres flexible-server update`: Show warning for scaling operations on SSDV2 servers and correct validation

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
@@ -360,6 +360,10 @@ def flexible_server_update_custom_func(cmd, client, instance,
     if instance.storage.type == "PremiumV2_LRS":
         instance.storage.tier = None
 
+        if sku_name or storage_gb:
+            logger.warning("You are changing the compute and/or storage size of the server "
+                           "The server needs to be restarted for this operation and you will see a short downtime.")
+
         if iops:
             instance.storage.iops = iops
 

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
@@ -361,8 +361,8 @@ def flexible_server_update_custom_func(cmd, client, instance,
         instance.storage.tier = None
 
         if sku_name or storage_gb:
-            logger.warning("You are changing the compute and/or storage size of the server "
-                           "The server needs to be restarted for this operation and you will see a short downtime.")
+            logger.warning("You are changing the compute and/or storage size of the server. "
+                           "The server will be restarted for this operation and you will see a short downtime.")
 
         if iops:
             instance.storage.iops = iops

--- a/src/azure-cli/azure/cli/command_modules/rdbms/validators.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/validators.py
@@ -430,20 +430,20 @@ def _valid_ssdv2_range(storage_gb, sku_info, tier, iops, throughput, instance):
         raise CLIError('The requested value for IOPS does not fall between {} and {} operations/sec.'
                        .format(min_iops, max_iops))
 
-    # find min and max values for throughout
-    min_throughout = sku_info[sku_tier]["supported_storageV2_throughput"]
+    # find min and max values for throughput
+    min_throughput = sku_info[sku_tier]["supported_storageV2_throughput"]
     if storage > 6:
-        max_storage_throughout = math.floor(max(0.25 * storage_iops, min_throughout))
+        max_storage_throughput = math.floor(max(0.25 * storage_iops, min_throughput))
     else:
-        max_storage_throughout = min_throughout
-    if sku_info[sku_tier]["supported_storageV2_throughput_max"] < max_storage_throughout:
-        max_throughout = sku_info[sku_tier]["supported_storageV2_throughput_max"]
+        max_storage_throughput = min_throughput
+    if sku_info[sku_tier]["supported_storageV2_throughput_max"] < max_storage_throughput:
+        max_throughput = sku_info[sku_tier]["supported_storageV2_throughput_max"]
     else:
-        max_throughout = max_storage_throughout
+        max_throughput = max_storage_throughput
 
-    if not min_throughout <= storage_throughput <= max_throughout:
+    if not min_throughput <= storage_throughput <= max_throughput:
         raise CLIError('The requested value for throughput does not fall between {} and {} MB/sec.'
-                       .format(min_throughout, max_throughout))
+                       .format(min_throughput, max_throughput))
 
 
 def _pg_tier_validator(tier, sku_info):

--- a/src/azure-cli/azure/cli/command_modules/rdbms/validators.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/validators.py
@@ -421,9 +421,9 @@ def _valid_ssdv2_range(storage_gb, sku_info, tier, iops, throughput, instance):
     storage = storage_gib * 1.07374182
     # find min and max values for IOPS
     min_iops = sku_info[sku_tier]["supported_storageV2_iops"]
-    supported_iops = sku_info[sku_tier]["supported_storageV2_iops_max"]
+    supported_max_iops = sku_info[sku_tier]["supported_storageV2_iops_max"]
     calculated_max_iops = math.floor(max(0, storage - 6) * 500 + min_iops)
-    max_iops = min(supported_iops, calculated_max_iops)
+    max_iops = min(supported_max_iops, calculated_max_iops)
 
     if not min_iops <= storage_iops <= max_iops:
         raise CLIError('The requested value for IOPS does not fall between {} and {} operations/sec.'
@@ -431,14 +431,12 @@ def _valid_ssdv2_range(storage_gb, sku_info, tier, iops, throughput, instance):
 
     # find min and max values for throughput
     min_throughput = sku_info[sku_tier]["supported_storageV2_throughput"]
+    supported_max_throughput = sku_info[sku_tier]["supported_storageV2_throughput_max"]
     if storage > 6:
         max_storage_throughput = math.floor(max(0.25 * storage_iops, min_throughput))
     else:
         max_storage_throughput = min_throughput
-    if sku_info[sku_tier]["supported_storageV2_throughput_max"] < max_storage_throughput:
-        max_throughput = sku_info[sku_tier]["supported_storageV2_throughput_max"]
-    else:
-        max_throughput = max_storage_throughput
+    max_throughput = min(supported_max_throughput, max_storage_throughput)
 
     if not min_throughput <= storage_throughput <= max_throughput:
         raise CLIError('The requested value for throughput does not fall between {} and {} MB/sec.'

--- a/src/azure-cli/azure/cli/command_modules/rdbms/validators.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/validators.py
@@ -421,10 +421,9 @@ def _valid_ssdv2_range(storage_gb, sku_info, tier, iops, throughput, instance):
     storage = storage_gib * 1.07374182
     # find min and max values for IOPS
     min_iops = sku_info[sku_tier]["supported_storageV2_iops"]
-    if sku_info[sku_tier]["supported_storageV2_iops"] < math.floor(max(0, storage - 6) * 500 + min_iops):
-        max_iops = sku_info[sku_tier]["supported_storageV2_iops_max"]
-    else:
-        max_iops = math.floor(max(0, storage - 6) * 500 + min_iops)
+    supported_iops = sku_info[sku_tier]["supported_storageV2_iops_max"]
+    calculated_max_iops = math.floor(max(0, storage - 6) * 500 + min_iops)
+    max_iops = min(supported_iops, calculated_max_iops)
 
     if not min_iops <= storage_iops <= max_iops:
         raise CLIError('The requested value for IOPS does not fall between {} and {} operations/sec.'


### PR DESCRIPTION
**Related command**
`az postgres flexible-server update`

**Description**<!--Mandatory-->
SSDv2 currently does not support online disk scaling operations which means any disk change operation results in restart. We need to display the restart message to customer both from CLI and Portal for SSDv2.

Find max iops value for ssdv2 server during create/update was being handled incorrectly.

**Testing Guide**
Manual
Warning message:
![image](https://github.com/user-attachments/assets/cd62d9ec-215f-44b2-a492-97428939a2ae)

Range validation fix.
<img width="796" alt="image" src="https://github.com/user-attachments/assets/0fad1c85-4fda-4911-9368-ca5e234db16e" />


**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
