### PR TITLE
{Packaging} Add warning message for Azure Linux 2.0

### DIFF
--- a/src/azure-cli/azure/cli/__main__.py
+++ b/src/azure-cli/azure/cli/__main__.py
@@ -9,6 +9,7 @@ import timeit
 start_time = timeit.default_timer()
 
 import sys
+import os
 
 from azure.cli.core import telemetry
 from azure.cli.core import get_default_cli
@@ -21,6 +22,14 @@ __version__ = "2.74.0"
 
 
 logger = get_logger(__name__)
+
+AZURELINUX2_WARNING_MESSAGE = (
+    "Azure CLI 2.74.0 is the final version available on Azure Linux (Mariner) 2.0 and will not receive further "
+    "updates. "
+    "We recommend migrating to Azure Linux 3.0 to access newer versions of Azure CLI and continue receiving updates. "
+    "For more information: https://go.microsoft.com/fwlink/?linkid=2322402. "
+    "To disable this warning message, set AZURE_CLI_DISABLE_AZURELINUX2_WARNING environment variable to any value. "
+)
 
 
 def cli_main(cli, args):
@@ -96,7 +105,6 @@ finally:
                         else:
                             upgrade_exit_code = subprocess.call(cmd, shell=platform.system() == 'Windows')
                     else:
-                        import os
                         devnull = open(os.devnull, 'w')
                         cmd.append('-y')
                         upgrade_exit_code = subprocess.call(cmd, shell=platform.system() == 'Windows', stdout=devnull)
@@ -114,6 +122,9 @@ finally:
         prompt_survey_message(az_cli)
     except Exception as ex:  # pylint: disable=broad-except
         logger.debug("Intercept survey prompt failed. %s", str(ex))
+
+    if 'AZURE_CLI_DISABLE_AZURELINUX2_WARNING' not in os.environ:
+        logger.warning(AZURELINUX2_WARNING_MESSAGE)
 
     telemetry.set_init_time_elapsed("{:.6f}".format(init_finish_time - start_time))
     telemetry.set_invoke_time_elapsed("{:.6f}".format(invoke_finish_time - init_finish_time))


### PR DESCRIPTION
**Description**<!--Mandatory-->
According to https://github.com/microsoft/azurelinux/issues/13555, Azure Linux 2.0 will reach its End of Life (EOL) on July 2025.

[Azure CLI 2.74.0](https://github.com/Azure/azure-cli/milestone/156) (release date: 2025-06-03) will be the last version that supports Azure Linux 2.0. [Azure CLI 2.75.0](https://github.com/Azure/azure-cli/milestone/157) (release date: 2025-07-01) will not be released for Azure Linux 2.0.

Similar to https://github.com/Azure/azure-cli/pull/29628, this PR displays a warning message solely for Azure Linux 2.0 RPMs:

> Azure CLI 2.74.0 is the last version available on Azure Linux (Mariner) 2.0 and will not receive updates. Consider migrating to Azure Linux 3.0 to use newer versions of Azure CLI. To disable this warning message, set AZURE_CLI_DISABLE_AZURELINUX2_WARNING environment variable to any value.

> [!NOTE]
> This PR will not be merged into `dev` branch. Instead, after 2.74.0 is released, a separate branch `release-2.74-azurelinux2` will be created and this PR will be merged into it. Then a separate release pipeline will be triggered specifically for Azure Linux 2.0.

Azure Linux 2.0 support will be fully dropped by https://github.com/Azure/azure-cli/pull/31533

**Testing Guide**
<!--Example commands with explanations.-->
```sh
az version

# Disable the warning message
export AZURE_CLI_DISABLE_AZURELINUX2_WARNING=1
az version
```