### PR TITLE
[DMS] `az dms project task create`: Add ability to use a lockless option for ensuring data consistency

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/dms/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/dms/_help.py
@@ -322,7 +322,7 @@ parameters:
             },
             // Optional setting to set the source server read only.
             "make_source_server_read_only": "true|false",
-            // Optional setting to enable consistent backup. True by default for the sync migration, and false otherwise.
+            // Optional setting to enable consistent backup. True by default for the sync migration, unless lockless is enabled.
             "enable_consistent_backup": "true|false",
             // Optional setting to enable lockless snapshot.
             "enable_consistent_backup_without_locks": "true|false",

--- a/src/azure-cli/azure/cli/command_modules/dms/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/dms/_help.py
@@ -324,6 +324,8 @@ parameters:
             "make_source_server_read_only": "true|false",
             // Optional setting to enable consistent backup. True by default for the sync migration, and false otherwise.
             "enable_consistent_backup": "true|false",
+            // Optional setting to enable lockless snapshot.
+            "enable_consistent_backup_without_locks": "true|false",
             // Optional. If true, all view definitions will be migrated in the selected databases.
             "migrate_all_views": "true|false",
             // Optional. If true, all trigger definitions will be migrated in the selected databases.

--- a/src/azure-cli/azure/cli/command_modules/dms/scenario_inputs.py
+++ b/src/azure-cli/azure/cli/command_modules/dms/scenario_inputs.py
@@ -70,7 +70,6 @@ def get_migrate_mysql_to_azuredbformysql_sync_input(database_options_json,
                                                       target_connection_info,
                                                       has_schema_migration_options=True,
                                                       has_consistent_snapshot_options=True,
-                                                      requires_consistent_snapshot=True,
                                                       has_binlog_position=False)
 
 
@@ -82,7 +81,6 @@ def get_migrate_mysql_to_azuredbformysql_offline_input(database_options_json,
                                                       target_connection_info,
                                                       has_schema_migration_options=True,
                                                       has_consistent_snapshot_options=True,
-                                                      requires_consistent_snapshot=False,
                                                       has_binlog_position=False)
 
 
@@ -94,7 +92,6 @@ def get_migrate_mysql_to_azuredbformysql_cdc_input(database_options_json,
                                                       target_connection_info,
                                                       has_schema_migration_options=False,
                                                       has_consistent_snapshot_options=False,
-                                                      requires_consistent_snapshot=False,
                                                       has_binlog_position=True)
 
 
@@ -103,7 +100,6 @@ def get_migrate_mysql_to_azuredbformysql_input(database_options_json,
                                                target_connection_info,
                                                has_schema_migration_options: bool,
                                                has_consistent_snapshot_options: bool,
-                                               requires_consistent_snapshot: bool,
                                                has_binlog_position: bool):
     database_options = []
     migration_level_settings = {}
@@ -140,12 +136,12 @@ def get_migrate_mysql_to_azuredbformysql_input(database_options_json,
         if not isinstance(migration_level_settings, dict):
             raise ValidationError('migration_level_settings should be a dictionary')
 
-    if requires_consistent_snapshot:
-        migration_level_settings['enableConsistentBackup'] = 'true'
-    elif has_consistent_snapshot_options:
+    if has_consistent_snapshot_options:
         make_source_server_read_only = database_options_json.get('make_source_server_read_only', False)
         set_optional(migration_level_settings, 'enableConsistentBackup', database_options_json,
                      'enable_consistent_backup')
+        set_optional(migration_level_settings, 'enableConsistentBackupWithoutLocks', database_options_json,
+                     'enable_consistent_backup_without_locks')
 
     if has_schema_migration_options:
         extract_schema_migration_options(migration_properties, database_options_json)


### PR DESCRIPTION
**Related command**
az dms project task create ...

**Description**<!--Mandatory-->
Our team has enabled a different way to enable consistency for migrations using the lockless method. This change removes the CLI default of setting consistent snapshot as the default method for enabling consistency and adds the ability to also set the lockless option.

**Testing Guide**
az dms project task create ... --database-options-json file.json

where file.json contains:
```
{
    "selected_databases": [...],
    "enable_consistent_backup_without_locks": "true"
}
```
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
