### PR TITLE
[ARO] `az aro update`: Fix credential refresh to handle clusters with invalid machinesets

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/aro/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/aro/custom.py
@@ -507,8 +507,11 @@ def get_cluster_network_resources(cli_ctx, oc, fail):
 
     # Ensure that worker_profiles_status exists
     # it will not be returned if the cluster resources do not exist
+
+    # We filter nonexistent subnets here as we only propagate subnet values for
+    # worker profiles/machinesets considered valid.
     if oc.worker_profiles_status is not None:
-        worker_subnets |= {w.subnet_id for w in oc.worker_profiles_status}
+        worker_subnets |= {w.subnet_id for w in oc.worker_profiles_status if w.subnet_id is not None}
 
     master_parts = parse_resource_id(master_subnet)
     vnet = resource_id(


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az aro update`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
- Updates the credential update/refresh process within `az aro update` to tolerate clusters with invalid machinesets - these are propagated on the ARO cluster resource under the `workerProfilesStatus` field, and currently cause the CLI to fail due to missing a valid subnet property, with the following error:

```
ERROR: (ValidationError) Failed to validate subnet 'None'. Please retry, if issue persists raise azure support ticket
```

**Testing Guide**
<!--Example commands with explanations.-->

Against an ARO cluster containing a machineset considered "invalid" (has 0 ready machines):
- Run `az aro update --refresh-credentials` on the latest Azure CLI release - will fail
- Run `az aro update --refresh-credentials` with this change - should pass

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[ARO] `az aro update`: Fix credential refresh to handle clusters with invalid machinesets

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
