### PR TITLE
[Identity] Add az identity federated-credential create/update: Add support for claims matching expressions with 2025-01-31-PREVIEW API version

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/identity/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/identity/__init__.py
@@ -7,15 +7,28 @@ import azure.cli.command_modules.identity._help  # pylint: disable=unused-import
 from azure.cli.core import AzCommandsLoader
 from azure.cli.core.profiles import ResourceType
 
-
 class IdentityCommandsLoader(AzCommandsLoader):
 
     def __init__(self, cli_ctx=None):
         from azure.cli.core.commands import CliCommandType
-        identity_custom = CliCommandType(operations_tmpl='azure.cli.command_modules.identity.custom#{}')
+        from azure.cli.command_modules.identity._client_factory import (_msi_user_identities_operations,
+                                                                      _msi_federated_identity_credentials_operations)
+
+        # Base identity commands
+        identity_custom = CliCommandType(
+            operations_tmpl='azure.cli.command_modules.identity.custom#{}',
+            client_factory=_msi_user_identities_operations
+        )
+
+        # Federated credential commands
+        federated_identity_custom = CliCommandType(
+            operations_tmpl='azure.cli.command_modules.identity.custom#{}',
+            client_factory=_msi_federated_identity_credentials_operations
+        )
+
         super().__init__(cli_ctx=cli_ctx,
-                         resource_type=ResourceType.MGMT_MSI,
-                         custom_command_type=identity_custom)
+                        resource_type=ResourceType.MGMT_MSI,
+                        custom_command_type=identity_custom)
 
     def load_command_table(self, args):
         from azure.cli.command_modules.identity.commands import load_command_table
@@ -25,6 +38,5 @@ class IdentityCommandsLoader(AzCommandsLoader):
     def load_arguments(self, command):
         from azure.cli.command_modules.identity._params import load_arguments
         load_arguments(self, command)
-
 
 COMMAND_LOADER_CLS = IdentityCommandsLoader

--- a/src/azure-cli/azure/cli/command_modules/identity/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/identity/_client_factory.py
@@ -26,5 +26,9 @@ def _msi_operations_operations(cli_ctx, _):
     return _msi_client_factory(cli_ctx).operations
 
 
-def _msi_federated_identity_credentials_operations(cli_ctx, _):
-    return _msi_client_factory(cli_ctx).federated_identity_credentials
+def _msi_federated_identity_credentials_operations(cli_ctx, **_):
+    """
+    api version is specified for federated identity credentials command because new api version (2023-01-31) of MSI does not support
+    flexible fic command. In order to avoid a breaking change, multi-api package is used.
+    """
+    return _msi_client_factory(cli_ctx, api_version='2025-01-31-PREVIEW').federated_identity_credentials

--- a/src/azure-cli/azure/cli/command_modules/identity/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/identity/_help.py
@@ -38,36 +38,59 @@ short-summary: List the associated resources for the identity.
 
 helps['identity federated-credential'] = """
 type: group
-short-summary: Manage federated identity credentials under user assigned identities.
+short-summary: "[Preview] Manage federated identity credentials under user assigned identities."
 min_api: 2025-01-31-PREVIEW
 """
 
 helps['identity federated-credential create'] = """
 type: command
+short-summary: "[Preview] Create a federated identity credential under an existing user assigned identity."
 min_api: 2025-01-31-PREVIEW
-short-summary: Create a federated identity credential under an existing user assigned identity.
+examples:
+  - name: Create a federated identity credential under a specific user assigned identity.
+    text: |
+        az identity federated-credential create --name myFicName --identity-name myIdentityName --resource-group myResourceGroup --issuer myIssuer --subject mySubject --audiences myAudiences
+  - name: Create a federated identity credential with claims matching expressions.
+    text: |
+        az identity federated-credential create --name myFicName --identity-name myIdentityName --resource-group myResourceGroup --issuer https://tokens.githubusercontent.com --audiences api://AzureADTokenExchange --claims-matching-expression-value "claims['sub'] startswith 'repo:contoso-org/contoso-repo:ref:refs/heads'" --claims-matching-expression-version 1
 """
 
 helps['identity federated-credential update'] = """
-min_api: 2025-01-31-PREVIEW
 type: command
-short-summary: Update a federated identity credential under an existing user assigned identity.
+short-summary: "[Preview] Update a federated identity credential under an existing user assigned identity."
+min_api: 2025-01-31-PREVIEW
+examples:
+  - name: Update a federated identity credential under a specific user assigned identity.
+    text: |
+        az identity federated-credential update --name myFicName --identity-name myIdentityName --resource-group myResourceGroup --issuer myIssuer --subject mySubject --audiences myAudiences
 """
 
 helps['identity federated-credential delete'] = """
-min_api: 2025-01-31-PREVIEW
 type: command
-short-summary: Delete a federated identity credential under an existing user assigned identity.
+short-summary: "[Preview] Delete a federated identity credential under an existing user assigned identity."
+min_api: 2025-01-31-PREVIEW
+examples:
+  - name: Delete a federated identity credential under a specific user assigned identity.
+    text: |
+        az identity federated-credential delete --name myFicName --identity-name myIdentityName --resource-group myResourceGroup
 """
 
 helps['identity federated-credential show'] = """
-min_api: 2025-01-31-PREVIEW
 type: command
-short-summary: Show a federated identity credential under an existing user assigned identity.
+short-summary: "[Preview] Show a federated identity credential under an existing user assigned identity."
+min_api: 2025-01-31-PREVIEW
+examples:
+  - name: Show a federated identity credential under a specific user assigned identity.
+    text: |
+        az identity federated-credential show --name myFicName --identity-name myIdentityName --resource-group myResourceGroup
 """
 
 helps['identity federated-credential list'] = """
-min_api: 2025-01-31-PREVIEW
 type: command
-short-summary: List all federated identity credentials under an existing user assigned identity.
+short-summary: "[Preview] List all federated identity credentials under an existing user assigned identity."
+min_api: 2025-01-31-PREVIEW
+examples:
+  - name: List all federated identity credentials under an existing user assigned identity.
+    text: |
+        az identity federated-credential list --identity-name myIdentityName --resource-group myResourceGroup
 """

--- a/src/azure-cli/azure/cli/command_modules/identity/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/identity/_help.py
@@ -48,6 +48,9 @@ examples:
   - name: Create a federated identity credential under a specific user assigned identity.
     text: |
         az identity federated-credential create --name myFicName --identity-name myIdentityName --resource-group myResourceGroup --issuer myIssuer --subject mySubject --audiences myAudiences
+  - name: Create a federated identity credential with claims matching expressions.
+    text: |
+        az identity federated-credential create --name myFicName --identity-name myIdentityName --resource-group myResourceGroup --issuer https://tokens.githubusercontent.com --audiences api://AzureADTokenExchange --claims-matching-expression-value "claims['sub'] startswith 'repo:contoso-org/contoso-repo:ref:refs/heads'" --claims-matching-expression-version 1
 """
 
 helps['identity federated-credential update'] = """

--- a/src/azure-cli/azure/cli/command_modules/identity/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/identity/_help.py
@@ -46,51 +46,28 @@ helps['identity federated-credential create'] = """
 type: command
 min_api: 2025-01-31-PREVIEW
 short-summary: Create a federated identity credential under an existing user assigned identity.
-examples:
-  - name: Create a federated identity credential under a specific user assigned identity.
-    text: |
-        az identity federated-credential create --name myFicName --identity-name myIdentityName --resource-group myResourceGroup --issuer myIssuer --subject mySubject --audiences myAudiences
-  - name: Create a federated identity credential with claims matching expressions.
-    text: |
-        az identity federated-credential create --name myFicName --identity-name myIdentityName --resource-group myResourceGroup --issuer https://tokens.githubusercontent.com --audiences api://AzureADTokenExchange --claims-matching-expression-value "claims['sub'] startswith 'repo:contoso-org/contoso-repo:ref:refs/heads'" --claims-matching-expression-version 1
 """
 
 helps['identity federated-credential update'] = """
 min_api: 2025-01-31-PREVIEW
 type: command
 short-summary: Update a federated identity credential under an existing user assigned identity.
-examples:
-  - name: Update a federated identity credential under a specific user assigned identity.
-    text: |
-        az identity federated-credential update --name myFicName --identity-name myIdentityName --resource-group myResourceGroup --issuer myIssuer --subject mySubject --audiences myAudiences
 """
 
 helps['identity federated-credential delete'] = """
 min_api: 2025-01-31-PREVIEW
 type: command
 short-summary: Delete a federated identity credential under an existing user assigned identity.
-examples:
-  - name: Delete a federated identity credential under a specific user assigned identity.
-    text: |
-        az identity federated-credential delete --name myFicName --identity-name myIdentityName --resource-group myResourceGroup
 """
 
 helps['identity federated-credential show'] = """
 min_api: 2025-01-31-PREVIEW
 type: command
 short-summary: Show a federated identity credential under an existing user assigned identity.
-examples:
-  - name: Show a federated identity credential under a specific user assigned identity.
-    text: |
-        az identity federated-credential show --name myFicName --identity-name myIdentityName --resource-group myResourceGroup
 """
 
 helps['identity federated-credential list'] = """
 min_api: 2025-01-31-PREVIEW
 type: command
 short-summary: List all federated identity credentials under an existing user assigned identity.
-examples:
-  - name: List all federated identity credentials under an existing user assigned identity.
-    text: |
-        az identity federated-credential list --identity-name myIdentityName --resource-group myResourceGroup
 """

--- a/src/azure-cli/azure/cli/command_modules/identity/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/identity/_help.py
@@ -39,10 +39,12 @@ short-summary: List the associated resources for the identity.
 helps['identity federated-credential'] = """
 type: group
 short-summary: Manage federated identity credentials under user assigned identities.
+min_api: 2025-01-31-PREVIEW
 """
 
 helps['identity federated-credential create'] = """
 type: command
+min_api: 2025-01-31-PREVIEW
 short-summary: Create a federated identity credential under an existing user assigned identity.
 examples:
   - name: Create a federated identity credential under a specific user assigned identity.
@@ -54,6 +56,7 @@ examples:
 """
 
 helps['identity federated-credential update'] = """
+min_api: 2025-01-31-PREVIEW
 type: command
 short-summary: Update a federated identity credential under an existing user assigned identity.
 examples:
@@ -63,6 +66,7 @@ examples:
 """
 
 helps['identity federated-credential delete'] = """
+min_api: 2025-01-31-PREVIEW
 type: command
 short-summary: Delete a federated identity credential under an existing user assigned identity.
 examples:
@@ -72,6 +76,7 @@ examples:
 """
 
 helps['identity federated-credential show'] = """
+min_api: 2025-01-31-PREVIEW
 type: command
 short-summary: Show a federated identity credential under an existing user assigned identity.
 examples:
@@ -81,6 +86,7 @@ examples:
 """
 
 helps['identity federated-credential list'] = """
+min_api: 2025-01-31-PREVIEW
 type: command
 short-summary: List all federated identity credentials under an existing user assigned identity.
 examples:

--- a/src/azure-cli/azure/cli/command_modules/identity/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/identity/_help.py
@@ -3,8 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-# pylint: disable=line-too-long, too-many-lines
-
 from knack.help_files import helps
 
 helps['identity'] = """
@@ -14,7 +12,7 @@ short-summary: Managed Identities
 
 helps['identity create'] = """
 type: command
-short-summary: Create Identities.
+short-summary: Create an identity.
 examples:
   - name: Create an identity.
     text: |
@@ -36,61 +34,71 @@ type: command
 short-summary: List the associated resources for the identity.
 """
 
+helps['identity show'] = """
+type: command
+short-summary: Show the details of a managed identity.
+"""
+
+helps['identity delete'] = """
+type: command
+short-summary: Delete a managed identity.
+"""
+
 helps['identity federated-credential'] = """
 type: group
-short-summary: "[Preview] Manage federated identity credentials under user assigned identities."
-min_api: 2025-01-31-PREVIEW
+short-summary: [Preview] Manage federated credentials under managed identities.
 """
 
 helps['identity federated-credential create'] = """
 type: command
-short-summary: "[Preview] Create a federated identity credential under an existing user assigned identity."
-min_api: 2025-01-31-PREVIEW
+short-summary: [Preview] Create a federated credential.
+parameters:
+  - name: --name -n
+    type: string
+    short-summary: Name of the federated credential.
+    long-summary: Must start with a letter or number, and can contain letters, numbers, underscores, and hyphens. Length must be between 3-120 characters.
+  - name: --identity-name
+    type: string
+    short-summary: Name of the managed identity.
+  - name: --issuer 
+    type: string
+    short-summary: The URL of the issuer to be trusted.
+    long-summary: For GitHub Actions, use 'https://token.actions.githubusercontent.com'
+  - name: --subject
+    type: string
+    short-summary: The identifier of the external identity.
+    long-summary: Cannot be used with claims-matching-expression-* parameters.
+  - name: --audiences
+    type: array
+    short-summary: List of audiences that can appear in the issued token.
 examples:
-  - name: Create a federated identity credential under a specific user assigned identity.
+  - name: Create a federated identity credential with subject matching
     text: |
-        az identity federated-credential create --name myFicName --identity-name myIdentityName --resource-group myResourceGroup --issuer myIssuer --subject mySubject --audiences myAudiences
-  - name: Create a federated identity credential with claims matching expressions.
-    text: |
-        az identity federated-credential create --name myFicName --identity-name myIdentityName --resource-group myResourceGroup --issuer https://tokens.githubusercontent.com --audiences api://AzureADTokenExchange --claims-matching-expression-value "claims['sub'] startswith 'repo:contoso-org/contoso-repo:ref:refs/heads'" --claims-matching-expression-version 1
+        az identity federated-credential create -g MyResourceGroup --identity-name MyIdentity -n MyFicName \\
+            --issuer https://token.actions.githubusercontent.com \\
+            --subject "system:serviceaccount:ns:svcaccount" \\
+            --audiences api://AzureADTokenExchange
 """
 
 helps['identity federated-credential update'] = """
 type: command
-short-summary: "[Preview] Update a federated identity credential under an existing user assigned identity."
-min_api: 2025-01-31-PREVIEW
-examples:
-  - name: Update a federated identity credential under a specific user assigned identity.
-    text: |
-        az identity federated-credential update --name myFicName --identity-name myIdentityName --resource-group myResourceGroup --issuer myIssuer --subject mySubject --audiences myAudiences
+short-summary: [Preview] Update a federated credential.
 """
 
 helps['identity federated-credential delete'] = """
 type: command
-short-summary: "[Preview] Delete a federated identity credential under an existing user assigned identity."
-min_api: 2025-01-31-PREVIEW
+short-summary: [Preview] Delete a federated credential.
 examples:
-  - name: Delete a federated identity credential under a specific user assigned identity.
-    text: |
-        az identity federated-credential delete --name myFicName --identity-name myIdentityName --resource-group myResourceGroup
+  - name: Delete a federated credential
+    text: az identity federated-credential delete -g MyResourceGroup --identity-name MyIdentity -n MyFicName
 """
 
 helps['identity federated-credential show'] = """
 type: command
-short-summary: "[Preview] Show a federated identity credential under an existing user assigned identity."
-min_api: 2025-01-31-PREVIEW
-examples:
-  - name: Show a federated identity credential under a specific user assigned identity.
-    text: |
-        az identity federated-credential show --name myFicName --identity-name myIdentityName --resource-group myResourceGroup
+short-summary: [Preview] Show details of a federated credential.
 """
 
 helps['identity federated-credential list'] = """
 type: command
-short-summary: "[Preview] List all federated identity credentials under an existing user assigned identity."
-min_api: 2025-01-31-PREVIEW
-examples:
-  - name: List all federated identity credentials under an existing user assigned identity.
-    text: |
-        az identity federated-credential list --identity-name myIdentityName --resource-group myResourceGroup
+short-summary: [Preview] List all federated credentials for a managed identity.
 """

--- a/src/azure-cli/azure/cli/command_modules/identity/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/identity/_params.py
@@ -3,18 +3,14 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-# pylint: disable=line-too-long, too-many-lines
 from knack.arguments import CLIArgumentType
-
 from azure.cli.core.commands.parameters import get_location_type, tags_type
 
-
 name_arg_type = CLIArgumentType(options_list=('--name', '-n'), metavar='NAME',
-                                help='The name of the identity resource.')
-
+                               help='The name of the identity resource.')
 
 def load_arguments(self, _):
-
+    # Base identity parameters
     with self.argument_context('identity') as c:
         c.argument('resource_name', arg_type=name_arg_type, id_part='name')
 
@@ -22,14 +18,43 @@ def load_arguments(self, _):
         c.argument('location', get_location_type(self.cli_ctx), required=False)
         c.argument('tags', tags_type)
 
-    with self.argument_context('identity federated-credential', min_api='2025-01-31-PREVIEW', is_preview=True) as c:
-        c.argument('federated_credential_name', options_list=('--name', '-n'), help='[Preview] The name of the federated identity credential resource.')
-        c.argument('identity_name', help='[Preview] The name of the identity resource.')
+    # Register federated-credential parameters as part of the identity group
+    with self.argument_context('identity federated-credential', is_preview=True) as c:
+        c.argument('federated_credential_name', options_list=('--name', '-n'),
+                  help='[Preview] The name of the federated identity credential resource. Must start with a letter, number and can contain letters, numbers, underscores, and hyphens. Length must be between 3-120 characters.',
+                  type=str)
+        c.argument('identity_name',
+                  help='[Preview] The name of the user assigned identity.')
 
-    for scope in ['identity federated-credential create', 'identity federated-credential update']:
-        with self.argument_context(scope, is_preview=True) as c:
-            c.argument('issuer', help='[Preview] The openId connect metadata URL of the issuer of the identity provider that Azure AD would use in the token exchange protocol for validating tokens before issuing a token as the user-assigned managed identity.')
-            c.argument('subject', help='[Preview] The sub value in the token sent to Azure AD for getting the user-assigned managed identity token. The value configured in the federated credential and the one in the incoming token must exactly match for Azure AD to issue the access token.')
-            c.argument('audiences', nargs='+', help='[Preview] The aud value in the token sent to Azure for getting the user-assigned managed identity token. The value configured in the federated credential and the one in the incoming token must exactly match for Azure to issue the access token.')
-            c.argument('claims_matching_expression_value', options_list=['--claims-matching-expression-value'], help='[Preview] The claims expression value for the federated identity credential.')
-            c.argument('claims_matching_expression_version', options_list=['--claims-matching-expression-version'], help='[Preview] The claims expression language version for the federated identity credential.')
+    # Register create/update specific parameters
+    with self.argument_context('identity federated-credential create', is_preview=True) as c:
+        c.argument('issuer',
+                  help='[Preview] The URL of the issuer to be trusted.',
+                  required=True)
+        c.argument('subject',
+                  help='[Preview] The identifier of the external identity. Cannot be used with claims-matching-expression-*.')
+        c.argument('audiences',
+                  nargs='+',
+                  help='[Preview] The list of audiences that can appear in the issued token.',
+                  required=True)
+        c.argument('claims_matching_expression_value',
+                  help='[Preview] The wildcard-based expression for matching incoming subject claims. Cannot be used with subject.')
+        c.argument('claims_matching_expression_version',
+                  type=int,
+                  help='[Preview] The version of the claims matching expression language.')
+
+    with self.argument_context('identity federated-credential update', is_preview=True) as c:
+        c.argument('issuer',
+                  help='[Preview] The URL of the issuer to be trusted.',
+                  required=True)
+        c.argument('subject',
+                  help='[Preview] The identifier of the external identity. Cannot be used with claims-matching-expression-*.')
+        c.argument('audiences',
+                  nargs='+',
+                  help='[Preview] The list of audiences that can appear in the issued token.',
+                  required=True)
+        c.argument('claims_matching_expression_value',
+                  help='[Preview] The wildcard-based expression for matching incoming subject claims. Cannot be used with subject.')
+        c.argument('claims_matching_expression_version',
+                  type=int,
+                  help='[Preview] The version of the claims matching expression language.')

--- a/src/azure-cli/azure/cli/command_modules/identity/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/identity/_params.py
@@ -22,7 +22,7 @@ def load_arguments(self, _):
         c.argument('location', get_location_type(self.cli_ctx), required=False)
         c.argument('tags', tags_type)
 
-    with self.argument_context('identity federated-credential', min_api='2022-01-31-preview') as c:
+    with self.argument_context('identity federated-credential', min_api='2025-01-31-PREVIEW') as c:
         c.argument('federated_credential_name', options_list=('--name', '-n'), help='The name of the federated identity credential resource.')
         c.argument('identity_name', help='The name of the identity resource.')
 
@@ -31,3 +31,5 @@ def load_arguments(self, _):
             c.argument('issuer', help='The openId connect metadata URL of the issuer of the identity provider that Azure AD would use in the token exchange protocol for validating tokens before issuing a token as the user-assigned managed identity.')
             c.argument('subject', help='The sub value in the token sent to Azure AD for getting the user-assigned managed identity token. The value configured in the federated credential and the one in the incoming token must exactly match for Azure AD to issue the access token.')
             c.argument('audiences', nargs='+', help='The aud value in the token sent to Azure for getting the user-assigned managed identity token. The value configured in the federated credential and the one in the incoming token must exactly match for Azure to issue the access token.')
+            c.argument('claims_matching_expression_value', options_list=['--claims-matching-expression-value'], help='The claims expression value for the federated identity credential.')
+            c.argument('claims_matching_expression_version', options_list=['--claims-matching-expression-version'], help='The claims expression language version for the federated identity credential.')

--- a/src/azure-cli/azure/cli/command_modules/identity/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/identity/_params.py
@@ -22,14 +22,14 @@ def load_arguments(self, _):
         c.argument('location', get_location_type(self.cli_ctx), required=False)
         c.argument('tags', tags_type)
 
-    with self.argument_context('identity federated-credential', min_api='2025-01-31-PREVIEW') as c:
-        c.argument('federated_credential_name', options_list=('--name', '-n'), help='The name of the federated identity credential resource.')
-        c.argument('identity_name', help='The name of the identity resource.')
+    with self.argument_context('identity federated-credential', min_api='2025-01-31-PREVIEW', is_preview=True) as c:
+        c.argument('federated_credential_name', options_list=('--name', '-n'), help='[Preview] The name of the federated identity credential resource.')
+        c.argument('identity_name', help='[Preview] The name of the identity resource.')
 
     for scope in ['identity federated-credential create', 'identity federated-credential update']:
-        with self.argument_context(scope) as c:
-            c.argument('issuer', help='The openId connect metadata URL of the issuer of the identity provider that Azure AD would use in the token exchange protocol for validating tokens before issuing a token as the user-assigned managed identity.')
-            c.argument('subject', help='The sub value in the token sent to Azure AD for getting the user-assigned managed identity token. The value configured in the federated credential and the one in the incoming token must exactly match for Azure AD to issue the access token.')
-            c.argument('audiences', nargs='+', help='The aud value in the token sent to Azure for getting the user-assigned managed identity token. The value configured in the federated credential and the one in the incoming token must exactly match for Azure to issue the access token.')
-            c.argument('claims_matching_expression_value', options_list=['--claims-matching-expression-value'], help='The claims expression value for the federated identity credential.')
-            c.argument('claims_matching_expression_version', options_list=['--claims-matching-expression-version'], help='The claims expression language version for the federated identity credential.')
+        with self.argument_context(scope, is_preview=True) as c:
+            c.argument('issuer', help='[Preview] The openId connect metadata URL of the issuer of the identity provider that Azure AD would use in the token exchange protocol for validating tokens before issuing a token as the user-assigned managed identity.')
+            c.argument('subject', help='[Preview] The sub value in the token sent to Azure AD for getting the user-assigned managed identity token. The value configured in the federated credential and the one in the incoming token must exactly match for Azure AD to issue the access token.')
+            c.argument('audiences', nargs='+', help='[Preview] The aud value in the token sent to Azure for getting the user-assigned managed identity token. The value configured in the federated credential and the one in the incoming token must exactly match for Azure to issue the access token.')
+            c.argument('claims_matching_expression_value', options_list=['--claims-matching-expression-value'], help='[Preview] The claims expression value for the federated identity credential.')
+            c.argument('claims_matching_expression_version', options_list=['--claims-matching-expression-version'], help='[Preview] The claims expression language version for the federated identity credential.')

--- a/src/azure-cli/azure/cli/command_modules/identity/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/identity/commands.py
@@ -39,7 +39,7 @@ def load_command_table(self, _):
 
     with self.command_group('identity federated-credential', federated_identity_credentials_sdk,
                             client_factory=_msi_federated_identity_credentials_operations,
-                            min_api='2022-01-31-preview') as g:
+                            min_api='2025-01-31-PREVIEW') as g:
         g.custom_command('create', 'create_or_update_federated_credential')
         g.custom_command('update', 'create_or_update_federated_credential')
         g.custom_show_command('show', 'show_federated_credential')

--- a/src/azure-cli/azure/cli/command_modules/identity/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/identity/commands.py
@@ -39,7 +39,8 @@ def load_command_table(self, _):
 
     with self.command_group('identity federated-credential', federated_identity_credentials_sdk,
                             client_factory=_msi_federated_identity_credentials_operations,
-                            min_api='2025-01-31-PREVIEW') as g:
+                            min_api='2025-01-31-PREVIEW',
+                            is_preview=True) as g:
         g.custom_command('create', 'create_or_update_federated_credential')
         g.custom_command('update', 'create_or_update_federated_credential')
         g.custom_show_command('show', 'show_federated_credential')

--- a/src/azure-cli/azure/cli/command_modules/identity/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/identity/commands.py
@@ -3,46 +3,30 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-
 from azure.cli.core.commands import CliCommandType
 
-from ._client_factory import _msi_user_identities_operations, _msi_operations_operations, \
-    _msi_federated_identity_credentials_operations
-
+from ._client_factory import (_msi_user_identities_operations,
+                           _msi_operations_operations,
+                           _msi_federated_identity_credentials_operations)
 from ._validators import process_msi_namespace
 
-
 def load_command_table(self, _):
-
-    identity_sdk = CliCommandType(
-        operations_tmpl='azure.mgmt.msi.operations#UserAssignedIdentitiesOperations.{}',
-        client_factory=_msi_user_identities_operations
-    )
-    msi_operations_sdk = CliCommandType(
-        operations_tmpl='azure.mgmt.msi.operations#Operations.{}',
-        client_factory=_msi_operations_operations
-    )
-    federated_identity_credentials_sdk = CliCommandType(
-        operations_tmpl='azure.mgmt.msi.operations#FederatedIdentityCredentialsOperations.{}',
-        client_factory=_msi_federated_identity_credentials_operations
-    )
-
-    with self.command_group('identity', identity_sdk, client_factory=_msi_user_identities_operations) as g:
+    # Base operations
+    with self.command_group('identity') as g:
         g.custom_command('create', 'create_identity', validator=process_msi_namespace)
-        g.show_command('show', 'get')
-        g.command('delete', 'delete')
+        g.command('show', 'get', operations_tmpl='azure.mgmt.msi.operations#UserAssignedIdentitiesOperations.{}')
+        g.command('delete', 'delete', operations_tmpl='azure.mgmt.msi.operations#UserAssignedIdentitiesOperations.{}')
         g.custom_command('list', 'list_user_assigned_identities')
         g.custom_command('list-resources', 'list_identity_resources', min_api='2021-09-30-preview')
+        g.command('list-operations', 'list', operations_tmpl='azure.mgmt.msi.operations#Operations.{}')
 
-    with self.command_group('identity', msi_operations_sdk, client_factory=_msi_operations_operations) as g:
-        g.command('list-operations', 'list')
-
-    with self.command_group('identity federated-credential', federated_identity_credentials_sdk,
-                            client_factory=_msi_federated_identity_credentials_operations,
-                            min_api='2025-01-31-PREVIEW',
-                            is_preview=True) as g:
+    # Federated credential operations
+    with self.command_group('identity federated-credential',
+                          operations_tmpl='azure.mgmt.msi.operations#FederatedIdentityCredentialsOperations.{}',
+                          client_factory=_msi_federated_identity_credentials_operations,
+                          is_preview=True) as g:
         g.custom_command('create', 'create_or_update_federated_credential')
         g.custom_command('update', 'create_or_update_federated_credential')
-        g.custom_show_command('show', 'show_federated_credential')
         g.custom_command('delete', 'delete_federated_credential', confirmation=True)
+        g.custom_command('show', 'show_federated_credential')
         g.custom_command('list', 'list_federated_credential')

--- a/src/azure-cli/azure/cli/command_modules/identity/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/identity/custom.py
@@ -5,7 +5,8 @@
 
 from azure.cli.core.profiles import ResourceType
 from azure.cli.core.azclierror import (
-    RequiredArgumentMissingError
+    RequiredArgumentMissingError,
+    MutuallyExclusiveArgumentError
 )
 
 
@@ -35,15 +36,36 @@ def list_identity_resources(cmd, resource_group_name, resource_name):
 
 
 def create_or_update_federated_credential(cmd, client, resource_group_name, identity_name, federated_credential_name,
-                                          issuer=None, subject=None, audiences=None):
+                                          issuer=None, subject=None, audiences=None, claims_matching_expression_value=None, claims_matching_expression_version=None):
     _default_audiences = ['api://AzureADTokenExchange']
     audiences = _default_audiences if not audiences else audiences
-    if not issuer or not subject:
-        raise RequiredArgumentMissingError('usage error: please provide both --issuer and --subject parameters')
+    if not issuer:
+        recommendation = "Please provide the issuer URL using --issuer parameter. For GitHub Actions, use 'https://token.actions.githubusercontent.com'"
+        raise RequiredArgumentMissingError('Issuer URL is required for federated credential creation', recommendation)
+    
+    # When subject is present, CME should be null
+    if subject:
+        claims_matching_expression_value = None
+        claims_matching_expression_version = None
+    elif not claims_matching_expression_value:
+        recommendation = [
+            "Option 1: Provide --subject to create a federated credential with direct subject matching",
+            "Option 2: Provide --claims-matching-expression-value and --claims-matching-expression-version to create a federated credential with claims matching expression"
+        ]
+        raise RequiredArgumentMissingError('Missing required authentication criteria for federated credential', recommendation)
+    
+    if subject and claims_matching_expression_value:
+        recommendation = [
+            "Option 1: Remove --subject to use claims matching expression",
+            "Option 2: Remove --claims-matching-expression-value and --claims-matching-expression-version to use subject"
+        ]
+        raise MutuallyExclusiveArgumentError('Subject and claims matching expression cannot be used together', recommendation)
 
     FederatedIdentityCredential = cmd.get_models('FederatedIdentityCredential', resource_type=ResourceType.MGMT_MSI,
                                                  operation_group='federated_identity_credentials')
-    parameters = FederatedIdentityCredential(issuer=issuer, subject=subject, audiences=audiences)
+    parameters = FederatedIdentityCredential(issuer=issuer, subject=subject, audiences=audiences, 
+                                           claims_matching_expression_value=claims_matching_expression_value,
+                                           claims_matching_expression_version=claims_matching_expression_version)
 
     return client.create_or_update(resource_group_name=resource_group_name, resource_name=identity_name,
                                    federated_identity_credential_resource_name=federated_credential_name,

--- a/src/azure-cli/azure/cli/command_modules/identity/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/identity/custom.py
@@ -9,7 +9,6 @@ from azure.cli.core.azclierror import (
     MutuallyExclusiveArgumentError
 )
 
-
 def list_user_assigned_identities(cmd, resource_group_name=None):
     from azure.cli.command_modules.identity._client_factory import _msi_client_factory
     client = _msi_client_factory(cmd.cli_ctx)
@@ -17,32 +16,31 @@ def list_user_assigned_identities(cmd, resource_group_name=None):
         return client.user_assigned_identities.list_by_resource_group(resource_group_name)
     return client.user_assigned_identities.list_by_subscription()
 
-
 def create_identity(client, resource_group_name, resource_name, location, tags=None):
     parameters = {}
     parameters['location'] = location
     if tags is not None:
         parameters['tags'] = tags
     return client.create_or_update(resource_group_name=resource_group_name,
-                                   resource_name=resource_name,
-                                   parameters=parameters)
-
+                                 resource_name=resource_name,
+                                 parameters=parameters)
 
 def list_identity_resources(cmd, resource_group_name, resource_name):
     from azure.cli.command_modules.identity._client_factory import _msi_list_resources_client
     client = _msi_list_resources_client(cmd.cli_ctx)
     return client.list_associated_resources(resource_group_name=resource_group_name,
-                                            resource_name=resource_name)
-
+                                         resource_name=resource_name)
 
 def create_or_update_federated_credential(cmd, client, resource_group_name, identity_name, federated_credential_name,
-                                          issuer=None, subject=None, audiences=None, claims_matching_expression_value=None, claims_matching_expression_version=None):
+                                        issuer=None, subject=None, audiences=None, claims_matching_expression_value=None,
+                                        claims_matching_expression_version=None):
     _default_audiences = ['api://AzureADTokenExchange']
     audiences = _default_audiences if not audiences else audiences
     if not issuer:
-        recommendation = "Please provide the issuer URL using --issuer parameter. For GitHub Actions, use 'https://token.actions.githubusercontent.com'"
+        recommendation = ("Please provide the issuer URL using --issuer parameter. "
+                        "For GitHub Actions, use 'https://token.actions.githubusercontent.com'")
         raise RequiredArgumentMissingError('Issuer URL is required for federated credential creation', recommendation)
-    
+
     # When subject is present, CME should be null
     if subject:
         claims_matching_expression_value = None
@@ -50,37 +48,43 @@ def create_or_update_federated_credential(cmd, client, resource_group_name, iden
     elif not claims_matching_expression_value:
         recommendation = [
             "Option 1: Provide --subject to create a federated credential with direct subject matching",
-            "Option 2: Provide --claims-matching-expression-value and --claims-matching-expression-version to create a federated credential with claims matching expression"
+            ("Option 2: Provide --claims-matching-expression-value and --claims-matching-expression-version "
+             "to create a federated credential with claims matching expression")
         ]
-        raise RequiredArgumentMissingError('Missing required authentication criteria for federated credential', recommendation)
-    
+        raise RequiredArgumentMissingError('Missing required authentication criteria for federated credential',
+                                         recommendation)
+
     if subject and claims_matching_expression_value:
         recommendation = [
             "Option 1: Remove --subject to use claims matching expression",
             "Option 2: Remove --claims-matching-expression-value and --claims-matching-expression-version to use subject"
         ]
-        raise MutuallyExclusiveArgumentError('Subject and claims matching expression cannot be used together', recommendation)
+        raise MutuallyExclusiveArgumentError('Subject and claims matching expression cannot be used together',
+                                           recommendation)
 
-    FederatedIdentityCredential = cmd.get_models('FederatedIdentityCredential', resource_type=ResourceType.MGMT_MSI,
-                                                 operation_group='federated_identity_credentials')
-    parameters = FederatedIdentityCredential(issuer=issuer, subject=subject, audiences=audiences, 
-                                           claims_matching_expression_value=claims_matching_expression_value,
-                                           claims_matching_expression_version=claims_matching_expression_version)
+    FederatedIdentityCredential = cmd.get_models('FederatedIdentityCredential',
+                                               resource_type=ResourceType.MGMT_MSI,
+                                               operation_group='federated_identity_credentials')
+    parameters = FederatedIdentityCredential(issuer=issuer,
+                                          subject=subject,
+                                          audiences=audiences,
+                                          claims_matching_expression_value=claims_matching_expression_value,
+                                          claims_matching_expression_version=claims_matching_expression_version)
 
-    return client.create_or_update(resource_group_name=resource_group_name, resource_name=identity_name,
-                                   federated_identity_credential_resource_name=federated_credential_name,
-                                   parameters=parameters)
-
+    return client.create_or_update(resource_group_name=resource_group_name,
+                                resource_name=identity_name,
+                                federated_identity_credential_resource_name=federated_credential_name,
+                                parameters=parameters)
 
 def delete_federated_credential(client, resource_group_name, identity_name, federated_credential_name):
-    return client.delete(resource_group_name=resource_group_name, resource_name=identity_name,
-                         federated_identity_credential_resource_name=federated_credential_name)
-
+    return client.delete(resource_group_name=resource_group_name,
+                       resource_name=identity_name,
+                       federated_identity_credential_resource_name=federated_credential_name)
 
 def show_federated_credential(client, resource_group_name, identity_name, federated_credential_name):
-    return client.get(resource_group_name=resource_group_name, resource_name=identity_name,
-                      federated_identity_credential_resource_name=federated_credential_name)
-
+    return client.get(resource_group_name=resource_group_name,
+                    resource_name=identity_name,
+                    federated_identity_credential_resource_name=federated_credential_name)
 
 def list_federated_credential(client, resource_group_name, identity_name):
     return client.list(resource_group_name=resource_group_name, resource_name=identity_name)


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az identity federated-credential create

**Description**<!--Mandatory-->
This PR adds support for claims matching expressions (CME) in federated credentials using the 2025-01-31-PREVIEW API version.  Linked workItem -> https://msazure.visualstudio.com/One/_workitems/edit/26876104

**Testing Guide**
<!--Example commands with explanations.--> 
**Create using claims matching expression**
az identity federated-credential create \
    --name myFicName \
    --identity-name myIdentityName \
    --resource-group myResourceGroup \
    --issuer https://tokens.githubusercontent.com \
    --audiences api://AzureADTokenExchange \
    --claims-matching-expression-value "claims['sub'] startswith 'repo:contoso-org/contoso-repo:ref:refs/heads'" \
    --claims-matching-expression-version 1

**Create using subject**
az identity federated-credential create \
    --name myFicName \
    --identity-name myIdentityName \
    --resource-group myResourceGroup \
    --issuer https://tokens.githubusercontent.com \
    --audiences api://AzureADTokenExchange \
    --subject "repo:contoso-org/contoso-repo:ref:refs/heads/main"
    
**Should error: missing both subject and CME**
az identity federated-credential create \
    --name myFicName \
    --identity-name myIdentityName \
    --resource-group myResourceGroup \
    --issuer https://tokens.githubusercontent.com

**Should error: cannot use both subject and CME**
az identity federated-credential create \
    --name myFicName \
    --identity-name myIdentityName \
    --resource-group myResourceGroup \
    --issuer https://tokens.githubusercontent.com \
    --subject "repo:contoso-org/contoso-repo:ref:refs/heads/main" \
    --claims-matching-expression-value "claims['sub'] startswith 'repo:'" \
    --claims-matching-expression-version 1

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
