### PR TITLE
consumption: remove redundant 'return None'

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/consumption/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/consumption/custom.py
@@ -95,10 +95,8 @@ def transform_usage_output(result):
     usageStart = result.get('usageStart', None)
     usageEnd = result.get('usageEnd', None)
     if usageStart or usageEnd:
-        usageStart = parser.parse(usageStart).strftime("%Y-%m-%dT%H:%M:%SZ") if usageStart else 'None'
-        usageEnd = parser.parse(usageEnd).strftime("%Y-%m-%dT%H:%M:%SZ") if usageEnd else 'None'
-    else:
-        return None
+        usageStart = parser.parse(usageStart).strftime("%Y-%m-%dT%H:%M:%SZ") if usageStart else None
+        usageEnd = parser.parse(usageEnd).strftime("%Y-%m-%dT%H:%M:%SZ") if usageEnd else None
     result['usageStart'] = usageStart
     result['usageEnd'] = usageEnd
     result['usageQuantity'] = str(result.get('usageQuantity', None))


### PR DESCRIPTION
**Related command**
`az consumption usage list --start-date 2019-01-01 --end-date 2019-02-01`

**Description**
This PR fixes an issue where `az consumption usage list` was returning an empty list (`[]`) even when usage data existed.

Now, the command correctly returns usage data when available, and returns an empty list only when there is truly no data.  
This improves accuracy and ensures users see expected results.

**Testing Guide**
Run the following command to verify the fix:

```bash
az consumption usage list --start-date 2019-01-01 --end-date 2019-02-01
```
Before: [] returned even if data existed

After: Actual usage data should be returned when available

History Notes
[Consumption] Fix: az consumption usage list now returns data correctly instead of empty list when available
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
