### PR TITLE
{LTS} Do not add `post` suffix for branches starting with `release`

### DIFF
--- a/scripts/release/pypi/build.sh
+++ b/scripts/release/pypi/build.sh
@@ -22,7 +22,7 @@ pip list
 
 script_dir=`cd $(dirname $BASH_SOURCE[0]); pwd`
 
-if [[ "$branch" != "release" ]]; then
+if [[ ! $branch =~ ^release ]]; then
     . $script_dir/../../ci/version.sh post`date -u '+%Y%m%d%H%M%S'`
 fi
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
The `pypi` build artifact of ec3172dd54637aadb24ab78cdfb7c7b956d26cd2 contains the `post` suffix:

![image](https://github.com/user-attachments/assets/5d9d00d4-4441-4336-b4b9-6cb84b47d32f)

These packages are incorrectly published to PyPI: https://pypi.org/project/azure-cli/2.66.1.post20250227030620/#files

![image](https://github.com/user-attachments/assets/4b7034fd-dfbc-432b-b263-5abf3a5cd7cc)

We should not add `post` suffix for branches starting with `release` including `release-lts-2.66`.

**Testing Guide**
Create a new branch `release-lts-2.66-test` and trigger the release pipeline. Make sure the artifacts does not contain `post` suffix.
