### PR TITLE
{Core} Bump MSAL to 1.32.0

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -54,7 +54,7 @@ DEPENDENCIES = [
     'knack~=0.11.0',
     'microsoft-security-utilities-secret-masker~=1.0.0b4',
     'msal-extensions==1.2.0',
-    'msal[broker]==1.31.2b1',
+    'msal[broker]==1.32.0',
     'msrestazure~=0.6.4',
     'packaging>=20.9',
     'pkginfo>=1.5.0.1',

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -103,7 +103,7 @@ jmespath==0.9.5
 jsondiff==2.0.0
 knack==0.11.0
 msal-extensions==1.2.0
-msal[broker]==1.31.2b1
+msal[broker]==1.32.0
 msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -104,7 +104,7 @@ jmespath==0.9.5
 jsondiff==2.0.0
 knack==0.11.0
 msal-extensions==1.2.0
-msal[broker]==1.31.2b1
+msal[broker]==1.32.0
 msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -103,7 +103,7 @@ jmespath==0.9.5
 jsondiff==2.0.0
 knack==0.11.0
 msal-extensions==1.2.0
-msal[broker]==1.31.2b1
+msal[broker]==1.32.0
 msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2


### PR DESCRIPTION
**Related command**
`az login --identity`

**Description**<!--Mandatory-->
Pick up MSAL 1.32.0: https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/799

The most valuable change is the resurrection of https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/754 by https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/795.

Managed identity can again be tested on a local machine through port mapping:

```sh
ssh -L 8000:169.254.169.254:80 -o "StrictHostKeyChecking no" $username@$ip

# In a separate terminal
export AZURE_POD_IDENTITY_AUTHORITY_HOST=http://localhost:8000 
az login --identity
```
