### PR TITLE
{AFD} Bug fix for Binding a socket to all network interfaces CVE-2018-1281

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/batchai/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/batchai/custom.py
@@ -1024,7 +1024,7 @@ def _get_available_local_port():
     Gets a random, available local port
     """
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)  # pylint: disable=no-member
-    s.bind(('', 0))
+    s.bind(('127.0.0.1', 0))
     s.listen(1)
     port = s.getsockname()[1]
     s.close()


### PR DESCRIPTION
https://github.com/Azure/azure-cli/blob/a4c9d4d5721f7156c58675dbaac71d9df41e16d1/src/azure-cli/azure/cli/command_modules/batchai/custom.py#L1027-L1027

fix the issue the socket should be bound to a specific interface, such as `127.0.0.1` (localhost), instead of all interfaces. This ensures that the socket is only accessible locally and not exposed to external networks. The change should be made in the `_get_available_local_port` function, specifically on line 1027 where the `bind` method is called.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
