### PR TITLE
{ContainerApp} Fix Cred Scan failure: Replace shared keys in container app test recordings

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/containerapp/tests/latest/recordings/test_container_app_mount_azurefile_e2e.yaml
+++ b/src/azure-cli/azure/cli/command_modules/containerapp/tests/latest/recordings/test_container_app_mount_azurefile_e2e.yaml
@@ -1619,7 +1619,7 @@ interactions:
     body: '{"location": "eastus", "tags": null, "properties": {"daprAIInstrumentationKey":
       null, "vnetConfiguration": null, "appLogsConfiguration": {"destination": "log-analytics",
       "logAnalyticsConfiguration": {"customerId": "a32e97eb-f2ba-4a43-a567-cda169fc8b81",
-      "sharedKey": "iwPYd3mvdKlNKYFlr6gw5v/zB2I0VWu3FN54YkjqCMIpA+GMjSdh1lQTMA6bEKkOMjsQ8jhTEk5Gb47i/aehdQ=="}},
+      "sharedKey": "testFakeSharedKey=="}},
       "customDomainConfiguration": null, "workloadProfiles": [{"workloadProfileType":
       "Consumption", "Name": "Consumption"}], "zoneRedundant": false}}'
     headers:

--- a/src/azure-cli/azure/cli/command_modules/containerapp/tests/latest/recordings/test_containerapp_create_with_environment_id.yaml
+++ b/src/azure-cli/azure/cli/command_modules/containerapp/tests/latest/recordings/test_containerapp_create_with_environment_id.yaml
@@ -1351,7 +1351,7 @@ interactions:
     body: '{"location": "eastus", "tags": null, "properties": {"daprAIInstrumentationKey":
       null, "vnetConfiguration": null, "appLogsConfiguration": {"destination": "log-analytics",
       "logAnalyticsConfiguration": {"customerId": "9cd877b2-e078-4660-8de2-713547c7ef39",
-      "sharedKey": "W6UAMXWrlGiAfMArhap4zmZyLKFKLAt+bE2kSpZQ8omxA0AGjkseU0ZxX070D59P9STvB4h+LGFm0vzAbPBdKw=="}},
+      "sharedKey": "testFakeSharedKey=="}},
       "customDomainConfiguration": null, "workloadProfiles": [{"workloadProfileType":
       "Consumption", "Name": "Consumption"}], "zoneRedundant": false}}'
     headers:
@@ -5318,7 +5318,7 @@ interactions:
     body: '{"location": "eastus", "tags": null, "properties": {"daprAIInstrumentationKey":
       null, "vnetConfiguration": null, "appLogsConfiguration": {"destination": "log-analytics",
       "logAnalyticsConfiguration": {"customerId": "9cd877b2-e078-4660-8de2-713547c7ef39",
-      "sharedKey": "W6UAMXWrlGiAfMArhap4zmZyLKFKLAt+bE2kSpZQ8omxA0AGjkseU0ZxX070D59P9STvB4h+LGFm0vzAbPBdKw=="}},
+      "sharedKey": "testFakeSharedKey=="}},
       "customDomainConfiguration": null, "workloadProfiles": [{"workloadProfileType":
       "Consumption", "Name": "Consumption"}], "zoneRedundant": false}}'
     headers:

--- a/src/azure-cli/azure/cli/command_modules/containerapp/tests/latest/recordings/test_containerapp_env_e2e.yaml
+++ b/src/azure-cli/azure/cli/command_modules/containerapp/tests/latest/recordings/test_containerapp_env_e2e.yaml
@@ -1351,7 +1351,7 @@ interactions:
     body: '{"location": "eastus", "tags": {"foo": "bar", "key1": "val1"}, "properties":
       {"daprAIInstrumentationKey": null, "vnetConfiguration": null, "appLogsConfiguration":
       {"destination": "log-analytics", "logAnalyticsConfiguration": {"customerId":
-      "2d765c2c-2516-4306-9f8e-18857e541c26", "sharedKey": "UPDos6Pr/YVlowD6RRATjCZRyVLRBjg3NLb6rola8w51MGDVX4BGaVdVFMV5zFBUTYBb0xBpQBvwPNrWWZRD3A=="}},
+      "2d765c2c-2516-4306-9f8e-18857e541c26", "sharedKey": "testFakeSharedKey=="}},
       "customDomainConfiguration": null, "workloadProfiles": [{"workloadProfileType":
       "Consumption", "Name": "Consumption"}], "zoneRedundant": false}}'
     headers:

--- a/src/azure-cli/azure/cli/command_modules/containerapp/tests/latest/recordings/test_containerapp_env_mtls.yaml
+++ b/src/azure-cli/azure/cli/command_modules/containerapp/tests/latest/recordings/test_containerapp_env_mtls.yaml
@@ -1351,7 +1351,7 @@ interactions:
     body: '{"location": "eastus", "tags": null, "properties": {"daprAIInstrumentationKey":
       null, "vnetConfiguration": null, "appLogsConfiguration": {"destination": "log-analytics",
       "logAnalyticsConfiguration": {"customerId": "7b1c9363-d0b6-4d01-818d-3dfd96edab0a",
-      "sharedKey": "zVSNPmgdUlipcYNDdsTd7TZzMrvQTQyBuTclMnZ4YOXY9dx3hzOcYdxyYAbm31xNn0xguMPNWSsLCEbeXuWKsA=="}},
+      "sharedKey": "testFakeSharedKey=="}},
       "customDomainConfiguration": null, "workloadProfiles": [{"workloadProfileType":
       "Consumption", "Name": "Consumption"}], "zoneRedundant": false, "peerAuthentication":
       {"mtls": {"enabled": true}}}}'


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
The shared keys in container app test recording files (generated by https://github.com/Azure/azure-cli/pull/31449) were not detected by `azdev scan` because it locates in low confidence level rules. However, they are scanned by `Credential Scanner`. This PR manually replces the shared keys in the test recordings with fake values though the test resources have been deleted and the logged shared keys are no longer valid

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
