### PR TITLE
{App Service} Fix: #21721: `az webapp config storage-account add`: Add validation for non-existent FileShare 

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -492,7 +492,7 @@ subscription than the app service environment, please use the resource ID for --
         c.argument('name', arg_type=webapp_name_arg_type, id_part=None)
 
     with self.argument_context('webapp config storage-account list') as c:
-        c.argument('name', arg_type=webapp_name_arg_type, id_part=None)
+        c.argument('name', help="Name of the web app.", arg_type=webapp_name_arg_type, id_part=None)
 
     with self.argument_context('webapp config hostname') as c:
         c.argument('webapp_name',
@@ -624,8 +624,10 @@ subscription than the app service environment, please use the resource ID for --
         c.argument('slot', options_list=['--slot', '-s'],
                    help="the name of the slot. Default to the productions slot if not specified")
     with self.argument_context('webapp config storage-account add') as c:
+        c.argument('name', help="Name of the web app.", id_part=None)
         c.argument('slot_setting', options_list=['--slot-setting'], help="With slot setting you can decide to make BYOS configuration sticky to a slot, meaning that when that slot is swapped, the storage account stays with that slot.")
     with self.argument_context('webapp config storage-account update') as c:
+        c.argument('name', help="Name of the web app.", id_part=None)
         c.argument('slot_setting', options_list=['--slot-setting'], help="With slot setting you can decide to make BYOS configuration sticky to a slot, meaning that when that slot is swapped, the storage account stays with that slot.")
 
     with self.argument_context('webapp config backup') as c:

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -581,7 +581,7 @@ def add_azure_storage_account(cmd, resource_group_name, name, custom_id, storage
                               share_name, access_key, mount_path=None, slot=None, slot_setting=False):
     from azure.storage.fileshare import ShareServiceClient
     AzureStorageInfoValue = cmd.get_models('AzureStorageInfoValue')
-    
+
     # Check if the file share exists
     share_service_client = ShareServiceClient(account_url=f"https://{account_name}.file.core.windows.net",
                                               credential=access_key)

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -579,7 +579,17 @@ def update_application_settings_polling(cmd, resource_group_name, name, app_sett
 
 def add_azure_storage_account(cmd, resource_group_name, name, custom_id, storage_type, account_name,
                               share_name, access_key, mount_path=None, slot=None, slot_setting=False):
+    from azure.storage.fileshare import ShareServiceClient
     AzureStorageInfoValue = cmd.get_models('AzureStorageInfoValue')
+    
+    # Check if the file share exists
+    share_service_client = ShareServiceClient(account_url=f"https://{account_name}.file.core.windows.net",
+                                              credential=access_key)
+    file_shares = share_service_client.list_shares()
+    share_names = [share.name for share in file_shares]
+    if share_name not in share_names:
+        raise ValidationError(f"The share '{share_name}' does not exist in the storage account '{account_name}'.")
+
     azure_storage_accounts = _generic_site_operation(cmd.cli_ctx, resource_group_name, name,
                                                      'list_azure_storage_accounts', slot)
 


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az webapp config storage-account add

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fixes #21721 

**Testing Guide**
<!--Example commands with explanations.-->
The following command now returns an error when <FILE_SHARE_NAME> doesn't exist in the target storage account:

az webapp config storage-account add -g <RESSOURCE_GROUP_NAME> -n <APP_SERVICE_NAME> --custom-id "test-az-cli" --storage-type AzureFiles --account-name <STORAGE_ACCOUNT_NAME> --share-name <FILE_SHARE_NAME> --access-key <STORAGE_ACCOUNT_ACCESS_KEY> --mount-path <MOUNT_PATH_ON_APP_SERVICE_FS>

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
