### PR TITLE
[policy] Add az policy breaking change warnings

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_breaking_change.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_breaking_change.py
@@ -1,0 +1,17 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from azure.cli.core.breaking_change import register_other_breaking_change
+
+register_other_breaking_change('policy assignment identity remove', 'Removing a user assigned identity will change in a future release of the resource commands. Removing a user assigned identity will require providing the --mi-user-assigned switch.')
+register_other_breaking_change('policy assignment identity assign', 'Replacing an existing identity will change in a future release of the resource commands. It will require first removing the existing identity.')
+register_other_breaking_change('policy assignment non-compliance-message create', 'The return value will change in a future release of the resource commands. It will be the single created message object rather than the full array of message objects.')
+register_other_breaking_change('policy assignment delete', 'Behavior will change in a future release of the resource commands. Bypassing the confirmation prompt will require providing the -y switch.')
+register_other_breaking_change('policy assignment non-compliance-message delete', 'Behavior will change in a future release of the resource commands. Bypassing the confirmation prompt will require providing the -y switch and nothing will be returned instead of the remaining list of messages.')
+register_other_breaking_change('policy definition delete', 'Behavior will change in a future release of the resource commands. Bypassing the confirmation prompt will require providing the -y switch.')
+register_other_breaking_change('policy exemption delete', 'Behavior will change in a future release of the resource commands. Bypassing the confirmation prompt will require providing the -y switch.')
+register_other_breaking_change('policy set-definition delete', 'Behavior will change in a future release of the resource commands. Bypassing the confirmation prompt will require providing the -y switch.')
+register_other_breaking_change('policy exemption create', 'Date format will change slightly in a future release of the resource commands. New format is ISO-8601, e.g. 2025-08-05T00:45:13Z instead of 2025-08-05T00:45:13+00:00.', '--expires-on')
+register_other_breaking_change('policy exemption update', 'Date format will change slightly in a future release of the resource commands. New format is ISO-8601, e.g. 2025-08-05T00:45:13Z instead of 2025-08-05T00:45:13+00:00.', '--expires-on')


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az policy

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
This PR is to add warnings for upcoming breaking changes due to moving to auto-generated az policy commands.

**Testing Guide**
<!--Example commands with explanations.-->
All warnings have been tested and confirmed to display correctly on current commands.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
