### PR TITLE
{Profile} `az login`: Announce `--username` breaking change for managed identity

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -61,11 +61,6 @@ _ASSIGNED_IDENTITY_INFO = 'assignedIdentityInfo'
 
 _AZ_LOGIN_MESSAGE = "Please run 'az login' to setup account."
 
-MANAGED_IDENTITY_ID_WARNING = (
-    "Passing the managed identity ID with --username is deprecated and will be removed in a future release. "
-    "Please use --client-id, --object-id or --resource-id instead."
-)
-
 
 def load_subscriptions(cli_ctx, all_clouds=False, refresh=False):
     profile = Profile(cli_ctx=cli_ctx)
@@ -257,7 +252,6 @@ class Profile:
             msi_creds = MSIAuthenticationWrapper(resource=resource, msi_res_id=resource_id)
         # The old way of re-using the same --username for 3 types of ID
         elif identity_id:
-            logger.warning(MANAGED_IDENTITY_ID_WARNING)
             if is_valid_resource_id(identity_id):
                 msi_creds = MSIAuthenticationWrapper(resource=resource, msi_res_id=identity_id)
                 identity_type = MsiAccountTypes.user_assigned_resource_id

--- a/src/azure-cli/azure/cli/command_modules/profile/_breaking_change.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/_breaking_change.py
@@ -1,0 +1,11 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from azure.cli.core.breaking_change import register_conditional_breaking_change, AzCLIOtherChange
+
+register_conditional_breaking_change(tag='ManagedIdentityUsernameBreakingChange', breaking_change=AzCLIOtherChange(
+    'login',
+    'Passing the managed identity ID with --username is deprecated and will be removed in 2.73.0. '
+    'Use --client-id, --object-id or --resource-id instead.'))

--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -143,6 +143,9 @@ def login(cmd, username=None, password=None, tenant=None, scopes=None, allow_no_
     if identity:
         if in_cloud_console():
             return profile.login_in_cloud_shell()
+        if username:
+            from azure.cli.core.breaking_change import print_conditional_breaking_change
+            print_conditional_breaking_change(cmd.cli_ctx, tag='ManagedIdentityUsernameBreakingChange')
         return profile.login_with_managed_identity(
             identity_id=username, client_id=client_id, object_id=object_id, resource_id=resource_id,
             allow_no_subscriptions=allow_no_subscriptions)


### PR DESCRIPTION
**Related command**
`az login --identity --username`

**Description**<!--Mandatory-->
Migrate #30525 to the new breaking change announcement framework: https://github.com/Azure/azure-cli/blob/dev/doc/how_to_introduce_breaking_changes.md

**Testing Guide**
```
az login --identity --username 111
```
