### PR TITLE
[ACR] Fix: enable dedicated endpoint on container registry resource when user confirms during az acr connected-registry create

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/connected_registry.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/connected_registry.py
@@ -11,7 +11,7 @@ from azure.cli.core.azclierror import ArgumentUsageError, InvalidArgumentValueEr
 from azure.cli.core.commands import LongRunningOperation
 from azure.cli.core.commands.client_factory import get_subscription_id
 from azure.cli.core.util import user_confirmation
-from ._client_factory import cf_acr_tokens, cf_acr_scope_maps
+from ._client_factory import cf_acr_tokens, cf_acr_scope_maps, cf_acr_registries
 from ._utils import (
     build_token_id,
     create_default_scope_map,
@@ -21,7 +21,7 @@ from ._utils import (
     parse_scope_map_actions,
     validate_managed_registry
 )
-from .custom import acr_update_custom
+from .custom import acr_update_custom, acr_update_set
 
 
 class ConnectedRegistryModes(Enum):
@@ -76,7 +76,9 @@ def acr_connected_registry_create(cmd,  # pylint: disable=too-many-locals, too-m
         user_confirmation("Dedicated data endpoints must be enabled to use connected-registry. Enabling might " +
                           "impact your firewall rules. Are you sure you want to enable it for '{}' registry?".format(
                               registry_name), yes)
-        acr_update_custom(cmd, registry, resource_group_name, data_endpoint_enabled=True)
+        acr_update_custom(cmd, registry, data_endpoint_enabled=True)
+        registry_client = cf_acr_registries(cmd.cli_ctx)
+        acr_update_set(cmd, registry_client, registry_name, resource_group_name, registry)
 
     from azure.core.exceptions import HttpResponseError as ErrorResponseException
     parent = None


### PR DESCRIPTION
**Related command**
az acr connected-registry create

**Description**<!--Mandatory-->
In #28807, the behavior of `az acr connected-registry create` was modified. If the user does not have dedicated data endpoint enabled for their ACR, then the command would ask whether they want to enable it before creating the Connected Registry. However, there is a glitch. The ACR resource would only be modified in-memory, meaning that dedicated endpoint would remain disabled on the actual ACR.

This PR ensures an API request to modify the ACR is made when the user wants to enable dedicated endpoint on their ACR while creating a Connected Registry. 

**Testing Guide**
1. Create an ACR: `az acr create -n [your name] -g [your rg] --sku premium`
2. Create a Connected Registry: `az acr connected-registry create -n [your choice of connected registry name] --registry [your ACR name] --repository hello-world`
3. Wait for the CLI to prompt "Dedicated data endpoints must be enabled to use connected-registry. Enabling might impact your firewall rules. Are you sure you want to enable it for [ACR name] registry?". Reply with `y`.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[ACR] OnPrem: Connected-registry create: Mode default value changed to readOnly (#28807)
[ACR] az acr connected-registry create/update: Add new parameters for enabling and setting interval for garbage collection within a connected registry (#30956)

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
