### PR TITLE
{Core} Fix #31047:  Remove unnecessary field get in action retrieval

### DIFF
--- a/src/azure-cli-core/azure/cli/core/breaking_change.py
+++ b/src/azure-cli-core/azure/cli/core/breaking_change.py
@@ -24,7 +24,7 @@ def _get_action_class(cli_ctx, action):
     if isinstance(action, type) and issubclass(action, argparse.Action):
         action_class = action
     elif isinstance(action, str):
-        action_class = cli_ctx.invocation.command_loader.cli_ctx.invocation.parser._registries['action'][action]  # pylint: disable=protected-access
+        action_class = cli_ctx.invocation.parser._registries['action'][action]  # pylint: disable=protected-access
     return action_class
 
 


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix #31047 
This issue is caused by an unverified modification I made while reusing code in Knack. I copied and modified the code, directly using the variable name `command_loader` and appending `cli_ctx.invocation.` before it. However, the correct field name is `commands_loader`. 
In fact, there's no need to use `commands_loader` because we already have `cli_ctx`.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
