### PR TITLE
[RDBMS] BREAKING CHANGE: `az postgres flexible-server create/upgrade`: Remove support of PG12 which has officially ended

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
@@ -459,7 +459,7 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
         )
 
         pg_version_upgrade_arg_type = CLIArgumentType(
-            arg_type=get_enum_type(['12', '13', '14', '15', '16', '17']),
+            arg_type=get_enum_type(['13', '14', '15', '16', '17']),
             options_list=['--version', '-v'],
             help='Server major version.'
         )

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_common.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_common.py
@@ -299,11 +299,6 @@ def flexible_server_version_upgrade(cmd, client, resource_group_name, server_nam
     current_version = int(instance.version.split('.')[0])
     if current_version >= int(version):
         raise CLIError("The version to upgrade to must be greater than the current version.")
-    if version == '12':
-        logger.warning("Support for PostgreSQL 12 has officially ended. As a result, "
-                       "the option to select version 12 will be removed in the near future. "
-                       "We recommend selecting PostgreSQL 13 or a later version for "
-                       "all future operations.")
 
     list_server_capability_info = get_postgres_server_capability_info(cmd, resource_group_name, server_name)
     eligible_versions = list_server_capability_info['supported_server_versions'][str(current_version)]

--- a/src/azure-cli/azure/cli/command_modules/rdbms/validators.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/validators.py
@@ -515,8 +515,7 @@ def _pg_version_validator(version, versions, is_create):
         if version not in versions:
             raise CLIError('Incorrect value for --version. Allowed values : {}'.format(sorted(versions)))
         if version == '12':
-            logger.warning("Support for PostgreSQL 12 has officially ended. As a result, "
-                           "the option to select version 12 will be removed in the near future. "
+            raise CLIError("Support for PostgreSQL 12 has officially ended. "
                            "We recommend selecting PostgreSQL 13 or a later version for "
                            "all future operations.")
 


### PR DESCRIPTION
**Related command**
`az postgres flexible-server create`
`az postgres flexible-server upgrade`

**Description**<!--Mandatory-->
Support for PostgreSQL 12 has officially ended. Committed to EOL tasks, remove choosing PG12 during create and upgrade

**Testing Guide**
Manually
```
az postgres flexible-server create -g testrg-n testpg12 --version 12
The default value of '--version' will be changed to '17' from '16' in next breaking change release(2.73.0) scheduled for May 2025.
The default value of '--create-default-database' will be changed to 'Disabled' from 'Enabled' in next breaking change release(2.73.0) scheduled for May 2025.
Update default value of "--sku-name" in next breaking change release(2.73.0) scheduled for May 2025. The default value will be changed from "Standard_D2s_v3" to a supported sku based on regional capabilities.
Checking the existence of the resource group 'nasc-runner'...
Resource group 'nasc-runner' exists ? : True 
Support for PostgreSQL 12 has officially ended. We recommend selecting PostgreSQL 13 or a later version for all future operations.

az postgres flexible-server upgrade -g testrg -n nasc-pg812 --version 12
az postgres flexible-server upgrade: '12' is not a valid value for '--version'. Allowed values: 13, 14, 15, 16, 17.

Examples from AI knowledge base:
az postgres flexible-server upgrade -g testgroup -n testsvr -v 17
Upgrade server 'testsvr' to PostgreSQL major version 17.

```


**History Notes**
[RDBMS] BREAKING CHANGE: `az postgres flexible-server create/upgrade`: Remove support of PG12 which has officially ended
