### PR TITLE
[Packaging] Drop Ubuntu 20.04 support

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -913,12 +913,6 @@ jobs:
     matrix:
       ${{ each arch in parameters.architectures }}:
         # https://wiki.ubuntu.com/Releases
-        Focal ${{ arch.name }}:
-          # 20.04
-          deb_system: ubuntu
-          distro: focal
-          arch: ${{ arch.value }}
-          pool: ${{ arch.pool }}
         Jammy ${{ arch.name }}:
           # 22.04
           deb_system: ubuntu
@@ -982,11 +976,6 @@ jobs:
   strategy:
     matrix:
       ${{ each arch in parameters.architectures }}:
-        Focal ${{ arch.name }}:
-          deb_system: ubuntu
-          distro: focal
-          arch: ${{ arch.value }}
-          pool: ${{ arch.pool }}
         Jammy ${{ arch.name }}:
           deb_system: ubuntu
           distro: jammy


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Similar to https://github.com/Azure/azure-cli/pull/28942

Ubuntu 20.04 will reach its EOL in May 2025, and our next release is also in May.

Ref: https://wiki.ubuntu.com/Releases

PS: ADO is retiring it earlier:
> The Ubuntu-20.04 retirement date for Microsoft-hosted agents has been moved to **April 15**.
-- https://devblogs.microsoft.com/devops/upcoming-updates-for-azure-pipelines-agents-images/#ubuntu