### PR TITLE
{core} `aaz`: Fix bug for int value to float value convert

### DIFF
--- a/src/azure-cli-core/azure/cli/core/aaz/_arg_action.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_arg_action.py
@@ -167,6 +167,9 @@ class AAZSimpleTypeArgAction(AAZArgAction):
         if isinstance(data, cls._schema.DataType):
             return data
 
+        if isinstance(data, int) and cls._schema.DataType == float:
+            return data
+
         raise AAZInvalidValueError(f"{cls._schema.DataType} type value expected, got '{data}'({type(data)})")
 
 

--- a/src/azure-cli-core/azure/cli/core/tests/test_aaz_arg.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_aaz_arg.py
@@ -1520,6 +1520,19 @@ class TestAAZArg(unittest.TestCase):
             "new_i_pv6": '00:00:00'
         })
 
+        # test assign the int value to the float field, it should be converted to float
+        action.setup_operations(dest_ops, ["{enable:True,tags:null,vnets:null,pt:12,newIPv6:'00:00:00'}"])
+        self.assertEqual(len(dest_ops._ops), 13)
+        dest_ops.apply(v, "properties")
+        self.assertEqual(v.properties, {
+            "enable": True,
+            "tags": None,
+            "vnets": None,
+            "pt": 12.0,
+            "new_i_pv6": '00:00:00'
+        })
+
+
     def test_aaz_has_value_for_buildin(self):
         from azure.cli.core.aaz import has_value, AAZUndefined
         self.assertTrue(has_value(0))


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

This change will convert the `int` number to `float` number when assign to a float type argument for backward compatible with existing behaviors.


**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
