### PR TITLE
{App Service} Hotfix: Remove fileshare validation

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -580,14 +580,6 @@ def update_application_settings_polling(cmd, resource_group_name, name, app_sett
 def add_azure_storage_account(cmd, resource_group_name, name, custom_id, storage_type, account_name,
                               share_name, access_key, mount_path=None, slot=None, slot_setting=False):
     AzureStorageInfoValue = cmd.get_models('AzureStorageInfoValue')
-    storage_client = get_mgmt_service_client(cmd.cli_ctx, StorageManagementClient)
-
-    # Check if the file share exists
-    try:
-        storage_client.file_shares.get(resource_group_name, account_name, share_name)
-    except:
-        raise ValidationError(f"The share '{share_name}' does not exist in the storage account '{account_name}'.")
-
     azure_storage_accounts = _generic_site_operation(cmd.cli_ctx, resource_group_name, name,
                                                      'list_azure_storage_accounts', slot)
 


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az webapp config storage-account add

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Validation was added Fix #21721, however this validation doesn't work as intended so removing it until this can be further investigated. There's commentary in #30990 that explains the issues and why this change needs to be rolled back.
 
**Testing Guide**
<!--Example commands with explanations.-->
az webapp config storage-account add -g <RESSOURCE_GROUP_NAME> -n <APP_SERVICE_NAME> --custom-id "test-az-cli" --storage-type AzureFiles --account-name <STORAGE_ACCOUNT_NAME> --share-name <FILE_SHARE_NAME> --access-key <STORAGE_ACCOUNT_ACCESS_KEY> --mount-path <MOUNT_PATH_ON_APP_SERVICE_FS>

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).