### PR TITLE
[Mysql] `az mysql flexible-server create`: Change default storage redundancy for BC SKU to local redundancy

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/mysql/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/mysql/custom.py
@@ -1696,11 +1696,7 @@ def _determine_acceleratedLogs(accelerated_logs, tier):
 
 
 def _determine_storage_redundancy(storage_redundancy, tier):
-    if storage_redundancy is None:
-        if tier == "MemoryOptimized":
-            storage_redundancy = "ZoneRedundancy"
-        else:
-            storage_redundancy = "LocalRedundancy"
+    storage_redundancy = "LocalRedundancy"
     return storage_redundancy
 
 


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
[Mysql] `az mysql flexible-server create`: Change default storage redundancy for BC SKU to local redundancy

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
