### PR TITLE
Do NOT Merge: [AKS] `az aks update`: Allow updating `--bootstrap-container-registry-resource-id` when `--bootstrap-artifact-source` is not provided

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -8388,8 +8388,10 @@ class AKSManagedClusterUpdateDecorator(BaseAKSManagedClusterDecorator):
 
         bootstrap_artifact_source = self.context.get_bootstrap_artifact_source()
         bootstrap_container_registry_resource_id = self.context.get_bootstrap_container_registry_resource_id()
-        if hasattr(mc, "bootstrap_profile") and bootstrap_artifact_source is not None:
-            if bootstrap_artifact_source != CONST_ARTIFACT_SOURCE_CACHE and bootstrap_container_registry_resource_id:
+        if hasattr(mc, "bootstrap_profile"):
+            if bootstrap_artifact_source is None and mc.bootstrap_profile is not None:
+                bootstrap_artifact_source = mc.bootstrap_profile.artifact_source # backfill from existing mc
+            if (bootstrap_artifact_source is None or bootstrap_artifact_source != CONST_ARTIFACT_SOURCE_CACHE) and bootstrap_container_registry_resource_id:
                 raise MutuallyExclusiveArgumentError(
                     "Cannot specify --bootstrap-container-registry-resource-id when "
                     "--bootstrap-artifact-source is not Cache."

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
@@ -11111,6 +11111,63 @@ class AKSManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
         with self.assertRaises(MutuallyExclusiveArgumentError):
             dec_mc_6 = dec_6.update_bootstrap_profile(mc_6)
 
+        dec_7 = AKSManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "bootstrap_container_registry_resource_id": acr_id_1,
+            },
+            ResourceType.MGMT_CONTAINERSERVICE,
+        )
+        mc_7 = self.models.ManagedCluster(location="test_location")
+        dec_7.context.attach_mc(mc_7)
+        with self.assertRaises(MutuallyExclusiveArgumentError):
+            dec_mc_7 = dec_7.update_bootstrap_profile(mc_7)
+
+        dec_8 = AKSManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "bootstrap_container_registry_resource_id": acr_id_1,
+            },
+            ResourceType.MGMT_CONTAINERSERVICE,
+        )
+        mc_8 = self.models.ManagedCluster(
+            location="test_location",
+            bootstrap_profile=self.models.ManagedClusterBootstrapProfile(
+                artifact_source="Direct",
+            ),
+        )
+        dec_8.context.attach_mc(mc_8)
+        with self.assertRaises(MutuallyExclusiveArgumentError):
+            dec_mc_8 = dec_8.update_bootstrap_profile(mc_8)
+
+        dec_9 = AKSManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "bootstrap_container_registry_resource_id": acr_id_2,
+            },
+            ResourceType.MGMT_CONTAINERSERVICE,
+        )
+        mc_9 = self.models.ManagedCluster(
+            location="test_location",
+            bootstrap_profile=self.models.ManagedClusterBootstrapProfile(
+                artifact_source="Cache",
+                container_registry_id=acr_id_1,
+            ),
+        )
+        dec_9.context.attach_mc(mc_9)
+        dec_mc_9 = dec_9.update_bootstrap_profile(mc_9)
+        ground_truth_mc_9 = self.models.ManagedCluster(
+            location="test_location",
+            bootstrap_profile=self.models.ManagedClusterBootstrapProfile(
+                artifact_source="Cache",
+                container_registry_id=acr_id_2,
+            ),
+        )
+        self.assertEqual(dec_mc_9, ground_truth_mc_9)
+
     def test_update_mc_profile_default(self):
         import inspect
 
@@ -11197,6 +11254,10 @@ class AKSManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
             blob_csi_driver=None,
             snapshot_controller=None,
         )
+        bootstrap_profile_1 = self.models.ManagedClusterBootstrapProfile(
+            artifact_source=None,
+            container_registry_id=None,
+        )
         ground_truth_mc_1 = self.models.ManagedCluster(
             location="test_location",
             agent_pool_profiles=[ground_truth_agent_pool_profile_1],
@@ -11204,6 +11265,7 @@ class AKSManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
             identity=ground_truth_identity_1,
             identity_profile=ground_truth_identity_profile_1,
             storage_profile=ground_truth_storage_profile_1,
+            bootstrap_profile=bootstrap_profile_1,
         )
         self.assertEqual(dec_mc_1, ground_truth_mc_1)
 


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

`az aks update`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

This PR is to fix the bug:
When the user runs `az aks update --bootstrap-container-registry-resource-id <new-acr-id>` to update the container registry resource ID, the request is ignored since `--bootstrap-artifact-source` is not provided.

The correct behavior is:

If the existing cluster's bootstrap profile artifact source is `Cache`, updating only ACR ID should be allowed.
If the existing cluster's bootstrap profile is empty or the artifact source is `Direct`, updating only ACR ID should be disallowed.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[AKS] `az aks update`: Allow updating `--bootstrap-container-registry-resource-id` when `--bootstrap-artifact-source` is not provided

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
