### PR TITLE
[containerapp] Fix containerapp update using yml file

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/containerapp/_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/containerapp/_utils.py
@@ -949,7 +949,8 @@ def _remove_readonly_attributes(containerapp_def):
         "latestRevisionFqdn",
         "customDomainVerificationId",
         "outboundIpAddresses",
-        "fqdn"
+        "fqdn",
+        "runningStatus"
     ]
 
     for unneeded_property in unneeded_properties:


### PR DESCRIPTION
**Related command**

- `az containerapp update` (passing `--yaml`)

**Description**

I think the upgrade to the new API version (https://github.com/Azure/azure-cli/pull/31276) lead to `runningStatus` appearing as a field at the top level when the YAML file passed to `az containerapp update` is run through the deserialiser.

It then caused an error before the command was run:

```
(InvalidRequestContent) The request content was invalid and could not be deserialized: 'Could not find member 'runningStatus' on object of type 'ResourceDefinition'. Path 'runningStatus', line 1, position 224.'.
```

The fix is to add it to the existing list of readonly attributes to remove.


**Testing Guide**

1) Save your current container apps template with `az containerapps show --output yaml > /tmp/template.yml`
2) Try to apply it with `az containerapps update --yaml /tmp/template.yml`

Example Python script here: https://github.com/rcpch/national-paediatric-diabetes-audit/blob/live/s/deploy-revision.py

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Container App] `az containerapp update` Modify `--yaml` template handling to fix `runningStatus` error

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
