### PR TITLE
{CI} Update homebrew to latest version during formula test

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -654,9 +654,9 @@ jobs:
 
   - bash: |
       set -ev
-      # Force relink python@3.xx in Homebrew to resolve the conflict with pre-installed python 3.xx on macOS-12 image
-      # See: https://github.com/Azure/azure-cli/issues/29054
-      brew unlink python@$3.12 && brew link --overwrite python@$3.12
+      # Force relink python@3.xx in Homebrew to resolve the conflict with pre-installed python 3.xx on macOS
+      # See: https://github.com/actions/runner-images/issues/9966
+      brew unlink python@3.12 && brew link --overwrite python@3.12
       brew unlink python@3.13 && brew link --overwrite python@3.13
       
       # update homebrew to latest version in case the formula is not compatible with the current homebrew version

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -659,6 +659,9 @@ jobs:
       python_version=3.12
       brew unlink python@$python_version && brew link --overwrite python@$python_version
       
+      # update homebrew to latest version in case the formula is not compatible with the current homebrew version
+      brew update
+      
       echo == Remove pre-installed azure-cli ==
       brew uninstall azure-cli
       

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -656,8 +656,8 @@ jobs:
       set -ev
       # Force relink python@3.xx in Homebrew to resolve the conflict with pre-installed python 3.xx on macOS-12 image
       # See: https://github.com/Azure/azure-cli/issues/29054
-      python_version=3.12
-      brew unlink python@$python_version && brew link --overwrite python@$python_version
+      brew unlink python@$3.12 && brew link --overwrite python@$3.12
+      brew unlink python@3.13 && brew link --overwrite python@3.13
       
       # update homebrew to latest version in case the formula is not compatible with the current homebrew version
       brew update


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Recently, azure-cli's formula added a new config `no_autobump! because: :requires_manual_review`, which is only compatible with homebrew>=4.5.4.

```
echo == Install azure-cli.rb formula ==
brew install --build-from-source $SYSTEM_ARTIFACTSDIRECTORY/homebrew/azure-cli.rb
== Install azure-cli.rb formula ==
Error: azure-cli: 'because' argument should use valid symbol or a string!
```

Update homebrew to the latest version in test script.

Ref:
- https://github.com/Homebrew/homebrew-core/pull/225001/files#diff-4defc7c88b431d79bf10a50aab619bb242b9d03673b3f0192b0651e5f078d975
- https://github.com/Homebrew/brew/pull/20021
- https://dev.azure.com/azclitools/public/_build/results?buildId=249293&view=logs&j=ebe8970d-a8af-5d7e-4086-8f4ce0be006b&t=3f22f999-770c-5d06-3bb8-1a936f5d8384
