### PR TITLE
{CORE} Don't attempt to issue subscription token for PIM requests

### DIFF
--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -1012,8 +1012,17 @@ def send_raw_request(cli_ctx, method, url, headers=None, uri_parameters=None,  #
             # TODO: In the future when multi-tenant subscription is supported, we won't be able to uniquely identify
             #   the token from subscription anymore.
             token_subscription = None
-            if url.lower().startswith(endpoints.resource_manager.rstrip('/')):
-                token_subscription = _extract_subscription_id(url)
+
+            resources_which_dont_require_subscription_id = [
+                "providers/Microsoft.Authorization/roleDefinitions"
+            ]
+
+            if url.lower().startswith(endpoints.resource_manager.rstrip("/")):
+                if all(
+                    res.lower() not in url.lower()
+                    for res in resources_which_dont_require_subscription_id
+                ):
+                    token_subscription = _extract_subscription_id(url)
             if token_subscription:
                 logger.debug('Retrieving token for resource %s, subscription %s', resource, token_subscription)
                 token_info, _, _ = profile.get_raw_token(resource, subscription=token_subscription)


### PR DESCRIPTION
**Related command**

```
az rest `
        --method put `
        --headers "Content-Type=application/json" `
        --url "https://management.azure.com/subscriptions/XXX/providers/Microsoft.Authorization/roleAssignmentScheduleRequests/${guid}?api-version=2020-10-01" `
        --body "@$tempFile"
```

**Description**<!--Mandatory-->

A PUT request to `Microsoft.Authorization/roleAssignmentScheduleRequests` activates a role assignment in Privileged Identity Management. Activating such a role might be required for the logged-in user to even list the subscriptions on the tenant.

However, azure-cli sees subscription id in the request, and prior to the ARM request it tries to get an access token for the subscription. The subscription that isn't available yet. This is a chicken-and-egg problem.

It looks like for this query a tenant-wide Bearer token is enough. The subscription ID in the URL actually means a scope for the role assignment.

Important caveat: I tested this change on PUT requests for role activation.

**Testing Guide**

- Have a tenant `your_test_tenant` with PIM enabled, and your user that needs a to activate a role via PIM to access the subscription. 
- `az login -t your_test_tenant --allow-no-subscriptions`
- Activate the role with azure-cli. Example for powershell:

```powershell
$userId = (az ad signed-in-user show --query id -o tsv)
$subscriptionId = "your_sub_id"
$roleScope = "/subscriptions/$subscriptionId"  # request role on entire subscription


$body = @{
    Properties = @{
        PrincipalId = $userId
        RoleDefinitionId = "/subscriptions/$subscriptionId/providers/Microsoft.Authorization/roleDefinitions/$roleId"
        RequestType = "SelfActivate"
        Justification = "xxx"
        ScheduleInfo = @{
            StartDateTime = $null
            Expiration = @{
                Duration = "PT480M"  # 8 hours
                Type = "AfterDuration"
            }
        }
    }
}


# Put request body into a temporary file to avoid issues with quoting in the az rest command
# https://learn.microsoft.com/cli/azure/use-azure-cli-successfully-quoting?tabs=bash1%2Cbash2%2Cbash3#json-strings
$tempFile = [System.IO.Path]::GetTempFileName()
$guid = [guid]::NewGuid().ToString()
try{
    $body | ConvertTo-Json -Depth 10 | Out-File -FilePath $tempFile

    az rest `
        --method put `
        --headers "Content-Type=application/json" `
        --url "https://management.azure.com${roleScope}/providers/Microsoft.Authorization/roleAssignmentScheduleRequests/${guid}?api-version=2020-10-01" `
        --body "@$tempFile" `
        --query "properties.status"
}
finally {
    # Clean up
    if (Test-Path $tempFile) {
        Remove-Item -Path $tempFile -Force
    }
}

```

<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[CORE] `az rest`: Use tenant-wide token when working with PIM roles

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
