### PR TITLE
{CI} Increase pytest worker number

### DIFF
--- a/scripts/release/debian/test_deb_package.py
+++ b/scripts/release/debian/test_deb_package.py
@@ -12,7 +12,7 @@ root_dir = f'/opt/az/lib/python3.{python_minor_version}/site-packages/azure/cli/
 mod_list = [mod for mod in sorted(os.listdir(root_dir)) if os.path.isdir(os.path.join(root_dir, mod)) and mod != '__pycache__']
 
 pytest_base_cmd = '/opt/az/bin/python3 -m pytest -v --forked -p no:warnings --log-level=WARN'
-pytest_parallel_cmd = '{} -n auto'.format(pytest_base_cmd)
+pytest_parallel_cmd = '{} -n logical'.format(pytest_base_cmd)
 
 # cloud: https://github.com/Azure/azure-cli/pull/14994
 # appservice: https://github.com/Azure/azure-cli/pull/19810

--- a/scripts/release/rpm/test_rpm_package.py
+++ b/scripts/release/rpm/test_rpm_package.py
@@ -12,7 +12,7 @@ root_dir = f'/usr/lib64/az/lib/{python_version}/site-packages/azure/cli/command_
 mod_list = [mod for mod in sorted(os.listdir(root_dir)) if os.path.isdir(os.path.join(root_dir, mod)) and mod != '__pycache__']
 
 pytest_base_cmd = f'PYTHONPATH=/usr/lib64/az/lib/{python_version}/site-packages python -m pytest -v --forked -p no:warnings --log-level=WARN'
-pytest_parallel_cmd = '{} -n auto'.format(pytest_base_cmd)
+pytest_parallel_cmd = '{} -n logical'.format(pytest_base_cmd)
 
 # cloud: https://github.com/Azure/azure-cli/pull/14994
 # appservice: https://github.com/Azure/azure-cli/pull/19810


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

In https://github.com/Azure/azure-cli/pull/30238, we upgrade to 4-core agent form 2 core.
Recently, we upgraded to 8-core agent, and pytest has 4 workers.
This PR doubles the number of workers by using logical core instead of physical core.

**Testing Guide**
<!--Example commands with explanations.-->
It saves 5-20% of time.
`Test Rpm Package Azure Linux 3.0 AMD64`  1h 20m 57s -> 1h 10m 39s
`Test Deb Packages Bookworm AMD64` 1h 13m 36s -> 59m 41s
`Test Deb Packages Noble AMD64` 1h 8m 11s -> 1h 5m 2s
`Test Rpm Package Azure Linux 3.0 AMD64` 1h 20m 57s -> 1h 10m 39s