### PR TITLE
{Packaging} Bump embedded Python to 3.12.10

### DIFF
--- a/build_scripts/windows/scripts/build.cmd
+++ b/build_scripts/windows/scripts/build.cmd
@@ -30,7 +30,7 @@ if "%ARCH%"=="x86" (
     echo Please set ARCH to "x86" or "x64"
     goto ERROR
 )
-set PYTHON_VERSION=3.12.8
+set PYTHON_VERSION=3.12.10
 
 set WIX_DOWNLOAD_URL="https://azurecliprod.blob.core.windows.net/msi/wix310-binaries-mirror.zip"
 set PYTHON_DOWNLOAD_URL="https://www.python.org/ftp/python/%PYTHON_VERSION%/python-%PYTHON_VERSION%-embed-%PYTHON_ARCH%.zip"

--- a/scripts/release/debian/build.sh
+++ b/scripts/release/debian/build.sh
@@ -15,7 +15,7 @@ set -exv
 ls -Rl /mnt/artifacts
 
 WORKDIR=`cd $(dirname $0); cd ../../../; pwd`
-PYTHON_VERSION="3.12.8"
+PYTHON_VERSION="3.12.10"
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Update APT packages


### PR DESCRIPTION
**Description**<!--Mandatory-->
Bump embedded Python to 3.12.10: https://docs.python.org/release/3.12.10/whatsnew/changelog.html#python-3-12-10

One of the important changes is:

> [gh-131423](https://github.com/python/cpython/issues/131423): Update bundled version of OpenSSL to 3.0.16.

According to https://github.com/openssl/openssl/releases/tag/openssl-3.0.16

> - Fixed timing side-channel in ECDSA signature computation. ([CVE-2024-13176](https://www.openssl.org/news/vulnerabilities.html#CVE-2024-13176))
> - Fixed possible OOB memory access with invalid low-level GF(2^m) elliptic curve parameters. ([CVE-2024-9143](https://www.openssl.org/news/vulnerabilities.html#CVE-2024-9143))


**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Core] Resolve CVE-2024-13176
[Core] Resolve CVE-2024-9143
