### PR TITLE
{ACR} Remove unnecessary network call in `az acr cache` subcommand

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_constants.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_constants.py
@@ -11,6 +11,8 @@ REGISTRY_RESOURCE_TYPE = ACR_RESOURCE_PROVIDER + '/registries'
 WEBHOOK_RESOURCE_TYPE = REGISTRY_RESOURCE_TYPE + '/webhooks'
 REPLICATION_RESOURCE_TYPE = REGISTRY_RESOURCE_TYPE + '/replications'
 
+CREDENTIAL_SET_RESOURCE_ID_TEMPLATE = '/subscriptions/{sub_id}/resourceGroups/{rg}/providers/Microsoft.ContainerRegistry/registries/{reg_name}/credentialSets/{cred_set_name}'
+
 TASK_RESOURCE_TYPE = REGISTRY_RESOURCE_TYPE + '/tasks'
 TASK_VALID_VSTS_URLS = ['visualstudio.com', 'dev.azure.com']
 TASK_RESOURCE_ID_TEMPLATE = '/subscriptions/{sub_id}/resourceGroups/{rg}/providers/Microsoft.ContainerRegistry/registries/{reg}/tasks/{name}'


### PR DESCRIPTION
**Related command**
```
az acr cache create
az acr cache update
```

**Description**
`az acr cache create` and `az acr cache update` are used to create and update cache rules under Azure Container Registry. A _cache rule_ is a sub resource of a container registry.

Currently, when the above two operations are performed, the code first makes a GET request to _registry_ resource, only to get the id of the resource by its name. It needs the registry id in order to create credential set id which is needed when creating and updating a cache rule. The credential set id can be determined without making the above GET request. This GET request is made on the registry resource, which implies the executing user must have 'Reader' role of the registry. This could lead to user overprivileging roles, e.g. now they have to give executing user registry read permissions, in additoinal to cache rule CRUD permissions.

This commit removed the GET registry request in cache create and cache update workflow. As a result, a role with only cache rule permissions is able to execute cache rule create and update. This makes our security model clearer, and also makes the operation more efficient.

**Testing Guide**
First create a container registry using `az acr create ...`.
Then create a credential set under this registry `az acr credential-set create ..`
Then create and update a cache rule

I have tested above scenarios and they all work as expected.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
