### PR TITLE
[Core] `aaz`: Support `Any` type with full value shorthand syntax allowed

### DIFF
--- a/src/azure-cli-core/azure/cli/core/aaz/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/__init__.py
@@ -12,7 +12,8 @@ Atomic commands can be generated from rest api by using aaz-dev tool.
 from ._arg import AAZArgumentsSchema, AAZArgEnum, AAZStrArg, AAZIntArg, AAZObjectArg, AAZDictArg, \
     AAZFreeFormDictArg, AAZFloatArg, AAZBaseArg, AAZBoolArg, AAZListArg, AAZResourceGroupNameArg, \
     AAZResourceLocationArg, AAZResourceIdArg, AAZSubscriptionIdArg, AAZUuidArg, AAZDateArg, AAZTimeArg, \
-    AAZDateTimeArg, AAZDurationArg, AAZFileArg, AAZPasswordArg, AAZPaginationTokenArg, AAZPaginationLimitArg
+    AAZDateTimeArg, AAZDurationArg, AAZFileArg, AAZPasswordArg, AAZPaginationTokenArg, AAZPaginationLimitArg, \
+    AAZAnyTypeArg
 from ._arg_fmt import AAZStrArgFormat, AAZIntArgFormat, AAZFloatArgFormat, AAZBoolArgFormat, AAZObjectArgFormat, \
     AAZDictArgFormat, AAZFreeFormDictArgFormat, AAZListArgFormat, AAZResourceLocationArgFormat, \
     AAZResourceIdArgFormat, AAZSubscriptionIdArgFormat, AAZUuidFormat, AAZDateFormat, AAZTimeFormat, \
@@ -22,7 +23,7 @@ from ._base import has_value, AAZValuePatch, AAZUndefined
 from ._command import AAZCommand, AAZWaitCommand, AAZCommandGroup, \
     register_callback, register_command, register_command_group, load_aaz_command_table, link_helper
 from ._field_type import AAZIntType, AAZFloatType, AAZStrType, AAZBoolType, AAZDictType, AAZFreeFormDictType, \
-    AAZListType, AAZObjectType, AAZIdentityObjectType
+    AAZListType, AAZObjectType, AAZIdentityObjectType, AAZAnyType
 from ._operation import AAZHttpOperation, AAZJsonInstanceUpdateOperation, AAZGenericInstanceUpdateOperation, \
     AAZJsonInstanceDeleteOperation, AAZJsonInstanceCreateOperation
 from ._prompt import AAZPromptInput, AAZPromptPasswordInput

--- a/src/azure-cli-core/azure/cli/core/aaz/_arg.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_arg.py
@@ -372,7 +372,7 @@ class AAZAnyTypeArg(AAZBaseArg, AAZAnyType):
         short_summary += shorthand_help_messages['short-summary-anytype']
         arg.help = short_summary
         return arg
-    
+
     @property
     def _type_in_help(self):
         return "Any"

--- a/src/azure-cli-core/azure/cli/core/aaz/_arg_action.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_arg_action.py
@@ -203,8 +203,11 @@ class AAZAnyTypeArgAction(AAZArgAction):
         # check if the value is a partial value
         key, _, v = cls._str_parser.split_partial_value(value)
         if key is not None:
-            raise AAZInvalidValueError(f"AnyType args only support full value shorthand syntax, please don't use partial value shorthand syntax. If it's a simple string, please wrap it with single quotes.")
-        
+            raise AAZInvalidValueError(
+                "AnyType args only support full value shorthand syntax, "
+                "please don't use partial value shorthand syntax. "
+                "If it's a simple string, please wrap it with single quotes.")
+
         # read from file
         path = os.path.expanduser(value)
         if os.path.exists(path):

--- a/src/azure-cli-core/azure/cli/core/aaz/_arg_browser.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_arg_browser.py
@@ -62,23 +62,10 @@ class AAZArgBrowser:
         else:
             raise NotImplementedError()
 
+    # Warning: This method is not used by the new aaz-dev-tools, it should be kept for backward compatibility
     def get_anytype_elements(self):
         """Iter over sub elements of list or dict."""
-        if self._arg_data is None:
-            # stop iteration
-            return
-
-        if isinstance(self._arg_data, dict):
-            for k, d in self._arg_data.items():
-                v = self._arg_value[k]
-                if isinstance(v, AAZBaseValue):
-                    # ignore fixed type element
-                    continue
-                # build AAZBaseValue from data without schema
-                v = AAZBaseValue(None, d)
-                yield k, AAZArgBrowser(v, d, parent=None)
-        else:
-            raise NotImplementedError()
+        return self.get_elements()
 
     @property
     def data(self):

--- a/src/azure-cli-core/azure/cli/core/aaz/_arg_fmt.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_arg_fmt.py
@@ -466,32 +466,9 @@ class AAZDictArgFormat(AAZBaseArgFormat):
         return value
 
 
-class AAZFreeFormDictArgFormat(AAZBaseArgFormat):
-
-    def __init__(self, max_properties=None, min_properties=None):
-        self._max_properties = max_properties
-        self._min_properties = min_properties
-
-    def __call__(self, ctx, value):
-        assert isinstance(value, AAZFreeFormDict)
-        data = value._data
-        if data == AAZUndefined or data is None:
-            return value
-
-        assert isinstance(data, dict)
-
-        if value._is_patch:
-            return value
-
-        if self._min_properties and len(value) < self._min_properties:
-            raise AAZInvalidArgValueError(
-                f"Invalid format: dict length is less than {self._min_properties}")
-
-        if self._max_properties and len(value) > self._max_properties:
-            raise AAZInvalidArgValueError(
-                f"Invalid format: dict length is greater than {self._max_properties}")
-
-        return value
+# Warning: This type should not be used any more, the new aaz-dev-tools only use AAZDictArgFormat
+class AAZFreeFormDictArgFormat(AAZDictArgFormat):
+    pass
 
 
 class AAZListArgFormat(AAZBaseArgFormat):

--- a/src/azure-cli-core/azure/cli/core/aaz/_arg_fmt.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_arg_fmt.py
@@ -15,7 +15,7 @@ from knack.log import get_logger
 
 from ._command_ctx import AAZCommandCtx
 from ._field_type import AAZSimpleType
-from ._field_value import AAZUndefined, AAZSimpleValue, AAZDict, AAZFreeFormDict, AAZList, AAZObject
+from ._field_value import AAZUndefined, AAZSimpleValue, AAZDict, AAZList, AAZObject
 from .exceptions import AAZInvalidArgValueError
 
 logger = get_logger(__name__)

--- a/src/azure-cli-core/azure/cli/core/aaz/_content_builder.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_content_builder.py
@@ -4,8 +4,8 @@
 # --------------------------------------------------------------------------------------------
 
 from ._base import AAZBaseValue, AAZUndefined
-from ._field_value import AAZSimpleValue, AAZBaseDictValue, AAZDict, AAZFreeFormDict, AAZList, AAZObject
-from ._field_type import AAZObjectType
+from ._field_value import AAZSimpleValue, AAZBaseDictValue, AAZDict, AAZList, AAZObject
+from ._field_type import AAZObjectType, AAZAnyType
 from ._arg_browser import AAZArgBrowser
 
 # pylint: disable=protected-access, too-many-nested-blocks, too-many-return-statements
@@ -131,19 +131,10 @@ class AAZContentBuilder:
 
         return None
 
+    # Warning: This method is not used by the new aaz-dev-tools, it should be kept for backward compatibility
     def set_anytype_elements(self, arg_key=None):
         """Set any type elements of free from dictionary"""
-        for value, arg in zip(self._values, self._args):
-            if not isinstance(value, AAZFreeFormDict):
-                raise NotImplementedError()
-
-            for key, sub_arg in arg.get_anytype_elements():
-                if sub_arg is not None and sub_arg.data != AAZUndefined:
-                    sub_arg = sub_arg.get_prop(arg_key)
-
-                if sub_arg is not None and sub_arg.data != AAZUndefined:
-                    if not sub_arg.is_patch and arg_key:
-                        value[key] = sub_arg.data
+        self.set_elements(AAZAnyType, arg_key=arg_key)
 
     def discriminate_by(self, prop_name, prop_value):
         """discriminate object by a specify property"""

--- a/src/azure-cli-core/azure/cli/core/aaz/_field_type.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_field_type.py
@@ -390,6 +390,7 @@ class AAZDictType(AAZBaseDictType):
     def __getitem__(self, key):
         return self.Element
 
+
 # Warning: This type should not be used any more, the new aaz-dev-tools only use AAZDictType with AAZAnyType
 class AAZFreeFormDictType(AAZDictType):
     """Free form dict value type"""

--- a/src/azure-cli-core/azure/cli/core/aaz/_field_value.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_field_value.py
@@ -3,10 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 # pylint: disable=protected-access
-import copy
-
 from ._base import AAZBaseValue, AAZValuePatch, AAZUndefined
-from .exceptions import AAZInvalidValueError
 import abc
 
 
@@ -57,8 +54,8 @@ class AAZSimpleValue(AAZBaseValue):
         return result
 
 
-class AAZAnyValue(AAZSimpleValue):
-    # TODO: may need to override the __getitem__, __setitem__, __delitem__, __getattr__, __setattr__, __delattr__, 
+class AAZAnyValue(AAZSimpleValue):  # pylint: disable=too-few-public-methods
+    # TODO: may need to override the __getitem__, __setitem__, __delitem__, __getattr__, __setattr__, __delattr__,
     pass
 
 

--- a/src/azure-cli-core/azure/cli/core/aaz/_help.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_help.py
@@ -22,6 +22,7 @@ except ImportError:
 shorthand_help_messages = {
     "show-help": 'Try "??" to show more.',
     "short-summary": 'Support shorthand-syntax, json-file and yaml-file.',
+    "short-summary-anytype": 'Support shorthand-syntax(full value only), json-file and yaml-file.',
     "long-summary": 'See https://aka.ms/cli-shorthand for more about shorthand syntax.'
 }
 

--- a/src/azure-cli-core/azure/cli/core/aaz/_utils.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_utils.py
@@ -190,13 +190,13 @@ class AAZShortHandSyntaxParser:
 
         if remain[:idx] in self.HELP_EXPRESSIONS:
             raise AAZShowHelp()
-        
+
         if convert_simple_type:
             try:
                 converted = json.loads(remain[:idx])
                 if isinstance(converted, (str, int, float, bool)):
                     return converted, idx
-            except Exception as ex:
+            except ValueError:
                 pass
 
         return remain[:idx], idx

--- a/src/azure-cli-core/azure/cli/core/aaz/_utils.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_utils.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 import re
 from collections import OrderedDict
-
+import json
 from azure.cli.core.aaz.exceptions import AAZInvalidShorthandSyntaxError
 from ._help import AAZShowHelp
 from ._base import AAZBlankArgValue
@@ -57,7 +57,7 @@ class AAZShortHandSyntaxParser:
         if remain.startswith('['):
             return self.parse_list(remain)
 
-        return self.parse_string(remain)
+        return self.parse_string(remain, convert_simple_type=True)
 
     def parse_dict(self, remain):  # pylint: disable=too-many-statements
         result = OrderedDict()
@@ -165,7 +165,7 @@ class AAZShortHandSyntaxParser:
             raise AAZInvalidShorthandSyntaxError(remain, idx, 1, "Expect character ']'")
         return result, idx
 
-    def parse_string(self, remain):
+    def parse_string(self, remain, convert_simple_type=False):
         idx = 0
         if len(remain) and remain[0] == "'":
             return self.parse_single_quotes_string(remain)
@@ -190,6 +190,14 @@ class AAZShortHandSyntaxParser:
 
         if remain[:idx] in self.HELP_EXPRESSIONS:
             raise AAZShowHelp()
+        
+        if convert_simple_type:
+            try:
+                converted = json.loads(remain[:idx])
+                if isinstance(converted, (str, int, float, bool)):
+                    return converted, idx
+            except Exception as ex:
+                pass
 
         return remain[:idx], idx
 

--- a/src/azure-cli-core/azure/cli/core/tests/test_aaz_arg.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_aaz_arg.py
@@ -107,81 +107,86 @@ class TestAAZArgShorthandSyntax(unittest.TestCase):
         parser = AAZShortHandSyntaxParser()
         self.assertEqual(parser("{}"), {})
         self.assertEqual(parser("{a:1,b:2,c:null,d:''}"), {
+            "a": 1,
+            "b": 2,
+            "c": None,
+            "d": ''
+        })
+        self.assertEqual(parser("{a:'1',b:'2',c:null,d:''}"), {
             "a": "1",
             "b": "2",
             "c": None,
             "d": ''
         })
         self.assertEqual(parser("{a:1,b:2,c:None,d:'',}"), {
-            "a": "1",
-            "b": "2",
+            "a": 1,
+            "b": 2,
             "c": "None",
             "d": ''
         })
         self.assertEqual(parser("{a:1,b:''/'}"), {
-            "a": "1",
+            "a": 1,
             "b": "'"
         })
 
-        self.assertEqual(parser("{a:1,b:'/'}"), {
+        self.assertEqual(parser("{a:'1',b:'/'}"), {
             "a": "1",
             "b": "/"
         })
 
         self.assertEqual(parser("{a:1,b:'//'}"), {
-            "a": "1",
+            "a": 1,
             "b": "//"
         })
 
         self.assertEqual(parser("{a:1,b:/}"), {
-            "a": "1",
+            "a": 1,
             "b": "/"
         })
 
-        self.assertEqual(parser("{a:1,b:2,c:Null,d:''}"), {
+        self.assertEqual(parser("{a:'1',b:'2',c:Null,d:''}"), {
             "a": "1",
             "b": "2",
             "c": "Null",
             "d": ''
         })
         self.assertEqual(parser("{a:1,b:2,c:none,d:'',}"), {
-            "a": "1",
-            "b": "2",
+            "a": 1,
+            "b": 2,
             "c": "none",
             "d": ''
         })
 
-        self.assertEqual(parser("{a:{a1:' \n '/',a2:2}}"), {
+        self.assertEqual(parser("{a:{a1:' \n '/',a2:2.2}}"), {
             "a": {
                 "a1": " \n '",
-                "a2": "2",
+                "a2": 2.2,
             }
         })
 
-        self.assertEqual(parser("{a:{a1:1,a2:2}}"), {
+        self.assertEqual(parser("{a:{a1:1,a2:'false'}}"), {
             "a": {
-                "a1": "1",
-                "a2": "2",
+                "a1": 1,
+                "a2": 'false',
             }
         })
-        self.assertEqual(parser("{a:{a1:1,a2:2},}"), {
+        self.assertEqual(parser("{a:{a1:'1.1',a2:true},}"), {
             "a": {
-                "a1": "1",
-                "a2": "2",
+                "a1": "1.1",
+                "a2": True,
             }
         })
-
-        self.assertEqual(parser("{a:{a1:{},a2:2}}"), {
+        self.assertEqual(parser("{a:{a1:{},a2:false}}"), {
             "a": {
                 "a1": {},
-                "a2": "2",
+                "a2": False,
             }
         })
 
         self.assertEqual(parser("{a:{a1,a2:2,c},a3,a4:''}"), {
             "a": {
                 "a1": AAZBlankArgValue,
-                "a2": "2",
+                "a2": 2,
                 "c": AAZBlankArgValue,
             },
             "a3": AAZBlankArgValue,
@@ -189,20 +194,20 @@ class TestAAZArgShorthandSyntax(unittest.TestCase):
         })
 
         self.assertEqual(parser("{a:1,'',c:1,e}"), {
-            "a": "1",
+            "a": 1,
             "": AAZBlankArgValue,
-            "c": "1",
+            "c": 1,
             "e": AAZBlankArgValue,
         })
 
-        self.assertEqual(parser("{a:[{prop1:1,prop2:2},{a1:[b,null,c,'d:e \"]'],a2:'2 3\t\"}',a4:'',a3:null,}],e:f,g:null}"), {
+        self.assertEqual(parser("{a:[{prop1:1,prop2:true},{a1:[b,3,3.4,true,false,'true','false',null,c,'d:e \"]'],a2:'2 3\t\"}',a4:'',a3:null,}],e:f,g:null}"), {
             "a": [
                 {
-                    "prop1": "1",
-                    "prop2": "2",
+                    "prop1": 1,
+                    "prop2": True,
                 },
                 {
-                    "a1": ["b", None, "c", 'd:e "]'],
+                    "a1": ["b", 3, 3.4, True, False, "true", "false", None, "c", 'd:e "]'],
                     "a2": '2 3\t"}',
                     "a4": '',
                     "a3": None,
@@ -346,7 +351,7 @@ class TestAAZArgShorthandSyntax(unittest.TestCase):
 
         ls = [1, 2, 3, 4]
         s = json.dumps(ls, separators=(',', ':'))
-        self.assertEqual(parser(s), ['1', '2', '3', '4'])
+        self.assertEqual(parser(s), ls)
 
         ls = ["1", "2"]
         s = json.dumps(ls, separators=(',', ':'))
@@ -563,10 +568,10 @@ class TestAAZArg(unittest.TestCase):
         dest_ops = AAZArgActionOperations()
         self.assertEqual(len(dest_ops._ops), 0)
 
-        action.setup_operations(dest_ops, ["[task1,task2,task_ext]"])
+        action.setup_operations(dest_ops, ["[0,'null',false,'true',1.2,'1.2','10']"])
         self.assertEqual(len(dest_ops._ops), 1)
         dest_ops.apply(v, "tasks")
-        self.assertEqual(v.tasks.to_serialized_data(), ["task1", "task2", "task_ext"])
+        self.assertEqual(v.tasks.to_serialized_data(), ["0", "null", "false", "true", "1.2", "1.2", "10"])
 
         # New argument
         schema.name = AAZStrArg(options=["--name", "-n"])
@@ -1148,40 +1153,202 @@ class TestAAZArg(unittest.TestCase):
         self.assertEqual(len(dest_ops._ops), 0)
 
         # null value
-        action.setup_operations(dest_ops, "null")
+        action.setup_operations(dest_ops, ["null"])
         self.assertEqual(len(dest_ops._ops), 1)
         dest_ops.apply(v, "tags")
         self.assertEqual(v.tags, None)
 
         # empty dict
-        action.setup_operations(dest_ops, "{}")
+        action.setup_operations(dest_ops, ["{}"])
         self.assertEqual(len(dest_ops._ops), 2)
         dest_ops.apply(v, "tags")
         self.assertEqual(v.tags, {})
 
-        # freeform dict
-        action.setup_operations(dest_ops, '{"a": 1, "b": null, "c": false, "d": "string", "e": [1, "str", null]}')
-        self.assertEqual(len(dest_ops._ops), 3)
+        # partial value
+        action.setup_operations(dest_ops, ["a=1", "b=false", "c=abc", "d='1'", "e='null'"])
+        self.assertEqual(len(dest_ops._ops), 7)
         dest_ops.apply(v, "tags")
-        self.assertEqual(v.tags, {"a": 1, "b": None, "c": False, "d": "string", "e": [1, "str", None]})
+        self.assertEqual(v.tags, {"a": 1, "b": False, "c": "abc", "d": "1", "e": 'null'})
+
+        # json string
+        action.setup_operations(dest_ops, ['{"a": 1, "c": false, "d": "string", "e": [1, "str", null]}'])
+        self.assertEqual(len(dest_ops._ops), 8)
+        dest_ops.apply(v, "tags")
+        self.assertEqual(v.tags, {"a": 1, "c": False, "d": "string", "e": [1, "str", None]})
 
         # blank value
         action.setup_operations(dest_ops, None)
-        self.assertEqual(len(dest_ops._ops), 4)
+        self.assertEqual(len(dest_ops._ops), 9)
         dest_ops.apply(v, "tags")
         self.assertEqual(v.tags, {"blank": True})
 
-        with self.assertRaises(aazerror.AAZInvalidValueError):
-            action.setup_operations(dest_ops, "'null'")
+        # with shorthand syntax
+        action.setup_operations(dest_ops, ["{a:1,b:false,c:abc,d:'1',e:'null'}"])
+        self.assertEqual(len(dest_ops._ops), 10)
+        dest_ops.apply(v, "tags")
+        self.assertEqual(v.tags, {"a": 1, "b": False, "c": "abc", "d": "1", "e": 'null'})
 
         with self.assertRaises(aazerror.AAZInvalidValueError):
-            action.setup_operations(dest_ops, "'123'")
+            action.setup_operations(dest_ops, ["'null'"])
 
         with self.assertRaises(aazerror.AAZInvalidValueError):
-            action.setup_operations(dest_ops, "123")
+            action.setup_operations(dest_ops, ["'123'"])
 
         with self.assertRaises(aazerror.AAZInvalidValueError):
-            action.setup_operations(dest_ops, "[1, 2, 3]")
+            action.setup_operations(dest_ops, ["123"])
+
+        with self.assertRaises(aazerror.AAZInvalidValueError):
+            action.setup_operations(dest_ops, ["[1, 2, 3]"])
+    
+    def test_aaz_any_arg(self):
+        # verify the shell_safe_json_parse function
+        from azure.cli.core.aaz._arg import AAZAnyTypeArg, AAZArgumentsSchema
+        from azure.cli.core.aaz._arg_action import AAZArgActionOperations
+        from azure.cli.core.aaz import has_value
+        from azure.cli.core.util import shell_safe_json_parse
+        schema = AAZArgumentsSchema()
+        v = schema()
+
+        schema.any = AAZAnyTypeArg(
+            options=["--any", "-a"],
+            nullable=True,
+            blank={"blank": True}
+        )
+
+        self.assertFalse(has_value(v.any))
+
+        arg = schema.any.to_cmd_arg("any")
+        action = arg.type.settings["action"]
+        dest_ops = AAZArgActionOperations()
+        self.assertEqual(len(dest_ops._ops), 0)
+
+        # null value
+        action.setup_operations(dest_ops, "null")
+        self.assertEqual(len(dest_ops._ops), 1)
+        dest_ops.apply(v, "any")
+        self.assertEqual(v.any, None)
+
+        # empty dict
+        action.setup_operations(dest_ops, "{}")
+        self.assertEqual(len(dest_ops._ops), 2)
+        dest_ops.apply(v, "any")
+        self.assertEqual(v.any, {})
+
+        # partial value should raise error
+        with self.assertRaises(aazerror.AAZInvalidValueError):
+            action.setup_operations(dest_ops, "a=1")
+        # assign a partial value like string
+        action.setup_operations(dest_ops, "'a=1'")
+        self.assertEqual(len(dest_ops._ops), 3)
+        dest_ops.apply(v, "any")
+        self.assertEqual(v.any, "a=1")
+
+        # empty list
+        action.setup_operations(dest_ops, "[]")
+        self.assertEqual(len(dest_ops._ops), 4)
+        dest_ops.apply(v, "any")
+        self.assertEqual(v.any, [])
+
+        # blank value
+        action.setup_operations(dest_ops, None)
+        self.assertEqual(len(dest_ops._ops), 5)
+        dest_ops.apply(v, "any")
+        self.assertEqual(v.any, {"blank": True})
+
+        # json string
+        action.setup_operations(dest_ops, '{"a": 1, "c": false, "d": "string", "e": [1, "str", null]}')
+        self.assertEqual(len(dest_ops._ops), 6)
+        dest_ops.apply(v, "any")
+        self.assertEqual(v.any, {"a": 1, "c": False, "d": "string", "e": [1, "str", None]})
+
+        # with shorthand syntax
+        action.setup_operations(dest_ops, "{a:1,b:false,c:abc,d:'1',e:'null'}")
+        self.assertEqual(len(dest_ops._ops), 7)
+        dest_ops.apply(v, "any")
+        self.assertEqual(v.any, {"a": 1, "b": False, "c": "abc", "d": "1", "e": 'null'})
+
+        # test strings
+        action.setup_operations(dest_ops, "'null'")
+        self.assertEqual(len(dest_ops._ops), 8)
+        dest_ops.apply(v, "any")
+        self.assertEqual(v.any, 'null')
+
+        action.setup_operations(dest_ops, "'1'")
+        self.assertEqual(len(dest_ops._ops), 9)
+        dest_ops.apply(v, "any")
+        self.assertEqual(v.any, '1')
+
+        action.setup_operations(dest_ops, "'false'")
+        self.assertEqual(len(dest_ops._ops), 10)
+        dest_ops.apply(v, "any")
+        self.assertEqual(v.any, 'false')
+
+        action.setup_operations(dest_ops, "'true'")
+        self.assertEqual(len(dest_ops._ops), 11)
+        dest_ops.apply(v, "any")
+        self.assertEqual(v.any, 'true')
+
+        # test int
+        action.setup_operations(dest_ops, "123")
+        self.assertEqual(len(dest_ops._ops), 12)
+        dest_ops.apply(v, "any")
+        self.assertEqual(v.any, 123)
+
+        # test float
+        action.setup_operations(dest_ops, "123.456")
+        self.assertEqual(len(dest_ops._ops), 13)
+        dest_ops.apply(v, "any")
+        self.assertEqual(v.any, 123.456)
+
+        # test bool
+        action.setup_operations(dest_ops, "true")
+        self.assertEqual(len(dest_ops._ops), 14)
+        dest_ops.apply(v, "any")
+        self.assertEqual(v.any, True)
+
+        action.setup_operations(dest_ops, "false")
+        self.assertEqual(len(dest_ops._ops), 15)
+        dest_ops.apply(v, "any")
+        self.assertEqual(v.any, False)
+
+        # test without nullable and blank value
+        schema.any2 = AAZAnyTypeArg(
+            options=["--any2"],
+        )
+        self.assertFalse(has_value(v.any2))
+
+        arg = schema.any2.to_cmd_arg("any")
+        action = arg.type.settings["action"]
+        dest_ops = AAZArgActionOperations()
+        self.assertEqual(len(dest_ops._ops), 0)
+        
+        action.setup_operations(dest_ops, "[]")
+        self.assertEqual(len(dest_ops._ops), 1)
+        dest_ops.apply(v, "any2")
+        self.assertEqual(v.any2, [])
+
+        with self.assertRaises(aazerror.AAZInvalidValueError):
+            action.setup_operations(dest_ops, None)
+        
+        with self.assertRaises(aazerror.AAZInvalidValueError):
+            action.setup_operations(dest_ops, "null")
+
+        self.assertEqual(shell_safe_json_parse("true"), True)
+        self.assertEqual(shell_safe_json_parse("false"), False)
+        self.assertEqual(shell_safe_json_parse("'true'"), "true")
+        self.assertEqual(shell_safe_json_parse('"false"'), "false")
+        self.assertEqual(shell_safe_json_parse("null"), None)
+        self.assertEqual(shell_safe_json_parse("'null'"), "null")
+        self.assertEqual(shell_safe_json_parse('"null"'), "null")
+        self.assertEqual(shell_safe_json_parse("123"), 123)
+        self.assertEqual(shell_safe_json_parse("'123'"), "123")
+        self.assertEqual(shell_safe_json_parse('"123"'), "123")
+        self.assertEqual(shell_safe_json_parse("[]"), [])
+        self.assertEqual(shell_safe_json_parse("['a', 'b', 'c']"), ["a", "b", "c"])
+        self.assertEqual(shell_safe_json_parse("[1, 2, 3]"), [1, 2, 3])
+        self.assertEqual(shell_safe_json_parse("{}"), {})
+        self.assertEqual(shell_safe_json_parse('{"a": 1, "b": 2, "c": 3}'), {"a": 1, "b": 2, "c": 3})
+        self.assertEqual(shell_safe_json_parse(r"'{\"a\":1,\"b\":2,\"c\":3}'"), '{"a":1,"b":2,"c":3}')
 
     def test_aaz_object_arg(self):
         from azure.cli.core.aaz._arg import AAZDictArg, AAZListArg, AAZObjectArg, AAZIntArg, AAZBoolArg, AAZFloatArg, \

--- a/src/azure-cli-core/azure/cli/core/tests/test_aaz_field.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_aaz_field.py
@@ -148,6 +148,114 @@ class TestAAZField(unittest.TestCase):
         assert v.properties.height._data == 121
 
 
+    def test_aaz_any_type(self):
+        from azure.cli.core.aaz._field_type import AAZObjectType, AAZDictType, AAZAnyType, AAZListType, AAZIntType, AAZStrType, AAZBoolType
+        from azure.cli.core.aaz._field_value import AAZObject, AAZAnyValue, AAZValuePatch, AAZUndefined
+        model_schema = AAZObjectType()
+        model_schema.any = AAZAnyType()
+        model_schema.nullable_any = AAZAnyType(nullable=True)
+        model_schema.additional = AAZDictType()
+        model_schema.additional.Element = AAZAnyType()
+        model_schema.nullable_additional = AAZDictType()
+        model_schema.nullable_additional.Element = AAZAnyType(nullable=True)
+        model_schema.array = AAZListType()
+        model_schema.array.Element = AAZAnyType()
+        model_schema.nullable_array = AAZListType()
+        model_schema.nullable_array.Element = AAZAnyType(nullable=True)
+        model_schema.patch_object = AAZObjectType(nullable=True)
+        model_schema.patch_object.obj = AAZObjectType()
+        model_schema.patch_object.obj.a = AAZIntType()
+        model_schema.patch_object.obj.b = AAZStrType()
+        model_schema.patch_object.obj.c = AAZBoolType()
+        model_schema.patch_object.obj.d = AAZAnyType(nullable=True)
+
+        v = AAZObject(schema=model_schema, data={})
+        assert v.any._is_patch
+        self.assertEqual(v.to_serialized_data(), {})
+
+        v.any = 1
+        self.assertEqual(v.any.to_serialized_data(), 1)
+        v.any = 0.1
+        self.assertEqual(v.any.to_serialized_data(), 0.1)
+        v.any = "1"
+        self.assertEqual(v.any.to_serialized_data(), "1")
+        v.any = True
+        self.assertEqual(v.any.to_serialized_data(), True)
+        v.any = False
+        self.assertEqual(v.any.to_serialized_data(), False)
+        v.any = [1, "123", None]
+        self.assertEqual(v.any.to_serialized_data(), [1, "123", None])
+        v.any = None
+        self.assertEqual(v.to_serialized_data(), {})
+        v.nullable_any = None
+        self.assertEqual(v.to_serialized_data(), {"nullable_any": None})
+
+        # verify additional and nullable_additional
+        v.additional = {"a": 1, "b": "str", "c": True, "d": None}
+        self.assertEqual(v.additional.to_serialized_data(), {"a": 1, "b": "str", "c": True})
+        v.nullable_additional = {"a": 1, "b": "str", "c": True, "d": None}
+        self.assertEqual(v.nullable_additional.to_serialized_data(), {"a": 1, "b": "str", "c": True, "d": None})
+
+        # verify array and nullable_array
+        v.array = [1, "123", None]
+        self.assertEqual(v.array.to_serialized_data(), [1, "123"])
+        v.nullable_array = [1, "123", None]
+        self.assertEqual(v.nullable_array.to_serialized_data(), [1, "123", None])
+
+        # verify the patch value assign to any type
+        # undefined patch value
+        _ = v.patch_object.obj.a
+        self.assertEqual(v.patch_object.obj.a._is_patch, True)
+        
+        v.any = v.patch_object
+        self.assertEqual(v.any._is_patch, True)
+        self.assertEqual(v.any.to_serialized_data(), AAZUndefined)
+        
+        v.array[2] = v.patch_object
+        self.assertEqual(v.array[2]._is_patch, True)
+        self.assertEqual(v.array.to_serialized_data(), [1, "123"])
+        
+        v.nullable_array[3] = v.patch_object
+        self.assertEqual(v.nullable_array[3]._is_patch, True)
+        self.assertEqual(v.nullable_array.to_serialized_data(), [1, "123", None])
+
+        # defined patch value
+        v.patch_object.obj.a = 1
+        v.patch_object.obj.b = "str"
+
+        v.any = v.patch_object
+        self.assertEqual(v.any._is_patch, False)
+        self.assertEqual(v.any.to_serialized_data(), {"obj": {"a": 1, "b": "str"}})
+        
+        v.array[2] = v.patch_object
+        self.assertEqual(v.array[2]._is_patch, False)
+        self.assertEqual(v.array.to_serialized_data(), [1, "123", {"obj": {"a": 1, "b": "str"}}])
+        
+        v.nullable_array[3] = v.patch_object
+        self.assertEqual(v.nullable_array[3]._is_patch, False)
+        self.assertEqual(v.nullable_array.to_serialized_data(), [1, "123", None, {"obj": {"a": 1, "b": "str"}}])
+
+        # defined patch value is None
+        v.patch_object = None
+        
+        v.any = v.patch_object
+        self.assertEqual(v.any._is_patch, True)
+        self.assertEqual(v.any.to_serialized_data(), AAZUndefined)
+        
+        v.nullable_any = v.patch_object
+        self.assertEqual(v.nullable_any._is_patch, False)
+        self.assertEqual(v.nullable_any.to_serialized_data(), None)
+
+         
+        v.array[2] = v.patch_object
+        self.assertEqual(v.array[2]._is_patch, True)
+        self.assertEqual(v.array.to_serialized_data(), [1, "123"])
+        
+        v.nullable_array[3] = v.patch_object
+        self.assertEqual(v.nullable_array[3]._is_patch, False)
+        self.assertEqual(v.nullable_array.to_serialized_data(), [1, "123", None, None])
+
+
     def test_aaz_dict_type(self):
         from azure.cli.core.aaz._field_type import AAZObjectType, AAZDictType, AAZStrType
         from azure.cli.core.aaz._field_value import AAZObject
@@ -213,7 +321,7 @@ class TestAAZField(unittest.TestCase):
 
     def test_aaz_free_form_dict_type(self):
         from azure.cli.core.aaz._field_type import AAZObjectType, AAZFreeFormDictType, AAZDictType, AAZListType
-        from azure.cli.core.aaz._field_value import AAZObject, AAZBaseValue, AAZUndefined, AAZValuePatch
+        from azure.cli.core.aaz._field_value import AAZObject, AAZBaseValue, AAZUndefined, AAZValuePatch, AAZAnyValue
         from azure.cli.core.aaz.exceptions import AAZInvalidValueError
 
         model_schema = AAZObjectType()
@@ -225,8 +333,10 @@ class TestAAZField(unittest.TestCase):
         v = AAZObject(schema=model_schema, data={})
 
         assert 'A' not in v.additional
+        assert v.additional['A']._is_patch
+        del v.additional['A']
         with self.assertRaises(KeyError):
-            v.additional['A']
+            del v.additional['A']
 
         v.additional['number'] = 1
         self.assertEqual(v.additional['number'], 1)
@@ -240,7 +350,7 @@ class TestAAZField(unittest.TestCase):
         for key, value in v.additional.items():
             self.assertEqual(key, 'number')
             self.assertEqual(value, 1)
-            self.assertTrue(isinstance(value, int))
+            self.assertTrue(isinstance(value, AAZAnyValue))
 
         v.additional.clear()
         self.assertEqual(len(v.additional), 0)
@@ -273,7 +383,7 @@ class TestAAZField(unittest.TestCase):
 
         del v.additional['bool']
         with self.assertRaises(KeyError):
-            v.additional['bool']
+            del v.additional['bool']
 
         v.additional['none'] = None
         self.assertEqual(v.additional['none'], None)
@@ -295,22 +405,25 @@ class TestAAZField(unittest.TestCase):
         })
 
         v.configs[0] = {'a': 1, 'b': 'str', 'c': True, 'd': None}
-        self.assertEqual(v.configs[0], {'a': 1, 'b': 'str', 'c': True, 'd': None})
+        self.assertEqual(v.configs[0].to_serialized_data(), {'a': 1, 'b': 'str', 'c': True, 'd': None})
         self.assertEqual(v.configs[0]._data, {'a': 1, 'b': 'str', 'c': True, 'd': None})
 
         v.configs[1] = {"obj": {"a": 1, "c": 2}}
-        del v.configs[1]['obj']['a']
-        self.assertEqual(v.configs[1], {"obj": {"c": 2}})
+        # AAZAnyValue is not support delete
+        with self.assertRaises(TypeError):
+            del v.configs[1]['obj']['a']
+        self.assertEqual(v.configs[1].to_serialized_data(), {"obj": {"a": 1, "c": 2}})
+        self.assertEqual(v.configs[1]._data, {"obj": {"a": 1, "c": 2}})
+        v.configs[1] = {"obj": {"c": 2}}
 
         v.configs[0] = None
         self.assertEqual(v.configs.to_serialized_data(), [{"obj": {"c": 2}}])
 
-        with self.assertRaises(AAZInvalidValueError):
-            v.nullable_additional['a'] = AAZValuePatch(AAZUndefined)
+        v.nullable_additional['a'] = AAZValuePatch(AAZUndefined)
+        self.assertTrue(v.nullable_additional._is_patch)
 
         self.assertTrue(v.additional._is_patch)
-        with self.assertRaises(AAZInvalidValueError):
-            v.nullable_additional['p'] = v.additional
+        v.nullable_additional['p'] = v.additional
 
         self.assertTrue(v.configs[1]._is_patch is False)
 
@@ -318,6 +431,11 @@ class TestAAZField(unittest.TestCase):
 
         v.configs[1]['more'] = True
         self.assertEqual(v.nullable_additional.to_serialized_data(), {
+            "p": {
+                'none': None,
+                'obj': {'a': 1, 'b': 'str', 'c': True, 'd': None},
+                'list': ['a', 1, True, None, ['s', 'v'], {'a': 1, 'b': 2}]
+            },
             "z": {"obj": {"c": 2}},
         })
 
@@ -328,7 +446,13 @@ class TestAAZField(unittest.TestCase):
                 'list': ['a', 1, True, None, ['s', 'v'], {'a': 1, 'b': 2}]
             },
             "configs": [{"obj": {"c": 2}, "more": True}],
-            "nullable_additional": {"z": {"obj": {"c": 2}}}
+            "nullable_additional": {
+                "p": {
+                    'none': None,
+                    'obj': {'a': 1, 'b': 'str', 'c': True, 'd': None},
+                    'list': ['a', 1, True, None, ['s', 'v'], {'a': 1, 'b': 2}]
+                },
+                "z": {"obj": {"c": 2}}}
         })
 
         v.nullable_additional = None


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

This PR add support of `Any` type for aaz commands. The aaz runtime enhanced the shorthand syntax so that the full value can be supported for `Any` type.

The `Any` type is a type allowing a value in `string`, `int`, `float`, `bool`, `list` and `dict`, which are basic types used in json. The `null` value is also accepted for **nullable** `Any` type.

The shorthand syntax will try to convert the input string to possible types, for example `1` will be convert as int type and `false` will be convert as bool type. If you want to input a string of `1`, it can be wrapped in a single quote string. Below are some examples:

- Assign int `1` value
``` bash
az some-command create --any-type-arg 1
# or
az some-command create --any-type-arg "1"
```
- Assign float `1.1` value
``` bash
az some-command create --any-type-arg 1.1
# or
az some-command create --any-type-arg "1.1"
```

- Assign bool `false` value
``` bash
az some-command create --any-type-arg false
# or
az some-command create --any-type-arg "false"
```

- Assign string `abc` value
```bash
az some-command create --any-type-arg abc
# or
az some-command create --any-type-arg "abc"
```
- Assign string `1` value
``` bash
az some-command create --any-type-arg "'1'"
```
- Assign string `false` value
```bash
# when value is `false` string
az some-command create --any-type-arg "'false'"
``` 

- Assign list value like
```json
[1, 1.1, false, "strvalue", "5"]
```
The shorthand syntan command:
``` bash
az some-command create --any-type-arg "[1,1.1,false,strvalue,'5']"
```

- Assign dict valuelike
```json
{
  "a": 1,
  "b": 1.1,
  "c": false,
  "d": "strvalue",
  "e": "5"
}
```
The shorthand syntan command:
``` bash
az some-command create --any-type-arg "{a:1,b:1.1,c:false,d:strvalue,e:'5'}"
```



**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
