### PR TITLE
{CI} Remove unused globals

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/azure_stack/zone_file/parse_zone_file.py
+++ b/src/azure-cli/azure/cli/command_modules/network/azure_stack/zone_file/parse_zone_file.py
@@ -289,8 +289,6 @@ def _add_record_names(text):
     Go through each line of the text and ensure that
     a name is defined.  Use previous record name if there is none.
     """
-    global SUPPORTED_RECORDS
-
     lines = text.split("\n")
     ret = []
     previous_record_name = None

--- a/src/azure-cli/azure/cli/command_modules/network/zone_file/parse_zone_file.py
+++ b/src/azure-cli/azure/cli/command_modules/network/zone_file/parse_zone_file.py
@@ -293,8 +293,6 @@ def _add_record_names(text):
     Go through each line of the text and ensure that
     a name is defined.  Use previous record name if there is none.
     """
-    global SUPPORTED_RECORDS
-
     lines = text.split("\n")
     ret = []
     previous_record_name = None


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
ERROR: /mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/network/azure_stack/zone_file/parse_zone_file.py:292:5: F824 `global SUPPORTED_RECORDS` is unused: name is never assigned in scope
/mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/network/azure_stack/zone_file/parse_zone_file.py:292:5: F824 `global SUPPORTED_RECORDS` is unused: name is never assigned in scope
/mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/network/zone_file/parse_zone_file.py:296:5: F824 `global SUPPORTED_RECORDS` is unused: name is never assigned in scope
/mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/network/zone_file/parse_zone_file.py:296:5: F824 `global SUPPORTED_RECORDS` is unused: name is never assigned in scope
4     F824 `global SUPPORTED_RECORDS` is unused: name is never assigned in scope
 
[Pipelines - Run 20250331.2 logs](https://dev.azure.com/azclitools/public/_build/results?buildId=231523&view=logs&jobId=36dd4138-4d53-5e46-00d9-e5cd9744be05&j=36dd4138-4d53-5e46-00d9-e5cd9744be05&t=1cf3879c-0a42-5ccd-7693-7a4781d739d8)

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
