### PR TITLE
[Service Connector] `az webapp connection create -h`: Clarify that system identity is a flag

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/_help.py
@@ -320,7 +320,7 @@ for source in SOURCE_RESOURCES:
             else:
                 system_identity_param = '''
             - name: --system-identity
-              short-summary: The system assigned identity auth info
+              short-summary: The flag to use system assigned identity auth info. 
               long-summary: |
                 Usage: --system-identity
 

--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/_help.py
@@ -320,7 +320,7 @@ for source in SOURCE_RESOURCES:
             else:
                 system_identity_param = '''
             - name: --system-identity
-              short-summary: The flag to use system assigned identity auth info.
+              short-summary: The flag to use system assigned identity auth info. No additional parameters are needed.
               long-summary: |
                 Usage: --system-identity
 

--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/_help.py
@@ -320,7 +320,7 @@ for source in SOURCE_RESOURCES:
             else:
                 system_identity_param = '''
             - name: --system-identity
-              short-summary: The flag to use system assigned identity auth info. 
+              short-summary: The flag to use system assigned identity auth info.
               long-summary: |
                 Usage: --system-identity
 


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az webapp/containerapp/spring connection create <target-service> -h

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
As stated in https://github.com/azure/azure-cli/issues/30896, `--system-identity` help description is not clear enough that it is used as a flag

**Testing Guide**
<!--Example commands with explanations.-->
az webapp connection create storage-blob -h

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
