### PR TITLE
[Core] PREVIEW: Support broker on WSL

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -999,6 +999,8 @@ def _create_identity_instance(cli_ctx, authority, tenant_id=None, client_id=None
     """Lazily import and create Identity instance to avoid unnecessary imports."""
     from .auth.identity import Identity
     from .util import should_encrypt_token_cache
+    from .telemetry import set_broker_info
+
     encrypt = should_encrypt_token_cache(cli_ctx)
 
     # EXPERIMENTAL: Use core.use_msal_http_cache=False to turn off MSAL HTTP cache.
@@ -1006,8 +1008,11 @@ def _create_identity_instance(cli_ctx, authority, tenant_id=None, client_id=None
 
     # On Windows, use core.enable_broker_on_windows=false to disable broker (WAM) for authentication.
     enable_broker_on_windows = cli_ctx.config.getboolean('core', 'enable_broker_on_windows', fallback=True)
-    from .telemetry import set_broker_info
     set_broker_info(enable_broker_on_windows)
+
+    # On WSL, use core.enable_broker_on_wsl=true to use broker (WAM)
+    enable_broker_on_wsl = cli_ctx.config.getboolean('core', 'enable_broker_on_wsl', fallback=False)
+    set_broker_info(enable_broker_on_wsl)
 
     # PREVIEW: In Azure Stack environment, use core.instance_discovery=false to disable MSAL's instance discovery.
     instance_discovery = cli_ctx.config.getboolean('core', 'instance_discovery', True)
@@ -1016,6 +1021,7 @@ def _create_identity_instance(cli_ctx, authority, tenant_id=None, client_id=None
                     encrypt=encrypt,
                     use_msal_http_cache=use_msal_http_cache,
                     enable_broker_on_windows=enable_broker_on_windows,
+                    enable_broker_on_wsl=enable_broker_on_wsl,
                     instance_discovery=instance_discovery)
 
 

--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -58,7 +58,8 @@ class Identity:  # pylint: disable=too-many-instance-attributes
     _service_principal_store_instance = None
 
     def __init__(self, authority, tenant_id=None, client_id=None, encrypt=False, use_msal_http_cache=True,
-                 enable_broker_on_windows=None, instance_discovery=None):
+                 enable_broker_on_windows=None, enable_broker_on_wsl=None,
+                 instance_discovery=None):
         """
         :param authority: Authentication authority endpoint. For example,
             - AAD: https://login.microsoftonline.com
@@ -74,6 +75,7 @@ class Identity:  # pylint: disable=too-many-instance-attributes
         self._encrypt = encrypt
         self._use_msal_http_cache = use_msal_http_cache
         self._enable_broker_on_windows = enable_broker_on_windows
+        self._enable_broker_on_wsl = enable_broker_on_wsl
         self._instance_discovery = instance_discovery
 
         # Build the authority in MSAL style
@@ -112,7 +114,10 @@ class Identity:  # pylint: disable=too-many-instance-attributes
     def _msal_public_app_kwargs(self):
         """kwargs for creating PublicClientApplication."""
         # enable_broker_on_windows can only be used on PublicClientApplication.
-        return {**self._msal_app_kwargs, "enable_broker_on_windows": self._enable_broker_on_windows}
+        return {**self._msal_app_kwargs,
+                "enable_broker_on_windows": self._enable_broker_on_windows,
+                "enable_broker_on_wsl": self._enable_broker_on_wsl
+                }
 
     @property
     def _msal_app(self):

--- a/src/azure-cli-core/azure/cli/core/telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry.py
@@ -76,6 +76,7 @@ class TelemetrySession:  # pylint: disable=too-many-instance-attributes
         self.user_agent = None
         # authentication-related
         self.enable_broker_on_windows = None
+        self.enable_broker_on_wsl = None
         self.msal_telemetry = None
         self.login_experience_v2 = None
 
@@ -232,6 +233,7 @@ class TelemetrySession:  # pylint: disable=too-many-instance-attributes
         set_custom_properties(result, 'SecretNames', ','.join(self.secret_names or []))
         # authentication-related
         set_custom_properties(result, 'EnableBrokerOnWindows', str(self.enable_broker_on_windows))
+        set_custom_properties(result, 'EnableBrokerOnWsl', str(self.enable_broker_on_wsl))
         set_custom_properties(result, 'MsalTelemetry', self.msal_telemetry)
         set_custom_properties(result, 'LoginExperienceV2', str(self.login_experience_v2))
 
@@ -471,9 +473,10 @@ def set_region_identified(region_input, region_identified):
 
 
 @decorators.suppress_all_exceptions()
-def set_broker_info(enable_broker_on_windows):
+def set_broker_info(enable_broker_on_windows, enable_broker_on_wsl):
     # Log the value of `enable_broker_on_windows`
     _session.enable_broker_on_windows = enable_broker_on_windows
+    _session.enable_broker_on_wsl = enable_broker_on_wsl
 
 
 @decorators.suppress_all_exceptions()


### PR DESCRIPTION
**Related command**
`az login`

**Description**<!--Mandatory-->
Require https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/766
Similar to #23828 

Support Web Account Manager (WAM) login on WSL.

**Testing Guide**

On WSL, users can opt in WAM login using:

```
az config set core.enable_broker_on_wsl=true
```

Then run

```
az login
```


**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Core] PREVIEW: Support Web Account Manager (WAM) login on WSL. To opt in, run `az config set core.enable_broker_on_wsl=true`