### PR TITLE
{Core} Add breaking change warning for azure stack users

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_breaking_change.py
+++ b/src/azure-cli-core/azure/cli/core/_breaking_change.py
@@ -1,0 +1,15 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+# pylint: disable=line-too-long
+
+from azure.cli.core.breaking_change import AzCLIOtherChange, register_conditional_breaking_change
+
+register_conditional_breaking_change(
+    tag='CloudProfilesDeprecate',
+    breaking_change=AzCLIOtherChange(
+        cmd='',
+        message="Starting from 2.73.0, the azure stack profiles ('2017-03-09-profile', '2018-03-01-hybrid', '2019-03-01-hybrid', '2020-09-01-hybrid') will be deprecated. Please use the 'latest' profile or the CLI 2.66.* (LTS) version instead."
+    )
+)

--- a/src/azure-cli-core/azure/cli/core/cloud.py
+++ b/src/azure-cli-core/azure/cli/core/cloud.py
@@ -622,13 +622,16 @@ def get_active_cloud(cli_ctx=None):
         from azure.cli.core import get_default_cli
         cli_ctx = get_default_cli()
     try:
-        return get_cloud(cli_ctx, get_active_cloud_name(cli_ctx))
+        cloud = get_cloud(cli_ctx, get_active_cloud_name(cli_ctx))
     except CloudNotRegisteredException as err:
         logger.warning(err)
         default_cloud_name = get_default_cloud_name()
         logger.warning("Resetting active cloud to'%s'.", default_cloud_name)
         _set_active_cloud(cli_ctx, default_cloud_name)
-        return get_cloud(cli_ctx, default_cloud_name)
+        cloud = get_cloud(cli_ctx, default_cloud_name)
+    if cloud.profile != 'latest':
+        logger.warning("Cloud profile '%s' will be deprecated in 2.73.0, please use the 'latest' profile or the CLI 2.66.* (LTS) version instead.", cloud.profile)
+    return cloud
 
 
 def get_cloud_subscription(cloud_name):

--- a/src/azure-cli-core/azure/cli/core/cloud.py
+++ b/src/azure-cli-core/azure/cli/core/cloud.py
@@ -630,7 +630,7 @@ def get_active_cloud(cli_ctx=None):
         _set_active_cloud(cli_ctx, default_cloud_name)
         cloud = get_cloud(cli_ctx, default_cloud_name)
     if cloud.profile != 'latest':
-        logger.warning("Cloud profile '%s' will be deprecated in 2.73.0, please use the 'latest' profile or the CLI 2.66.* (LTS) version instead.", cloud.profile)
+        logger.warning("Cloud profile '%s' will be deprecated starting from 2.73.0. Please use the 'latest' profile or the CLI 2.66.* (LTS) version instead.", cloud.profile)
     return cloud
 
 


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

The following warning messages will be displayed when using azure-stack profiles:

![image](https://github.com/user-attachments/assets/a4e79d6c-855e-49e5-a744-81d7cc7584ff)


**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
