### PR TITLE
[Keyvault] `az keyvault secret download` : Add overwrite flag

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/keyvault/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_params.py
@@ -558,6 +558,8 @@ def load_arguments(self, _):
         c.argument('encoding', arg_type=get_enum_type(secret_encoding_values), options_list=['--encoding', '-e'],
                    help="Encoding of the secret. By default, will look for the 'file-encoding' tag on the secret. "
                         "Otherwise will assume 'utf-8'.", default=None)
+        c.argument('overwrite', arg_type=get_three_state_flag(), options_list=['--overwrite'], help="Overwrite the file if it exists.",
+                   default=False)
 
     for scope in ['download', 'backup', 'restore']:
         with self.argument_context('keyvault secret {}'.format(scope)) as c:

--- a/src/azure-cli/azure/cli/command_modules/keyvault/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_params.py
@@ -558,8 +558,7 @@ def load_arguments(self, _):
         c.argument('encoding', arg_type=get_enum_type(secret_encoding_values), options_list=['--encoding', '-e'],
                    help="Encoding of the secret. By default, will look for the 'file-encoding' tag on the secret. "
                         "Otherwise will assume 'utf-8'.", default=None)
-        c.argument('overwrite', arg_type=get_three_state_flag(), options_list=['--overwrite'], help="Overwrite the file if it exists.",
-                   default=False)
+        c.argument('overwrite', arg_type=get_three_state_flag(), options_list=['--overwrite'], help="Overwrite the file if it exists.")
 
     for scope in ['download', 'backup', 'restore']:
         with self.argument_context('keyvault secret {}'.format(scope)) as c:

--- a/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
@@ -1460,10 +1460,13 @@ def update_key_rotation_policy(cmd, client, value, key_name=None):
 
 
 # region KeyVault Secret
-def download_secret(client, file_path, name=None, encoding=None, version='', overwrite: bool = False):  # pylint: disable=unused-argument
+def download_secret(client, file_path, name=None, encoding=None, version='', overwrite=False):  # pylint: disable=unused-argument
     """ Download a secret from a KeyVault. """
     if not overwrite and (os.path.isfile(file_path) or os.path.isdir(file_path)):
-        raise CLIError("File or directory named '{}' already exists.".format(file_path))
+        raise CLIError(
+            "File or directory named '{}' already exists. "
+            "Use --overwrite to overwrite the existing file.".format(file_path)
+        )
 
     secret = client.get_secret(name, version)
 

--- a/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
@@ -1460,9 +1460,9 @@ def update_key_rotation_policy(cmd, client, value, key_name=None):
 
 
 # region KeyVault Secret
-def download_secret(client, file_path, name=None, encoding=None, version=''):  # pylint: disable=unused-argument
+def download_secret(client, file_path, name=None, encoding=None, version='', overwrite: bool = False):  # pylint: disable=unused-argument
     """ Download a secret from a KeyVault. """
-    if os.path.isfile(file_path) or os.path.isdir(file_path):
+    if not overwrite and (os.path.isfile(file_path) or os.path.isdir(file_path)):
         raise CLIError("File or directory named '{}' already exists.".format(file_path))
 
     secret = client.get_secret(name, version)

--- a/src/azure-cli/azure/cli/command_modules/keyvault/tests/latest/recordings/test_keyvault_secret.yaml
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/tests/latest/recordings/test_keyvault_secret.yaml
@@ -13,21 +13,21 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_secret000001/providers/Microsoft.KeyVault/vaults/cli-test-kv-se-000002?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_secret000001/providers/Microsoft.KeyVault/vaults/cli-test-kv-se-000002","name":"cli-test-kv-se-000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"systemData":{"createdBy":"yishiwang@microsoft.com","createdByType":"User","createdAt":"2025-03-11T04:46:32.478Z","lastModifiedBy":"yishiwang@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2025-03-11T04:46:32.478Z"},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"3707fb2f-ac10-4591-a04f-8b0d786ea37d","permissions":{"keys":["all"],"secrets":["all"],"certificates":["all"],"storage":["all"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":7,"enableRbacAuthorization":false,"vaultUri":"https://cli-test-kv-se-000002.vault.azure.net/","provisioningState":"Succeeded","publicNetworkAccess":"Enabled"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_secret000001/providers/Microsoft.KeyVault/vaults/cli-test-kv-se-000002","name":"cli-test-kv-se-000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"systemData":{"createdBy":"test@example.com","createdByType":"User","createdAt":"2025-06-11T06:29:31.689Z","lastModifiedBy":"test@example.com","lastModifiedByType":"User","lastModifiedAt":"2025-06-11T06:29:31.689Z"},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"bbf48380-10d9-4b16-bbc1-6f320c300908","permissions":{"keys":["all"],"secrets":["all"],"certificates":["all"],"storage":["all"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":7,"enableRbacAuthorization":false,"vaultUri":"https://cli-test-kv-se-000002.vault.azure.net/","provisioningState":"Succeeded","publicNetworkAccess":"Enabled"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1044'
+      - '1030'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:47:08 GMT
+      - Wed, 11 Jun 2025 06:30:08 GMT
       expires:
       - '-1'
       pragma:
@@ -41,11 +41,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-service-version:
-      - 2.2.29.0
+      - 2.2.135.0
       x-ms-ratelimit-remaining-subscription-global-reads:
-      - '3749'
+      - '16499'
       x-msedge-ref:
-      - 'Ref A: 0F452B94AEF341E8BF87342274AC9ED4 Ref B: MAA201060513047 Ref C: 2025-03-11T04:47:08Z'
+      - 'Ref A: 45AFC52A005E48EC9A67D415087EB6FD Ref B: SYD03EDGE0806 Ref C: 2025-06-11T06:30:08Z'
     status:
       code: 200
       message: OK
@@ -63,21 +63,21 @@ interactions:
       ParameterSetName:
       - -n --object-id --secret-permissions
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?$filter=resourceType%20eq%20%27Microsoft.KeyVault%2Fvaults%27%20and%20name%20eq%20%27cli-test-kv-se-000002%27&api-version=2015-11-01
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_secret000001/providers/Microsoft.KeyVault/vaults/cli-test-kv-se-000002","name":"cli-test-kv-se-000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}}],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?%24filter=resourceType+eq+%27Microsoft.KeyVault%2fvaults%27+and+name+eq+%27cli-test-kv-se-000002%27&api-version=2015-11-01&%24skiptoken=rdJBb5swGIDh%2f%2bJzDo4zLpV2SOuQgbARqVNqiwtKUcDGZEocMRzlv89QlGqT0CS0gy8%2bPP786b2BpvhloqpRF%2fB0A5fT1ZSHojHnvL66G1B04VW8l5Clfpejty6Qp4pKhdxZxdvEELtuSQchtbs6YsclwYnhUpRChjW3oiZo4wUN%2fA4WoMgvZtIUbIMoIh5N90awdSteIeT2uYxYrUj%2fjk4s18mK6DdNt8lyNGX%2bM296eGJUgTeWWr6MWeDYUNIKQqF3jj2uCF4bgnxJ8QGRdA%2fj7U6PbFv0o64mUMLc39P9N44cuvVL8uL%2bLw9elAYtxcrt5LkSbKe45JbqoB3Rf62Vp6Ei2K97gqJ917NcHmzEVCuYMjH2FUfusLKm9rGCS1t8FM2IT0wscFgJqZZCu%2b2m3OtpYsPSTewJfDRUipqnCSSaI2rV53bvi6824ubHqf5whYyXJD%2br4uxeu2V%2fNZOBp%2by%2fVZOBhcOGbibdOeUM7qOdaXpGPQM99jMJzylogB8NTdJzKhroPzqa5OeUlIE7uP8G"}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_secret000001/providers/Microsoft.KeyVault/vaults/cli-test-kv-se-000002","name":"cli-test-kv-se-000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1080'
+      - '272'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:47:10 GMT
+      - Wed, 11 Jun 2025 06:30:08 GMT
       expires:
       - '-1'
       pragma:
@@ -89,9 +89,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-global-reads:
-      - '3749'
+      - '16499'
       x-msedge-ref:
-      - 'Ref A: 8FD842E64C85452F939A4FAD04401C3D Ref B: MAA201060516021 Ref C: 2025-03-11T04:47:09Z'
+      - 'Ref A: B8F2F37B70CE49F186071F75FCC9170D Ref B: SYD03EDGE1110 Ref C: 2025-06-11T06:30:08Z'
     status:
       code: 200
       message: OK
@@ -109,21 +109,21 @@ interactions:
       ParameterSetName:
       - -n --object-id --secret-permissions
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_secret000001/providers/Microsoft.KeyVault/vaults/cli-test-kv-se-000002?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_secret000001/providers/Microsoft.KeyVault/vaults/cli-test-kv-se-000002","name":"cli-test-kv-se-000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"systemData":{"createdBy":"yishiwang@microsoft.com","createdByType":"User","createdAt":"2025-03-11T04:46:32.478Z","lastModifiedBy":"yishiwang@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2025-03-11T04:46:32.478Z"},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"3707fb2f-ac10-4591-a04f-8b0d786ea37d","permissions":{"keys":["all"],"secrets":["all"],"certificates":["all"],"storage":["all"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":7,"enableRbacAuthorization":false,"vaultUri":"https://cli-test-kv-se-000002.vault.azure.net/","provisioningState":"Succeeded","publicNetworkAccess":"Enabled"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_secret000001/providers/Microsoft.KeyVault/vaults/cli-test-kv-se-000002","name":"cli-test-kv-se-000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"systemData":{"createdBy":"test@example.com","createdByType":"User","createdAt":"2025-06-11T06:29:31.689Z","lastModifiedBy":"test@example.com","lastModifiedByType":"User","lastModifiedAt":"2025-06-11T06:29:31.689Z"},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"bbf48380-10d9-4b16-bbc1-6f320c300908","permissions":{"keys":["all"],"secrets":["all"],"certificates":["all"],"storage":["all"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":7,"enableRbacAuthorization":false,"vaultUri":"https://cli-test-kv-se-000002.vault.azure.net/","provisioningState":"Succeeded","publicNetworkAccess":"Enabled"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1044'
+      - '1030'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:47:11 GMT
+      - Wed, 11 Jun 2025 06:30:09 GMT
       expires:
       - '-1'
       pragma:
@@ -137,18 +137,18 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-service-version:
-      - 2.2.29.0
+      - 2.2.135.0
       x-ms-ratelimit-remaining-subscription-global-reads:
-      - '3749'
+      - '16499'
       x-msedge-ref:
-      - 'Ref A: 8821BF07C0044F158F193BCA6A27F638 Ref B: MAA201060514035 Ref C: 2025-03-11T04:47:10Z'
+      - 'Ref A: C9561E108C0C4F61BD606F6B6D5150D2 Ref B: SYD03EDGE2106 Ref C: 2025-06-11T06:30:09Z'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"location": "westus", "tags": {}, "properties": {"tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
+    body: '{"location": "westus", "tags": {}, "properties": {"tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
       "sku": {"family": "A", "name": "standard"}, "accessPolicies": [{"tenantId":
-      "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "objectId": "3707fb2f-ac10-4591-a04f-8b0d786ea37d",
+      "72f988bf-86f1-41af-91ab-2d7cd011db47", "objectId": "bbf48380-10d9-4b16-bbc1-6f320c300908",
       "permissions": {"keys": ["all"], "secrets": ["all", "purge"], "certificates":
       ["all"], "storage": ["all"]}}], "vaultUri": "https://cli-test-kv-se-000002.vault.azure.net/",
       "enabledForDeployment": false, "enableSoftDelete": true, "softDeleteRetentionInDays":
@@ -170,21 +170,21 @@ interactions:
       ParameterSetName:
       - -n --object-id --secret-permissions
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_secret000001/providers/Microsoft.KeyVault/vaults/cli-test-kv-se-000002?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_secret000001/providers/Microsoft.KeyVault/vaults/cli-test-kv-se-000002","name":"cli-test-kv-se-000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"systemData":{"createdBy":"yishiwang@microsoft.com","createdByType":"User","createdAt":"2025-03-11T04:46:32.478Z","lastModifiedBy":"yishiwang@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2025-03-11T04:47:13.114Z"},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"3707fb2f-ac10-4591-a04f-8b0d786ea37d","permissions":{"keys":["all"],"secrets":["all","purge"],"certificates":["all"],"storage":["all"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":7,"enableRbacAuthorization":false,"vaultUri":"https://cli-test-kv-se-000002.vault.azure.net/","provisioningState":"Succeeded","publicNetworkAccess":"Enabled"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_secret000001/providers/Microsoft.KeyVault/vaults/cli-test-kv-se-000002","name":"cli-test-kv-se-000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"systemData":{"createdBy":"test@example.com","createdByType":"User","createdAt":"2025-06-11T06:29:31.689Z","lastModifiedBy":"test@example.com","lastModifiedByType":"User","lastModifiedAt":"2025-06-11T06:30:10.255Z"},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"bbf48380-10d9-4b16-bbc1-6f320c300908","permissions":{"keys":["all"],"secrets":["all","purge"],"certificates":["all"],"storage":["all"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":7,"enableRbacAuthorization":false,"vaultUri":"https://cli-test-kv-se-000002.vault.azure.net/","provisioningState":"Succeeded","publicNetworkAccess":"Enabled"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1052'
+      - '1038'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:47:13 GMT
+      - Wed, 11 Jun 2025 06:30:10 GMT
       expires:
       - '-1'
       pragma:
@@ -198,13 +198,15 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-service-version:
-      - 2.2.29.0
+      - 2.2.135.0
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/australiaeast/beeae929-5b08-4fcd-bb14-80ee87ef74a9
       x-ms-ratelimit-remaining-subscription-global-writes:
-      - '2999'
+      - '11999'
       x-ms-ratelimit-remaining-subscription-writes:
-      - '199'
+      - '799'
       x-msedge-ref:
-      - 'Ref A: EBCD3759591F40E0B9FEB717064AED6E Ref B: MAA201060514035 Ref C: 2025-03-11T04:47:11Z'
+      - 'Ref A: 38D08C2D3C0143EB91ED86D355882E9B Ref B: SYD03EDGE2106 Ref C: 2025-06-11T06:30:09Z'
     status:
       code: 200
       message: OK
@@ -226,7 +228,7 @@ interactions:
       ParameterSetName:
       - --vault-name -n --value
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: PUT
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1?api-version=7.4
   response:
@@ -241,7 +243,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:47:15 GMT
+      - Wed, 11 Jun 2025 06:30:11 GMT
       expires:
       - '-1'
       pragma:
@@ -249,16 +251,16 @@ interactions:
       strict-transport-security:
       - max-age=31536000;includeSubDomains
       www-authenticate:
-      - Bearer authorization="https://login.microsoftonline.com/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
+      - Bearer authorization="https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47",
         resource="https://vault.azure.net"
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.9;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
     status:
       code: 401
       message: Unauthorized
@@ -280,12 +282,12 @@ interactions:
       ParameterSetName:
       - --vault-name -n --value
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: PUT
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1?api-version=7.4
   response:
     body:
-      string: '{"value":"ABC123","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/f9557720362042d4954a56ac75da2726","attributes":{"enabled":true,"created":1741668435,"updated":1741668435,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-8"}}'
+      string: '{"value":"ABC123","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/97ed66c6ba334ce5acbb09208b4d0f21","attributes":{"enabled":true,"created":1749623412,"updated":1749623412,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-8"}}'
     headers:
       cache-control:
       - no-cache
@@ -294,7 +296,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:47:15 GMT
+      - Wed, 11 Jun 2025 06:30:11 GMT
       expires:
       - '-1'
       pragma:
@@ -304,11 +306,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.9;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
     status:
       code: 200
       message: OK
@@ -330,12 +332,12 @@ interactions:
       ParameterSetName:
       - --vault-name -n --value
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: PUT
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/secret2?api-version=7.4
   response:
     body:
-      string: '{"value":"123456","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret2/f5fb4d1fe02d43d496682677c38f52d0","attributes":{"enabled":true,"created":1741668436,"updated":1741668436,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-8"}}'
+      string: '{"value":"123456","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret2/703af807e12f42a581d01673e00092ae","attributes":{"enabled":true,"created":1749623413,"updated":1749623413,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-8"}}'
     headers:
       cache-control:
       - no-cache
@@ -344,7 +346,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:47:15 GMT
+      - Wed, 11 Jun 2025 06:30:12 GMT
       expires:
       - '-1'
       pragma:
@@ -354,11 +356,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.12;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
     status:
       code: 200
       message: OK
@@ -376,12 +378,12 @@ interactions:
       ParameterSetName:
       - --vault-name
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: GET
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets?api-version=7.4
   response:
     body:
-      string: '{"value":[{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1","attributes":{"enabled":true,"created":1741668435,"updated":1741668435,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-8"}},{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret2","attributes":{"enabled":true,"created":1741668436,"updated":1741668436,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'
+      string: '{"value":[{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1","attributes":{"enabled":true,"created":1749623412,"updated":1749623412,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-8"}},{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret2","attributes":{"enabled":true,"created":1749623413,"updated":1749623413,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'
     headers:
       cache-control:
       - no-cache
@@ -390,7 +392,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:47:17 GMT
+      - Wed, 11 Jun 2025 06:30:12 GMT
       expires:
       - '-1'
       pragma:
@@ -400,11 +402,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.12;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
     status:
       code: 200
       message: OK
@@ -422,12 +424,12 @@ interactions:
       ParameterSetName:
       - --vault-name --maxresults
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: GET
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets?maxresults=10&api-version=7.4
   response:
     body:
-      string: '{"value":[{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1","attributes":{"enabled":true,"created":1741668435,"updated":1741668435,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-8"}},{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret2","attributes":{"enabled":true,"created":1741668436,"updated":1741668436,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'
+      string: '{"value":[{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1","attributes":{"enabled":true,"created":1749623412,"updated":1749623412,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-8"}},{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret2","attributes":{"enabled":true,"created":1749623413,"updated":1749623413,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'
     headers:
       cache-control:
       - no-cache
@@ -436,7 +438,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:47:18 GMT
+      - Wed, 11 Jun 2025 06:30:14 GMT
       expires:
       - '-1'
       pragma:
@@ -446,11 +448,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.13;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
     status:
       code: 200
       message: OK
@@ -468,12 +470,12 @@ interactions:
       ParameterSetName:
       - --vault-name --maxresults
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: GET
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets?maxresults=1&api-version=7.4
   response:
     body:
-      string: '{"value":[{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1","attributes":{"enabled":true,"created":1741668435,"updated":1741668435,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-8"}}],"nextLink":"https://cli-test-kv-se-000002.vault.azure.net:443/secrets?api-version=7.4&$skiptoken=eyJOZXh0TWFya2VyIjoiMiE4MCFNREF3TURFMElYTmxZM0psZEM5VFJVTlNSVlF5SVRBd01EQXlPQ0U1T1RrNUxURXlMVE14VkRJek9qVTVPalU1TGprNU9UazVPVGxhSVEtLSIsIlRhcmdldExvY2F0aW9uIjowfQ&maxresults=1"}'
+      string: '{"value":[{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1","attributes":{"enabled":true,"created":1749623412,"updated":1749623412,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-8"}}],"nextLink":"https://cli-test-kv-se-000002.vault.azure.net:443/secrets?api-version=7.4&$skiptoken=eyJOZXh0TWFya2VyIjoiMiE4MCFNREF3TURFMElYTmxZM0psZEM5VFJVTlNSVlF5SVRBd01EQXlPQ0U1T1RrNUxURXlMVE14VkRJek9qVTVPalU1TGprNU9UazVPVGxhSVEtLSIsIlRhcmdldExvY2F0aW9uIjowfQ&maxresults=1"}'
     headers:
       cache-control:
       - no-cache
@@ -482,7 +484,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:47:18 GMT
+      - Wed, 11 Jun 2025 06:30:14 GMT
       expires:
       - '-1'
       pragma:
@@ -492,11 +494,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.8;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
     status:
       code: 200
       message: OK
@@ -514,12 +516,12 @@ interactions:
       ParameterSetName:
       - --vault-name --maxresults
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: GET
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets?api-version=7.4&$skiptoken=eyJOZXh0TWFya2VyIjoiMiE4MCFNREF3TURFMElYTmxZM0psZEM5VFJVTlNSVlF5SVRBd01EQXlPQ0U1T1RrNUxURXlMVE14VkRJek9qVTVPalU1TGprNU9UazVPVGxhSVEtLSIsIlRhcmdldExvY2F0aW9uIjowfQ&maxresults=1
   response:
     body:
-      string: '{"value":[{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret2","attributes":{"enabled":true,"created":1741668436,"updated":1741668436,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'
+      string: '{"value":[{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret2","attributes":{"enabled":true,"created":1749623413,"updated":1749623413,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'
     headers:
       cache-control:
       - no-cache
@@ -528,7 +530,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:47:18 GMT
+      - Wed, 11 Jun 2025 06:30:15 GMT
       expires:
       - '-1'
       pragma:
@@ -538,11 +540,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.8;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
     status:
       code: 200
       message: OK
@@ -565,12 +567,12 @@ interactions:
       ParameterSetName:
       - --vault-name -n --value --tags --description
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: PUT
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1?api-version=7.4
   response:
     body:
-      string: '{"value":"DEF456","contentType":"test type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/af59c589280e4294904564bb7e725666","attributes":{"enabled":true,"created":1741668440,"updated":1741668440,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"test":"foo","file-encoding":"utf-8"}}'
+      string: '{"value":"DEF456","contentType":"test type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/3cfb7ee08a124c7184c14b9cab5fc42b","attributes":{"enabled":true,"created":1749623415,"updated":1749623415,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"test":"foo","file-encoding":"utf-8"}}'
     headers:
       cache-control:
       - no-cache
@@ -579,7 +581,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:47:19 GMT
+      - Wed, 11 Jun 2025 06:30:15 GMT
       expires:
       - '-1'
       pragma:
@@ -589,11 +591,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.15;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
     status:
       code: 200
       message: OK
@@ -611,12 +613,12 @@ interactions:
       ParameterSetName:
       - --vault-name -n
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: GET
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/versions?api-version=7.4
   response:
     body:
-      string: '{"value":[{"contentType":"test type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/af59c589280e4294904564bb7e725666","attributes":{"enabled":true,"created":1741668440,"updated":1741668440,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"test":"foo","file-encoding":"utf-8"}},{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/f9557720362042d4954a56ac75da2726","attributes":{"enabled":true,"created":1741668435,"updated":1741668435,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'
+      string: '{"value":[{"contentType":"test type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/3cfb7ee08a124c7184c14b9cab5fc42b","attributes":{"enabled":true,"created":1749623415,"updated":1749623415,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"test":"foo","file-encoding":"utf-8"}},{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/97ed66c6ba334ce5acbb09208b4d0f21","attributes":{"enabled":true,"created":1749623412,"updated":1749623412,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'
     headers:
       cache-control:
       - no-cache
@@ -625,7 +627,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:47:20 GMT
+      - Wed, 11 Jun 2025 06:30:15 GMT
       expires:
       - '-1'
       pragma:
@@ -635,11 +637,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.9;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
     status:
       code: 200
       message: OK
@@ -657,12 +659,12 @@ interactions:
       ParameterSetName:
       - --vault-name -n --maxresults
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: GET
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/versions?maxresults=10&api-version=7.4
   response:
     body:
-      string: '{"value":[{"contentType":"test type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/af59c589280e4294904564bb7e725666","attributes":{"enabled":true,"created":1741668440,"updated":1741668440,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"test":"foo","file-encoding":"utf-8"}},{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/f9557720362042d4954a56ac75da2726","attributes":{"enabled":true,"created":1741668435,"updated":1741668435,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'
+      string: '{"value":[{"contentType":"test type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/3cfb7ee08a124c7184c14b9cab5fc42b","attributes":{"enabled":true,"created":1749623415,"updated":1749623415,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"test":"foo","file-encoding":"utf-8"}},{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/97ed66c6ba334ce5acbb09208b4d0f21","attributes":{"enabled":true,"created":1749623412,"updated":1749623412,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'
     headers:
       cache-control:
       - no-cache
@@ -671,7 +673,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:47:21 GMT
+      - Wed, 11 Jun 2025 06:30:17 GMT
       expires:
       - '-1'
       pragma:
@@ -681,11 +683,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.14;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
     status:
       code: 200
       message: OK
@@ -703,12 +705,12 @@ interactions:
       ParameterSetName:
       - --vault-name -n --maxresults
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: GET
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/versions?maxresults=1&api-version=7.4
   response:
     body:
-      string: '{"value":[{"contentType":"test type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/af59c589280e4294904564bb7e725666","attributes":{"enabled":true,"created":1741668440,"updated":1741668440,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"test":"foo","file-encoding":"utf-8"}}],"nextLink":"https://cli-test-kv-se-000002.vault.azure.net:443/secrets/secret1/versions?api-version=7.4&$skiptoken=eyJOZXh0TWFya2VyIjoiMiExMjQhTURBd01EUTNJWE5sWTNKbGRDOVRSVU5TUlZReEwwWTVOVFUzTnpJd016WXlNRFF5UkRRNU5UUkJOVFpCUXpjMVJFRXlOekkySVRBd01EQXlPQ0U1T1RrNUxURXlMVE14VkRJek9qVTVPalU1TGprNU9UazVPVGxhSVEtLSIsIlRhcmdldExvY2F0aW9uIjowfQ&maxresults=1"}'
+      string: '{"value":[{"contentType":"test type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/3cfb7ee08a124c7184c14b9cab5fc42b","attributes":{"enabled":true,"created":1749623415,"updated":1749623415,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"test":"foo","file-encoding":"utf-8"}}],"nextLink":"https://cli-test-kv-se-000002.vault.azure.net:443/secrets/secret1/versions?api-version=7.4&$skiptoken=eyJOZXh0TWFya2VyIjoiMiExMjQhTURBd01EUTNJWE5sWTNKbGRDOVRSVU5TUlZReEx6azNSVVEyTmtNMlFrRXpNelJEUlRWQlEwSkNNRGt5TURoQ05FUXdSakl4SVRBd01EQXlPQ0U1T1RrNUxURXlMVE14VkRJek9qVTVPalU1TGprNU9UazVPVGxhSVEtLSIsIlRhcmdldExvY2F0aW9uIjowfQ&maxresults=1"}'
     headers:
       cache-control:
       - no-cache
@@ -717,7 +719,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:47:21 GMT
+      - Wed, 11 Jun 2025 06:30:17 GMT
       expires:
       - '-1'
       pragma:
@@ -727,11 +729,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.14;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
     status:
       code: 200
       message: OK
@@ -749,12 +751,12 @@ interactions:
       ParameterSetName:
       - --vault-name -n --maxresults
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: GET
-    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/versions?api-version=7.4&$skiptoken=eyJOZXh0TWFya2VyIjoiMiExMjQhTURBd01EUTNJWE5sWTNKbGRDOVRSVU5TUlZReEwwWTVOVFUzTnpJd016WXlNRFF5UkRRNU5UUkJOVFpCUXpjMVJFRXlOekkySVRBd01EQXlPQ0U1T1RrNUxURXlMVE14VkRJek9qVTVPalU1TGprNU9UazVPVGxhSVEtLSIsIlRhcmdldExvY2F0aW9uIjowfQ&maxresults=1
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/versions?api-version=7.4&$skiptoken=eyJOZXh0TWFya2VyIjoiMiExMjQhTURBd01EUTNJWE5sWTNKbGRDOVRSVU5TUlZReEx6azNSVVEyTmtNMlFrRXpNelJEUlRWQlEwSkNNRGt5TURoQ05FUXdSakl4SVRBd01EQXlPQ0U1T1RrNUxURXlMVE14VkRJek9qVTVPalU1TGprNU9UazVPVGxhSVEtLSIsIlRhcmdldExvY2F0aW9uIjowfQ&maxresults=1
   response:
     body:
-      string: '{"value":[{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/f9557720362042d4954a56ac75da2726","attributes":{"enabled":true,"created":1741668435,"updated":1741668435,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'
+      string: '{"value":[{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/97ed66c6ba334ce5acbb09208b4d0f21","attributes":{"enabled":true,"created":1749623412,"updated":1749623412,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'
     headers:
       cache-control:
       - no-cache
@@ -763,7 +765,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:47:22 GMT
+      - Wed, 11 Jun 2025 06:30:17 GMT
       expires:
       - '-1'
       pragma:
@@ -773,11 +775,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.14;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
     status:
       code: 200
       message: OK
@@ -795,12 +797,12 @@ interactions:
       ParameterSetName:
       - --vault-name -n
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: GET
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/?api-version=7.4
   response:
     body:
-      string: '{"value":"DEF456","contentType":"test type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/af59c589280e4294904564bb7e725666","attributes":{"enabled":true,"created":1741668440,"updated":1741668440,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"test":"foo","file-encoding":"utf-8"}}'
+      string: '{"value":"DEF456","contentType":"test type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/3cfb7ee08a124c7184c14b9cab5fc42b","attributes":{"enabled":true,"created":1749623415,"updated":1749623415,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"test":"foo","file-encoding":"utf-8"}}'
     headers:
       cache-control:
       - no-cache
@@ -809,7 +811,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:47:23 GMT
+      - Wed, 11 Jun 2025 06:30:18 GMT
       expires:
       - '-1'
       pragma:
@@ -819,11 +821,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.12;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
     status:
       code: 200
       message: OK
@@ -841,12 +843,12 @@ interactions:
       ParameterSetName:
       - --vault-name -n -v
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: GET
-    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/f9557720362042d4954a56ac75da2726?api-version=7.4
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/97ed66c6ba334ce5acbb09208b4d0f21?api-version=7.4
   response:
     body:
-      string: '{"value":"ABC123","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/f9557720362042d4954a56ac75da2726","attributes":{"enabled":true,"created":1741668435,"updated":1741668435,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-8"}}'
+      string: '{"value":"ABC123","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/97ed66c6ba334ce5acbb09208b4d0f21","attributes":{"enabled":true,"created":1749623412,"updated":1749623412,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-8"}}'
     headers:
       cache-control:
       - no-cache
@@ -855,7 +857,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:47:24 GMT
+      - Wed, 11 Jun 2025 06:30:18 GMT
       expires:
       - '-1'
       pragma:
@@ -865,11 +867,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.12;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
     status:
       code: 200
       message: OK
@@ -887,12 +889,12 @@ interactions:
       ParameterSetName:
       - --id
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: GET
-    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/f9557720362042d4954a56ac75da2726?api-version=7.4
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/97ed66c6ba334ce5acbb09208b4d0f21?api-version=7.4
   response:
     body:
-      string: '{"value":"ABC123","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/f9557720362042d4954a56ac75da2726","attributes":{"enabled":true,"created":1741668435,"updated":1741668435,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-8"}}'
+      string: '{"value":"ABC123","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/97ed66c6ba334ce5acbb09208b4d0f21","attributes":{"enabled":true,"created":1749623412,"updated":1749623412,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-8"}}'
     headers:
       cache-control:
       - no-cache
@@ -901,7 +903,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:47:25 GMT
+      - Wed, 11 Jun 2025 06:30:19 GMT
       expires:
       - '-1'
       pragma:
@@ -911,11 +913,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.12;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
     status:
       code: 200
       message: OK
@@ -937,12 +939,12 @@ interactions:
       ParameterSetName:
       - --vault-name -n --enabled
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: PATCH
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/?api-version=7.4
   response:
     body:
-      string: '{"contentType":"test type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/af59c589280e4294904564bb7e725666","attributes":{"enabled":false,"created":1741668440,"updated":1741668446,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"test":"foo","file-encoding":"utf-8"}}'
+      string: '{"contentType":"test type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/3cfb7ee08a124c7184c14b9cab5fc42b","attributes":{"enabled":false,"created":1749623415,"updated":1749623420,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"test":"foo","file-encoding":"utf-8"}}'
     headers:
       cache-control:
       - no-cache
@@ -951,7 +953,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:47:25 GMT
+      - Wed, 11 Jun 2025 06:30:20 GMT
       expires:
       - '-1'
       pragma:
@@ -961,11 +963,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.14;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
     status:
       code: 200
       message: OK
@@ -985,12 +987,12 @@ interactions:
       ParameterSetName:
       - --vault-name -n --file
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: POST
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/backup?api-version=7.4
   response:
     body:
-      string: '{"value":"KUF6dXJlS2V5VmF1bHRTZWNyZXRCYWNrdXBWMS5taWNyb3NvZnQuY29tZXlKcmFXUWlPaUpqTURjeU0ySXpPQzAxWmpBM0xUUTNZVEl0T1RNeVppMHpaREZqT1RNNE9EQTBPVElpTENKaGJHY2lPaUpTVTBFdFQwRkZVQzB5TlRZaUxDSmxibU1pT2lKQk1qVTJRMEpETFVoVE5URXlJbjAuRnc4TmZxM21tZFRSMEJ5SF9VOXdBRXlYYVZlU0Q0WF9lT1l4R1pWbXJzSGFjTzZYbjZxWDhxSkQwQ1k1eElyVUI3UU5TR01UQmF1WFFsTy12YlcxUFJrNFowWFRKalM2RjJtSERZSDlTTDRXMWtiMlUtWjhvQVl0b25RUGQ4Ti10SXo2dlNjS2JJNlprS0dvY0c0UWhGdlZWemZyckFlYnBDRm4xT2pzTmowdXpsdHRYLXNvTVplTXJWWXNrUllOTy1GUlh2UzZSaXRIZm5qQmI3elhza2xXT04xSm1mdS0waFllNHdQdnRJTzNOU2RjV3ZMbUZTVzhlWHpscjRudXFaRVlyNU1oSjNad3JyZHgzWndqZ0d2QVpGekdKWkZ1dnZzWElsUm4xUnFvWDlUOVg2VDlzRXpnZTZJMVE5anZNelI4M21vZ2tZOEI3OVB3RDVJTmxFNDktQWoyR3pTQ3k4d1oyQ25QbEptaXNSQmFONW5MRjVINlI5cWc3WHVpODVOVzV2TjNUcnFvT21PRTM1YzVoaFQ1dTBUeDZjd0VyOFZIOFlxcG5XRGhySHduS3JSQUVicEROQllFLVR2STlDRFB1UUFaNnRnejFWRV9nQWpDTERGWkMzUk9ETmNzcEljMFY4WTJ2SkRIOW83ZmpIa1FDY1ZEVUdTU3ZUaVZlUnlJTVRCZ3RuNmk0M210dFcxU05hTXQtMGs3RUdqUFc2Yko5Ym5JbWlVOEVPWFlnU2NLMG5TblROZHZTNlRPVXpfYXdsQmpZSklYcjJWSUFKbTJ3X1lJSTBpdktLWEd3V1VnSkRDQV9rVTJuVWlaTlVnSFdNTHZsSFRtSzRyQ3V4Z2FPUXNZR09UX3gteUpqTFNmZERNdy1PajBtaERWdmY4SEhPNWV4d3cuZ05tSlRWLWN0dkpjYXlFSEJlTTU5dy52M0ZlZ3Q5eEdiMlJuOFJXZktwRFpCZ1BfbkljdUtIWXpyUklsOHhIYWIwd2dhaXFULXFKRkNXcWFPQnhTamVVZ3dhRDduNFJOMGwtM0c2elZlQl9QZzN2RVBWRjV4QXdqcDY5OTB6V2N5dC1MOV9jM3RKQVJTclhRU2g2ZVRwYmZwVGNReGh4Y2xKcFpHcFdRbFJPUlhXb0VqcENKeWFYd0lUUDZ0QVoxbXpLZmdoN2hwUlpOVm1OdWRhbXljNW9LQUg3cTA0amFxVWp2RERabWQ2b2hHSVRXTV9td2kwb2lsNW10WlA1VnVGWi1xVnN2TUd6SGI3dVRiYVd3b2tKMFphQl9RWDg4UE1GRVJjQkNjdlppNDVSdVEwTnpaU0JMQWd2bmsxZ2pHQXkwLUxoLTU5bmFOVnphMGx5RE8xZ2Q4dnpDZlFSa0kxWllFY2ZCMkNzd1QxSDR6cktoVnFxc2V5ZlFqMElMQUNHalo2SXZOZ1FSa2dzT29hSFB3UWsyaXhWQjZrRzhGYzFfdExMSnFacVVaVGFLZWk2NVk5WjBVOGxmdG05b1pEbE5HQl9MWnF5LTFIa3dPQzFZODV6N19vdnA0UllfVWhyTlVKY1hxRUh1bl9lR2pjU3N4Rlp2cXFXdTY5bktZc1dCalJsTVVwcjB1YldtZGxvUk80MFRaR3NPX21JTVJPb0RWVEVCYkRreXBsWFJ0N3F2aVhERzdBZEpBZ0ZUWlpEYkFuN21wOHBsSU5WNTMyaTVVeFZMeTVUcl9yQlpVQnBpeVdBZ3V6T1cyYmVpSk54bGVYb2ZHcnBSbFY1X3lZQzhNbVR0OThmQ1ZXV0NQQ3FqMGpzSXZmbWtoaGFJb1VZWVVGekRsRUNwdERrSDZ2dmNCTWdNMWhFanlrTktNYU5FY2RxcHRFMlo4UjI5a1FaSWlhRXc1dXFpVUh2YXV6eWl4UUFuVGFNRDNaNnZfN2JrNWxVN3FwVUFwc0tCV0dXZzJpaEY1dFFjM3cyRnpHOFRrNTVfSjNQSUk4cEJVc3VuRHlfWFQ1anVUSnk5T0ZoUXNQRVA5aVAyby1yTGpwSHZkcEVObTNqQ241OHlrSmdFZFFmckI2eEM5Z051c2FxM2hFMGE3VW5FRWZBOE9VUk1HaWVOWVZjU3A1SUdINzlYQnJWZEhBRVFoUHhrYWp1V1BlcnB0NWNJOElSTUU5OUVHcTdjYWlwYWZQTEd0WGJDVDhheGV0a3hQSVVCYXdSVWFsaWh5MVJob3EtTU55T25RdW9KN0ZfOHJMT3IxVTNUNzFmQWh6TE52dEdmTkdQb3hxLUJPdXhtSllDRTdMOV90dGVoV2ZLYXRBd3NDZ3FTXzFWaVg4ZFhNa2Q5cWlMb2x2eEU1MFg1MDhxeENDR0p5d1pYb3dHSzdUdHNBajlFSkkwV1d3cmpFVThwRHNlMWNjYXExaWh6WTV4blV3X3BhdkpZeDliYWNCdG1KMTdwaGs4WlBOazhhWnVpTW1lSkM3VFhRRDNaYW8yWVI2M3gwM1FxaHIxUTNZUy05d0NVcmNlU2lNaGpvSUF6WFluME16ZWF5QTZtV1p3ZmVybDE3MC1NcHBvNXhESVdqaG5oNHNxOU9tdVlHcTI4bGpBTHdkQVQwTEtoU2lKSFVmNTIzeEZ3a3R3NThTMDhwYzh6NlhwWVM0X3lnRnFPUU1aNlFndHZCZy1CcGEtREl2MEZ3SkN6Z28wcVFaTEhyaHNLcmRrcXlkeGw1MFhpQXFtdXZmUTZCRThUcEVFLWJBY1NVTFRSMnVpY1ZfazFqNGhQa0JtMnBGMXdtcnJGM3hoZ21CMGUtNFhYN19Fc29uMFZFTHhnVE92a2Q5dm1QWkF1VXRjTzNlM2ZtTWhSQ0xON2J2RGZaaGpMRGkzN1luU01VOE5nLUJITU1XaFdOLWFDazg5bnBqSHVRUzVUTXNZWnllR3g1YkZ0SjhRb0N1cEo3eXpGRnlwanhOM3pCcFd4WnIzcWNnR3o3ZHRzX190U3V6QTRBeHp2UHlmdDJ3X21zNHRrY2Q0cndxTVdNRnc4WVI2d3FlMXRHS2tDM0hiOGtLQWhRSnlkbUp6TmlVc3MyckxPUGV3QlRkaEp4T0FseW9RTEFFVExSdVdkYzllN2ttQXZrUVhZbTZ1WFNBNUxiaHl4eUNBbGpwZWN3TkU3aXFpVDd6cmRiREFmRkhJeG11NTRzOUdtWU5hS3lCdWRmd0w4czFPZTI0UlhmTm1NdlhiSl9faFlJdllTYXROR3pFV2VfRC1xWXpLZWl2aWVwcEFzS2U2NmRLRkRVbGJpRnR4TVBjamVzbDJpZzlHeFBxRGJoandOcU5qZHhGSXpvTWdIOXp1eXhndS1tYkFLNkN6TVNXRDl5bFlWZUIxOFJ5X2MzU0kxRnkyeE1aQ3RwdDJueE9LOXZLdDN1WnhZZ3VRVVR5YklNQ1JTZm1QWlJOWnZpWUtOckRqZlo3Z3VWQ0VOeEdMMlB3ZjNlZW1fNUtWOHJ1ZXhWSXJ4RVFjUi1lV2pIcWl2dWhhSDk3YnVkbWtRWnpKRUVQOVl5VUI1dW5pdU5IYkxBcmQ2NXhPYUNTR21wQnJfRXJ5MDZHZzZlc1FvWXFLS2NzckE4RXFSX0JENTdqVTdnSzR5bm9DcDhPcUpnbkNkQ1BQZ1B4VHBIY1VBUlhIOW1JY2s2Z0U1WG1wYnR0RThRb1BZdTJoSHQzSGNmaWhYbExsdkpWZG9URTMtN0NBbUdwa2UxWUI0dXJvWl9vR3hKWnRCcWNfYWdISEEySXpGNDJGR213dnF4bWt4NlNCbWVZNVFjT0tnNHlCMEx6NlF1b29DcXpvLXFQUl81OVBzM0FXbWEtS3Itdl90WWV1bTZSZXhWaTY0VzFYR3JUeFU0NnNBV0ZidU1QVVRSZDNUSUZZdHVsUFJsdHRKdFdyVFJ1SkVyNUJBSmpBVlB1TGlQdEdsVVFtZFRMN0N5LWRSYUJJTjhSaVE1QzNhU0ZEZ0dBVW1ET2JjM0phSTVfVk15eW1CTXNNX1VEZ0xjYTNkeG9iM2w3ZzVnRmFNczE0ZFczWkNnSlNXSTBYZ1d0MGZ5TGJBZWJIY19QajRtSmxWblRzTzJRaUV3eUZ0aE54UTVRazdkbnVDaDEzRXdBeUthMFNTZ3puN3JtZjdGMF85TldDSlRMQWVOdk5meXRzWjRFNWRINmJQQm8zNWhxOWphU1B0RGJ1Y1dsbm05NHhjWVFBZFNITThOVVlMaDBfel9zdlg2b0prTm9ROUdRazh6a3ExZHFOc3hiWGdSalFBRGZrWUR5ZXFlc1R1MVN4MS0zQmF0dThhckh3TWVrOFl6cEdaV0xzZGpTVUxkNnp4MnVnZlJjUmFzdTlRZDAwSDNYZHY3N1pvaTJKYndlNHpvSExKY0I2eEE5akJWMzdzSUJWYWZGOWdMM2Uxd2VCUWtfOG9Fc29Zb0VhWnNyTVNQTWlJYnZaUFdLMmZtdHhKTzFTeDhTMFdtWnJkVW1pbXgwYVFmdXpEX0RzRVRMWnFsajJPdTFCbFJXeHJtVmJnY2hLV2NVSGFGbjluczg4YnUtWUZVSi1yV2gtazdXRzZiYmNBQm5JbF9acy1jSWw3MVVCSy1vZzBhUU5Cb2ZnUzZ1a0R2dXo1NXc5N21meWZPazRHRGJoWkxFUUJkYXR0MlZvUFpiVXpHZDNyMlV4Z0JVdEpBSUMzcXpJN2VUNVVLSkRHeDNMWTNSSGpYVHRzaE42TzlTMWhTc1NSa3FYMFdvUEt3OVJna0RWUWNaQXpNYlBHdEVYMEE5OUZGd2hLZUpXc2JYMDlnUjBMSHduM1RXelVJRmhvRmdKR1BLZUFEVkZnYnRBc3hZVDcxTkJJZmhNNG5wSjFwVFBpcG9qR1EtaGkxZzRmYWdoQXc0eTRJMW4zRGR2QlI1cmF1QWtPQlJ1M2FHV2ZaMDlZblItMkZKelRsOGlzbW1KWHdYZVJyaWFHbkl0c0s3eDFwMlM4QU1WMmY0aHg3MzZaekUtQjhrQjZVQTlzZ0VLbHJzc2xNWUQ0U1Y4RUJpMEdhSmFvOE5ITXE1a0VnX05hZzcyTExESGVkRWVSMlEya3RXdkhaWTdFTHVkUU90WUdQWDFWdU1IVmJSdndTaU1oUUNSTHQ2ckI4dEZzdVhIVENSYllvNUtacFJiSW5HMHljakEyWWdnM05BTm5pLUFaQ0ZjM2NueWR1UWVhdEhUcW9aa09YMkRvZ01CY2hBbkU5WlVUNFlPOU9kR3paajVsQk5OUlZ4ZmJJMTJzdmZfOEw4WHNqTUF4dFRhVWVxTG9kYmxaZUtGMUlpU2Ria2ZaS0dGb1daZHc1Z09EQ055UlFHa3BfblMydVd3WlBvRkxpdnY3b1F3NktVdkxMZVdIYjhwVlJ5UTJlTDRQRFRXOGh5Z2tSblQ1WTdVcTVxZDl6V0RhMFJ3aE5vZGlfUVN0LThnck1ZVTRCRGV1dVh4b3pQV2dfOGsxUDRyWjRrb1VFbUs1S00xRzN3VHFGaHpoN0xPOElrTFRoc1c5QjN2U3pwNm1xSkhtZ2JBQV9jOUp3XzJIemhwRm9EazlfamFEc0xPRklLSy1PN3RObUdoVnFQaGQwUVBJTjZUTGtmVEtTS3JHaWNpSnIwLjJEMUdIcHR4SXRlSDZONlBwQmZXOWwwa0lFZkttWGtFZk02NlRfYzRNbWM"}'
+      string: '{"value":"KUF6dXJlS2V5VmF1bHRTZWNyZXRCYWNrdXBWMS5taWNyb3NvZnQuY29tZXlKcmFXUWlPaUpqTURjeU0ySXpPQzAxWmpBM0xUUTNZVEl0T1RNeVppMHpaREZqT1RNNE9EQTBPVElpTENKaGJHY2lPaUpTVTBFdFQwRkZVQzB5TlRZaUxDSmxibU1pT2lKQk1qVTJRMEpETFVoVE5URXlJbjAuTVpYSkdiZkJvLVJCNFloS2RXRzFTQlhkMjVUNTZXaWhIamltMVhHbWU4SE94bHczaWZ6UXVwWWJMNl9QdDNxQ24xMnNTWjNTQWhpdElGNlpSaENjUlQyNXZISEV4bmcyeWM3NUdWQzZmREdHa2hGakxtTFFQeU91S2M4NmxfanVkN1dsWnBmM3lkWnJKdnpHXzhSQ2kwcnd2eExuYWREUTFIQ1NMdk9WeW5Cc0hjX3VkdzlxRVdBRkp3YTY4cWtFT2dlNm1GbGVKb1p2LXdVWVVKRFMwUlN6U2xvWU96UTlaNDMydzh2aHYwNFV5Qy1UcnctY1BWcVlRRTRjOFF0b3ZpZDVxRE4wZ1pHbE93X25PQ3hwVkx6QUU4ZTg5VmRwekI4WUE5SEd2RDQ0TGhwR09GTWl0QUF2OUpqTTJxYzMweFJNMk51Uy1odFRBMmFpQV9hOVR3QVB4bUc5TzBMQWNfODdvTkpkbU5WdnRLYTZDek5EeHRxMXdHRE1VTGFteDJxUXJnd190NFZEU1d5TEdMM1lFaFdrQ2hLdGl5SHJBNDZITy1Yd0wzU3lFQzlHeDQ3TDNmQzJIeS14V1g5ajFzNFpZYTJTM3J1aVYzWlNoZkZtVWJ2b29vS0NNWTl4ekZrT3NoVjJPQnRkMXJrRXdkMjNjVnFKdjJseEVkMnY4UlN6ZkJHb2ttLTlPODRNb0tpVElyZ1hJY0hucURSOG4zaFVHT25hVFVXbHZIdWdPelFDdDJuNC1HbkNOQlRoWUJvMEJNdEFSR3FvaTU1cWJQNE9mOGhycGNtYXBkWGQydzJOS04zZ2RsdTBDYjZQdUh5QkpnY1NpUVdYaDZXWDcwNnRJQVh5SkF2Si0yczR0NVZnVFp3U1dqdEh5T01NSDVpejh3WHVRMzAucE5waHFOZEpCZEc5REtPNDFIX2dmZy5ycEpVejBTT2dFT2JZc2NLTnpDV3Q4cmJFVWtzeFJTQzVrM21SbV9QMVpmcDN4YlBlTUpoRXo0NWRnVWdQNmdLSGNZVFBYQmZjS3lWUXZyYWR2WExtM0VKd0tpT0FwWEhXTGJTOXV6OVl4UzlEcnJlRWZCMkFsYm05SjFjbWZNQnVsZWJmc01BNkd0UTBPdlU0OWg4azAtLXo0dWo2Wm95YkhTWDhWZ042ZDA0cjhaSjFlVDFqWGJvS0pnMmg2SkgwUndLMUdoam80WXI0RjdVUDNyVVVybFJuLTZ5Vk5NTXhFUDJqdE11UnBHMVNma0hpUlBBcmdQWE44b2g3OG5fLXpXN2x0c1QxWWRxSUwwSlZMT0RETVFzb05XV3YtTjlYVDVpZFNIZkUtOEtLSm1vMk9GQjZraTNVWFJxN3pXR3FKSE9XRHBtbkJEUVVUWnE0UlpFS0tNY0M1OFp5YnRNQ1Z3dzU0LS1kc1ZrQVZTZnFrd2NyX2FodXpzVG10cU5WUHdsZkxXRFZMZnJaWmFLWGQ2V2hZYTVEbFVyeXlzSTdBR1NKOEV5LWhaQXF0WGV5ZWFXZXo2bW4wd0FhZ0dLOUFXNk1JNW5Rdy1xcl85UUJpVGZ3UmN2YlVFR01Bc0lWdUpwZG5EZl92aU5lZG41eGdBNmdlVmtMUlhrRVZmcE5lTkJHV1FQcFBoWGp1OUF5WVJYTFllZ3dkbFB6V1JFRHp6WjFNQXFFOVhfZVJTNUdXQUVIRjVwM0NtcThjdm4xVXlfR0pZODBNQURqY2k2Z2oyMGpNRnpKV0lmMklfcnhrd1Y1TUEyMmY1dUpqY0pPVEpXMjRTSzRHY1c2T09KWFNEdmo0U1ZlSDhZbFNBSXhfY0JSSDN0dVF4b1ItR3ViVEN2dWRwbUxxMk43UHRZd3l1MDF6SmVMbU1qUmxjSXdnM1FkUzRZc3RGU0dzZ0R6Znl4RzhPV1htTndPcGpaNTJ4UjVRQjM3NUlPaXpSTG45RjRwQzJVRHY5NkJjeWkxU2pOS3pKTlVtUmpqd1hBWmZaaHdiRHB4SjEwS1FxU04tc0xObVdNNTlCLW9OT1hHN1VWQWY1Z3NDMnMxampucldtUk9yWDVDZGhlZWRfUG40YUZ2ZnVfbmdGakpld3o0ckZhMHFUX3hjX3lVQ0NNNk1TMm9YMXc4M2pHcE5idWxBcGQ0bzd3enJXUGpIcmVacHI2Z2t6U3FCVEJlWXp1cVZMSHBoVlRtVEMwQ2lxcy1PTmtsOWltalpYb0dONzROLXJVbHdZT2t2VEFQOGxxZDA2ZXYtUGJ1U1hLdlpkM0h3WVNjZG9rUUdRd1NkbUpZYlhndDVsWURjUkpxdGl3Q3lVcWlzcTM0Tjk5YzNsa0tMUEdMWXNNZi0zbUF4UHdYbHd2enFKcWdqd1BhSHktamxmeGFOcG1BOU5tdU5iSGQzLV9XaVg2Z1NFMHI0UWpsc1VDMTJIdzJ0bTVnd18zcC1BVnFTeXpVZng5Ri1oYXlGdHBfUlNaX1hGbC1XUEhaV2VOaFZsa3pWZGpYM1BuUHZDbmRtWUI2RU9UazZpWFRPcklhZEZVNm1YWnQtRG1uMG85LUVqRXA5eU5tLUxacEZEMVIwQko3azdGajd3RlVPdHl4UDNDemd0UVpxdkdoaHVFa3ZLR2lpT2lyUjdxaXU1TERzcmRsanZOSFc4Y1BENEk2YUJfckM0U0ROczVPLWdYRW9jcURVN1RjYUxZTGFVVWdWSjBPeE5HeUdBZTBLdWJxektPM1BBYl9HWE1xbnotNHMxdVBLejlyenhNbGZRUVo5NENwYWFQMXUxaFNGSFFLNmF6WkhXNy1ubEFRc09IZXpVWG1LSDV1d0xLMjNaVllGbmM5UEtPaHh4R2NNeTJFR3RGQk01T2t1cVEyWUQtZVA3SVgxWEM2eU1FN2FaN2FUSjBrNE9mVjBEN2N2eF82VFdtWkg0OHVIR1U4QVd5MXJvWUpvT25NTlF2dlBCR1kwOHcyZ0dOOFFaRG04TFRJeVUtZ1FVRklzeUFZWTZTalF3bV9xLTZHc2dtenRBS1RUbzgzbkhmWlRsaGZpMWRqSjlqRkVDdG4wZUxnSmxUaWhxNW81eEZndzZQVnM3QzVRVU9mRWxtY2dWeE5hampZOVlNdFZaTWFjXzh1bnhLRlRJLWwya0o1bFBUVDhISFdJYW42SWliQmluNFlaTmRDM2Myd21ZQXlCanIyaFFfQk1IcmQ0RVlfTVZtQzNuQWtLX0RpR25RSVl4WGVmc2kxeFRUcWZlaGJWakVPeDhQa1RBbTFMLVFqM1lYM0dfU3FYRWNvYTlQRk5uU0RnTEtoSnBycjRYbkh2bmpxYnJSV1lhbGZwc0xPWXhwbTBmRS1WYm1aQVhjb0pSRFA0QUptOGZ1eXM3Q0NFME4wUFhDeGYxbExJVzByakU2QjZJR2cxWHhCVnduUVBpd0NfaXhvbURmSUREOW01SWR1bWVWSC1MeW5LcWZaWUhVZFZPak1kWkNQM3VjZ3cyYmpMc0xzVl84RzN4bXNVZUk0SW02OGdfb1VFRG5qY05oNWV5VVVhcW1FYjhSU1BjMm15MGQxeFVEdTZwY1pnS0xfUm8xcGhmNWRucFE0RkRDVjcwZzg2Z3V3S3VwQTRQX2dmbUdBdl9WYkstbWV2NlQ3VEZHcGxBTmJnUndaZGNhbjVoZHJHYVdvSEFCT2E5SEVnSUo3d1hKZUdfa3B6dGxFM28tRVQ3R3RDWm5ZZUQ1aGp1TXktNmJHcHhpb0VYQzF2NUI4cUVybkwzcjBGQjlmNm5aODBzR1Nnd2lxMG5VNjUxVE5FMTVTOEhkUm96aHJwX1p0M1FyVGUtZ3ZndXkxVHM4b0txTzBJRi1TQXh0T0JmRWtjQkVDaHYzaE1rbG9DcFIzN1JDZVQ3M01CUlFFd3hOYkpUbTRPLU5xcy1IdHpsVjNHQm14Smt0dUJEME9xdWxVU0VDb2VLelh5Y0hyUTUyQUdOX09wMWFqQnJOZlpZZHJzWENqQ1Bqc3NlcTVaSzN2VFpFbkZuLXJVM0ZnemlhUjZUZnlLUVV3V2VEQmNBcVJKdDhPeG9CRDQxT216cXBXeklRSXBERmpWVkQzLTcxalc3ZDBLM3R3VDVuME1PcG43NXZ6LWNBSng5X0hNLXVNSVFwc3JGMG5FeXF3SVFMSHFCb3dkRHdDdWU2akZtSHc1RFluZEF4b3BUdUtRVnk3Rk1yTWItbWZWRmtJMEotbDk1YWZYSFBiZU9DWlNxdV9TY3h6Ump6a1l0VGJNTjZ0a1JrNlFGY1IzUldRVjc1ZHFEaUV3RGJndnQ1a2RncWx5ZC1ZeFJQRU1hQ0V0Mzd3NVFKSzlRTFkyMVFVLXhBNXpqcGl0T2VMeGJLamFjSV84VlBZTWZNX1dtNjVvT0ZUWHB4WG1WLWItckU4aXpCV0NJZC0ycnI4aTVnVWprWUZSOWp1Q1BSVGphNk8xekxBU3RnU1lMUk00S2NfaU5OS2FJZkVqZElRbjdFa3liZGstVkMxWDhEcGFLRUg1b21XNDg0b3ctNVFPaWh4UG9OS3dwamQxMUdDbmZSbTZXa292bVBfUUt6c01BbFlSelNqSFZya3VJQ0pBQmNHR0hRZUpyRXNFMnFfQmRfdE53ODUzcjM1cmRwV0JRQ2J5Q1dZMDdEVVF6em1CVFZsQlFjaVZaWmxnLUZpWTVUdUxJSGF0Z1dXQy1NOEoyUXVTZG4xUU5tdmpCcklNVUsxcmpQTmdYUG9OVk9YVnZzaFdYeEpPTG1JUE5HV1dOenBWWlk2bW05RDVXbjRmMGNzZWEwNTdNdnVkaGc5Q1hvQXFPcEdXNkhSZWFMNndhbDZWSUNHMW1GcTFUb21ZdFBHTnphNzVRX0Y0Qmx0QzVyQWkzcThEcldPVHV4N05GQWF4N29idmZRZm5GdGZack1hOVZ1eUF3aXZlR0hiaFo4ZElnNGptaTFWQW5SV3h5TkdLZmxIdnhmX2xpbkt0OVZLYmNMZXZwYnFCMWYyaVlxaWY4bnYzVTBhcmMxLTduQjR5S3NoeUhJT3ZtYWNOYjBpSW5laXVrVGFDZklrcjJueHdGSVJtNTl3TDUxa2VDZ2RfcjlwTWhCN0luc2NINFRzU0N2V2pWMDdiNmc4UHZYNlBxUTcwUDFfaHhOTGRkNkxQUGZtWlJUWGhRd0VCVXJLdUJVOE9KbXFJWTdDVnp3VXpUaVVaQmp0S050ODlXaXo0Uno2MDhkXzBMYVluTlU4SG5MdV9kNnF4SFVzMzZOanUxRlB0Ym52NjFMUFRhZnlwYnhDamlvWlhEVF9pVmdMb1FFTXRaTG0zcWx4QlVxR1VwS1lUZUsyRzBEUmhRZU1EZ2xud0tjSEV3Z0ZKYXFqSFNncWM1eVB1aHdsYUFiVDhobERkQlcycTA2RG96b3hzVXJMMGJ0YkxoT0tlRS1pOHlrMEIwb0FxMk9UanhGamVwbVZldTZUTVVDUHVpY3N2UW1ieXljem1lOU51ZUJJOXVicVl1NW0yRDMwbDBiREFVRTR0dE9SUWNwb2cyWmpjTlAwZXV5SXZlTUd5Q2lFQnppYmFtNGpabElROFlucU9wWGZYZUFtMGlHMTIzWjFpUGoxMm1yNlJ3LnRjdFdJY01sMFNkM1lBMHYyYkQ3YV9PNU50b3hWbjZSZmdybDd2d2JUaTQ"}'
     headers:
       cache-control:
       - no-cache
@@ -999,7 +1001,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:47:26 GMT
+      - Wed, 11 Jun 2025 06:30:20 GMT
       expires:
       - '-1'
       pragma:
@@ -1009,11 +1011,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.12;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
     status:
       code: 200
       message: OK
@@ -1033,13 +1035,13 @@ interactions:
       ParameterSetName:
       - --vault-name -n
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: DELETE
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1?api-version=7.4
   response:
     body:
-      string: '{"recoveryId":"https://cli-test-kv-se-000002.vault.azure.net/deletedsecrets/secret1","deletedDate":1741668448,"scheduledPurgeDate":1742273248,"contentType":"test
-        type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/af59c589280e4294904564bb7e725666","attributes":{"enabled":false,"created":1741668440,"updated":1741668446,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"test":"foo","file-encoding":"utf-8"}}'
+      string: '{"recoveryId":"https://cli-test-kv-se-000002.vault.azure.net/deletedsecrets/secret1","deletedDate":1749623422,"scheduledPurgeDate":1750228222,"contentType":"test
+        type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/3cfb7ee08a124c7184c14b9cab5fc42b","attributes":{"enabled":false,"created":1749623415,"updated":1749623420,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"test":"foo","file-encoding":"utf-8"}}'
     headers:
       cache-control:
       - no-cache
@@ -1048,7 +1050,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:47:27 GMT
+      - Wed, 11 Jun 2025 06:30:21 GMT
       expires:
       - '-1'
       pragma:
@@ -1058,11 +1060,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.8;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
     status:
       code: 200
       message: OK
@@ -1082,7 +1084,7 @@ interactions:
       ParameterSetName:
       - --vault-name -n
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: DELETE
     uri: https://cli-test-kv-se-000002.vault.azure.net/deletedsecrets/secret1?api-version=7.4
   response:
@@ -1092,7 +1094,7 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Tue, 11 Mar 2025 04:48:28 GMT
+      - Wed, 11 Jun 2025 06:31:22 GMT
       expires:
       - '-1'
       pragma:
@@ -1102,11 +1104,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.12;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
     status:
       code: 204
       message: No Content
@@ -1126,12 +1128,12 @@ interactions:
       ParameterSetName:
       - --vault-name -n
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: DELETE
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/secret2?api-version=7.4
   response:
     body:
-      string: '{"recoveryId":"https://cli-test-kv-se-000002.vault.azure.net/deletedsecrets/secret2","deletedDate":1741668570,"scheduledPurgeDate":1742273370,"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret2/f5fb4d1fe02d43d496682677c38f52d0","attributes":{"enabled":true,"created":1741668436,"updated":1741668436,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-8"}}'
+      string: '{"recoveryId":"https://cli-test-kv-se-000002.vault.azure.net/deletedsecrets/secret2","deletedDate":1749623543,"scheduledPurgeDate":1750228343,"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret2/703af807e12f42a581d01673e00092ae","attributes":{"enabled":true,"created":1749623413,"updated":1749623413,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-8"}}'
     headers:
       cache-control:
       - no-cache
@@ -1140,7 +1142,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:49:30 GMT
+      - Wed, 11 Jun 2025 06:32:23 GMT
       expires:
       - '-1'
       pragma:
@@ -1150,11 +1152,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.10;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
     status:
       code: 200
       message: OK
@@ -1172,7 +1174,7 @@ interactions:
       ParameterSetName:
       - --vault-name
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: GET
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets?api-version=7.4
   response:
@@ -1186,7 +1188,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:49:30 GMT
+      - Wed, 11 Jun 2025 06:32:24 GMT
       expires:
       - '-1'
       pragma:
@@ -1196,16 +1198,16 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.8;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
     status:
       code: 200
       message: OK
 - request:
-    body: '{"value": "KUF6dXJlS2V5VmF1bHRTZWNyZXRCYWNrdXBWMS5taWNyb3NvZnQuY29tZXlKcmFXUWlPaUpqTURjeU0ySXpPQzAxWmpBM0xUUTNZVEl0T1RNeVppMHpaREZqT1RNNE9EQTBPVElpTENKaGJHY2lPaUpTVTBFdFQwRkZVQzB5TlRZaUxDSmxibU1pT2lKQk1qVTJRMEpETFVoVE5URXlJbjAuRnc4TmZxM21tZFRSMEJ5SF9VOXdBRXlYYVZlU0Q0WF9lT1l4R1pWbXJzSGFjTzZYbjZxWDhxSkQwQ1k1eElyVUI3UU5TR01UQmF1WFFsTy12YlcxUFJrNFowWFRKalM2RjJtSERZSDlTTDRXMWtiMlUtWjhvQVl0b25RUGQ4Ti10SXo2dlNjS2JJNlprS0dvY0c0UWhGdlZWemZyckFlYnBDRm4xT2pzTmowdXpsdHRYLXNvTVplTXJWWXNrUllOTy1GUlh2UzZSaXRIZm5qQmI3elhza2xXT04xSm1mdS0waFllNHdQdnRJTzNOU2RjV3ZMbUZTVzhlWHpscjRudXFaRVlyNU1oSjNad3JyZHgzWndqZ0d2QVpGekdKWkZ1dnZzWElsUm4xUnFvWDlUOVg2VDlzRXpnZTZJMVE5anZNelI4M21vZ2tZOEI3OVB3RDVJTmxFNDktQWoyR3pTQ3k4d1oyQ25QbEptaXNSQmFONW5MRjVINlI5cWc3WHVpODVOVzV2TjNUcnFvT21PRTM1YzVoaFQ1dTBUeDZjd0VyOFZIOFlxcG5XRGhySHduS3JSQUVicEROQllFLVR2STlDRFB1UUFaNnRnejFWRV9nQWpDTERGWkMzUk9ETmNzcEljMFY4WTJ2SkRIOW83ZmpIa1FDY1ZEVUdTU3ZUaVZlUnlJTVRCZ3RuNmk0M210dFcxU05hTXQtMGs3RUdqUFc2Yko5Ym5JbWlVOEVPWFlnU2NLMG5TblROZHZTNlRPVXpfYXdsQmpZSklYcjJWSUFKbTJ3X1lJSTBpdktLWEd3V1VnSkRDQV9rVTJuVWlaTlVnSFdNTHZsSFRtSzRyQ3V4Z2FPUXNZR09UX3gteUpqTFNmZERNdy1PajBtaERWdmY4SEhPNWV4d3cuZ05tSlRWLWN0dkpjYXlFSEJlTTU5dy52M0ZlZ3Q5eEdiMlJuOFJXZktwRFpCZ1BfbkljdUtIWXpyUklsOHhIYWIwd2dhaXFULXFKRkNXcWFPQnhTamVVZ3dhRDduNFJOMGwtM0c2elZlQl9QZzN2RVBWRjV4QXdqcDY5OTB6V2N5dC1MOV9jM3RKQVJTclhRU2g2ZVRwYmZwVGNReGh4Y2xKcFpHcFdRbFJPUlhXb0VqcENKeWFYd0lUUDZ0QVoxbXpLZmdoN2hwUlpOVm1OdWRhbXljNW9LQUg3cTA0amFxVWp2RERabWQ2b2hHSVRXTV9td2kwb2lsNW10WlA1VnVGWi1xVnN2TUd6SGI3dVRiYVd3b2tKMFphQl9RWDg4UE1GRVJjQkNjdlppNDVSdVEwTnpaU0JMQWd2bmsxZ2pHQXkwLUxoLTU5bmFOVnphMGx5RE8xZ2Q4dnpDZlFSa0kxWllFY2ZCMkNzd1QxSDR6cktoVnFxc2V5ZlFqMElMQUNHalo2SXZOZ1FSa2dzT29hSFB3UWsyaXhWQjZrRzhGYzFfdExMSnFacVVaVGFLZWk2NVk5WjBVOGxmdG05b1pEbE5HQl9MWnF5LTFIa3dPQzFZODV6N19vdnA0UllfVWhyTlVKY1hxRUh1bl9lR2pjU3N4Rlp2cXFXdTY5bktZc1dCalJsTVVwcjB1YldtZGxvUk80MFRaR3NPX21JTVJPb0RWVEVCYkRreXBsWFJ0N3F2aVhERzdBZEpBZ0ZUWlpEYkFuN21wOHBsSU5WNTMyaTVVeFZMeTVUcl9yQlpVQnBpeVdBZ3V6T1cyYmVpSk54bGVYb2ZHcnBSbFY1X3lZQzhNbVR0OThmQ1ZXV0NQQ3FqMGpzSXZmbWtoaGFJb1VZWVVGekRsRUNwdERrSDZ2dmNCTWdNMWhFanlrTktNYU5FY2RxcHRFMlo4UjI5a1FaSWlhRXc1dXFpVUh2YXV6eWl4UUFuVGFNRDNaNnZfN2JrNWxVN3FwVUFwc0tCV0dXZzJpaEY1dFFjM3cyRnpHOFRrNTVfSjNQSUk4cEJVc3VuRHlfWFQ1anVUSnk5T0ZoUXNQRVA5aVAyby1yTGpwSHZkcEVObTNqQ241OHlrSmdFZFFmckI2eEM5Z051c2FxM2hFMGE3VW5FRWZBOE9VUk1HaWVOWVZjU3A1SUdINzlYQnJWZEhBRVFoUHhrYWp1V1BlcnB0NWNJOElSTUU5OUVHcTdjYWlwYWZQTEd0WGJDVDhheGV0a3hQSVVCYXdSVWFsaWh5MVJob3EtTU55T25RdW9KN0ZfOHJMT3IxVTNUNzFmQWh6TE52dEdmTkdQb3hxLUJPdXhtSllDRTdMOV90dGVoV2ZLYXRBd3NDZ3FTXzFWaVg4ZFhNa2Q5cWlMb2x2eEU1MFg1MDhxeENDR0p5d1pYb3dHSzdUdHNBajlFSkkwV1d3cmpFVThwRHNlMWNjYXExaWh6WTV4blV3X3BhdkpZeDliYWNCdG1KMTdwaGs4WlBOazhhWnVpTW1lSkM3VFhRRDNaYW8yWVI2M3gwM1FxaHIxUTNZUy05d0NVcmNlU2lNaGpvSUF6WFluME16ZWF5QTZtV1p3ZmVybDE3MC1NcHBvNXhESVdqaG5oNHNxOU9tdVlHcTI4bGpBTHdkQVQwTEtoU2lKSFVmNTIzeEZ3a3R3NThTMDhwYzh6NlhwWVM0X3lnRnFPUU1aNlFndHZCZy1CcGEtREl2MEZ3SkN6Z28wcVFaTEhyaHNLcmRrcXlkeGw1MFhpQXFtdXZmUTZCRThUcEVFLWJBY1NVTFRSMnVpY1ZfazFqNGhQa0JtMnBGMXdtcnJGM3hoZ21CMGUtNFhYN19Fc29uMFZFTHhnVE92a2Q5dm1QWkF1VXRjTzNlM2ZtTWhSQ0xON2J2RGZaaGpMRGkzN1luU01VOE5nLUJITU1XaFdOLWFDazg5bnBqSHVRUzVUTXNZWnllR3g1YkZ0SjhRb0N1cEo3eXpGRnlwanhOM3pCcFd4WnIzcWNnR3o3ZHRzX190U3V6QTRBeHp2UHlmdDJ3X21zNHRrY2Q0cndxTVdNRnc4WVI2d3FlMXRHS2tDM0hiOGtLQWhRSnlkbUp6TmlVc3MyckxPUGV3QlRkaEp4T0FseW9RTEFFVExSdVdkYzllN2ttQXZrUVhZbTZ1WFNBNUxiaHl4eUNBbGpwZWN3TkU3aXFpVDd6cmRiREFmRkhJeG11NTRzOUdtWU5hS3lCdWRmd0w4czFPZTI0UlhmTm1NdlhiSl9faFlJdllTYXROR3pFV2VfRC1xWXpLZWl2aWVwcEFzS2U2NmRLRkRVbGJpRnR4TVBjamVzbDJpZzlHeFBxRGJoandOcU5qZHhGSXpvTWdIOXp1eXhndS1tYkFLNkN6TVNXRDl5bFlWZUIxOFJ5X2MzU0kxRnkyeE1aQ3RwdDJueE9LOXZLdDN1WnhZZ3VRVVR5YklNQ1JTZm1QWlJOWnZpWUtOckRqZlo3Z3VWQ0VOeEdMMlB3ZjNlZW1fNUtWOHJ1ZXhWSXJ4RVFjUi1lV2pIcWl2dWhhSDk3YnVkbWtRWnpKRUVQOVl5VUI1dW5pdU5IYkxBcmQ2NXhPYUNTR21wQnJfRXJ5MDZHZzZlc1FvWXFLS2NzckE4RXFSX0JENTdqVTdnSzR5bm9DcDhPcUpnbkNkQ1BQZ1B4VHBIY1VBUlhIOW1JY2s2Z0U1WG1wYnR0RThRb1BZdTJoSHQzSGNmaWhYbExsdkpWZG9URTMtN0NBbUdwa2UxWUI0dXJvWl9vR3hKWnRCcWNfYWdISEEySXpGNDJGR213dnF4bWt4NlNCbWVZNVFjT0tnNHlCMEx6NlF1b29DcXpvLXFQUl81OVBzM0FXbWEtS3Itdl90WWV1bTZSZXhWaTY0VzFYR3JUeFU0NnNBV0ZidU1QVVRSZDNUSUZZdHVsUFJsdHRKdFdyVFJ1SkVyNUJBSmpBVlB1TGlQdEdsVVFtZFRMN0N5LWRSYUJJTjhSaVE1QzNhU0ZEZ0dBVW1ET2JjM0phSTVfVk15eW1CTXNNX1VEZ0xjYTNkeG9iM2w3ZzVnRmFNczE0ZFczWkNnSlNXSTBYZ1d0MGZ5TGJBZWJIY19QajRtSmxWblRzTzJRaUV3eUZ0aE54UTVRazdkbnVDaDEzRXdBeUthMFNTZ3puN3JtZjdGMF85TldDSlRMQWVOdk5meXRzWjRFNWRINmJQQm8zNWhxOWphU1B0RGJ1Y1dsbm05NHhjWVFBZFNITThOVVlMaDBfel9zdlg2b0prTm9ROUdRazh6a3ExZHFOc3hiWGdSalFBRGZrWUR5ZXFlc1R1MVN4MS0zQmF0dThhckh3TWVrOFl6cEdaV0xzZGpTVUxkNnp4MnVnZlJjUmFzdTlRZDAwSDNYZHY3N1pvaTJKYndlNHpvSExKY0I2eEE5akJWMzdzSUJWYWZGOWdMM2Uxd2VCUWtfOG9Fc29Zb0VhWnNyTVNQTWlJYnZaUFdLMmZtdHhKTzFTeDhTMFdtWnJkVW1pbXgwYVFmdXpEX0RzRVRMWnFsajJPdTFCbFJXeHJtVmJnY2hLV2NVSGFGbjluczg4YnUtWUZVSi1yV2gtazdXRzZiYmNBQm5JbF9acy1jSWw3MVVCSy1vZzBhUU5Cb2ZnUzZ1a0R2dXo1NXc5N21meWZPazRHRGJoWkxFUUJkYXR0MlZvUFpiVXpHZDNyMlV4Z0JVdEpBSUMzcXpJN2VUNVVLSkRHeDNMWTNSSGpYVHRzaE42TzlTMWhTc1NSa3FYMFdvUEt3OVJna0RWUWNaQXpNYlBHdEVYMEE5OUZGd2hLZUpXc2JYMDlnUjBMSHduM1RXelVJRmhvRmdKR1BLZUFEVkZnYnRBc3hZVDcxTkJJZmhNNG5wSjFwVFBpcG9qR1EtaGkxZzRmYWdoQXc0eTRJMW4zRGR2QlI1cmF1QWtPQlJ1M2FHV2ZaMDlZblItMkZKelRsOGlzbW1KWHdYZVJyaWFHbkl0c0s3eDFwMlM4QU1WMmY0aHg3MzZaekUtQjhrQjZVQTlzZ0VLbHJzc2xNWUQ0U1Y4RUJpMEdhSmFvOE5ITXE1a0VnX05hZzcyTExESGVkRWVSMlEya3RXdkhaWTdFTHVkUU90WUdQWDFWdU1IVmJSdndTaU1oUUNSTHQ2ckI4dEZzdVhIVENSYllvNUtacFJiSW5HMHljakEyWWdnM05BTm5pLUFaQ0ZjM2NueWR1UWVhdEhUcW9aa09YMkRvZ01CY2hBbkU5WlVUNFlPOU9kR3paajVsQk5OUlZ4ZmJJMTJzdmZfOEw4WHNqTUF4dFRhVWVxTG9kYmxaZUtGMUlpU2Ria2ZaS0dGb1daZHc1Z09EQ055UlFHa3BfblMydVd3WlBvRkxpdnY3b1F3NktVdkxMZVdIYjhwVlJ5UTJlTDRQRFRXOGh5Z2tSblQ1WTdVcTVxZDl6V0RhMFJ3aE5vZGlfUVN0LThnck1ZVTRCRGV1dVh4b3pQV2dfOGsxUDRyWjRrb1VFbUs1S00xRzN3VHFGaHpoN0xPOElrTFRoc1c5QjN2U3pwNm1xSkhtZ2JBQV9jOUp3XzJIemhwRm9EazlfamFEc0xPRklLSy1PN3RObUdoVnFQaGQwUVBJTjZUTGtmVEtTS3JHaWNpSnIwLjJEMUdIcHR4SXRlSDZONlBwQmZXOWwwa0lFZkttWGtFZk02NlRfYzRNbWM"}'
+    body: '{"value": "KUF6dXJlS2V5VmF1bHRTZWNyZXRCYWNrdXBWMS5taWNyb3NvZnQuY29tZXlKcmFXUWlPaUpqTURjeU0ySXpPQzAxWmpBM0xUUTNZVEl0T1RNeVppMHpaREZqT1RNNE9EQTBPVElpTENKaGJHY2lPaUpTVTBFdFQwRkZVQzB5TlRZaUxDSmxibU1pT2lKQk1qVTJRMEpETFVoVE5URXlJbjAuTVpYSkdiZkJvLVJCNFloS2RXRzFTQlhkMjVUNTZXaWhIamltMVhHbWU4SE94bHczaWZ6UXVwWWJMNl9QdDNxQ24xMnNTWjNTQWhpdElGNlpSaENjUlQyNXZISEV4bmcyeWM3NUdWQzZmREdHa2hGakxtTFFQeU91S2M4NmxfanVkN1dsWnBmM3lkWnJKdnpHXzhSQ2kwcnd2eExuYWREUTFIQ1NMdk9WeW5Cc0hjX3VkdzlxRVdBRkp3YTY4cWtFT2dlNm1GbGVKb1p2LXdVWVVKRFMwUlN6U2xvWU96UTlaNDMydzh2aHYwNFV5Qy1UcnctY1BWcVlRRTRjOFF0b3ZpZDVxRE4wZ1pHbE93X25PQ3hwVkx6QUU4ZTg5VmRwekI4WUE5SEd2RDQ0TGhwR09GTWl0QUF2OUpqTTJxYzMweFJNMk51Uy1odFRBMmFpQV9hOVR3QVB4bUc5TzBMQWNfODdvTkpkbU5WdnRLYTZDek5EeHRxMXdHRE1VTGFteDJxUXJnd190NFZEU1d5TEdMM1lFaFdrQ2hLdGl5SHJBNDZITy1Yd0wzU3lFQzlHeDQ3TDNmQzJIeS14V1g5ajFzNFpZYTJTM3J1aVYzWlNoZkZtVWJ2b29vS0NNWTl4ekZrT3NoVjJPQnRkMXJrRXdkMjNjVnFKdjJseEVkMnY4UlN6ZkJHb2ttLTlPODRNb0tpVElyZ1hJY0hucURSOG4zaFVHT25hVFVXbHZIdWdPelFDdDJuNC1HbkNOQlRoWUJvMEJNdEFSR3FvaTU1cWJQNE9mOGhycGNtYXBkWGQydzJOS04zZ2RsdTBDYjZQdUh5QkpnY1NpUVdYaDZXWDcwNnRJQVh5SkF2Si0yczR0NVZnVFp3U1dqdEh5T01NSDVpejh3WHVRMzAucE5waHFOZEpCZEc5REtPNDFIX2dmZy5ycEpVejBTT2dFT2JZc2NLTnpDV3Q4cmJFVWtzeFJTQzVrM21SbV9QMVpmcDN4YlBlTUpoRXo0NWRnVWdQNmdLSGNZVFBYQmZjS3lWUXZyYWR2WExtM0VKd0tpT0FwWEhXTGJTOXV6OVl4UzlEcnJlRWZCMkFsYm05SjFjbWZNQnVsZWJmc01BNkd0UTBPdlU0OWg4azAtLXo0dWo2Wm95YkhTWDhWZ042ZDA0cjhaSjFlVDFqWGJvS0pnMmg2SkgwUndLMUdoam80WXI0RjdVUDNyVVVybFJuLTZ5Vk5NTXhFUDJqdE11UnBHMVNma0hpUlBBcmdQWE44b2g3OG5fLXpXN2x0c1QxWWRxSUwwSlZMT0RETVFzb05XV3YtTjlYVDVpZFNIZkUtOEtLSm1vMk9GQjZraTNVWFJxN3pXR3FKSE9XRHBtbkJEUVVUWnE0UlpFS0tNY0M1OFp5YnRNQ1Z3dzU0LS1kc1ZrQVZTZnFrd2NyX2FodXpzVG10cU5WUHdsZkxXRFZMZnJaWmFLWGQ2V2hZYTVEbFVyeXlzSTdBR1NKOEV5LWhaQXF0WGV5ZWFXZXo2bW4wd0FhZ0dLOUFXNk1JNW5Rdy1xcl85UUJpVGZ3UmN2YlVFR01Bc0lWdUpwZG5EZl92aU5lZG41eGdBNmdlVmtMUlhrRVZmcE5lTkJHV1FQcFBoWGp1OUF5WVJYTFllZ3dkbFB6V1JFRHp6WjFNQXFFOVhfZVJTNUdXQUVIRjVwM0NtcThjdm4xVXlfR0pZODBNQURqY2k2Z2oyMGpNRnpKV0lmMklfcnhrd1Y1TUEyMmY1dUpqY0pPVEpXMjRTSzRHY1c2T09KWFNEdmo0U1ZlSDhZbFNBSXhfY0JSSDN0dVF4b1ItR3ViVEN2dWRwbUxxMk43UHRZd3l1MDF6SmVMbU1qUmxjSXdnM1FkUzRZc3RGU0dzZ0R6Znl4RzhPV1htTndPcGpaNTJ4UjVRQjM3NUlPaXpSTG45RjRwQzJVRHY5NkJjeWkxU2pOS3pKTlVtUmpqd1hBWmZaaHdiRHB4SjEwS1FxU04tc0xObVdNNTlCLW9OT1hHN1VWQWY1Z3NDMnMxampucldtUk9yWDVDZGhlZWRfUG40YUZ2ZnVfbmdGakpld3o0ckZhMHFUX3hjX3lVQ0NNNk1TMm9YMXc4M2pHcE5idWxBcGQ0bzd3enJXUGpIcmVacHI2Z2t6U3FCVEJlWXp1cVZMSHBoVlRtVEMwQ2lxcy1PTmtsOWltalpYb0dONzROLXJVbHdZT2t2VEFQOGxxZDA2ZXYtUGJ1U1hLdlpkM0h3WVNjZG9rUUdRd1NkbUpZYlhndDVsWURjUkpxdGl3Q3lVcWlzcTM0Tjk5YzNsa0tMUEdMWXNNZi0zbUF4UHdYbHd2enFKcWdqd1BhSHktamxmeGFOcG1BOU5tdU5iSGQzLV9XaVg2Z1NFMHI0UWpsc1VDMTJIdzJ0bTVnd18zcC1BVnFTeXpVZng5Ri1oYXlGdHBfUlNaX1hGbC1XUEhaV2VOaFZsa3pWZGpYM1BuUHZDbmRtWUI2RU9UazZpWFRPcklhZEZVNm1YWnQtRG1uMG85LUVqRXA5eU5tLUxacEZEMVIwQko3azdGajd3RlVPdHl4UDNDemd0UVpxdkdoaHVFa3ZLR2lpT2lyUjdxaXU1TERzcmRsanZOSFc4Y1BENEk2YUJfckM0U0ROczVPLWdYRW9jcURVN1RjYUxZTGFVVWdWSjBPeE5HeUdBZTBLdWJxektPM1BBYl9HWE1xbnotNHMxdVBLejlyenhNbGZRUVo5NENwYWFQMXUxaFNGSFFLNmF6WkhXNy1ubEFRc09IZXpVWG1LSDV1d0xLMjNaVllGbmM5UEtPaHh4R2NNeTJFR3RGQk01T2t1cVEyWUQtZVA3SVgxWEM2eU1FN2FaN2FUSjBrNE9mVjBEN2N2eF82VFdtWkg0OHVIR1U4QVd5MXJvWUpvT25NTlF2dlBCR1kwOHcyZ0dOOFFaRG04TFRJeVUtZ1FVRklzeUFZWTZTalF3bV9xLTZHc2dtenRBS1RUbzgzbkhmWlRsaGZpMWRqSjlqRkVDdG4wZUxnSmxUaWhxNW81eEZndzZQVnM3QzVRVU9mRWxtY2dWeE5hampZOVlNdFZaTWFjXzh1bnhLRlRJLWwya0o1bFBUVDhISFdJYW42SWliQmluNFlaTmRDM2Myd21ZQXlCanIyaFFfQk1IcmQ0RVlfTVZtQzNuQWtLX0RpR25RSVl4WGVmc2kxeFRUcWZlaGJWakVPeDhQa1RBbTFMLVFqM1lYM0dfU3FYRWNvYTlQRk5uU0RnTEtoSnBycjRYbkh2bmpxYnJSV1lhbGZwc0xPWXhwbTBmRS1WYm1aQVhjb0pSRFA0QUptOGZ1eXM3Q0NFME4wUFhDeGYxbExJVzByakU2QjZJR2cxWHhCVnduUVBpd0NfaXhvbURmSUREOW01SWR1bWVWSC1MeW5LcWZaWUhVZFZPak1kWkNQM3VjZ3cyYmpMc0xzVl84RzN4bXNVZUk0SW02OGdfb1VFRG5qY05oNWV5VVVhcW1FYjhSU1BjMm15MGQxeFVEdTZwY1pnS0xfUm8xcGhmNWRucFE0RkRDVjcwZzg2Z3V3S3VwQTRQX2dmbUdBdl9WYkstbWV2NlQ3VEZHcGxBTmJnUndaZGNhbjVoZHJHYVdvSEFCT2E5SEVnSUo3d1hKZUdfa3B6dGxFM28tRVQ3R3RDWm5ZZUQ1aGp1TXktNmJHcHhpb0VYQzF2NUI4cUVybkwzcjBGQjlmNm5aODBzR1Nnd2lxMG5VNjUxVE5FMTVTOEhkUm96aHJwX1p0M1FyVGUtZ3ZndXkxVHM4b0txTzBJRi1TQXh0T0JmRWtjQkVDaHYzaE1rbG9DcFIzN1JDZVQ3M01CUlFFd3hOYkpUbTRPLU5xcy1IdHpsVjNHQm14Smt0dUJEME9xdWxVU0VDb2VLelh5Y0hyUTUyQUdOX09wMWFqQnJOZlpZZHJzWENqQ1Bqc3NlcTVaSzN2VFpFbkZuLXJVM0ZnemlhUjZUZnlLUVV3V2VEQmNBcVJKdDhPeG9CRDQxT216cXBXeklRSXBERmpWVkQzLTcxalc3ZDBLM3R3VDVuME1PcG43NXZ6LWNBSng5X0hNLXVNSVFwc3JGMG5FeXF3SVFMSHFCb3dkRHdDdWU2akZtSHc1RFluZEF4b3BUdUtRVnk3Rk1yTWItbWZWRmtJMEotbDk1YWZYSFBiZU9DWlNxdV9TY3h6Ump6a1l0VGJNTjZ0a1JrNlFGY1IzUldRVjc1ZHFEaUV3RGJndnQ1a2RncWx5ZC1ZeFJQRU1hQ0V0Mzd3NVFKSzlRTFkyMVFVLXhBNXpqcGl0T2VMeGJLamFjSV84VlBZTWZNX1dtNjVvT0ZUWHB4WG1WLWItckU4aXpCV0NJZC0ycnI4aTVnVWprWUZSOWp1Q1BSVGphNk8xekxBU3RnU1lMUk00S2NfaU5OS2FJZkVqZElRbjdFa3liZGstVkMxWDhEcGFLRUg1b21XNDg0b3ctNVFPaWh4UG9OS3dwamQxMUdDbmZSbTZXa292bVBfUUt6c01BbFlSelNqSFZya3VJQ0pBQmNHR0hRZUpyRXNFMnFfQmRfdE53ODUzcjM1cmRwV0JRQ2J5Q1dZMDdEVVF6em1CVFZsQlFjaVZaWmxnLUZpWTVUdUxJSGF0Z1dXQy1NOEoyUXVTZG4xUU5tdmpCcklNVUsxcmpQTmdYUG9OVk9YVnZzaFdYeEpPTG1JUE5HV1dOenBWWlk2bW05RDVXbjRmMGNzZWEwNTdNdnVkaGc5Q1hvQXFPcEdXNkhSZWFMNndhbDZWSUNHMW1GcTFUb21ZdFBHTnphNzVRX0Y0Qmx0QzVyQWkzcThEcldPVHV4N05GQWF4N29idmZRZm5GdGZack1hOVZ1eUF3aXZlR0hiaFo4ZElnNGptaTFWQW5SV3h5TkdLZmxIdnhmX2xpbkt0OVZLYmNMZXZwYnFCMWYyaVlxaWY4bnYzVTBhcmMxLTduQjR5S3NoeUhJT3ZtYWNOYjBpSW5laXVrVGFDZklrcjJueHdGSVJtNTl3TDUxa2VDZ2RfcjlwTWhCN0luc2NINFRzU0N2V2pWMDdiNmc4UHZYNlBxUTcwUDFfaHhOTGRkNkxQUGZtWlJUWGhRd0VCVXJLdUJVOE9KbXFJWTdDVnp3VXpUaVVaQmp0S050ODlXaXo0Uno2MDhkXzBMYVluTlU4SG5MdV9kNnF4SFVzMzZOanUxRlB0Ym52NjFMUFRhZnlwYnhDamlvWlhEVF9pVmdMb1FFTXRaTG0zcWx4QlVxR1VwS1lUZUsyRzBEUmhRZU1EZ2xud0tjSEV3Z0ZKYXFqSFNncWM1eVB1aHdsYUFiVDhobERkQlcycTA2RG96b3hzVXJMMGJ0YkxoT0tlRS1pOHlrMEIwb0FxMk9UanhGamVwbVZldTZUTVVDUHVpY3N2UW1ieXljem1lOU51ZUJJOXVicVl1NW0yRDMwbDBiREFVRTR0dE9SUWNwb2cyWmpjTlAwZXV5SXZlTUd5Q2lFQnppYmFtNGpabElROFlucU9wWGZYZUFtMGlHMTIzWjFpUGoxMm1yNlJ3LnRjdFdJY01sMFNkM1lBMHYyYkQ3YV9PNU50b3hWbjZSZmdybDd2d2JUaTQ"}'
     headers:
       Accept:
       - application/json
@@ -1222,12 +1224,12 @@ interactions:
       ParameterSetName:
       - --vault-name --file
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: POST
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/restore?api-version=7.4
   response:
     body:
-      string: '{"contentType":"test type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/af59c589280e4294904564bb7e725666","attributes":{"enabled":false,"created":1741668440,"updated":1741668446,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"test":"foo","file-encoding":"utf-8"}}'
+      string: '{"contentType":"test type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/3cfb7ee08a124c7184c14b9cab5fc42b","attributes":{"enabled":false,"created":1749623415,"updated":1749623420,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"test":"foo","file-encoding":"utf-8"}}'
     headers:
       cache-control:
       - no-cache
@@ -1236,7 +1238,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:49:31 GMT
+      - Wed, 11 Jun 2025 06:32:25 GMT
       expires:
       - '-1'
       pragma:
@@ -1246,11 +1248,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.8;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
     status:
       code: 200
       message: OK
@@ -1268,12 +1270,12 @@ interactions:
       ParameterSetName:
       - --vault-name -n
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: GET
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/versions?api-version=7.4
   response:
     body:
-      string: '{"value":[{"contentType":"test type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/af59c589280e4294904564bb7e725666","attributes":{"enabled":false,"created":1741668440,"updated":1741668446,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"test":"foo","file-encoding":"utf-8"}},{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/f9557720362042d4954a56ac75da2726","attributes":{"enabled":true,"created":1741668435,"updated":1741668435,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'
+      string: '{"value":[{"contentType":"test type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/3cfb7ee08a124c7184c14b9cab5fc42b","attributes":{"enabled":false,"created":1749623415,"updated":1749623420,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"test":"foo","file-encoding":"utf-8"}},{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/97ed66c6ba334ce5acbb09208b4d0f21","attributes":{"enabled":true,"created":1749623412,"updated":1749623412,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'
     headers:
       cache-control:
       - no-cache
@@ -1282,7 +1284,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:49:32 GMT
+      - Wed, 11 Jun 2025 06:32:26 GMT
       expires:
       - '-1'
       pragma:
@@ -1292,11 +1294,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.8;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
     status:
       code: 200
       message: OK
@@ -1316,13 +1318,13 @@ interactions:
       ParameterSetName:
       - --vault-name -n
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: DELETE
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1?api-version=7.4
   response:
     body:
-      string: '{"recoveryId":"https://cli-test-kv-se-000002.vault.azure.net/deletedsecrets/secret1","deletedDate":1741668573,"scheduledPurgeDate":1742273373,"contentType":"test
-        type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/af59c589280e4294904564bb7e725666","attributes":{"enabled":false,"created":1741668440,"updated":1741668446,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"test":"foo","file-encoding":"utf-8"}}'
+      string: '{"recoveryId":"https://cli-test-kv-se-000002.vault.azure.net/deletedsecrets/secret1","deletedDate":1749623547,"scheduledPurgeDate":1750228347,"contentType":"test
+        type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/3cfb7ee08a124c7184c14b9cab5fc42b","attributes":{"enabled":false,"created":1749623415,"updated":1749623420,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"test":"foo","file-encoding":"utf-8"}}'
     headers:
       cache-control:
       - no-cache
@@ -1331,7 +1333,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:49:33 GMT
+      - Wed, 11 Jun 2025 06:32:26 GMT
       expires:
       - '-1'
       pragma:
@@ -1341,11 +1343,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.11;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
     status:
       code: 200
       message: OK
@@ -1363,7 +1365,7 @@ interactions:
       ParameterSetName:
       - --vault-name
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: GET
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets?api-version=7.4
   response:
@@ -1377,7 +1379,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:49:34 GMT
+      - Wed, 11 Jun 2025 06:32:27 GMT
       expires:
       - '-1'
       pragma:
@@ -1387,11 +1389,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.13;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
     status:
       code: 200
       message: OK
@@ -1409,7 +1411,7 @@ interactions:
       ParameterSetName:
       - --vault-name --maxresults
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: GET
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets?maxresults=10&api-version=7.4
   response:
@@ -1423,7 +1425,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:49:35 GMT
+      - Wed, 11 Jun 2025 06:32:28 GMT
       expires:
       - '-1'
       pragma:
@@ -1433,11 +1435,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.15;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
     status:
       code: 200
       message: OK
@@ -1460,12 +1462,12 @@ interactions:
       ParameterSetName:
       - --vault-name -n --file --encoding
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: PUT
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-8?api-version=7.4
   response:
     body:
-      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-8/37eb0598aee74239a18839cc2bb50253","attributes":{"enabled":true,"created":1741668576,"updated":1741668576,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-8"}}'
+      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-8/1c5246eb821f4b668e19f1773fca6c65","attributes":{"enabled":true,"created":1749623549,"updated":1749623549,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-8"}}'
     headers:
       cache-control:
       - no-cache
@@ -1474,7 +1476,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:49:36 GMT
+      - Wed, 11 Jun 2025 06:32:28 GMT
       expires:
       - '-1'
       pragma:
@@ -1484,11 +1486,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.12;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
     status:
       code: 200
       message: OK
@@ -1506,12 +1508,12 @@ interactions:
       ParameterSetName:
       - --vault-name -n --file
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: GET
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-8/?api-version=7.4
   response:
     body:
-      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-8/37eb0598aee74239a18839cc2bb50253","attributes":{"enabled":true,"created":1741668576,"updated":1741668576,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-8"}}'
+      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-8/1c5246eb821f4b668e19f1773fca6c65","attributes":{"enabled":true,"created":1749623549,"updated":1749623549,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-8"}}'
     headers:
       cache-control:
       - no-cache
@@ -1520,7 +1522,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:49:37 GMT
+      - Wed, 11 Jun 2025 06:32:29 GMT
       expires:
       - '-1'
       pragma:
@@ -1530,11 +1532,57 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.9;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - keyvault secret download
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --vault-name -n --file --overwrite
+      User-Agent:
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
+    method: GET
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-8/?api-version=7.4
+  response:
+    body:
+      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-8/1c5246eb821f4b668e19f1773fca6c65","attributes":{"enabled":true,"created":1749623549,"updated":1749623549,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-8"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '338'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 11 Jun 2025 06:32:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=13.70.96.14;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.2455.1
     status:
       code: 200
       message: OK
@@ -1557,12 +1605,12 @@ interactions:
       ParameterSetName:
       - --vault-name -n --file --encoding
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: PUT
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-16le?api-version=7.4
   response:
     body:
-      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-16le/c2eba6c2827e42a0bf2103560aea62b5","attributes":{"enabled":true,"created":1741668578,"updated":1741668578,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-16le"}}'
+      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-16le/e1cb74c99380452ebaefb62872e3b2e6","attributes":{"enabled":true,"created":1749623551,"updated":1749623551,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-16le"}}'
     headers:
       cache-control:
       - no-cache
@@ -1571,7 +1619,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:49:37 GMT
+      - Wed, 11 Jun 2025 06:32:30 GMT
       expires:
       - '-1'
       pragma:
@@ -1581,11 +1629,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.9;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
     status:
       code: 200
       message: OK
@@ -1603,12 +1651,12 @@ interactions:
       ParameterSetName:
       - --vault-name -n --file
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: GET
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-16le/?api-version=7.4
   response:
     body:
-      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-16le/c2eba6c2827e42a0bf2103560aea62b5","attributes":{"enabled":true,"created":1741668578,"updated":1741668578,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-16le"}}'
+      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-16le/e1cb74c99380452ebaefb62872e3b2e6","attributes":{"enabled":true,"created":1749623551,"updated":1749623551,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-16le"}}'
     headers:
       cache-control:
       - no-cache
@@ -1617,7 +1665,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:49:38 GMT
+      - Wed, 11 Jun 2025 06:32:31 GMT
       expires:
       - '-1'
       pragma:
@@ -1627,11 +1675,57 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.8;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - keyvault secret download
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --vault-name -n --file --overwrite
+      User-Agent:
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
+    method: GET
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-16le/?api-version=7.4
+  response:
+    body:
+      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-16le/e1cb74c99380452ebaefb62872e3b2e6","attributes":{"enabled":true,"created":1749623551,"updated":1749623551,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-16le"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '344'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 11 Jun 2025 06:32:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=13.70.96.10;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.2455.1
     status:
       code: 200
       message: OK
@@ -1654,12 +1748,12 @@ interactions:
       ParameterSetName:
       - --vault-name -n --file --encoding
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: PUT
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-16be?api-version=7.4
   response:
     body:
-      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-16be/70d72a43cb8d4b8fb4a9b37bfd11fbaa","attributes":{"enabled":true,"created":1741668580,"updated":1741668580,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-16be"}}'
+      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-16be/cbfadff22bfb4f35a2fa23b17d80355b","attributes":{"enabled":true,"created":1749623553,"updated":1749623553,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-16be"}}'
     headers:
       cache-control:
       - no-cache
@@ -1668,7 +1762,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:49:39 GMT
+      - Wed, 11 Jun 2025 06:32:32 GMT
       expires:
       - '-1'
       pragma:
@@ -1678,11 +1772,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.14;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
     status:
       code: 200
       message: OK
@@ -1700,12 +1794,12 @@ interactions:
       ParameterSetName:
       - --vault-name -n --file
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: GET
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-16be/?api-version=7.4
   response:
     body:
-      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-16be/70d72a43cb8d4b8fb4a9b37bfd11fbaa","attributes":{"enabled":true,"created":1741668580,"updated":1741668580,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-16be"}}'
+      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-16be/cbfadff22bfb4f35a2fa23b17d80355b","attributes":{"enabled":true,"created":1749623553,"updated":1749623553,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-16be"}}'
     headers:
       cache-control:
       - no-cache
@@ -1714,7 +1808,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:49:40 GMT
+      - Wed, 11 Jun 2025 06:32:33 GMT
       expires:
       - '-1'
       pragma:
@@ -1724,11 +1818,57 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.8;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - keyvault secret download
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --vault-name -n --file --overwrite
+      User-Agent:
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
+    method: GET
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-16be/?api-version=7.4
+  response:
+    body:
+      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-16be/cbfadff22bfb4f35a2fa23b17d80355b","attributes":{"enabled":true,"created":1749623553,"updated":1749623553,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"utf-16be"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '344'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 11 Jun 2025 06:32:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=13.70.96.8;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.2455.1
     status:
       code: 200
       message: OK
@@ -1751,12 +1891,12 @@ interactions:
       ParameterSetName:
       - --vault-name -n --file --encoding
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: PUT
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-ascii?api-version=7.4
   response:
     body:
-      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-ascii/ee02b288d82e49539a4bdbe7fa218961","attributes":{"enabled":true,"created":1741668581,"updated":1741668581,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"ascii"}}'
+      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-ascii/c431a44d7a1149a0828f3067320a6213","attributes":{"enabled":true,"created":1749623555,"updated":1749623555,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"ascii"}}'
     headers:
       cache-control:
       - no-cache
@@ -1765,7 +1905,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:49:41 GMT
+      - Wed, 11 Jun 2025 06:32:34 GMT
       expires:
       - '-1'
       pragma:
@@ -1775,11 +1915,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.11;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
     status:
       code: 200
       message: OK
@@ -1797,12 +1937,12 @@ interactions:
       ParameterSetName:
       - --vault-name -n --file
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: GET
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-ascii/?api-version=7.4
   response:
     body:
-      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-ascii/ee02b288d82e49539a4bdbe7fa218961","attributes":{"enabled":true,"created":1741668581,"updated":1741668581,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"ascii"}}'
+      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-ascii/c431a44d7a1149a0828f3067320a6213","attributes":{"enabled":true,"created":1749623555,"updated":1749623555,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"ascii"}}'
     headers:
       cache-control:
       - no-cache
@@ -1811,7 +1951,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:49:42 GMT
+      - Wed, 11 Jun 2025 06:32:35 GMT
       expires:
       - '-1'
       pragma:
@@ -1821,11 +1961,57 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.8;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - keyvault secret download
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --vault-name -n --file --overwrite
+      User-Agent:
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
+    method: GET
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-ascii/?api-version=7.4
+  response:
+    body:
+      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-ascii/c431a44d7a1149a0828f3067320a6213","attributes":{"enabled":true,"created":1749623555,"updated":1749623555,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"ascii"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '338'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 11 Jun 2025 06:32:36 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=13.70.96.8;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.2455.1
     status:
       code: 200
       message: OK
@@ -1848,12 +2034,12 @@ interactions:
       ParameterSetName:
       - --vault-name -n --file --encoding
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: PUT
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-base64?api-version=7.4
   response:
     body:
-      string: '{"value":"VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0VGVzdFNlY3JldA0K\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-base64/e67503f1d4354902853ee5a77a29b477","attributes":{"enabled":true,"created":1741668583,"updated":1741668583,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"base64"}}'
+      string: '{"value":"VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0VGVzdFNlY3JldA0K\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-base64/1a94b8b4c3b94409ab9b0e8804e63bdc","attributes":{"enabled":true,"created":1749623557,"updated":1749623557,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"base64"}}'
     headers:
       cache-control:
       - no-cache
@@ -1862,7 +2048,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:49:43 GMT
+      - Wed, 11 Jun 2025 06:32:36 GMT
       expires:
       - '-1'
       pragma:
@@ -1872,11 +2058,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.12;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
     status:
       code: 200
       message: OK
@@ -1894,12 +2080,12 @@ interactions:
       ParameterSetName:
       - --vault-name -n --file
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: GET
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-base64/?api-version=7.4
   response:
     body:
-      string: '{"value":"VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0VGVzdFNlY3JldA0K\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-base64/e67503f1d4354902853ee5a77a29b477","attributes":{"enabled":true,"created":1741668583,"updated":1741668583,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"base64"}}'
+      string: '{"value":"VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0VGVzdFNlY3JldA0K\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-base64/1a94b8b4c3b94409ab9b0e8804e63bdc","attributes":{"enabled":true,"created":1749623557,"updated":1749623557,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"base64"}}'
     headers:
       cache-control:
       - no-cache
@@ -1908,7 +2094,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:49:43 GMT
+      - Wed, 11 Jun 2025 06:32:36 GMT
       expires:
       - '-1'
       pragma:
@@ -1918,11 +2104,57 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.13;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - keyvault secret download
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --vault-name -n --file --overwrite
+      User-Agent:
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
+    method: GET
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-base64/?api-version=7.4
+  response:
+    body:
+      string: '{"value":"VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0VGVzdFNlY3JldA0K\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-base64/1a94b8b4c3b94409ab9b0e8804e63bdc","attributes":{"enabled":true,"created":1749623557,"updated":1749623557,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"base64"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '356'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 11 Jun 2025 06:32:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=13.70.96.15;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.2455.1
     status:
       code: 200
       message: OK
@@ -1945,12 +2177,12 @@ interactions:
       ParameterSetName:
       - --vault-name -n --file --encoding
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: PUT
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-hex?api-version=7.4
   response:
     body:
-      string: '{"value":"546573745365637265745465737453656372657454657374536563726574546573745365637265740d0a","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-hex/e4557d29843240fdae28ff917bb27710","attributes":{"enabled":true,"created":1741668585,"updated":1741668585,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"hex"}}'
+      string: '{"value":"546573745365637265745465737453656372657454657374536563726574546573745365637265740d0a","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-hex/953a5a5030c248818d70caf7ea9854c7","attributes":{"enabled":true,"created":1749623559,"updated":1749623559,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"hex"}}'
     headers:
       cache-control:
       - no-cache
@@ -1959,7 +2191,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:49:44 GMT
+      - Wed, 11 Jun 2025 06:32:38 GMT
       expires:
       - '-1'
       pragma:
@@ -1969,11 +2201,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.8;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
     status:
       code: 200
       message: OK
@@ -1991,12 +2223,12 @@ interactions:
       ParameterSetName:
       - --vault-name -n --file
       User-Agent:
-      - AZURECLI/2.70.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
     method: GET
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-hex/?api-version=7.4
   response:
     body:
-      string: '{"value":"546573745365637265745465737453656372657454657374536563726574546573745365637265740d0a","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-hex/e4557d29843240fdae28ff917bb27710","attributes":{"enabled":true,"created":1741668585,"updated":1741668585,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"hex"}}'
+      string: '{"value":"546573745365637265745465737453656372657454657374536563726574546573745365637265740d0a","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-hex/953a5a5030c248818d70caf7ea9854c7","attributes":{"enabled":true,"created":1749623559,"updated":1749623559,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"hex"}}'
     headers:
       cache-control:
       - no-cache
@@ -2005,7 +2237,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Mar 2025 04:49:46 GMT
+      - Wed, 11 Jun 2025 06:32:39 GMT
       expires:
       - '-1'
       pragma:
@@ -2015,11 +2247,57 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=223.167.210.55;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=13.70.96.11;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.9.2203.1
+      - 1.9.2455.1
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - keyvault secret download
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --vault-name -n --file --overwrite
+      User-Agent:
+      - AZURECLI/2.74.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.22631-SP0)
+    method: GET
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-hex/?api-version=7.4
+  response:
+    body:
+      string: '{"value":"546573745365637265745465737453656372657454657374536563726574546573745365637265740d0a","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-hex/953a5a5030c248818d70caf7ea9854c7","attributes":{"enabled":true,"created":1749623559,"updated":1749623559,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"tags":{"file-encoding":"hex"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '376'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 11 Jun 2025 06:32:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=13.70.96.9;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.9.2455.1
     status:
       code: 200
       message: OK


### PR DESCRIPTION
**Related command**
keyvault

**Description**<!--Mandatory-->
* From feature request: https://github.com/Azure/azure-cli/issues/30994
* `az keyvault secret download` command previously failed when provided with an existing file for the file path parameter.
* Feature was requested to allow users to provide an existing file along with the overwrite flag to allow the secret downloaded to be overwritten onto the selected file path. 
* This feature allows users to provide an additional flag to the `az keyvault secret download` command to overwrite the existing file with the downloaded secret.
* Cassette for re-recorded for future tests

**Testing Guide**
* `az keyvault secret download --vault-name {kv} -n download-{enc} --file "{dest_path}" --overwrite` : overwrite existing path file with the contents of the downloaded secret

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).