### PR TITLE
[Packaging] Bump Python to 3.12 on RHEL and CentOS Stream

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -816,13 +816,13 @@ jobs:
           dockerfile: ubi
           image: registry.access.redhat.com/ubi8/ubi:8.4
           artifact: rpm-ubi8-${{ arch.value }}
-          python_package: python39
+          python_package: python3.12
           pool: ${{ arch.pool }}
         Red Hat Universal Base Image 9 ${{ arch.name }}:
           dockerfile: ubi
           image: registry.access.redhat.com/ubi9/ubi:9.0.0
           artifact: rpm-ubi9-${{ arch.value }}
-          python_package: python3.9
+          python_package: python3.12
           pool: ${{ arch.pool }}
   steps:
   - bash: ./scripts/ci/install_docker.sh
@@ -864,17 +864,17 @@ jobs:
           artifact: rpm-ubi8-${{ arch.value }}
           distro: el8
           image: registry.access.redhat.com/ubi8/ubi:8.4
-          python_package: python39
-          python_cmd: python3.9
-          pip_cmd: pip3.9
+          python_package: python3.12
+          python_cmd: python3.12
+          pip_cmd: pip3.12
           pool: ${{ arch.pool }}
         Red Hat Universal Base Image 9 ${{ arch.name }}:
           artifact: rpm-ubi9-${{ arch.value }}
           distro: el9
           image: registry.access.redhat.com/ubi9/ubi:9.0.0
-          python_package: python3.9
-          python_cmd: python3.9
-          pip_cmd: pip3.9
+          python_package: python3.12
+          python_cmd: python3.12
+          pip_cmd: pip3.12
           pool: ${{ arch.pool }}
   steps:
   - task: DownloadPipelineArtifact@1

--- a/scripts/release/rpm/azure-cli.spec
+++ b/scripts/release/rpm/azure-cli.spec
@@ -58,6 +58,7 @@ deactivate
 
 # Fix up %{buildroot} appearing in some files...
 for d in %{buildroot}%{cli_lib_dir}/bin/*; do perl -p -i -e "s#%{buildroot}##g" $d; done;
+rm %{buildroot}%{cli_lib_dir}/pyvenv.cfg
 
 # Create executable (entry script)
 

--- a/scripts/release/rpm/test_rpm_in_docker.sh
+++ b/scripts/release/rpm/test_rpm_in_docker.sh
@@ -7,7 +7,7 @@ export USERNAME=azureuser
 
 dnf --nogpgcheck install /mnt/rpm/$RPM_NAME -y
 
-dnf install git gcc $PYTHON_PACKAGE-devel findutils -y
+dnf install git gcc $PYTHON_PACKAGE-devel findutils $PYTHON_PACKAGE-pip -y
 
 ln -s -f /usr/bin/$PYTHON_CMD /usr/bin/python
 ln -s -f /usr/bin/$PIP_CMD /usr/bin/pip

--- a/scripts/release/rpm/test_rpm_in_docker.sh
+++ b/scripts/release/rpm/test_rpm_in_docker.sh
@@ -7,7 +7,7 @@ export USERNAME=azureuser
 
 dnf --nogpgcheck install /mnt/rpm/$RPM_NAME -y
 
-dnf install git gcc $PYTHON_PACKAGE-devel findutils $PYTHON_PACKAGE-pip -y
+dnf install git findutils $PYTHON_PACKAGE-pip -y
 
 ln -s -f /usr/bin/$PYTHON_CMD /usr/bin/python
 ln -s -f /usr/bin/$PIP_CMD /usr/bin/pip

--- a/scripts/release/rpm/ubi.dockerfile
+++ b/scripts/release/rpm/ubi.dockerfile
@@ -5,7 +5,7 @@ ARG image=registry.access.redhat.com/ubi8/ubi:8.4
 
 FROM ${image} AS build-env
 ARG cli_version=dev
-ARG python_package=python39
+ARG python_package=python3.12
 
 RUN yum update -y
 RUN yum install -y wget rpm-build gcc libffi-devel ${python_package}-devel openssl-devel make bash diffutils patch dos2unix perl
@@ -18,7 +18,7 @@ COPY . .
 # We have to explicitly specify 'python39' to install Python 3.9.
 RUN --mount=type=secret,id=PIP_INDEX_URL export PIP_INDEX_URL=$(cat /run/secrets/PIP_INDEX_URL) && \
     dos2unix ./scripts/release/rpm/azure-cli.spec && \
-    REPO_PATH=$(pwd) CLI_VERSION=$cli_version PYTHON_PACKAGE=$python_package PYTHON_CMD=python3.9 \
+    REPO_PATH=$(pwd) CLI_VERSION=$cli_version PYTHON_PACKAGE=$python_package PYTHON_CMD=$python_package \
     rpmbuild -v -bb --clean scripts/release/rpm/azure-cli.spec && \
     cp /root/rpmbuild/RPMS/*/azure-cli-${cli_version}-1.*.rpm /azure-cli-dev.rpm && \
     mkdir /out && cp /root/rpmbuild/RPMS/*/azure-cli-${cli_version}-1.*.rpm /out/


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

This PR bumps the Python dependency to 3.12. **Some extensions may need to be reinstalled if they become non-functional**: `az extension remove -n xxx && az extension add -n xxx`

After this PR, Mariner 2.0 is the only one relies on Python 3.9, the rest of the distros use 3.12.