### PR TITLE
{CI} Use Ubuntu 24.04 on ARM agent

### DIFF
--- a/.azure-pipelines/templates/variables.yml
+++ b/.azure-pipelines/templates/variables.yml
@@ -2,5 +2,5 @@ variables:
   ubuntu_pool: 'pool-ubuntu-2204'
   ubuntu_multi_core_pool: 'pool-ubuntu-latest-multi-core'
   windows_pool: 'pool-windows-2019'
-  ubuntu_arm64_pool: 'ubuntu-arm64-2004-pool'
+  ubuntu_arm64_pool: 'pool-ubuntu-latest-arm64'
   macos_pool: 'macOS-14'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ parameters:
     pool: pool-ubuntu-latest-multi-core
   - name: ARM64
     value: arm64
-    pool: ubuntu-arm64-2004-pool
+    pool: pool-ubuntu-latest-arm64
 
 jobs:
 - job: CheckPullRequest

--- a/scripts/ci/install_docker.sh
+++ b/scripts/ci/install_docker.sh
@@ -5,11 +5,7 @@ if [[ $(dpkg --print-architecture) == "amd64" ]]; then
     echo "Docker is already installed on AMD64"
     exit 0
 fi
-# https://docs.docker.com/engine/security/rootless/
-/bin/bash -c "$(curl -fsSL https://get.docker.com)"
-sudo apt-get install -y uidmap
-dockerd-rootless-setuptool.sh install
-export XDG_RUNTIME_DIR=/home/cloudtest/.docker/run
-PATH=/usr/bin:/sbin:/usr/sbin:$PATH dockerd-rootless.sh &
-sleep 5
-docker context use rootless
+
+# https://docs.docker.com/engine/install/ubuntu/#install-using-the-convenience-script
+curl -fsSL https://get.docker.com/ | sh
+sudo chmod 666 /var/run/docker.sock


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

This PR enables `pool-ubuntu-latest-arm64` pool, which uses Ubuntu 24.04

This PR also changes rootless docker to normal docker.

Related PR:
- https://github.com/Azure/azure-cli/pull/30996
- https://github.com/Azure/azure-cli/pull/31123