### PR TITLE
{Auth} Clarify `Identity` class's boundary

### DIFF
--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -41,10 +41,7 @@ logger = get_logger(__name__)
 
 
 class Identity:  # pylint: disable=too-many-instance-attributes
-    """Class to manage identities:
-        - user
-        - service principal
-        - TODO: managed identity
+    """Manage user or service principal identities and log into Microsoft identity platform.
     """
 
     # MSAL token cache.
@@ -199,12 +196,6 @@ class Identity:  # pylint: disable=too-many-instance-attributes
         entry = sp_auth.get_entry_to_persist()
         self._service_principal_store.save_entry(entry)
 
-    def login_with_managed_identity(self, scopes, identity_id=None):  # pylint: disable=too-many-statements
-        raise NotImplementedError
-
-    def login_in_cloud_shell(self, scopes):
-        raise NotImplementedError
-
     def logout_user(self, username):
         # If username is an SP client ID, it is ignored
         accounts = self._msal_app.get_accounts(username)
@@ -250,9 +241,6 @@ class Identity:  # pylint: disable=too-many-instance-attributes
         entry = self._service_principal_store.load_entry(client_id, self.tenant_id)
         client_credential = ServicePrincipalAuth(entry).get_msal_client_credential()
         return ServicePrincipalCredential(client_id, client_credential, **self._msal_app_kwargs)
-
-    def get_managed_identity_credential(self, client_id=None):
-        raise NotImplementedError
 
 
 class ServicePrincipalAuth:  # pylint: disable=too-many-instance-attributes


### PR DESCRIPTION
**Related command**
`az login`

**Description**<!--Mandatory-->
Part of #25959

`Identity` will never be used for managed identity authentication, as managed identity inherently differs from user or service principal:

- User or service principal talks to Microsoft Entra eSTS, so it requires an `authority`. Also, because the network request is expensive, a local token cache is used. 
- Managed identity talks to IMDS on the local machine, so no `authority` is required. As IMDS has its own token cache, a local token cache is not necessary.

Of course, it is possible to make `authority` optional and `Identity` work for managed identity, but this requires more effort and blurs `Identity`'s boundary. According to https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow, the public-facing name of eSTS is "Microsoft identity platform", so calling this class `Identity` and limit it to user or service principal authentication is accurate and reasonable.

This PR clarifies `Identity` class's boundary and deletes unused methods.
