### PR TITLE
{Role} `az role assignment list`: Announce `--include-classic-administrators` deprecation breaking change

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/_breaking_change.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_breaking_change.py
@@ -1,0 +1,8 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from azure.cli.core.breaking_change import register_argument_deprecate
+
+register_argument_deprecate('role assignment list', '--include-classic-administrators')

--- a/src/azure-cli/azure/cli/command_modules/role/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_params.py
@@ -329,8 +329,7 @@ def load_arguments(self, _):
                    "use the object id and not the app id.")
         c.argument('ids', nargs='+', help='space-separated role assignment ids')
         c.argument('include_classic_administrators', arg_type=get_three_state_flag(),
-                   help='list default role assignments for subscription classic administrators, aka co-admins',
-                   deprecate_info=c.deprecate(target='--include-classic-administrators'))
+                   help='list default role assignments for subscription classic administrators, aka co-admins')
         c.argument('description', is_preview=True, min_api='2020-04-01-preview', help='Description of role assignment.')
         c.argument('condition', is_preview=True, min_api='2020-04-01-preview', help='Condition under which the user can be granted permission.')
         c.argument('condition_version', is_preview=True, min_api='2020-04-01-preview', help='Version of the condition syntax. If --condition is specified without --condition-version, default to 2.0.')


### PR DESCRIPTION
**Related command**
`az role assignment list --include-classic-administrators`

**Description**<!--Mandatory-->
Migrate https://github.com/Azure/azure-cli/pull/29404 to the new breaking change announcement framework: https://github.com/Azure/azure-cli/blob/dev/doc/how_to_introduce_breaking_changes.md

**Testing Guide**
```
az role assignment list --include-classic-administrators
az role assignment list -h
```
