### PR TITLE
{CI} Continue on Error for SBOM task

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -226,6 +226,7 @@ jobs:
 
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'SBOM'
+    continueOnError: true
     inputs:
       BuildDropPath: 'build_scripts/windows/out/'
 
@@ -270,6 +271,7 @@ jobs:
 
     - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
       displayName: 'SBOM'
+      continueOnError: true
       inputs:
         BuildDropPath: 'build_scripts/windows/out/'
 
@@ -370,6 +372,7 @@ jobs:
 
     - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
       displayName: 'SBOM'
+      continueOnError: true
       inputs:
         BuildDropPath: $(Build.ArtifactStagingDirectory)
         DockerImagesToScan: 'clibuild$BUILD_BUILDNUMBER:latest'
@@ -451,6 +454,7 @@ jobs:
 
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'SBOM'
+    continueOnError: true
     inputs:
       BuildDropPath: $(Build.ArtifactStagingDirectory)
 
@@ -621,6 +625,7 @@ jobs:
 
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'SBOM'
+    continueOnError: true
     inputs:
       BuildDropPath: $(Build.ArtifactStagingDirectory)
 
@@ -732,6 +737,7 @@ jobs:
 
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'SBOM'
+    continueOnError: true
     inputs:
       BuildDropPath: $(Build.ArtifactStagingDirectory)
 
@@ -822,6 +828,7 @@ jobs:
       filePath: scripts/release/rpm/pipeline.sh
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'SBOM'
+    continueOnError: true
     inputs:
       BuildDropPath: $(Build.ArtifactStagingDirectory)
   - task: PublishPipelineArtifact@0
@@ -941,6 +948,7 @@ jobs:
 
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'SBOM'
+    continueOnError: true
     inputs:
       BuildDropPath: $(Build.ArtifactStagingDirectory)
 


### PR DESCRIPTION
This PR adds `continueOnError: true` to the SBOM task in the pipeline to prevent CI failures when SBOM generation encounters issues.

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
