### PR TITLE
{Core} Fix incorrect _get_message and _get_tag in MergedStatusTag

### DIFF
--- a/src/azure-cli-core/azure/cli/core/breaking_change.py
+++ b/src/azure-cli-core/azure/cli/core/breaking_change.py
@@ -106,10 +106,10 @@ class MergedStatusTag(StatusTag):
         self.tags = list(tags)
 
         def _get_merged_tag(self):
-            return ''.join({tag._get_tag(self) for tag in self.tags})  # pylint: disable=protected-access
+            return ''.join({tag._get_tag(tag) for tag in self.tags})  # pylint: disable=protected-access
 
         def _get_merged_msg(self):
-            return '\n'.join({tag._get_message(self) for tag in self.tags})  # pylint: disable=protected-access
+            return '\n'.join({tag._get_message(tag) for tag in self.tags})  # pylint: disable=protected-access
 
         super().__init__(cli_ctx, tag.object_type, tag.target, tag_func=_get_merged_tag,
                          message_func=_get_merged_msg, color=tag._color)


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
This is a fix for incorrect _get_message and _get_tag in MergedStatusTag. Document generation directly call _get_message from a tag but there is a bug in its implementation.
This didn't be discovered because cli call property method message(self) and tag(self) instead of _get_message and _get_tag.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
