### PR TITLE
[storage copy] Update the default `AZCOPY_VERSION` to 10.28.0

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
@@ -22,7 +22,7 @@ logger = get_logger(__name__)
 
 STORAGE_RESOURCE_ENDPOINT = "https://storage.azure.com"
 SERVICES = {'blob', 'file'}
-AZCOPY_VERSION = '10.13.0'
+AZCOPY_VERSION = '10.28.0'
 
 
 class AzCopy:


### PR DESCRIPTION
**Related command**
`az storage copy`

**Description**
By default, when the `azcopy` binary is missing, the `az storage copy` command would download the `1.13.0` version of `azcopy`. That version is outdated and missing several fixes, compared to the latest one (`10.28.0`). This PR updates the default version to `10.28.0

**Testing Guide**
With a brand new environment, do:

```bash
az login
az storage copy
```

Now, the `azcopy` binary should have been downloaded to the az cli binary directory (`~/.azure/bin/azcopy` by default)

```bash
~/.azure/bin/azcopy --version
```
This should output: `azcopy version 10.28.0`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
