### PR TITLE
[Profile] BREAKING CHANGE: `az login`: Drop `--username` for managed identity authentication

### DIFF
--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -636,19 +636,6 @@ class TestProfile(unittest.TestCase):
         self.assertEqual(s['user']['type'], 'servicePrincipal')
         self.assertEqual(s['user']['assignedIdentityInfo'], 'MSIClient-{}'.format(test_client_id))
 
-        # Old way of using identity_id
-        subscriptions = profile.login_with_managed_identity(identity_id=test_client_id)
-
-        self.assertEqual(len(subscriptions), 1)
-        s = subscriptions[0]
-        self.assertEqual(s['name'], self.display_name1)
-        self.assertEqual(s['id'], self.id1.split('/')[-1])
-        self.assertEqual(s['tenantId'], self.test_mi_tenant)
-
-        self.assertEqual(s['user']['name'], 'userAssignedIdentity')
-        self.assertEqual(s['user']['type'], 'servicePrincipal')
-        self.assertEqual(s['user']['assignedIdentityInfo'], 'MSIClient-{}'.format(test_client_id))
-
     @mock.patch('azure.cli.core.auth.adal_authentication.MSIAuthenticationWrapper', autospec=True)
     @mock.patch('azure.cli.core._profile.SubscriptionFinder._create_subscription_client', autospec=True)
     def test_login_with_mi_user_assigned_object_id(self, create_subscription_client_mock,
@@ -689,14 +676,6 @@ class TestProfile(unittest.TestCase):
         self.assertEqual(s['user']['type'], 'servicePrincipal')
         self.assertEqual(s['user']['assignedIdentityInfo'], 'MSIObject-{}'.format(test_object_id))
 
-        # Old way of using identity_id
-        subscriptions = profile.login_with_managed_identity(identity_id=test_object_id)
-
-        s = subscriptions[0]
-        self.assertEqual(s['user']['name'], 'userAssignedIdentity')
-        self.assertEqual(s['user']['type'], 'servicePrincipal')
-        self.assertEqual(s['user']['assignedIdentityInfo'], 'MSIObject-{}'.format(test_object_id))
-
     @mock.patch('requests.get', autospec=True)
     @mock.patch('azure.cli.core._profile.SubscriptionFinder._create_subscription_client', autospec=True)
     def test_login_with_mi_user_assigned_resource_id(self, create_subscription_client_mock,
@@ -724,14 +703,6 @@ class TestProfile(unittest.TestCase):
         mock_get.return_value = good_response
 
         subscriptions = profile.login_with_managed_identity(resource_id=test_res_id)
-
-        s = subscriptions[0]
-        self.assertEqual(s['user']['name'], 'userAssignedIdentity')
-        self.assertEqual(s['user']['type'], 'servicePrincipal')
-        self.assertEqual(subscriptions[0]['user']['assignedIdentityInfo'], 'MSIResource-{}'.format(test_res_id))
-
-        # Old way of using identity_id
-        subscriptions = profile.login_with_managed_identity(identity_id=test_res_id)
 
         s = subscriptions[0]
         self.assertEqual(s['user']['name'], 'userAssignedIdentity')

--- a/src/azure-cli/azure/cli/command_modules/profile/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/__init__.py
@@ -45,7 +45,7 @@ class ProfileCommandsLoader(AzCommandsLoader):
 
         with self.argument_context('login') as c:
             c.argument('username', options_list=['--username', '-u'],
-                       help='User name, service principal client ID, or managed identity ID.')
+                       help='User name or service principal client ID.')
             c.argument('password', options_list=['--password', '-p'],
                        help='User password or service principal secret. Will prompt if not given.')
             c.argument('tenant', options_list=['--tenant', '-t'], validator=validate_tenant,

--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -147,7 +147,7 @@ def login(cmd, username=None, password=None, tenant=None, scopes=None, allow_no_
             from azure.cli.core.breaking_change import print_conditional_breaking_change
             print_conditional_breaking_change(cmd.cli_ctx, tag='ManagedIdentityUsernameBreakingChange')
         return profile.login_with_managed_identity(
-            identity_id=username, client_id=client_id, object_id=object_id, resource_id=resource_id,
+            client_id=client_id, object_id=object_id, resource_id=resource_id,
             allow_no_subscriptions=allow_no_subscriptions)
     if in_cloud_console():  # tell users they might not need login
         logger.warning(_CLOUD_CONSOLE_LOGIN_WARNING)


### PR DESCRIPTION
**Related command**
`az login --identity`

**Description**<!--Mandatory-->
Follow-up of #30525, #31061
Part of #25959

**Testing Guide**
This should return an error:
```
az login --identity --username
TODO
```

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Profile] BREAKING CHANGE: `az login`: `--username` no longer accepts user-assigned managed identity ID. Explicitly specify `--client-id`, `--object-id` or `--resource-id` instead