### PR TITLE
{AKS} `az aks create`: Add upcoming breaking change announcement

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_breaking_change.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_breaking_change.py
@@ -6,4 +6,4 @@
 from azure.cli.core.breaking_change import register_default_value_breaking_change
 
 register_default_value_breaking_change('aks create', '--node-vm-size', 'Standard_DS2_V2 (Linux), Standard_DS2_V3 (Windows)', 'Dynamically Selected By Azure')
-# The default value of `--node-vm-size` will be changed to `namically Selected By Azure` from `Standard_DS2_V2 (Linux), Standard_DS2_V3 (Windows)` in next breaking change release(2.xx.0).
+# The default value of `--node-vm-size` will be changed to `Dynamically Selected By Azure` from `Standard_DS2_V2 (Linux), Standard_DS2_V3 (Windows)` in next breaking change release(2.xx.0).

--- a/src/azure-cli/azure/cli/command_modules/acs/_breaking_change.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_breaking_change.py
@@ -1,0 +1,9 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------
+
+from azure.cli.core.breaking_change import register_default_value_breaking_change
+
+register_default_value_breaking_change('aks create', '--node-vm-size', 'Standard_DS2_V2 (Linux), Standard_DS2_V3 (Windows)', 'Dynamically Selected By Azure')
+# The default value of `--node-vm-size` will be changed to `namically Selected By Azure` from `Standard_DS2_V2 (Linux), Standard_DS2_V3 (Windows)` in next breaking change release(2.xx.0).

--- a/src/azure-cli/azure/cli/command_modules/acs/_breaking_change.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_breaking_change.py
@@ -6,4 +6,4 @@
 from azure.cli.core.breaking_change import register_default_value_breaking_change
 
 register_default_value_breaking_change('aks create', '--node-vm-size', 'Standard_DS2_V2 (Linux), Standard_DS2_V3 (Windows)', 'Dynamically Selected By Azure')
-# The default value of `--node-vm-size` will be changed to `Dynamically Selected By Azure` from `Standard_DS2_V2 (Linux), Standard_DS2_V3 (Windows)` in next breaking change release(2.xx.0).
+# The default value of `--node-vm-size` will be changed to `Dynamically Selected By Azure` from `Standard_DS2_V2 (Linux), Standard_DS2_V3 (Windows)` in next breaking change release(2.73.0).

--- a/src/azure-cli/azure/cli/command_modules/acs/_breaking_change.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_breaking_change.py
@@ -5,5 +5,9 @@
 
 from azure.cli.core.breaking_change import register_default_value_breaking_change
 
-register_default_value_breaking_change('aks create', '--node-vm-size', 'Standard_DS2_V2 (Linux), Standard_DS2_V3 (Windows)', 'Dynamically Selected By Azure')
-# The default value of `--node-vm-size` will be changed to `Dynamically Selected By Azure` from `Standard_DS2_V2 (Linux), Standard_DS2_V3 (Windows)` in next breaking change release(2.73.0).
+register_default_value_breaking_change(
+    'aks create',
+    '--node-vm-size',
+    'Standard_DS2_V2 (Linux), Standard_DS2_V3 (Windows)',
+    'Dynamically Selected By Azure'
+)


### PR DESCRIPTION
**Related command**
az aks create

**Description**
This PR introduces an announcement for breaking changes in az aks create. The default value of --node-vm-size will be changing from 'Standard_DS2_V2 (Linux), Standard_DS2_V3 (Windows)' to being dynamically selected by the AKS resource provider based on quota and capacity.

**Testing Guide**
Behavior is not changed

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
