### PR TITLE
[AKS] `az aks create/update`: Update recording rule group create logic for managed prometheus addon

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/recordingrules/create.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/recordingrules/create.py
@@ -61,7 +61,7 @@ def put_rules(cmd, default_rule_group_id, default_rule_group_name, mac_region, c
         except CLIError as e:
             error = e
     else:
-        raise error
+        raise error # pylint: disable=used-before-assignment
 
 
 # pylint: disable=line-too-long

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/recordingrules/create.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/recordingrules/create.py
@@ -17,12 +17,9 @@ def get_recording_rules_template(cmd, azure_monitor_workspace_resource_id):
     r = send_raw_request(cmd.cli_ctx, "GET", url, headers=headers)
     data = json.loads(r.text)
 
-    # Safely filter the templates with case-insensitive check
     filtered_templates = [
         template for template in data.get('value', [])
-        if template.get("properties", {}).get("alertRuleType", "").lower() == "microsoft.alertsmanagement/prometheusrulegroups"
-        and isinstance(template.get("properties", {}).get("rulesArmTemplate", {}).get("resources"), list)
-        and all(
+        if template.get("properties", {}).get("alertRuleType", "").lower() == "microsoft.alertsmanagement/prometheusrulegroups" and isinstance(template.get("properties", {}).get("rulesArmTemplate", {}).get("resources"), list) and all(
             isinstance(rule, dict) and "record" in rule and "expression" in rule
             for resource in template["properties"]["rulesArmTemplate"]["resources"]
             if resource.get("type", "").lower() == "microsoft.alertsmanagement/prometheusrulegroups"
@@ -59,9 +56,7 @@ def put_rules(cmd, default_rule_group_id, default_rule_group_name, mac_region, c
                              body=body, headers=headers)
             break
         except CLIError as e:
-            error = e
-    else:
-        raise error  # pylint: disable=used-before-assignment
+            raise e
 
 
 # pylint: disable=line-too-long

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/recordingrules/create.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/recordingrules/create.py
@@ -61,7 +61,7 @@ def put_rules(cmd, default_rule_group_id, default_rule_group_name, mac_region, c
         except CLIError as e:
             error = e
     else:
-        raise error # pylint: disable=used-before-assignment
+        raise error  # pylint: disable=used-before-assignment
 
 
 # pylint: disable=line-too-long

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/recordingrules/create.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/recordingrules/create.py
@@ -16,7 +16,21 @@ def get_recording_rules_template(cmd, azure_monitor_workspace_resource_id):
     url = f"{armendpoint}{azure_monitor_workspace_resource_id}/providers/microsoft.alertsManagement/alertRuleRecommendations?api-version={ALERTS_API}"
     r = send_raw_request(cmd.cli_ctx, "GET", url, headers=headers)
     data = json.loads(r.text)
-    return data['value']
+
+    # Safely filter the templates with case-insensitive check
+    filtered_templates = [
+        template for template in data.get('value', [])
+        if template.get("properties", {}).get("alertRuleType", "").lower() == "microsoft.alertsmanagement/prometheusrulegroups"
+        and isinstance(template.get("properties", {}).get("rulesArmTemplate", {}).get("resources"), list)
+        and all(
+            isinstance(rule, dict) and "record" in rule and "expression" in rule
+            for resource in template["properties"]["rulesArmTemplate"]["resources"]
+            if resource.get("type", "").lower() == "microsoft.alertsmanagement/prometheusrulegroups"
+            for rule in resource.get("properties", {}).get("rules", [])
+        )
+    ]
+
+    return filtered_templates
 
 
 # pylint: disable=line-too-long
@@ -47,7 +61,7 @@ def put_rules(cmd, default_rule_group_id, default_rule_group_name, mac_region, c
         except CLIError as e:
             error = e
     else:
-        raise error  # pylint: disable=used-before-assignment
+        raise error
 
 
 # pylint: disable=line-too-long
@@ -56,7 +70,7 @@ def create_rules(cmd, cluster_subscription, cluster_resource_group_name, cluster
     # with urllib.request.urlopen("https://defaultrulessc.blob.core.windows.net/defaultrules/ManagedPrometheusDefaultRecordingRules.json") as url:
     #     default_rules_template = json.loads(url.read().decode())
     default_rules_template = get_recording_rules_template(cmd, azure_monitor_workspace_resource_id)
-    default_rule_group_name = truncate_rule_group_name("NodeRecordingRulesRuleGroup-{0}".format(cluster_name))
+    default_rule_group_name = truncate_rule_group_name("{0}-{1}".format(default_rules_template[0]["properties"]["name"], cluster_name))
     default_rule_group_id = "/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.AlertsManagement/prometheusRuleGroups/{2}".format(
         cluster_subscription,
         cluster_resource_group_name,
@@ -75,7 +89,7 @@ def create_rules(cmd, cluster_subscription, cluster_resource_group_name, cluster
     )
     put_rules(cmd, default_rule_group_id, default_rule_group_name, mac_region, cluster_resource_id, azure_monitor_workspace_resource_id, cluster_name, default_rules_template, url, True, 0)
 
-    default_rule_group_name = truncate_rule_group_name("KubernetesRecordingRulesRuleGroup-{0}".format(cluster_name))
+    default_rule_group_name = truncate_rule_group_name("{0}-{1}".format(default_rules_template[1]["properties"]["name"], cluster_name))
     default_rule_group_id = "/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.AlertsManagement/prometheusRuleGroups/{2}".format(
         cluster_subscription,
         cluster_resource_group_name,
@@ -93,7 +107,7 @@ def create_rules(cmd, cluster_subscription, cluster_resource_group_name, cluster
     if enable_windows_recording_rules is not True:
         enable_windows_recording_rules = False
 
-    default_rule_group_name = truncate_rule_group_name("NodeRecordingRulesRuleGroup-Win-{0}".format(cluster_name))
+    default_rule_group_name = truncate_rule_group_name("{0}-{1}".format(default_rules_template[2]["properties"]["name"], cluster_name))
     default_rule_group_id = "/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.AlertsManagement/prometheusRuleGroups/{2}".format(
         cluster_subscription,
         cluster_resource_group_name,
@@ -106,7 +120,7 @@ def create_rules(cmd, cluster_subscription, cluster_resource_group_name, cluster
     )
     put_rules(cmd, default_rule_group_id, default_rule_group_name, mac_region, cluster_resource_id, azure_monitor_workspace_resource_id, cluster_name, default_rules_template, url, enable_windows_recording_rules, 2)
 
-    default_rule_group_name = truncate_rule_group_name("NodeAndKubernetesRecordingRulesRuleGroup-Win-{0}".format(cluster_name))
+    default_rule_group_name = truncate_rule_group_name("{0}-{1}".format(default_rules_template[3]["properties"]["name"], cluster_name))
     default_rule_group_id = "/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.AlertsManagement/prometheusRuleGroups/{2}".format(
         cluster_subscription,
         cluster_resource_group_name,

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/recordingrules/create.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/recordingrules/create.py
@@ -70,7 +70,7 @@ def create_rules(cmd, cluster_subscription, cluster_resource_group_name, cluster
     # with urllib.request.urlopen("https://defaultrulessc.blob.core.windows.net/defaultrules/ManagedPrometheusDefaultRecordingRules.json") as url:
     #     default_rules_template = json.loads(url.read().decode())
     default_rules_template = get_recording_rules_template(cmd, azure_monitor_workspace_resource_id)
-    default_rule_group_name = truncate_rule_group_name("{0}-{1}".format(default_rules_template[0]["properties"]["name"], cluster_name))
+    default_rule_group_name = truncate_rule_group_name("{0}-{1}".format(default_rules_template[0]["name"], cluster_name))
     default_rule_group_id = "/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.AlertsManagement/prometheusRuleGroups/{2}".format(
         cluster_subscription,
         cluster_resource_group_name,
@@ -89,7 +89,7 @@ def create_rules(cmd, cluster_subscription, cluster_resource_group_name, cluster
     )
     put_rules(cmd, default_rule_group_id, default_rule_group_name, mac_region, cluster_resource_id, azure_monitor_workspace_resource_id, cluster_name, default_rules_template, url, True, 0)
 
-    default_rule_group_name = truncate_rule_group_name("{0}-{1}".format(default_rules_template[1]["properties"]["name"], cluster_name))
+    default_rule_group_name = truncate_rule_group_name("{0}-{1}".format(default_rules_template[1]["name"], cluster_name))
     default_rule_group_id = "/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.AlertsManagement/prometheusRuleGroups/{2}".format(
         cluster_subscription,
         cluster_resource_group_name,
@@ -107,7 +107,7 @@ def create_rules(cmd, cluster_subscription, cluster_resource_group_name, cluster
     if enable_windows_recording_rules is not True:
         enable_windows_recording_rules = False
 
-    default_rule_group_name = truncate_rule_group_name("{0}-{1}".format(default_rules_template[2]["properties"]["name"], cluster_name))
+    default_rule_group_name = truncate_rule_group_name("{0}-{1}".format(default_rules_template[2]["name"], cluster_name))
     default_rule_group_id = "/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.AlertsManagement/prometheusRuleGroups/{2}".format(
         cluster_subscription,
         cluster_resource_group_name,
@@ -120,7 +120,7 @@ def create_rules(cmd, cluster_subscription, cluster_resource_group_name, cluster
     )
     put_rules(cmd, default_rule_group_id, default_rule_group_name, mac_region, cluster_resource_id, azure_monitor_workspace_resource_id, cluster_name, default_rules_template, url, enable_windows_recording_rules, 2)
 
-    default_rule_group_name = truncate_rule_group_name("{0}-{1}".format(default_rules_template[3]["properties"]["name"], cluster_name))
+    default_rule_group_name = truncate_rule_group_name("{0}-{1}".format(default_rules_template[3]["name"], cluster_name))
     default_rule_group_id = "/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.AlertsManagement/prometheusRuleGroups/{2}".format(
         cluster_subscription,
         cluster_resource_group_name,


### PR DESCRIPTION
**Related command**
```az aks create -n kaveeshcli22 -g kaveeshcli --location westeurope --enable-azure-monitor-metrics --azure-monitor-workspace-resource-id "{full_id}" --grafana-resource-id "{full_id}"```

```az aks create -n kaveeshcli22 -g kaveeshcli --disable-azure-monitor-metrics ```

**Description**<!--Mandatory-->
The recording rules manifest has been updated in TiP and will soon be deployed to production which will include other alerts rule recommendations. I'm updating the CLI code to filter down to the rule groups that the managed prometheus needs for onboarding in this PR.

**Testing Guide**

Scenario 1 : Region where TiP manifest is available

- Enable Microsoft.AlertsManagement/testinproduction in your subscription
- Use the command with and without the azure-monitor-workspace-resource-id parameter similar to `az aks create -n kaveeshcli22 -g kaveeshcli --location westcentralus --enable-azure-monitor-metrics"` and it should result in a success. (Currently the change is only deployed to westcentralus)


Scenario 2 : Region where TiP manifest is *not* available

- Use the command with and without the azure-monitor-workspace-resource-id parameter similar to `az aks create -n kaveeshcli22 -g kaveeshcli --location westeurope --enable-azure-monitor-metrics"` and it should result in a success. 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
