### PR TITLE
{CI} Add exception in Credential Scanner

### DIFF
--- a/scripts/ci/credscan/CredScanSuppressions.json
+++ b/scripts/ci/credscan/CredScanSuppressions.json
@@ -653,6 +653,12 @@
         "src\\azure-cli\\azure\\cli\\command_modules\\batchai\\tests\\latest\\recordings\\test_batchai_manual_scale_scenario.yaml"
       ],
       "_justification": "[BATCHAI] request body password for testing"
+    },
+    {
+      "file": [
+        "src\\azure-cli\\azure\\cli\\command_modules\\rdbms\\flexible_server_custom_postgres.py"
+      ],
+      "_justification": "[RDBMS] False positive"
     }
   ]
 }


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Credential Scanner raises
```
##[error]1. Credential Scanner Error CSCAN-GENERAL0030 - File: src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py:src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py. Line: 193. Column 3. 
Signature: 4437f095d08224d8fa3ba459bdf3c04eda1552b093c54217622502e91385ca39
Tool: Credential Scanner: Rule: CSCAN-GENERAL0030 (User Login Credentials). https://aka.ms/credscan
A potential secret was detected in 'flexible_server_custom_postgres.py':(CSCAN-GENERAL0030 User Login Credentials) Validate file contains secrets, remove, roll credential, and use approved store. For additional information on secret remediation see https://aka.ms/credscan.
```

This seems to be a false positive. This line does not contain any secret.

https://github.com/Azure/azure-cli/blob/8555531877d441fdd53edc82773ece95f4f73262/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py#L193

This line was introduced in https://github.com/Azure/azure-cli/pull/30999#discussion_r2011392617