### PR TITLE
{Core} Decouple `get_raw_token` from SDK token protocol

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -460,7 +460,7 @@ class Profile:
             if tenant:
                 raise CLIError("Tenant shouldn't be specified for Cloud Shell account")
             from .auth.msal_credentials import CloudShellCredential
-            sdk_cred = CredentialAdaptor(CloudShellCredential())
+            cred = CloudShellCredential()
 
         elif managed_identity_type:
             # managed identity
@@ -468,29 +468,33 @@ class Profile:
                 raise CLIError("Tenant shouldn't be specified for managed identity account")
             if _on_azure_arc():
                 from .auth.msal_credentials import ManagedIdentityCredential
-                sdk_cred = CredentialAdaptor(ManagedIdentityCredential())
+                cred = ManagedIdentityCredential()
             else:
+                # TODO: Wait until MSAL migration
                 from .auth.util import scopes_to_resource
-                sdk_cred = MsiAccountTypes.msi_auth_factory(managed_identity_type, managed_identity_id,
-                                                            scopes_to_resource(scopes))
+                cred = MsiAccountTypes.msi_auth_factory(managed_identity_type, managed_identity_id,
+                                                        scopes_to_resource(scopes))
 
         else:
-            sdk_cred = CredentialAdaptor(self._create_credential(account, tenant_id=tenant))
+            cred = self._create_credential(account, tenant_id=tenant)
 
-        sdk_token = sdk_cred.get_token(*scopes)
+        msal_token = cred.acquire_token(scopes)
         # Convert epoch int 'expires_on' to datetime string 'expiresOn' for backward compatibility
         # WARNING: expiresOn is deprecated and will be removed in future release.
         import datetime
-        expiresOn = datetime.datetime.fromtimestamp(sdk_token.expires_on).strftime("%Y-%m-%d %H:%M:%S.%f")
+        from .auth.util import now_timestamp
+        from .auth.constants import EXPIRES_IN, ACCESS_TOKEN
+        expires_on = now_timestamp() + msal_token[EXPIRES_IN]
+        expiresOn = datetime.datetime.fromtimestamp(expires_on).strftime("%Y-%m-%d %H:%M:%S.%f")
 
         token_entry = {
-            'accessToken': sdk_token.token,
-            'expires_on': sdk_token.expires_on,  # epoch int, like 1605238724
+            'accessToken': msal_token[ACCESS_TOKEN],
+            'expires_on': expires_on,  # epoch int, like 1605238724
             'expiresOn': expiresOn  # datetime string, like "2020-11-12 13:50:47.114324"
         }
 
         # Build a tuple of (token_type, token, token_entry)
-        token_tuple = 'Bearer', sdk_token.token, token_entry
+        token_tuple = 'Bearer', msal_token[ACCESS_TOKEN], token_entry
 
         # Return a tuple of (token_tuple, subscription, tenant)
         return (token_tuple,

--- a/src/azure-cli-core/azure/cli/core/auth/util.py
+++ b/src/azure-cli-core/azure/cli/core/auth/util.py
@@ -151,7 +151,7 @@ def build_sdk_access_token(token_entry):
     # This can slow down commands that doesn't need azure.core, like `az account get-access-token`.
     # So We define our own AccessToken.
     from .constants import ACCESS_TOKEN, EXPIRES_IN
-    return AccessToken(token_entry[ACCESS_TOKEN], _now_timestamp() + token_entry[EXPIRES_IN])
+    return AccessToken(token_entry[ACCESS_TOKEN], now_timestamp() + token_entry[EXPIRES_IN])
 
 
 def decode_access_token(access_token):
@@ -177,6 +177,6 @@ def read_response_templates():
     return success_template, error_template
 
 
-def _now_timestamp():
+def now_timestamp():
     import time
     return int(time.time())


### PR DESCRIPTION
**Related command**
`az account get-access-token`

**Description**<!--Mandatory-->
Require #25959

Importing `azure.core.credentials.AccessToken` is expensive. That's why #19898 defines our own `AccessToken`.

After #25959 is implemented, there will be no need for `get_raw_token` to use Python SDK's token protocol and data structure at all.

In this PR, `get_raw_token` directly calls `acquire_token` on MSAL credentials, instead of Python SDK's `get_token` protocol.

**Testing Guide**
```
az account get-access-token
```
