### PR TITLE
{Misc.} Remove `pkg_resources`

### DIFF
--- a/doc/sphinx/azhelpgen/__init__.py
+++ b/doc/sphinx/azhelpgen/__init__.py
@@ -2,5 +2,3 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
-import pkg_resources
-pkg_resources.declare_namespace(__name__)

--- a/doc/sphinx/cligroup/__init__.py
+++ b/doc/sphinx/cligroup/__init__.py
@@ -2,5 +2,3 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
-import pkg_resources
-pkg_resources.declare_namespace(__name__)

--- a/src/azure-cli/azure/cli/command_modules/maps/tests/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/maps/tests/__init__.py
@@ -2,5 +2,3 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
-import pkg_resources
-pkg_resources.declare_namespace(__name__)

--- a/src/azure-cli/azure/cli/command_modules/maps/tests/latest/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/maps/tests/latest/__init__.py
@@ -2,5 +2,3 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
-import pkg_resources
-pkg_resources.declare_namespace(__name__)

--- a/tools/automation/verify/verify_packages.py
+++ b/tools/automation/verify/verify_packages.py
@@ -12,7 +12,7 @@ import glob
 import filecmp
 import logging
 import unittest
-from pkg_resources import working_set
+from importlib.metadata import distributions
 
 import automation.utilities.path as automation_path
 from automation.utilities.const import COMMAND_MODULE_PREFIX
@@ -48,7 +48,7 @@ class PackageVerifyTests(unittest.TestCase):
     def test_azure_cli_module_installation(self):
         expected_modules = set([n for n, _ in automation_path.get_command_modules_paths(include_prefix=True)])
 
-        installed_command_modules = [dist.key for dist in list(working_set) if dist.key.startswith(COMMAND_MODULE_PREFIX)]
+        installed_command_modules = [dist.metadata['Name'] for dist in distributions() if dist.metadata['Name'].startswith(COMMAND_MODULE_PREFIX)]
 
         logger.info('Installed command modules %s', installed_command_modules)
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

`pkg_resources` is deprecated and importing it in setuptools 80.9.0 raises this warning:
```
[root@1197773e3b76 /]# python3.12 -c 'import pkg_resources'
<string>:1: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
```

This PR removes its usage.

Related issue: https://github.com/Azure/azure-cli/issues/31591