### PR TITLE
{Packaging} Bump `semver` to 3.0.4

### DIFF
--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -122,7 +122,7 @@ python-dateutil==2.8.0
 requests-oauthlib==1.2.0
 requests[socks]==2.32.3
 scp==0.13.2
-semver==2.13.0
+semver==3.0.4
 six==1.16.0
 sshtunnel==0.1.5
 tabulate==0.8.9

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -123,7 +123,7 @@ python-dateutil==2.8.0
 requests-oauthlib==1.2.0
 requests[socks]==2.32.3
 scp==0.13.2
-semver==2.13.0
+semver==3.0.4
 six==1.16.0
 sshtunnel==0.1.5
 tabulate==0.8.9

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -124,7 +124,7 @@ pywin32==306
 requests-oauthlib==1.2.0
 requests[socks]==2.32.3
 scp==0.13.2
-semver==2.13.0
+semver==3.0.4
 six==1.16.0
 sshtunnel==0.1.5
 tabulate==0.8.9

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -142,7 +142,7 @@ DEPENDENCIES = [
     'PyGithub~=1.38',
     'PyNaCl~=1.5.0',
     'scp~=0.13.2',
-    'semver==2.13.0',
+    'semver~=3.0',
     'setuptools',
     'six>=1.10.0',  # six is still used by countless extensions
     'sshtunnel~=0.1.4',


### PR DESCRIPTION
**Description**<!--Mandatory-->
Close https://github.com/Azure/azure-cli/issues/31519

`semver` was pinned to `2.13.0` by https://github.com/Azure/azure-cli/pull/16857. [`2.13.0`](https://pypi.org/project/semver/2.13.0/) was released 5 years ago.
