### PR TITLE
[ARM] Fix various issues with `az bicep`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
@@ -108,6 +108,16 @@ def run_bicep_command(cli_ctx, args, auto_install=True, custom_env=None):
 
 
 def ensure_bicep_installation(cli_ctx, release_tag=None, target_platform=None, stdout=True):
+    if _use_binary_from_path(cli_ctx):
+        from shutil import which
+
+        if which("bicep") is None:
+            raise ValidationError(
+                'Could not find the "bicep" executable on PATH. To install Bicep via Azure CLI, set the "bicep.use_binary_from_path" configuration to False and run "az bicep install".'  # pylint: disable=line-too-long
+            )
+
+        return
+
     system = platform.system()
     machine = platform.machine()
     installation_path = _get_bicep_installation_path(system)

--- a/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
@@ -55,6 +55,7 @@ _logger = get_logger(__name__)
 
 _requests_verify = not should_disable_connection_verify()
 
+
 def validate_bicep_target_scope(template_schema, deployment_scope):
     target_scope = _template_schema_to_target_scope(template_schema)
     if target_scope != deployment_scope:

--- a/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
@@ -285,18 +285,22 @@ def _get_bicep_installed_version(bicep_executable_path):
     return _extract_version(installed_version_output)
 
 
+def _is_arm_architecture(machine):
+    return machine in ("arm64", "aarch64", "aarch64_be", "armv8b", "armv8l")
+
+
 def _has_musl_library_only():
     return os.path.exists("/lib/ld-musl-x86_64.so.1") and not os.path.exists("/lib/x86_64-linux-gnu/libc.so.6")
 
 
 def _get_bicep_download_url(system, machine, release_tag, target_platform=None):
     if not target_platform:
-        if system == "Windows" and machine == "arm64":
+        if system == "Windows" and _is_arm_architecture(machine):
             target_platform = "win-arm64"
         elif system == "Windows":
             # default to x64
             target_platform = "win-x64"
-        elif system == "Linux" and machine == "arm64":
+        elif system == "Linux" and _is_arm_architecture(machine):
             target_platform = "linux-arm64"
         elif system == "Linux" and _has_musl_library_only():
             # check for alpine linux
@@ -304,7 +308,7 @@ def _get_bicep_download_url(system, machine, release_tag, target_platform=None):
         elif system == "Linux":
             # default to x64
             target_platform = "linux-x64"
-        elif system == "Darwin" and machine == "arm64":
+        elif system == "Darwin" and _is_arm_architecture(machine):
             target_platform = "osx-arm64"
         elif system == "Darwin":
             # default to x64

--- a/src/azure-cli/azure/cli/command_modules/resource/_bicep_config.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_bicep_config.py
@@ -11,14 +11,20 @@ _use_binary_from_path_config_default_value = "if_found_in_ci"
 _check_version_config_key = "check_version"
 _check_version_config_default_value = True
 
+
 def get_use_binary_from_path_config(cli_ctx):
-    return cli_ctx.config.get(_config_section, _use_binary_from_path_config_key, _use_binary_from_path_config_default_value).lower()
+    return cli_ctx.config.get(
+        _config_section, _use_binary_from_path_config_key, _use_binary_from_path_config_default_value
+    ).lower()
+
 
 def set_use_binary_from_path_config(cli_ctx, value):
     cli_ctx.config.set_value(_config_section, _use_binary_from_path_config_key, value)
 
+
 def remove_use_binary_from_path_config(cli_ctx):
     cli_ctx.config.remove_option(_config_section, _use_binary_from_path_config_key)
+
 
 def get_check_version_config(cli_ctx):
     return cli_ctx.config.getboolean(_config_section, _check_version_config_key, _check_version_config_default_value)

--- a/src/azure-cli/azure/cli/command_modules/resource/_bicep_config.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_bicep_config.py
@@ -1,0 +1,19 @@
+_config_section = "bicep"
+
+_use_binary_from_path_config_key = "use_binary_from_path"
+_use_binary_from_path_config_default_value = "if_found_in_ci"
+
+_check_version_config_key = "check_version"
+_check_version_config_default_value = True
+
+def get_use_binary_from_path_config(cli_ctx):
+    return cli_ctx.config.get(_config_section, _use_binary_from_path_config_key, _use_binary_from_path_config_default_value).lower()
+
+def set_use_binary_from_path_config(cli_ctx, value):
+    cli_ctx.config.set_value(_config_section, _use_binary_from_path_config_key, value)
+
+def remove_use_binary_from_path_config(cli_ctx):
+    cli_ctx.config.remove_option(_config_section, _use_binary_from_path_config_key)
+
+def get_check_version_config(cli_ctx):
+    return cli_ctx.config.getboolean(_config_section, _check_version_config_key, _check_version_config_default_value)

--- a/src/azure-cli/azure/cli/command_modules/resource/_bicep_config.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_bicep_config.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
 _config_section = "bicep"
 
 _use_binary_from_path_config_key = "use_binary_from_path"

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_bicep.py
@@ -163,6 +163,18 @@ class TestBicep(unittest.TestCase):
         ensure_bicep_installation(self.cli_ctx, release_tag="v0.1.0")
 
         dirname_mock.assert_not_called()
+            
+    @mock.patch("azure.cli.command_modules.resource._bicep._get_bicep_installation_path")
+    @mock.patch("shutil.which")
+    def test_ensure_bicep_installation_skip_download_if_use_binary_from_path_is_true(
+        self, which_stub, _get_bicep_installation_path_mock
+    ):
+        which_stub.return_value = True
+        self.cli_ctx.config.set_value("bicep", "use_binary_from_path", "true")
+
+        ensure_bicep_installation(self.cli_ctx, release_tag="v0.1.0")
+
+        _get_bicep_installation_path_mock.assert_not_called()
 
     def test_validate_target_scope_raise_error_if_target_scope_does_not_match_deployment_scope(self):
         with self.assertRaisesRegex(

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_bicep.py
@@ -220,6 +220,9 @@ class TestBicep(unittest.TestCase):
         download_url = _get_bicep_download_url("Linux", "arm64", "v0.26.54")
         self.assertEqual(download_url, "https://downloads.bicep.azure.com/v0.26.54/bicep-linux-arm64")
 
+        download_url = _get_bicep_download_url("Linux", "aarch64", "v0.26.54")
+        self.assertEqual(download_url, "https://downloads.bicep.azure.com/v0.26.54/bicep-linux-arm64")
+
         download_url = _get_bicep_download_url("Linux", "x64", "v0.26.54")
         self.assertEqual(download_url, "https://downloads.bicep.azure.com/v0.26.54/bicep-linux-x64")
 


### PR DESCRIPTION
**Related command**
- `az deployment`
- `az stack`
- `az bicep`

**Description**<!--Mandatory-->
This PR resolves two issues affecting the az deployment, az stack, and az bicep commands:
- The commands sometimes incorrectly check for the latest Bicep version, even when `use_binary_from_path` is set to `true` and `check_version` is `false`.
- On aarch64 architecture, the `bicep install/upgrade` command downloads the x64 binary instead of the ARM binary.

Closes https://github.com/Azure/azure-cli/issues/29809.
Closes https://github.com/Azure/azure-cli/issues/29435.

**Testing Guide**
- Run `az deployment tenant/mg/sub/group create` with a `.bicepparam` file.
- Run `bicep install/upgrade` on an aarch64 machine.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[ARM] Fix #29809: `az deployment` / `az stack` / `az bicep`: Fix an issue where the commands mistakenly check for the latest Bicep version, even when `use_binary_from_path` is `true` and `check_version` is `false`
[ARM] Fix #29435: `az bicep install / upgrade`: Fix an issue where the command downloads the x64 binary instead of the ARM binary on aarch64 machines

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
