### PR TITLE
{Auth} Refactor `MsiAccountTypes`

### DIFF
--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -950,7 +950,7 @@ class TestProfile(unittest.TestCase):
         consolidated = profile._normalize_properties('systemAssignedIdentity',
                                                      [deepcopy(self.test_mi_subscription)],
                                                      True,
-                                                     user_assigned_identity_id="MSI")
+                                                     assigned_identity_info="MSI")
         profile._set_subscriptions(consolidated)
         cred, subscription_id, _ = profile.get_login_credentials()
 
@@ -967,7 +967,7 @@ class TestProfile(unittest.TestCase):
             'userAssignedIdentity',
             [deepcopy(self.test_mi_subscription)],
             True,
-            user_assigned_identity_id='MSIClient-{}'.format(self.test_mi_client_id)
+            assigned_identity_info='MSIClient-{}'.format(self.test_mi_client_id)
         )
         profile._set_subscriptions(consolidated, secondary_key_name='name')
         cred, subscription_id, _ = profile.get_login_credentials()
@@ -985,7 +985,7 @@ class TestProfile(unittest.TestCase):
             'userAssignedIdentity',
             [deepcopy(self.test_mi_subscription)],
             True,
-            user_assigned_identity_id='MSIObject-{}'.format(self.test_mi_object_id)
+            assigned_identity_info='MSIObject-{}'.format(self.test_mi_object_id)
         )
         profile._set_subscriptions(consolidated, secondary_key_name='name')
         cred, subscription_id, _ = profile.get_login_credentials()
@@ -1003,7 +1003,7 @@ class TestProfile(unittest.TestCase):
             'userAssignedIdentity',
             [deepcopy(self.test_mi_subscription)],
             True,
-            user_assigned_identity_id='MSIResource-{}'.format(self.test_mi_resource_id))
+            assigned_identity_info='MSIResource-{}'.format(self.test_mi_resource_id))
         profile._set_subscriptions(consolidated, secondary_key_name='name')
         cred, subscription_id, _ = profile.get_login_credentials()
 
@@ -1109,7 +1109,7 @@ class TestProfile(unittest.TestCase):
         consolidated = profile._normalize_properties('systemAssignedIdentity',
                                                      [deepcopy(self.test_mi_subscription)],
                                                      True,
-                                                     user_assigned_identity_id='MSI')
+                                                     assigned_identity_info='MSI')
         profile._set_subscriptions(consolidated)
 
         credential_out = {'credential': None}
@@ -1144,7 +1144,7 @@ class TestProfile(unittest.TestCase):
             'userAssignedIdentity',
             [deepcopy(self.test_mi_subscription)],
             True,
-            user_assigned_identity_id='MSIClient-{}'.format(self.test_mi_client_id)
+            assigned_identity_info='MSIClient-{}'.format(self.test_mi_client_id)
         )
         profile._set_subscriptions(consolidated)
 
@@ -1175,7 +1175,7 @@ class TestProfile(unittest.TestCase):
             'userAssignedIdentity',
             [deepcopy(self.test_mi_subscription)],
             True,
-            user_assigned_identity_id='MSIObject-{}'.format(self.test_mi_object_id)
+            assigned_identity_info='MSIObject-{}'.format(self.test_mi_object_id)
         )
         profile._set_subscriptions(consolidated)
 
@@ -1206,7 +1206,7 @@ class TestProfile(unittest.TestCase):
             'userAssignedIdentity',
             [deepcopy(self.test_mi_subscription)],
             True,
-            user_assigned_identity_id='MSIResource-{}'.format(self.test_mi_resource_id)
+            assigned_identity_info='MSIResource-{}'.format(self.test_mi_resource_id)
         )
         profile._set_subscriptions(consolidated)
 


### PR DESCRIPTION
**Related command**
`az login`

**Description**<!--Mandatory-->
`MsiAccountTypes` is used for managed identity authentication, but the name "MSI" is no longer accurate as it has been renamed to "managed identity". The official document doesn't even mention the name "MSI" anymore: https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview

Service principal authentication has its dedicated class `azure.cli.core.auth.identity.ServicePrincipalAuth`. So should managed identity authentication. This PR renames `azure.cli.core._profile.MsiAccountTypes` to `ManagedIdentityAuth`.

In addition, the `user_assigned_identity_id` argument of `azure.cli.core._profile.Profile._normalize_properties` is renamed to `assigned_identity_info` to better reflect its meaning.

**Testing Guide**
`az login --identity`
