### PR TITLE
{Core} Fix #31222: `aaz`: Subresource can be empty 

### DIFF
--- a/src/azure-cli-core/azure/cli/core/aaz/_selector.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_selector.py
@@ -55,6 +55,4 @@ class AAZJsonSelector(AAZSelector):
 
     def required(self):
         value = self.get()
-        if not has_value(value):
-            raise UserFault("ResourceNotFoundError")
         return value

--- a/src/azure-cli-core/azure/cli/core/aaz/_selector.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_selector.py
@@ -5,7 +5,6 @@
 # from azure.core.exceptions import ResourceExistsError, ResourceNotFoundError
 from azure.cli.core.azclierror import UserFault
 
-from ._base import has_value
 from .exceptions import AAZUnknownFieldError
 
 


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
fix: https://github.com/Azure/azure-cli/issues/31222

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
