### PR TITLE
{Appconfig} Disable incorrect test cases

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_aad_auth.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_aad_auth.py
@@ -8,6 +8,7 @@
 import json
 import os
 import time
+import unittest
 
 from azure.cli.command_modules.appconfig._credential import AppConfigurationCliCredential
 from azure.cli.command_modules.appconfig._utils import get_appconfig_data_client
@@ -223,7 +224,7 @@ class AppConfigAadAuthLiveScenarioTest(ScenarioTest):
         assert expected_exported_kvs == exported_kvs
         os.remove(exported_file_path)
 
-
+    @unittest.skip("Incorrect test case")
     @mock.patch('azure.cli.core.auth.adal_authentication.MSIAuthenticationWrapper.set_token')
     @mock.patch('azure.cli.core.auth.adal_authentication.MSIAuthenticationWrapper.get_token')
     @mock.patch('azure.cli.core._profile.Profile.get_subscription')
@@ -246,7 +247,7 @@ class AppConfigAadAuthLiveScenarioTest(ScenarioTest):
         # Assert that get_token was called with the correct scope
         appconfig_credential._impl.get_token.assert_called_once_with(f"{APPCONFIG_AUTH_TOKEN_AUDIENCE}/.default")
 
-
+    @unittest.skip("Incorrect test case")
     @mock.patch('azure.cli.core.auth.msal_credentials.UserCredential')
     @mock.patch('azure.cli.core.auth.credential_adaptor.CredentialAdaptor.get_token')
     @mock.patch('azure.cli.core._profile.Profile.get_subscription')


### PR DESCRIPTION
**Description**<!--Mandatory-->
Fix https://github.com/Azure/azure-cli/pull/30983#discussion_r2009667404

These 2 tests from #30983 are incorrect as they should not assume the credential type. It is Azure CLI Core's internal implementation. Azure CLI Core only guarantees `get_token` is implemented. 

`test_azconfig_mi_token_override` blocks https://github.com/Azure/azure-cli/pull/31092 as `cli_ctx` is a `mock.MagicMock()`, forcing `cli_ctx.config.getboolean('core', 'use_msal_managed_identity', fallback=False)` to be a `MagicMock` (`True`). In this case, a `CredentialAdaptor` is returned, instead of `MSIAuthenticationWrapper`.
