### PR TITLE
{ACR} Fixed a bug where creating cache rule without credential set would fail

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/cache.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/cache.py
@@ -56,9 +56,9 @@ def acr_cache_create(cmd,
                      resource_group_name=None,
                      cred_set=None):
 
+    rg = get_resource_group_name_by_registry_name(cmd.cli_ctx, registry_name, resource_group_name)
     if cred_set:
         sub_id = get_subscription_id(cmd.cli_ctx)
-        rg = get_resource_group_name_by_registry_name(cmd.cli_ctx, registry_name, resource_group_name)
         # Format the credential set ID using subscription ID, resource group, registry name, and credential set name
         cred_set_id = CREDENTIAL_SET_RESOURCE_ID_TEMPLATE.format(
             sub_id=sub_id,


### PR DESCRIPTION
**Related command**
`az acr cache create`

**Description**<!--Mandatory-->
With latest az cli 2.70 release we unfortunately introduced a regression. Creating a cache rule without a credential set would crash. It is caused by a local variable not declared in the correct scope.

A bug issue has been created to track this issue:
https://github.com/Azure/acr/issues/822

This commit fixed the issue. Now creating cache rules work as expected.

**Testing Guide**
First create a container registry, e.g.
```
az acr create -n shaorenau --resource-group shaoren-rg -l southeastasia --sku standard
```

Then create a cache rule without credential set, e.g.
```
az acr cache create -r shaorenau -n helloCacheAWS -s public.ecr.aws/docker/library/hello-world -t hello-world
```
The creation should succeed without any error.

Then test the scenario of 'creating a cache rule with credential set', to insure no regression has been introduced.
Create a credential set, e.g.
```
az acr credential-set create -r shaorenau -n DockerHubCredSet -l docker.io -u
        https://MyKeyvault.vault.azure.net/secrets/usernamesecret -p
        https://MyKeyvault.vault.azure.net/secrets/passwordsecret
```

Create a cache rule with credential set, e.g.
```
az acr cache create -r shaorenau -n helloCacheDH -s docker.io/library/hello-world -t hello-world-dh -c DockerHubCredSet
```