### PR TITLE
[Sql] `az sql ltr-policy set`: Remove ltr backup policy unused parameter `--access-tier`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/sql/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/_help.py
@@ -242,7 +242,7 @@ type: command
 short-summary: Update long term retention settings for a database.
 examples:
   - name: Set long term retention for a database.
-    text: az sql db ltr-policy set -g mygroup -s myserver -n mydb --weekly-retention "P1W" --monthly-retention "P6M" --yearly-retention "P1Y" --week-of-year 26 --access-tier "Archive" --make-backups-immutable true
+    text: az sql db ltr-policy set -g mygroup -s myserver -n mydb --weekly-retention "P1W" --monthly-retention "P6M" --yearly-retention "P1Y" --week-of-year 26 --make-backups-immutable true
 """
 
 helps['sql db ltr-policy show'] = """

--- a/src/azure-cli/azure/cli/command_modules/sql/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/_params.py
@@ -1307,8 +1307,7 @@ def load_arguments(self, _):
                 'monthly_retention',
                 'yearly_retention',
                 'week_of_year',
-                'make_backups_immutable',
-                'backup_storage_access_tier'])
+                'make_backups_immutable'])
 
         c.argument('weekly_retention',
                    help='Retention for the weekly backup. '
@@ -1331,12 +1330,6 @@ def load_arguments(self, _):
         c.argument('make_backups_immutable',
                    help='Whether to make the LTR backups immutable.',
                    arg_type=get_three_state_flag())
-
-        c.argument('backup_storage_access_tier',
-                   options_list=['--access-tier', '--backup-storage-access-tier'],
-                   arg_type=get_enum_type(["Hot", "Archive"]),
-                   help='The access tier of a LTR backup.'
-                   'Possible values = [Hot, Archive]')
 
     with self.argument_context('sql db ltr-backup') as c:
         c.argument('location_name',

--- a/src/azure-cli/azure/cli/command_modules/sql/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/custom.py
@@ -3080,7 +3080,6 @@ def update_long_term_retention(
         yearly_retention=None,
         week_of_year=None,
         make_backups_immutable=None,
-        backup_storage_access_tier=None,
         **kwargs):
     '''
     Updates long term retention for managed database
@@ -3097,10 +3096,6 @@ def update_long_term_retention(
          Do you want to proceed?""")
         if not confirmation:
             return
-
-    if backup_storage_access_tier and backup_storage_access_tier.lower() not in BACKUP_STORAGE_ACCESS_TIERS:
-        raise CLIError('Please specify a valid backup storage access tier type for backup storage access tier.'
-                       'See \'--help\' for more details.')
 
     kwargs['weekly_retention'] = weekly_retention
 

--- a/src/azure-cli/azure/cli/command_modules/sql/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/custom.py
@@ -96,9 +96,6 @@ from ._util import (
 
 logger = get_logger(__name__)
 
-BACKUP_STORAGE_ACCESS_TIERS = ["hot",
-                               "archive"]
-
 ###############################################
 #                Common funcs                 #
 ###############################################
@@ -3106,8 +3103,6 @@ def update_long_term_retention(
     kwargs['week_of_year'] = week_of_year
 
     kwargs['make_backups_immutable'] = make_backups_immutable
-
-    kwargs['backup_storage_access_tier'] = backup_storage_access_tier
 
     policy = client.begin_create_or_update(
         database_name=database_name,

--- a/src/azure-cli/azure/cli/command_modules/sql/tests/latest/test_sql_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/tests/latest/test_sql_commands.py
@@ -1277,7 +1277,6 @@ class SqlServerDbLongTermRetentionScenarioTest(ScenarioTest):
             'yearly_retention': 'P2M',
             'week_of_year': 12,
             'make_backups_immutable': 'False',
-            'backup_storage_access_tier': 'Archive',
             'encryption_protector' : 'https://test123343strehan.vault.azure.net/keys/testk1/604b0e26e2a24eeaab30b80c8d7bb1c1',
             'keys' : '"https://test123343strehan.vault.azure.net/keys/k2/66f51a6e70f04067af8eaf77805e88b1" "https://test123343strehan.vault.azure.net/keys/testk1/604b0e26e2a24eeaab30b80c8d7bb1c1" "https://test123343strehan.vault.azure.net/keys/testk1/96151496df864e32aa62a3c1857b2931"',
             'umi' : '/subscriptions/e1775f9f-a286-474d-b6f0-29c42ac74554/resourcegroups/ArmTemplate/providers/Microsoft.ManagedIdentity/userAssignedIdentities/shobhittest'
@@ -1289,14 +1288,12 @@ class SqlServerDbLongTermRetentionScenarioTest(ScenarioTest):
             ' --weekly-retention {weekly_retention} --monthly-retention {monthly_retention}'
             ' --yearly-retention {yearly_retention} --week-of-year {week_of_year}'
             ' --make-backups-immutable {make_backups_immutable}',
-            ' --access-tier {backup_storage_access_tier}',
             checks=[
                 self.check('resourceGroup', '{rg}'),
                 self.check('weeklyRetention', '{weekly_retention}'),
                 self.check('monthlyRetention', '{monthly_retention}'),
                 self.check('yearlyRetention', '{yearly_retention}'),
-                self.check('makeBackupsImmutable', '{make_backups_immutable}'),
-                self.check('backupStorageAccessTier', '{backup_storage_access_tier}')])
+                self.check('makeBackupsImmutable', '{make_backups_immutable}')])
 
         # test get long term retention policy on live database
         self.cmd(
@@ -1306,8 +1303,7 @@ class SqlServerDbLongTermRetentionScenarioTest(ScenarioTest):
                 self.check('weeklyRetention', '{weekly_retention}'),
                 self.check('monthlyRetention', '{monthly_retention}'),
                 self.check('yearlyRetention', '{yearly_retention}'),
-                self.check('makeBackupsImmutable', '{make_backups_immutable}'),
-                self.check('backupStorageAccessTier', '{backup_storage_access_tier}')])
+                self.check('makeBackupsImmutable', '{make_backups_immutable}')])
 
         # test list long term retention backups for location
         # with resource group


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
sql db ltr-policy set 
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Remove an unused parameter backup_storage_access_tier from Az sql ltr-policy set command. 
**Benefit**
<!--Why is this change beneficial?-->
This change will remove the unused parameter backup_storage_access_tier from the Az sql ltr-policy set command, which will make cmd simple
**Testing Guide**
<!--Example commands with explanations.-->

'sql db ltr-policy set -g {rg} -s {server_name} -n {database_name}'
' --weekly-retention {weekly_retention} --monthly-retention {monthly_retention}'
' --yearly-retention {yearly_retention} --week-of-year {week_of_year}'
' --make-backups-immutable {make_backups_immutable}


**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Az sql ltr-policy set 


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
