### PR TITLE
{CI} Revert to Ubuntu 20.04 on ARM agent

### DIFF
--- a/.azure-pipelines/templates/variables.yml
+++ b/.azure-pipelines/templates/variables.yml
@@ -2,5 +2,5 @@ variables:
   ubuntu_pool: 'pool-ubuntu-2204'
   ubuntu_multi_core_pool: 'pool-ubuntu-latest-multi-core'
   windows_pool: 'pool-windows-2019'
-  ubuntu_arm64_pool: 'pool-ubuntu-latest-arm64'
+  ubuntu_arm64_pool: 'ubuntu-arm64-2004-pool'
   macos_pool: 'macOS-14'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ parameters:
     pool: pool-ubuntu-latest-multi-core
   - name: ARM64
     value: arm64
-    pool: pool-ubuntu-latest-arm64
+    pool: ubuntu-arm64-2004-pool
 
 jobs:
 - job: CheckPullRequest


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Partially revert https://github.com/Azure/azure-cli/pull/30996.

Arm agent raises `docker: Error response from daemon: open /sys/fs/cgroup/user.slice/user-1000.slice/cgroup.controllers: no such file or directory` when run docker command. Revert to Ubuntu 20.04 to unblock release.

Ref: https://dev.azure.com/azclitools/public/_build/results?buildId=230090&view=logs&jobId=f970374f-0f25-5e15-cb2e-539daf27ea54&j=f970374f-0f25-5e15-cb2e-539daf27ea54&t=04e949c8-23b2-574b-c689-3d7f03b1f36c