### PR TITLE
{Microsoft Entra ID} `az ad`: Ignore global `--subscription` in subgroups

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_params.py
@@ -23,13 +23,13 @@ JSON_PROPERTY_HELP = "Should be JSON file path or in-line JSON string. See examp
 # pylint: disable=too-many-statements
 def load_arguments(self, _):
     with self.argument_context('ad') as c:
-        c.ignore('_subscription')  # hide global subscription param
         c.argument('owner_object_id', help="owner's object id")
         c.argument('show_mine', action='store_true', help='list entities owned by the current user')
         c.argument('include_all', options_list='--all', action='store_true',
                    help='list all entities, expect long delay if under a big organization')
 
     with self.argument_context('ad app') as c:
+        c.ignore('_subscription')
         # https://learn.microsoft.com/en-us/graph/api/resources/application?view=graph-rest-1.0
         c.argument('app_id', help='application id')
         c.argument('application_object_id', options_list=('--object-id',))
@@ -176,6 +176,7 @@ def load_arguments(self, _):
         c.argument('identifier', options_list=['--id'], help='identifier uri, application id, or object id of the associated application')
 
     with self.argument_context('ad sp') as c:
+        c.ignore('_subscription')
         c.argument('identifier', options_list=['--id'], help='service principal name, or object id')
 
     with self.argument_context('ad sp create') as c:
@@ -253,6 +254,7 @@ def load_arguments(self, _):
         c.argument('query_filter', options_list=['--filter'], help='OData filter, e.g. --filter "displayname eq \'test\' and servicePrincipalType eq \'Application\'"')
 
     with self.argument_context('ad user') as c:
+        c.ignore('_subscription')
         c.argument('mail_nickname', help='mail alias. Defaults to user principal name')
         c.argument('force_change_password_next_login', arg_type=get_three_state_flag(), help='Require the user to change their password the next time they log in. Only valid when --password is specified')
         c.argument('account_enabled', arg_type=get_three_state_flag(), help='enable the user account')
@@ -280,6 +282,7 @@ def load_arguments(self, _):
 
     group_help_msg = "group's object id or display name(prefix also works if there is a unique match)"
     with self.argument_context('ad group') as c:
+        c.ignore('_subscription')
         for arg in VARIANT_GROUP_ID_ARGS:
             c.argument(arg, options_list=['--group', '-g'], validator=validate_group, help=group_help_msg)
 
@@ -311,6 +314,7 @@ def load_arguments(self, _):
         c.argument('member_object_id', options_list='--member-id', help=member_id_help_msg)
 
     with self.argument_context('ad signed-in-user') as c:
+        c.ignore('_subscription')
         c.argument('object_type', options_list=['--type', '-t'], help='object type filter, e.g. "application", "servicePrincipal"  "group", etc')
 
     with self.argument_context('role') as c:


### PR DESCRIPTION
**Related command**
`az ad`

**Description**<!--Mandatory-->
Fix https://github.com/Azure/azure-cli/pull/27296#issuecomment-1878581800

Currently, the global `--subscription` argument is ignored on `az ad` command group (#6516).

When generating reference doc, all `command_loaders` are loaded:

https://github.com/Azure/azure-cli/blob/dc4393dfe5319df8ce4190f12f3f981ff8f49563/src/azure-cli-core/azure/cli/core/__init__.py#L497-L502

If `role` command module is loaded before the `ad` extension, commands under `az ad ds` (https://github.com/Azure/azure-cli-extensions/pull/2842) will not have `--subscription`.

This PR moves `c.ignore('_subscription')` to subgroups to avoid affecting other groups under `az ad`, including `az ad ds`:

```
> az ad -h
...
Subgroups:
    app            : Manage Microsoft Entra applications.
    group          : Manage Microsoft Entra groups.
    signed-in-user : Show graph information about current signed-in user in CLI.
    sp             : Manage Microsoft Entra service principals.
    user           : Manage Microsoft Entra users.
```

