### PR TITLE
{Auth} Support interactive re-authentication with WAM

### DIFF
--- a/src/azure-cli-core/azure/cli/core/auth/msal_credentials.py
+++ b/src/azure-cli-core/azure/cli/core/auth/msal_credentials.py
@@ -68,23 +68,30 @@ class UserCredential:  # pylint: disable=too-few-public-methods
             # browser is available.
             if 'data' in kwargs:
                 logger.warning(ex)
-                logger.warning("\nThe default web browser has been opened at %s for scope '%s'. "
-                               "Please continue the login in the web browser.",
-                               self._msal_app.authority.authorization_endpoint, ' '.join(scopes))
-
-                from .util import read_response_templates
-                success_template, error_template = read_response_templates()
-
-                result = self._msal_app.acquire_token_interactive(
-                    scopes, login_hint=self._account['username'],
-                    port=8400 if self._msal_app.authority.is_adfs else None,
-                    success_template=success_template, error_template=error_template, **kwargs)
-                check_result(result)
-
+                result = self._acquire_token_interactive(scopes, **kwargs)
             # For other scenarios like Storage Conditional Access MFA step-up, do not
             # launch browser, but show the error message and `az login` command instead.
             else:
                 raise
+        return result
+
+    def _acquire_token_interactive(self, scopes, **kwargs):
+        from .util import read_response_templates
+        success_template, error_template = read_response_templates()
+
+        def _prompt_launching_ui(ui=None, **_):
+            logger.warning(
+                "Interactively acquiring token for scope '%s'. Continue the login in the %s.",
+                ' '.join(scopes), 'web browser' if ui == 'browser' else 'pop-up window')
+
+        result = self._msal_app.acquire_token_interactive(
+            scopes, login_hint=self._account['username'],
+            port=8400 if self._msal_app.authority.is_adfs else None,
+            success_template=success_template, error_template=error_template,
+            parent_window_handle=self._msal_app.CONSOLE_WINDOW_HANDLE,
+            on_before_launching_ui=_prompt_launching_ui,
+            **kwargs)
+        check_result(result)
         return result
 
 


### PR DESCRIPTION
**Related command**
`az ssh vm`

**Description**<!--Mandatory-->
Fix #30519

When supporting WAM (#23828), interactive re-authentication was not included.

When getting SSH certificate requires step-up, CLI fails with

```
ValueError: parent_window_handle is required when you opted into using broker. You need to provide the window
handle of your GUI application, or use msal.PublicClientApplication.CONSOLE_WINDOW_HANDLE when and only when
your application is a console app.
```

This PR sets `parent_window_handle` during interactive re-authentication so that it can work with WAM too.

**Testing Guide**
`az ssh vm`

To directly trigger interactive re-authentication, replace L56~L57

```py
        result = self._msal_app.acquire_token_silent_with_error(
            scopes, self._account, claims_challenge=claims_challenge, **kwargs)
```

with

```py
        result = self._acquire_token_interactive(scopes, **kwargs)
```
