### PR TITLE
{Packaging} Port #30905: Do not add `post` suffix for branches starting with `release`

### DIFF
--- a/scripts/release/pypi/build.sh
+++ b/scripts/release/pypi/build.sh
@@ -22,7 +22,7 @@ pip list
 
 script_dir=`cd $(dirname $BASH_SOURCE[0]); pwd`
 
-if [[ "$branch" != "release" ]]; then
+if [[ ! $branch =~ ^release ]]; then
     . $script_dir/../../ci/version.sh post`date -u '+%Y%m%d%H%M%S'`
 fi
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
Port #30905 to `dev` branch.
