### PR TITLE
[Packaging] Drop Azure Linux (Mariner) 2.0 support

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -344,12 +344,6 @@ jobs:
   strategy:
     matrix:
       ${{ each arch in parameters.architectures }}:
-        Mariner 2.0 ${{ arch.name }}:
-          pool: ${{ arch.pool }}
-          artifactName: docker-mariner2.0-${{ arch.value }}
-          dockerfile: azure-linux.dockerfile
-          packageArtifactName: rpm-mariner2.0-${{ arch.value }}
-          image: mcr.microsoft.com/cbl-mariner/base/core:2.0
         Azure Linux 3.0 ${{ arch.name }}:
           pool: ${{ arch.pool }}
           artifactName: docker-azurelinux3.0-${{ arch.value }}
@@ -393,9 +387,6 @@ jobs:
   strategy:
     matrix:
       ${{ each arch in parameters.architectures }}:
-        Mariner 2.0 ${{ arch.name }}:
-          pool: ${{ arch.pool }}
-          artifactName: docker-mariner2.0-${{ arch.value }}
         Azure Linux 3.0 ${{ arch.name }}:
           pool: ${{ arch.pool }}
           artifactName: docker-azurelinux3.0-${{ arch.value }}
@@ -717,10 +708,6 @@ jobs:
   strategy:
     matrix:
       ${{ each arch in parameters.architectures }}:
-        Mariner 2.0 ${{ arch.name }}:
-          image: mcr.microsoft.com/cbl-mariner/base/core:2.0
-          artifact: rpm-mariner2.0-${{ arch.value }}
-          pool: ${{ arch.pool }}
         Azure Linux 3.0 ${{ arch.name }}:
           image: mcr.microsoft.com/azurelinux/base/core:3.0
           artifact: rpm-azurelinux3.0-${{ arch.value }}
@@ -766,10 +753,6 @@ jobs:
   strategy:
     matrix:
       ${{ each arch in parameters.architectures }}:
-        Mariner 2.0 ${{ arch.name }}:
-          image: mcr.microsoft.com/cbl-mariner/base/core:2.0
-          artifact: rpm-mariner2.0-${{ arch.value }}
-          pool: ${{ arch.pool }}
         Azure Linux 3.0 ${{ arch.name }}:
           image: mcr.microsoft.com/azurelinux/base/core:3.0
           artifact: rpm-azurelinux3.0-${{ arch.value }}

--- a/scripts/release/rpm/README.md
+++ b/scripts/release/rpm/README.md
@@ -14,10 +14,10 @@ _Fedora:_
 docker build --target build-env -f ./scripts/release/rpm/fedora.dockerfile -t azure/azure-cli:fedora29-builder .
 ```
 
-_Mariner:_
+_Azure Linux:_
 
 ```bash
-docker build --target build-env -f ./scripts/release/rpm/mariner.dockerfile -t azure/azure-cli:mariner-builder .
+docker build --target build-env -f ./scripts/release/rpm/azurelinux.dockerfile -t azure/azure-cli:azurelinux-builder .
 ```
 
 After several minutes, this will have created a Docker image named `azure/azure-cli:centos7-builder` containing an
@@ -34,9 +34,9 @@ _Fedora:_
 docker run azure/azure-cli:fedora29-builder cat /root/rpmbuild/RPMS/x86_64/azure-cli-dev-1.fc29.x86_64.rpm > ./bin/azure-cli-dev-1.fc29.x86_64.rpm
 ```
 
-_Mariner:_
+_Azure Linux:_
 ```bash
-docker run azure/azure-cli:mariner-builder cat /usr/src/mariner/RPMS/x86_64/azure-cli-dev-1.cm1.x86_64.rpm > ./bin/azure-cli-dev-1.cm1.x86_64.rpm
+docker run azure/azure-cli:azurelinux-builder cat /usr/src/azl/RPMS/x86_64/azure-cli-dev-1.azl3.x86_64.rpm > ./bin/azure-cli-dev-1.azl3.x86_64.rpm
 ```
 
 This launches a container running from the image built and tagged by the previous command, prints the contents of the

--- a/scripts/release/rpm/azure-cli.spec
+++ b/scripts/release/rpm/azure-cli.spec
@@ -65,7 +65,7 @@ rm %{buildroot}%{cli_lib_dir}/pyvenv.cfg
 #   - We also can't use %{_lib}, because %{_lib} expands to different values on difference OSes：
 #     https://github.com/Azure/azure-cli/pull/20061
 #     - Fedora/CentOS/RedHat: relative path 'lib64'
-#     - Mariner: abolute path '/usr/lib'
+#     - Azure Linux: absolute path '/usr/lib'
 # The only solution left is to hard-code 'lib64' as we only release 64-bit RPM packages.
 mkdir -p %{buildroot}%{_bindir}
 python_version=$(ls %{buildroot}%{cli_lib_dir}/lib/ | head -n 1)

--- a/scripts/release/rpm/azurelinux.dockerfile
+++ b/scripts/release/rpm/azurelinux.dockerfile
@@ -1,4 +1,4 @@
-ARG image=mcr.microsoft.com/cbl-mariner/base/core:2.0
+ARG image=mcr.microsoft.com/azurelinux/base/core:3.0
 
 FROM ${image} AS build-env
 ARG cli_version=dev
@@ -6,7 +6,7 @@ ARG cli_version=dev
 RUN tdnf update -y
 
 # kernel-headers, glibc-devel, binutils are needed to install psutil python package on ARM64
-# ca-certificates: Mariner by default only adds a very minimal set of root certs to trust certain Microsoft
+# ca-certificates: Azure Linux by default only adds a very minimal set of root certs to trust certain Microsoft
 # resources (primarily packages.microsoft.com). ca-certificates contains the official Microsoft curated set of
 # trusted root certificates. It has replaced the set of Mozilla Trusted Root Certificates.
 RUN tdnf install -y binutils file rpm-build gcc libffi-devel python3-devel openssl-devel make diffutils patch \
@@ -16,9 +16,6 @@ WORKDIR /azure-cli
 
 COPY . .
 
-# Mariner 2.0's python3 is 3.9, the rpm paths are
-#   /usr/src/mariner/RPMS/x86_64/azure-cli-2.63.0-1.cm2.x86_64.rpm
-#   /usr/src/mariner/RPMS/aarch64/azure-cli-2.63.0-1.cm2.aarch64.rpm
 # Azure Linux 3's python3 is 3.12, the rpm paths are
 #   /usr/src/azl/RPMS/x86_64/azure-cli-2.63.0-1.azl3.x86_64.rpm
 #   /usr/src/azl/RPMS/aarch64/azure-cli-2.63.0-1.azl3.aarch64.rpm

--- a/scripts/release/rpm/pipeline_azurelinux.sh
+++ b/scripts/release/rpm/pipeline_azurelinux.sh
@@ -6,7 +6,7 @@ set -exv
 
 : "${BUILD_STAGINGDIRECTORY:?BUILD_STAGINGDIRECTORY environment variable not set.}"
 
-# IMAGE should be Azure Linux docker image url, such as mcr.microsoft.com/cbl-mariner/base/core:2.0
+# IMAGE should be Azure Linux docker image url, such as mcr.microsoft.com/azurelinux/base/core:3.0
 : "${IMAGE:?IMAGE environment variable not set.}"
 
 CLI_VERSION=`cat src/azure-cli/azure/cli/__main__.py | grep __version__ | sed s/' '//g | sed s/'__version__='// |  sed s/\"//g`


### PR DESCRIPTION
**Description**<!--Mandatory-->
Azure Linux 2.0 will reach its End of Life (EOL) on July 2025. [Azure CLI 2.74.0](https://github.com/Azure/azure-cli/milestone/156) (release date: 2025-06-03) will be the last version that supports Azure Linux 2.0. [Azure CLI 2.75.0](https://github.com/Azure/azure-cli/milestone/157) (release date: 2025-07-01) will not be released for Azure Linux 2.0.

References:

- https://eng.ms/docs/products/azure-linux/overview/20eol
- Email: 🚨 ACTION REQUIRED: Azure Linux 2.0 End of Life – Upgrade to Azure Linux 3.0
