### PR TITLE
[Network] Fix #31294: `az network vnet update`: Refine processing logic of `--address-prefixes`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/vnet/_create.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/vnet/_create.py
@@ -147,7 +147,7 @@ class Create(AAZCommand):
         _args_schema.ipam_pool_prefix_allocations = AAZListArg(
             options=["--ipam-allocations", "--ipam-pool-prefix-allocations"],
             arg_group="AddressSpace",
-            help="A list of IPAM Pools allocating IP address prefixes. If provided, --address-prefixes would be empty and should not be specified.",
+            help="A list of IPAM Pools allocating IP address prefixes. If provided, --address-prefixes would be ignored and should not be specified.",
         )
 
         ipam_pool_prefix_allocations = cls._args_schema.ipam_pool_prefix_allocations

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/vnet/_list.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/vnet/_list.py
@@ -57,12 +57,12 @@ class List(AAZCommand):
 
     def _execute_operations(self):
         self.pre_operations()
-        condition_0 = has_value(self.ctx.subscription_id) and has_value(self.ctx.args.resource_group) is not True
-        condition_1 = has_value(self.ctx.args.resource_group) and has_value(self.ctx.subscription_id)
+        condition_0 = has_value(self.ctx.args.resource_group) and has_value(self.ctx.subscription_id)
+        condition_1 = has_value(self.ctx.subscription_id) and has_value(self.ctx.args.resource_group) is not True
         if condition_0:
-            self.VirtualNetworksListAll(ctx=self.ctx)()
-        if condition_1:
             self.VirtualNetworksList(ctx=self.ctx)()
+        if condition_1:
+            self.VirtualNetworksListAll(ctx=self.ctx)()
         self.post_operations()
 
     @register_callback
@@ -78,7 +78,7 @@ class List(AAZCommand):
         next_link = self.deserialize_output(self.ctx.vars.instance.next_link)
         return result, next_link
 
-    class VirtualNetworksListAll(AAZHttpOperation):
+    class VirtualNetworksList(AAZHttpOperation):
         CLIENT_TYPE = "MgmtClient"
 
         def __call__(self, *args, **kwargs):
@@ -92,7 +92,7 @@ class List(AAZCommand):
         @property
         def url(self):
             return self.client.format_url(
-                "/subscriptions/{subscriptionId}/providers/Microsoft.Network/virtualNetworks",
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks",
                 **self.url_parameters
             )
 
@@ -107,6 +107,10 @@ class List(AAZCommand):
         @property
         def url_parameters(self):
             parameters = {
+                **self.serialize_url_param(
+                    "resourceGroupName", self.ctx.args.resource_group,
+                    required=True,
+                ),
                 **self.serialize_url_param(
                     "subscriptionId", self.ctx.subscription_id,
                     required=True,
@@ -376,7 +380,7 @@ class List(AAZCommand):
 
             return cls._schema_on_200
 
-    class VirtualNetworksList(AAZHttpOperation):
+    class VirtualNetworksListAll(AAZHttpOperation):
         CLIENT_TYPE = "MgmtClient"
 
         def __call__(self, *args, **kwargs):
@@ -390,7 +394,7 @@ class List(AAZCommand):
         @property
         def url(self):
             return self.client.format_url(
-                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks",
+                "/subscriptions/{subscriptionId}/providers/Microsoft.Network/virtualNetworks",
                 **self.url_parameters
             )
 
@@ -405,10 +409,6 @@ class List(AAZCommand):
         @property
         def url_parameters(self):
             parameters = {
-                **self.serialize_url_param(
-                    "resourceGroupName", self.ctx.args.resource_group,
-                    required=True,
-                ),
                 **self.serialize_url_param(
                     "subscriptionId", self.ctx.subscription_id,
                     required=True,

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/vnet/_update.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/vnet/_update.py
@@ -129,7 +129,7 @@ class Update(AAZCommand):
         _args_schema.ipam_pool_prefix_allocations = AAZListArg(
             options=["--ipam-allocations", "--ipam-pool-prefix-allocations"],
             arg_group="AddressSpace",
-            help="A list of IPAM Pools allocating IP address prefixes. If provided, --address-prefixes would be empty and should not be specified.",
+            help="A list of IPAM Pools allocating IP address prefixes. If a non-empty value is provided, --address-prefixes would be ignored.",
             nullable=True,
         )
 

--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -5575,7 +5575,7 @@ class VNetUpdate(_VNetUpdate):
 
     def pre_operations(self):
         args = self.ctx.args
-        if has_value(args.ipam_pool_prefix_allocations):
+        if args.ipam_pool_prefix_allocations.to_serialized_data():
             args.address_prefixes = []
 
     def post_instance_update(self, instance):


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az network vnet update`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix https://github.com/Azure/azure-cli/issues/31294
Ignore address prefixes as an empty array only when ipam pool has non-empty value.
aaz https://github.com/Azure/aaz/pull/747

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
