### PR TITLE
[ARM] `az deployment`: Fix issue where Bicep is not found in CI environments

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
@@ -220,10 +220,14 @@ def get_bicep_latest_release_tag():
         raise ClientRequestError(f"Error while attempting to retrieve the latest Bicep version: {err}.")
 
 
-def bicep_version_greater_than_or_equal_to(version):
-    system = platform.system()
-    installation_path = _get_bicep_installation_path(system)
-    installed_version = _get_bicep_installed_version(installation_path)
+def bicep_version_greater_than_or_equal_to(cli_ctx, version):
+    if _use_binary_from_path(cli_ctx):
+        installed_version = _get_bicep_installed_version("bicep")
+    else:
+        system = platform.system()
+        installation_path = _get_bicep_installation_path(system)
+        installed_version = _get_bicep_installed_version(installation_path)
+
     parsed_version = semver.VersionInfo.parse(version)
     return installed_version >= parsed_version
 

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -1069,11 +1069,11 @@ def _parse_bicepparam_file(cmd, template_file, parameters):
     ensure_bicep_installation(cmd.cli_ctx, stdout=False)
 
     minimum_supported_version_bicepparam_compilation = "0.14.85"
-    if not bicep_version_greater_than_or_equal_to(minimum_supported_version_bicepparam_compilation):
+    if not bicep_version_greater_than_or_equal_to(cmd.cli_ctx, minimum_supported_version_bicepparam_compilation):
         raise ArgumentUsageError(f"Unable to compile .bicepparam file with the current version of Bicep CLI. Please upgrade Bicep CLI to {minimum_supported_version_bicepparam_compilation} or later.")
 
     minimum_supported_version_supplemental_param = "0.22.6"
-    if _get_parameter_count(parameters) > 1 and not bicep_version_greater_than_or_equal_to(minimum_supported_version_supplemental_param):
+    if _get_parameter_count(parameters) > 1 and not bicep_version_greater_than_or_equal_to(cmd.cli_ctx, minimum_supported_version_supplemental_param):
         raise ArgumentUsageError(f"Current version of Bicep CLI does not support supplemental parameters with .bicepparam file. Please upgrade Bicep CLI to {minimum_supported_version_supplemental_param} or later.")
 
     bicepparam_file = _get_bicepparam_file_path(parameters)
@@ -4681,9 +4681,9 @@ def format_bicep_file(cmd, file, stdout=None, outdir=None, outfile=None, newline
     minimum_supported_version = "0.12.1"
     kebab_case_params_supported_version = "0.26.54"
 
-    if bicep_version_greater_than_or_equal_to(minimum_supported_version):
+    if bicep_version_greater_than_or_equal_to(cmd.cli_ctx, minimum_supported_version):
         args = ["format", file]
-        use_kebab_case_params = bicep_version_greater_than_or_equal_to(kebab_case_params_supported_version)
+        use_kebab_case_params = bicep_version_greater_than_or_equal_to(cmd.cli_ctx, kebab_case_params_supported_version)
         newline_kind = newline_kind or newline
 
         # Auto is no longer supported by Bicep formatter v2. Use LF as default.
@@ -4719,26 +4719,26 @@ def publish_bicep_file(cmd, file, target, documentationUri=None, documentation_u
     minimum_supported_version = "0.4.1008"
     kebab_case_param_supported_version = "0.26.54"
 
-    if bicep_version_greater_than_or_equal_to(minimum_supported_version):
+    if bicep_version_greater_than_or_equal_to(cmd.cli_ctx, minimum_supported_version):
         args = ["publish", file, "--target", target]
-        use_kebab_case_params = bicep_version_greater_than_or_equal_to(kebab_case_param_supported_version)
+        use_kebab_case_params = bicep_version_greater_than_or_equal_to(cmd.cli_ctx, kebab_case_param_supported_version)
         documentation_uri = documentation_uri or documentationUri
 
         if documentation_uri:
             minimum_supported_version_for_documentationUri_parameter = "0.14.46"
-            if bicep_version_greater_than_or_equal_to(minimum_supported_version_for_documentationUri_parameter):
+            if bicep_version_greater_than_or_equal_to(cmd.cli_ctx, minimum_supported_version_for_documentationUri_parameter):
                 args += ["--documentation-uri" if use_kebab_case_params else "--documentationUri", documentation_uri]
             else:
                 logger.error("az bicep publish with --documentationUri/-d parameter could not be executed with the current version of Bicep CLI. Please upgrade Bicep CLI to v%s or later.", minimum_supported_version_for_documentationUri_parameter)
         if with_source:
             minimum_supported_version_for_publish_with_source = "0.23.1"
-            if bicep_version_greater_than_or_equal_to(minimum_supported_version_for_publish_with_source):
+            if bicep_version_greater_than_or_equal_to(cmd.cli_ctx, minimum_supported_version_for_publish_with_source):
                 args += ["--with-source"]
             else:
                 logger.error("az bicep publish with --with-source/-s parameter could not be executed with the current version of Bicep CLI. Please upgrade Bicep CLI to v%s or later.", minimum_supported_version_for_publish_with_source)
         if force:
             minimum_supported_version_for_publish_force = "0.17.1"
-            if bicep_version_greater_than_or_equal_to(minimum_supported_version_for_publish_force):
+            if bicep_version_greater_than_or_equal_to(cmd.cli_ctx, minimum_supported_version_for_publish_force):
                 args += ["--force"]
             else:
                 logger.error("az bicep publish with --force parameter could not be executed with the current version of Bicep CLI. Please upgrade Bicep CLI to v%s or later.", minimum_supported_version_for_publish_force)
@@ -4752,7 +4752,7 @@ def restore_bicep_file(cmd, file, force=None):
     ensure_bicep_installation(cmd.cli_ctx)
 
     minimum_supported_version = "0.4.1008"
-    if bicep_version_greater_than_or_equal_to(minimum_supported_version):
+    if bicep_version_greater_than_or_equal_to(cmd.cli_ctx, minimum_supported_version):
         args = ["restore", file]
         if force:
             args += ["--force"]
@@ -4772,7 +4772,7 @@ def decompileparams_bicep_file(cmd, file, bicep_file=None, outdir=None, outfile=
     ensure_bicep_installation(cmd.cli_ctx)
 
     minimum_supported_version = "0.18.4"
-    if bicep_version_greater_than_or_equal_to(minimum_supported_version):
+    if bicep_version_greater_than_or_equal_to(cmd.cli_ctx, minimum_supported_version):
         args = ["decompile-params", file]
         if bicep_file:
             args += ["--bicep-file", bicep_file]
@@ -4803,7 +4803,7 @@ def generate_params_file(cmd, file, no_restore=None, outdir=None, outfile=None, 
     ensure_bicep_installation(cmd.cli_ctx, stdout=False)
 
     minimum_supported_version = "0.7.4"
-    if bicep_version_greater_than_or_equal_to(minimum_supported_version):
+    if bicep_version_greater_than_or_equal_to(cmd.cli_ctx, minimum_supported_version):
         args = ["generate-params", file]
         if no_restore:
             args += ["--no-restore"]
@@ -4830,7 +4830,7 @@ def lint_bicep_file(cmd, file, no_restore=None, diagnostics_format=None):
     ensure_bicep_installation(cmd.cli_ctx, stdout=False)
 
     minimum_supported_version = "0.7.4"
-    if bicep_version_greater_than_or_equal_to(minimum_supported_version):
+    if bicep_version_greater_than_or_equal_to(cmd.cli_ctx, minimum_supported_version):
         args = ["lint", file]
         if no_restore:
             args += ["--no-restore"]

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_custom.py
@@ -671,8 +671,8 @@ class TestFormatBicepFile(unittest.TestCase):
 
         # Assert.
         mock_bicep_version_greater_than_or_equal_to.assert_has_calls([
-            mock.call("0.12.1"),
-            mock.call("0.26.54"),
+            mock.call(cmd.cli_ctx, "0.12.1"),
+            mock.call(cmd.cli_ctx, "0.26.54"),
         ])
         mock_run_bicep_command.assert_called_once_with(cmd.cli_ctx, ["format", file_path, "--stdout"])
 
@@ -689,7 +689,7 @@ class TestPublishWithSource(unittest.TestCase):
 
         # Assert.
         mock_bicep_version_greater_than_or_equal_to.assert_has_calls([
-            mock.call("0.4.1008"), # Min version for 'bicep publish'
+            mock.call(cmd.cli_ctx, "0.4.1008"), # Min version for 'bicep publish'
         ])
         mock_run_bicep_command.assert_called_once_with(cmd.cli_ctx, ['publish', file_path, '--target', 'br:contoso.azurecr.io/bicep/mymodule:v1'])
 
@@ -705,9 +705,9 @@ class TestPublishWithSource(unittest.TestCase):
 
         # Assert.
         mock_bicep_version_greater_than_or_equal_to.assert_has_calls([
-            mock.call("0.4.1008"), # Min version for 'bicep publish'
-            mock.call('0.26.54'),
-            mock.call("0.23.1") # Min version for 'bicep publish --with-source'
+            mock.call(cmd.cli_ctx, "0.4.1008"), # Min version for 'bicep publish'
+            mock.call(cmd.cli_ctx, '0.26.54'),
+            mock.call(cmd.cli_ctx, "0.23.1") # Min version for 'bicep publish --with-source'
         ])
         mock_run_bicep_command.assert_called_once_with(cmd.cli_ctx, ['publish', file_path, '--target', 'br:contoso.azurecr.io/bicep/mymodule:v1', '--with-source'])
 


### PR DESCRIPTION
**Related command**
`az deployment`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
My previous PR (https://github.com/Azure/azure-cli/pull/31041) fixed several Bicep-related issues but uncovered another: when verifying if certain Bicep features are supported by the installed version, Azure CLI incorrectly uses the binary from its cache folder, even when it's configured to use the one on the system path in an CI environment. This PR fixes that behavior.


**Testing Guide**
Run `az deployment group create -f main.bicep ...` in an ADO pipeline.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
