### PR TITLE
{Cloud} `az cloud register`: Compatible with more response formats from ARM endpoint API

### DIFF
--- a/src/azure-cli-core/azure/cli/core/cloud.py
+++ b/src/azure-cli-core/azure/cli/core/cloud.py
@@ -246,7 +246,7 @@ def _add_starting_dot(suffix):
 def _get_arm_endpoint(arm_dict, is_suffix=False):
     def _get_processed_arm_endpoint(name, add_dot=False, fallback_value=None):
         if is_suffix:
-            return (_add_starting_dot(arm_dict['suffixes'][name]) if add_dot else arm_dict['suffixes'][name]) if name in arm_dict['suffixes'] else fallback_value
+            return (_add_starting_dot(arm_dict['suffixes'][name]) if add_dot else arm_dict['suffixes'][name]) if 'suffixes' in arm_dict and name in arm_dict['suffixes'] else fallback_value
         return arm_dict[name] if name in arm_dict else fallback_value
     return _get_processed_arm_endpoint
 

--- a/src/azure-cli/azure/cli/command_modules/cloud/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/cloud/custom.py
@@ -47,7 +47,13 @@ def _populate_from_metadata_endpoint(arm_endpoint, session=None):
         response = session.get(metadata_endpoint)
         if response.status_code == 200:
             metadata = response.json()
-            return _arm_to_cli_mapper(metadata)
+            if isinstance(metadata, dict):
+                return _arm_to_cli_mapper(metadata)
+            elif isinstance(metadata, list):
+                return _arm_to_cli_mapper(metadata[0])
+            else:
+                msg = 'Response body does not contain valid json. Response content: {}'.format(str(metadata))
+                raise CLIError(error_msg_fmt.format(msg))
         msg = 'Server returned status code {} for {}'.format(response.status_code, metadata_endpoint)
         raise CLIError(error_msg_fmt.format(msg))
     except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError) as err:


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix https://github.com/Azure/azure-cli/issues/31547

ARM endpoint API `$ARM_HOST/metadata/endpoints` may return different formats for different API versions and different clouds. For example:
- https://**management.azure.com**/metadata/endpoints?api-version=**2015-01-01** returns a _**json object without suffixes**_
```
{"galleryEndpoint":"https://gallery.azure.com/","graphEndpoint":"https://graph.windows.net/","portalEndpoint":"https://portal.azure.com/","authentication":{"loginEndpoint":"https://login.microsoftonline.com/","audiences":["https://management.core.windows.net/","https://management.azure.com/"]}}
```
- https://**management.azure.com**/metadata/endpoints?api-version=**2019-10-01** returns a _**json array with suffixes**_
```
[{"portal":"https://portal.azure.com","authentication":{"loginEndpoint":"https://login.microsoftonline.com/","audiences":["https://management.core.windows.net/","https://management.azure.com/"],"tenant":"common","identityProvider":"AAD"},"media":"https://rest.media.azure.net","graphAudience":"https://graph.windows.net/","graph":"https://graph.windows.net/","name":"AzureCloud","suffixes":{"azureDataLakeStoreFileSystem":"azuredatalakestore.net","acrLoginServer":"azurecr.io","sqlServerHostname":"database.windows.net","azureDataLakeAnalyticsCatalogAndJob":"azuredatalakeanalytics.net","keyVaultDns":"vault.azure.net","storage":"core.windows.net","azureFrontDoorEndpointSuffix":"azurefd.net"},"batch":"https://batch.core.windows.net/","resourceManager":"https://management.azure.com/","vmImageAliasDoc":"https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-compute/quickstart-templates/aliases.json","activeDirectoryDataLake":"https://datalake.azure.net/","sqlManagement":"https://management.core.windows.net:8443/","gallery":"https://gallery.azure.com/"},{"portal":"https://portal.azure.cn","authentication":{"loginEndpoint":"https://login.chinacloudapi.cn","audiences":["https://management.core.chinacloudapi.cn","https://management.chinacloudapi.cn"],"tenant":"common","identityProvider":"AAD"},"media":"https://rest.media.chinacloudapi.cn","graphAudience":"https://graph.chinacloudapi.cn","graph":"https://graph.chinacloudapi.cn","name":"AzureChinaCloud","suffixes":{"acrLoginServer":"azurecr.cn","sqlServerHostname":"database.chinacloudapi.cn","keyVaultDns":"vault.azure.cn","storage":"core.chinacloudapi.cn","azureFrontDoorEndpointSuffix":""},"batch":"https://batch.chinacloudapi.cn","resourceManager":"https://management.chinacloudapi.cn","vmImageAliasDoc":"https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-compute/quickstart-templates/aliases.json","sqlManagement":"https://management.core.chinacloudapi.cn:8443","gallery":"https://gallery.chinacloudapi.cn"},{"portal":"https://portal.azure.us","authentication":{"loginEndpoint":"https://login.microsoftonline.us","audiences":["https://management.core.usgovcloudapi.net","https://management.usgovcloudapi.net"],"tenant":"common","identityProvider":"AAD"},"media":"https://rest.media.usgovcloudapi.net","graphAudience":"https://graph.windows.net","graph":"https://graph.windows.net","name":"AzureUSGovernment","suffixes":{"acrLoginServer":"azurecr.us","sqlServerHostname":"database.usgovcloudapi.net","keyVaultDns":"vault.usgovcloudapi.net","storage":"core.usgovcloudapi.net","azureFrontDoorEndpointSuffix":""},"batch":"https://batch.core.usgovcloudapi.net","resourceManager":"https://management.usgovcloudapi.net","vmImageAliasDoc":"https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-compute/quickstart-templates/aliases.json","sqlManagement":"https://management.core.usgovcloudapi.net:8443","gallery":"https://gallery.usgovcloudapi.net"}]
```
- https://**management.azure.com**/metadata/endpoints?api-version=**2022-09-01** returns a _**json object with suffixes**_
```
{"portal":"https://portal.azure.com","authentication":{"loginEndpoint":"https://login.microsoftonline.com","audiences":["https://management.core.windows.net/","https://management.azure.com/"],"tenant":"common","identityProvider":"AAD"},"media":"https://rest.media.azure.net","graphAudience":"https://graph.windows.net/","graph":"https://graph.windows.net/","name":"AzureCloud","suffixes":{"azureDataLakeStoreFileSystem":"azuredatalakestore.net","acrLoginServer":"azurecr.io","sqlServerHostname":"database.windows.net","azureDataLakeAnalyticsCatalogAndJob":"azuredatalakeanalytics.net","keyVaultDns":"vault.azure.net","storage":"core.windows.net","azureFrontDoorEndpointSuffix":"azurefd.net","storageSyncEndpointSuffix":"afs.azure.net","mhsmDns":"managedhsm.azure.net","mysqlServerEndpoint":"mysql.database.azure.com","postgresqlServerEndpoint":"postgres.database.azure.com","mariadbServerEndpoint":"mariadb.database.azure.com","synapseAnalytics":"dev.azuresynapse.net","attestationEndpoint":"attest.azure.net"},"batch":"https://batch.core.windows.net/","resourceManager":"https://management.azure.com/","vmImageAliasDoc":"https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-compute/quickstart-templates/aliases.json","activeDirectoryDataLake":"https://datalake.azure.net/","sqlManagement":"https://management.core.windows.net:8443/","microsoftGraphResourceId":"https://graph.microsoft.com/","appInsightsResourceId":"https://api.applicationinsights.io","appInsightsTelemetryChannelResourceId":"https://dc.applicationinsights.azure.com/v2/track","attestationResourceId":"https://attest.azure.net","synapseAnalyticsResourceId":"https://dev.azuresynapse.net","logAnalyticsResourceId":"https://api.loganalytics.io","ossrDbmsResourceId":"https://ossrdbms-aad.database.windows.net"}
```

- However, https://**management.redmond.ext-s31r1304.masd.stbtest.microsoft.com**/metadata/endpoints?api-version=2022-09-01 returns a _**json array with suffixes**_
```
[{"portal":"https://portal.redmond.ext-s31r1304.masd.stbtest.microsoft.com/","authentication":{"loginEndpoint":"https://adfs.redmond.ext-s31r1304.masd.stbtest.microsoft.com/adfs","audiences":["https://management.adfs.s31r1304.masd.stbtest.microsoft.com/e8b7057b-9773-4e8f-ba0e-57c12612fb80"]},"graphAudience":"https://graph.redmond.ext-s31r1304.masd.stbtest.microsoft.com/","graph":"https://graph.redmond.ext-s31r1304.masd.stbtest.microsoft.com/","name":"AzureStack-User-e8b7057b-9773-4e8f-ba0e-57c12612fb80","suffixes":{"keyVaultDns":"vault.redmond.ext-s31r1304.masd.stbtest.microsoft.com","storage":"redmond.ext-s31r1304.masd.stbtest.microsoft.com"},"gallery":"https://providers.s31r1304.masd.stbtest.microsoft.com:30016/"}]
```

What makes things worse, ARM doesn't have spec definition for this API. This PR aims for enhance `az cloud register` to be able to handle both Json Object and Json Array response formats with/without suffixes

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
