### PR TITLE
[ACR] Tests: Remove 'acr credential renew` tests from core registry scenario

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/tests/hybrid_2020_09_01/test_acr_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/tests/hybrid_2020_09_01/test_acr_commands.py
@@ -58,28 +58,6 @@ class AcrCommandsTests(ScenarioTest):
         password2 = credential['passwords'][1]['value']
         assert username and password and password2
 
-        # renew password
-        credential = self.cmd('acr credential renew -n {} -g {} --password-name {}'.format(
-            registry_name, resource_group, 'password')).get_output_in_json()
-        renewed_username = credential['username']
-        renewed_password = credential['passwords'][0]['value']
-        renewed_password2 = credential['passwords'][1]['value']
-        assert renewed_username and renewed_password and renewed_password2
-        assert username == renewed_username
-        assert password != renewed_password
-        assert password2 == renewed_password2
-
-        # renew password2
-        credential = self.cmd('acr credential renew -n {} -g {} --password-name {}'.format(
-            registry_name, resource_group, 'password2')).get_output_in_json()
-        renewed_username = credential['username']
-        renewed_password = credential['passwords'][0]['value']
-        renewed_password2 = credential['passwords'][1]['value']
-        assert renewed_username and renewed_password and renewed_password2
-        assert username == renewed_username
-        assert password != renewed_password
-        assert password2 != renewed_password2
-
         # test acr delete
         self.cmd('acr delete -n {} -g {} -y'.format(registry_name, resource_group))
 

--- a/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_commands.py
@@ -67,28 +67,6 @@ class AcrCommandsTests(ScenarioTest):
         password2 = credential['passwords'][1]['value']
         assert username and password and password2
 
-        # renew password
-        credential = self.cmd('acr credential renew -n {} -g {} --password-name {}'.format(
-            registry_name, resource_group, 'password')).get_output_in_json()
-        renewed_username = credential['username']
-        renewed_password = credential['passwords'][0]['value']
-        renewed_password2 = credential['passwords'][1]['value']
-        assert renewed_username and renewed_password and renewed_password2
-        assert username == renewed_username
-        assert password != renewed_password
-        assert password2 == renewed_password2
-
-        # renew password2
-        credential = self.cmd('acr credential renew -n {} -g {} --password-name {}'.format(
-            registry_name, resource_group, 'password2')).get_output_in_json()
-        renewed_username = credential['username']
-        renewed_password = credential['passwords'][0]['value']
-        renewed_password2 = credential['passwords'][1]['value']
-        assert renewed_username and renewed_password and renewed_password2
-        assert username == renewed_username
-        assert password != renewed_password
-        assert password2 != renewed_password2
-
         # test acr delete
         self.cmd('acr delete -n {} -g {} -y'.format(registry_name, resource_group))
 


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
With the existence of `azdev mask` , credentials are changed to `***` from their original string such as `DFKJGD234354`. One of our tests checks if two generated passwords are not equal to each other and that the rotation happened successfully. However, since az cli pipeline uses recordings to check the test, these core scenario tests often fail as the masked secret of `***` are equal to another. 
**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
