### PR TITLE
[App Service] `az functionapp list-flexconsumption-locations`: Add `--details` and `--runtime` parameters to provide more details

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -232,6 +232,9 @@ subscription than the app service environment, please use the resource ID for --
     with self.argument_context('functionapp list-flexconsumption-locations') as c:
         c.argument('zone_redundant', arg_type=get_three_state_flag(),
                    help='Filter the list to return only locations which support zone redundancy.', is_preview=True)
+        c.argument('details', arg_type=get_three_state_flag(),
+                   help='Include the runtime details of the regions.', is_preview=True)
+        c.argument('runtime', help="limit the output to just the specified runtime", is_preview=True)
 
     with self.argument_context('webapp deleted list') as c:
         c.argument('name', arg_type=webapp_name_arg_type, id_part=None)

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -232,7 +232,7 @@ subscription than the app service environment, please use the resource ID for --
     with self.argument_context('functionapp list-flexconsumption-locations') as c:
         c.argument('zone_redundant', arg_type=get_three_state_flag(),
                    help='Filter the list to return only locations which support zone redundancy.', is_preview=True)
-        c.argument('details', arg_type=get_three_state_flag(),
+        c.argument('show_details', options_list=['--show-details'], arg_type=get_three_state_flag(),
                    help='Include the runtime details of the regions.', is_preview=True)
         c.argument('runtime', help="limit the output to just the specified runtime", is_preview=True)
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -6125,10 +6125,10 @@ def get_subscription_locations(cli_ctx):
     return [item.name for item in result]
 
 
-def list_flexconsumption_locations(cmd, zone_redundant=False, details=False, runtime=None):
+def list_flexconsumption_locations(cmd, zone_redundant=False, show_details=False, runtime=None):
     client = web_client_factory(cmd.cli_ctx)
 
-    if runtime and not details:
+    if runtime and not show_details:
         raise ArgumentUsageError(
             '--runtime is only valid with --details parameter. '
             'Please try again without the --details parameter.')
@@ -6142,7 +6142,7 @@ def list_flexconsumption_locations(cmd, zone_redundant=False, details=False, run
     sub_regions_list = get_subscription_locations(cmd.cli_ctx)
     regions = [x for x in regions if x in sub_regions_list]
 
-    if not details:
+    if not show_details:
         return [{'name': x} for x in regions]
 
     return [{'name': x, 'details': list_flex_function_app_all_runtimes(cmd, x, runtime)} for x in regions]

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -1810,18 +1810,13 @@ def list_function_app_runtimes(cmd, os_type=None):
     return {WINDOWS_OS_NAME: windows_stacks, LINUX_OS_NAME: linux_stacks}
 
 
-def list_flex_function_app_runtimes(cmd, location, runtime, ignore_error=False):
-    try:
-        runtime_helper = _FlexFunctionAppStackRuntimeHelper(cmd, location, runtime)
-        runtimes = [r for r in runtime_helper.stacks if runtime == r.name]
-        if not runtimes:
-            raise ValidationError("Runtime '{}' not supported for function apps on the Flex Consumption plan."
-                                  .format(runtime))
-        return runtime_helper.stacks
-    except Exception:
-        if ignore_error:
-            return []
-        raise  # Rethrow the caught exception
+def list_flex_function_app_runtimes(cmd, location, runtime):
+    runtime_helper = _FlexFunctionAppStackRuntimeHelper(cmd, location, runtime)
+    runtimes = [r for r in runtime_helper.stacks if runtime == r.name]
+    if not runtimes:
+        raise ValidationError("Runtime '{}' not supported for function apps on the Flex Consumption plan."
+                              .format(runtime))
+    return runtime_helper.stacks
 
 
 def delete_logic_app(cmd, resource_group_name, name, slot=None):
@@ -6159,8 +6154,16 @@ def list_flex_function_app_all_runtimes(cmd, location, runtime=None):
         runtimes = [runtime]
 
     return [{'runtime': x,
-             'runtime-details': list_flex_function_app_runtimes(cmd, location, x, True)}
+             'runtime-details': get_runtime_details_ignore_error(cmd, location, x)}
             for x in runtimes]
+
+
+def get_runtime_details_ignore_error(cmd, location, runtime):
+    try:
+        runtime_helper = _FlexFunctionAppStackRuntimeHelper(cmd, location, runtime)
+        return runtime_helper.stacks
+    except Exception:  # pylint: disable=broad-except
+        return None
 
 
 def list_flexconsumption_zone_redundant_locations(cmd):

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -6145,7 +6145,13 @@ def list_flexconsumption_locations(cmd, zone_redundant=False, details=False, run
         regions = [x for x in regions if "FCZONEREDUNDANCY" in x.org_domain]
 
     regions = [x.name.lower().replace(' ', '') for x in regions]
-    return [{x: list_flex_function_app_all_runtimes(cmd, x, runtime)} for x in regions]
+    sub_regions_list = get_subscription_locations(cmd.cli_ctx)
+    regions = [x for x in regions if x in sub_regions_list]
+
+    if not details:
+        return [{'name': x} for x in regions]
+
+    return [{'name': x, 'details': list_flex_function_app_all_runtimes(cmd, x, runtime)} for x in regions]
 
 
 def list_flex_function_app_all_runtimes(cmd, location, runtime=None):
@@ -6153,7 +6159,7 @@ def list_flex_function_app_all_runtimes(cmd, location, runtime=None):
     if runtime:
         runtimes = [runtime]
 
-    return [{x: list_flex_function_app_runtimes(cmd, location, x, True)} for x in runtimes]
+    return [{'runtime': x, 'runtime-details': list_flex_function_app_runtimes(cmd, location, x, True)} for x in runtimes]
 
 def list_flexconsumption_zone_redundant_locations(cmd):
     client = web_client_factory(cmd.cli_ctx)

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -4582,7 +4582,7 @@ class _FlexFunctionAppStackRuntimeHelper:
 
     def get_flex_raw_function_app_stacks(self, cmd, location, runtime):
         stacks_api_url = '/providers/Microsoft.Web/locations/{}/functionAppStacks?' \
-                         'api-version=2023-12-01&removeHiddenStacks=true&removeDeprecatedStacks=true&stack={}'
+                         'api-version=2020-10-01&removeHiddenStacks=true&removeDeprecatedStacks=true&stack={}'
         if runtime == "dotnet-isolated":
             runtime = "dotnet"
         request_url = cmd.cli_ctx.cloud.endpoints.resource_manager + stacks_api_url.format(location, runtime)
@@ -6145,7 +6145,7 @@ def list_flexconsumption_locations(cmd, zone_redundant=False, details=False, run
         regions = [x for x in regions if "FCZONEREDUNDANCY" in x.org_domain]
 
     regions = [x.name.lower().replace(' ', '') for x in regions]
-    return [{x: list_flex_function_app_all_runtimes(cmd, x, "java")} for x in regions]
+    return [{x: list_flex_function_app_all_runtimes(cmd, x, runtime)} for x in regions]
 
 
 def list_flex_function_app_all_runtimes(cmd, location, runtime=None):

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -1816,13 +1816,12 @@ def list_flex_function_app_runtimes(cmd, location, runtime, ignore_error=False):
         runtimes = [r for r in runtime_helper.stacks if runtime == r.name]
         if not runtimes:
             raise ValidationError("Runtime '{}' not supported for function apps on the Flex Consumption plan."
-                                .format(runtime))
+                                  .format(runtime))
         return runtime_helper.stacks
-    except Exception as e:
+    except Exception:
         if ignore_error:
             return []
-        else:
-            raise  # Rethrow the caught exception 
+        raise  # Rethrow the caught exception
 
 
 def delete_logic_app(cmd, resource_group_name, name, slot=None):
@@ -6136,11 +6135,11 @@ def list_flexconsumption_locations(cmd, zone_redundant=False, details=False, run
 
     if runtime and not details:
         raise ArgumentUsageError(
-                '--runtime is only valid with --details parameter. '
-                'Please try again without the --details parameter.')
+            '--runtime is only valid with --details parameter. '
+            'Please try again without the --details parameter.')
 
     regions = client.list_geo_regions(sku="FlexConsumption")
-    
+
     if zone_redundant:
         regions = [x for x in regions if "FCZONEREDUNDANCY" in x.org_domain]
 
@@ -6155,17 +6154,21 @@ def list_flexconsumption_locations(cmd, zone_redundant=False, details=False, run
 
 
 def list_flex_function_app_all_runtimes(cmd, location, runtime=None):
-    runtimes = ["dotnet-isolated", "node", "python", "java",  "powershell"]
+    runtimes = ["dotnet-isolated", "node", "python", "java", "powershell"]
     if runtime:
         runtimes = [runtime]
 
-    return [{'runtime': x, 'runtime-details': list_flex_function_app_runtimes(cmd, location, x, True)} for x in runtimes]
+    return [{'runtime': x,
+             'runtime-details': list_flex_function_app_runtimes(cmd, location, x, True)}
+            for x in runtimes]
+
 
 def list_flexconsumption_zone_redundant_locations(cmd):
     client = web_client_factory(cmd.cli_ctx)
     regions = client.list_geo_regions(sku="FlexConsumption")
     regions = [x for x in regions if "FCZONEREDUNDANCY" in x.org_domain]
     return [{'name': x.name.lower().replace(' ', '')} for x in regions]
+
 
 def list_locations(cmd, sku, linux_workers_enabled=None, hyperv_workers_enabled=None):
     web_client = web_client_factory(cmd.cli_ctx)

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands.py
@@ -819,7 +819,7 @@ class FunctionAppFlex(LiveScenarioTest):
         self.assertTrue(len(locations) > 0)
 
     def test_functionapp_list_flexconsumption_locations_details(self):
-        locations = self.cmd('functionapp list-flexconsumption-locations --details --runtime java').get_output_in_json()
+        locations = self.cmd('functionapp list-flexconsumption-locations --show-details --runtime java').get_output_in_json()
         self.assertTrue(len(locations) > 0)
         self.assertTrue(locations[0]['name'] is not None)
         self.assertTrue(locations[0]['details'][0]['runtime'] is not None)

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands.py
@@ -818,6 +818,13 @@ class FunctionAppFlex(LiveScenarioTest):
         locations = self.cmd('functionapp list-flexconsumption-locations --zone-redundant').get_output_in_json()
         self.assertTrue(len(locations) > 0)
 
+    def test_functionapp_list_flexconsumption_locations_details(self):
+        locations = self.cmd('functionapp list-flexconsumption-locations --details --runtime java').get_output_in_json()
+        self.assertTrue(len(locations) > 0)
+        self.assertTrue(locations[0]['name'] is not None)
+        self.assertTrue(locations[0]['details'][0]['runtime'] is not None)
+        self.assertTrue(locations[0]['details'][0]['runtime'] == 'java') 
+
     def test_functionapp_list_flexconsumption_runtimes(self):
         runtimes = self.cmd('functionapp list-flexconsumption-runtimes -l eastasia --runtime python').get_output_in_json()
         self.assertTrue(len(runtimes) == 2)


### PR DESCRIPTION
**Related command**
az functionapp list-flexconsumption-locations

**Description**<!--Mandatory-->
Add --details and --runtime parameter to az functionapp list-flexconsumption-locations. The --details parameter will provide more details about the locations including the supported runtimes, and the --runtime parameter will filter the locations based on the runtime.

**Testing Guide**
<!--Example commands with explanations.-->
- az functionapp list-flexconsumption-locations --details
- az functionapp list-flexconsumption-locations --runtime java --details

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
