### PR TITLE
{Auth} Bring back `get_msal_token`

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -497,6 +497,14 @@ class Profile:
                 None if tenant else str(account[_SUBSCRIPTION_ID]),
                 str(tenant if tenant else account[_TENANT_ID]))
 
+    def get_msal_token(self, scopes, data):
+        """Get VM SSH certificate. Do not use it for other purposes. To get an access token, use get_raw_token instead.
+        """
+        credential, _, _ = self.get_login_credentials()
+        certificate_string = credential.get_token(*scopes, data=data).token
+        # The first value used to be username, but it is no longer used.
+        return None, certificate_string
+
     def _normalize_properties(self, user, subscriptions, is_service_principal, cert_sn_issuer_auth=None,
                               user_assigned_identity_id=None):
         consolidated = []


### PR DESCRIPTION
**Related command**
`az ssh vm`

**Description**<!--Mandatory-->
#19853 removed `Profile.get_msal_token` and let `ssh` extension call `profile.get_login_credentials` and `credential.get_token` to get the certificate:

https://github.com/Azure/azure-cli-extensions/blob/695bd02037a7a8abd6b0ac76ae1ac1559ae46c41/src/ssh/azext_ssh/custom.py#L231-L233

```py
        credential, _, _ = profile.get_login_credentials(subscription_id=profile.get_subscription()["id"])
        certificatedata = credential.get_token(*scopes, data=data)
        certificate = certificatedata.token
```

This turns out to be a bad design as

1. No SDK is involved, but the SDK token protocol `get_token` is used.
2. SDK token protocol `get_token` doesn't support `data` argument at all. This is a CLI-specific extension/alteration.
3. With the support of `get_token_info` protocol (https://github.com/Azure/azure-cli/pull/30928), `get_token` is deprecated.

This PR brings back `get_msal_token`, so that `ssh` extension can seamlessly switch to the old interface without any update:

https://github.com/Azure/azure-cli-extensions/blob/695bd02037a7a8abd6b0ac76ae1ac1559ae46c41/src/ssh/azext_ssh/custom.py#L229

```py
    if hasattr(profile, "get_msal_token"):
        # we used to use the username from the token but now we throw it away
        _, certificate = profile.get_msal_token(scopes, data)
```

**Testing Guide**
```
az ssh vm --resource-group xxx --vm-name xxx
```
