### PR TITLE
{CI} Pin azdev to 0.1.90

### DIFF
--- a/.azure-pipelines/templates/azdev_setup.yml
+++ b/.azure-pipelines/templates/azdev_setup.yml
@@ -16,7 +16,7 @@ steps:
       chmod +x env/bin/activate
       . env/bin/activate
       python -m pip install -U pip
-      pip install azdev
+      pip install azdev==0.1.90
       azdev --version
 
       if [ -z "$CLI_EXT_REPO_PATH" ]; then


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Bypass `disallowed_html_tag_from_command` rule in `Check CLI Linter`

```
-  FAIL - HIGH severity: disallowed_html_tag_from_command
    Command: `acr login` - Disallowed html tags ['<registry url>'] in long summary. If content is a placeholder, please remove <> or wrap it with backtick. For more info please refer to: https://review.learn.microsoft.com/en-us/help/platform/validation-ref/disallowed-html-tag?branch=main
    Command: `batchai cluster node list` - Disallowed html tags ['<public ip>', '<admin user name>', "<node's SSH port number>"] in long summary. If content is a placeholder, please remove <> or wrap it with backtick. For more info please refer to: https://review.learn.microsoft.com/en-us/help/platform/validation-ref/disallowed-html-tag?branch=main
    Command: `batchai job node list` - Disallowed html tags ['<public ip>', '<admin user name>', "<node's SSH port number>"] in long summary. If content is a placeholder, please remove <> or wrap it with backtick. For more info please refer to: https://review.learn.microsoft.com/en-us/help/platform/validation-ref/disallowed-html-tag?branch=main
```

Ref: https://dev.azure.com/azclitools/release/_build/results?buildId=223094&view=logs&j=168ccbe3-da49-5c0b-6478-08f7016e4bf5
