### PR TITLE
{Test} Update the response processing in EmailAddressReplacer

### DIFF
--- a/src/azure-cli-testsdk/azure/cli/testsdk/utilities.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/utilities.py
@@ -50,7 +50,12 @@ def force_progress_logging():
 
 
 def _byte_to_str(byte_or_str):
-    return str(byte_or_str, 'utf-8') if isinstance(byte_or_str, bytes) else byte_or_str
+    if isinstance(byte_or_str, bytes):
+        try:
+            return byte_or_str.decode('utf-8')
+        except UnicodeDecodeError:
+            pass
+    return byte_or_str
 
 
 class StorageAccountKeyReplacer(RecordingProcessor):
@@ -230,7 +235,8 @@ class EmailAddressReplacer(RecordingProcessor):
     def process_response(self, response):
         if response['body']['string']:
             body = _byte_to_str(response['body']['string'])
-            response['body']['string'] = self._replace_email_address(body)
+            if isinstance(body, str):
+                response['body']['string'] = self._replace_email_address(body)
         return response
 
 

--- a/src/azure-cli-testsdk/azure/cli/testsdk/utilities.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/utilities.py
@@ -50,12 +50,7 @@ def force_progress_logging():
 
 
 def _byte_to_str(byte_or_str):
-    if isinstance(byte_or_str, bytes):
-        try:
-            return byte_or_str.decode('utf-8')
-        except UnicodeDecodeError:
-            pass
-    return byte_or_str
+    return str(byte_or_str, 'utf-8') if isinstance(byte_or_str, bytes) else byte_or_str
 
 
 class StorageAccountKeyReplacer(RecordingProcessor):
@@ -234,9 +229,12 @@ class EmailAddressReplacer(RecordingProcessor):
 
     def process_response(self, response):
         if response['body']['string']:
-            body = _byte_to_str(response['body']['string'])
-            if isinstance(body, str):
+            try:
+                body = _byte_to_str(response['body']['string'])
                 response['body']['string'] = self._replace_email_address(body)
+            except UnicodeDecodeError:
+                # If the body is not a string, we cannot decode it, so we skip the replacement
+                pass
         return response
 
 


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

{Test} Update the response processing in EmailAddressReplacer. In some scenario tests, we may download some binary files, which cannot be converted to utf8-encoded strings, resulting in errors. Related to #31262.

The following is a sample error when running test case [test_aks_install_kubectl](https://github.com/Azure/azure-cli/blob/dev/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py#L6180), which downloads the binary kubectl
```
azEnv/lib/python3.12/site-packages/vcr/config.py:178: in before_record_response
    response = function(response)
               ^^^^^^^^^^^^^^^^^^
azure-cli/src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/base.py:209: in _process_response_recording
    response = processor.process_response(response)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
azure-cli/src/azure-cli-testsdk/azure/cli/testsdk/utilities.py:232: in process_response
    body = _byte_to_str(response['body']['string'])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

byte_or_str = b'\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00>\x00\x01\x00\x00\x00`\x15H\x00\x00\x00\x00\x00@\x00\...ld-id\x00.note.go.buildid\x00.elfdata\x00.rodata\x00.typelink\x00.itablink\x00.gosymtab\x00.gopclntab\x00.shstrtab\x00'

    def _byte_to_str(byte_or_str):
>       return str(byte_or_str, 'utf-8') if isinstance(byte_or_str, bytes) else byte_or_str
               ^^^^^^^^^^^^^^^^^^^^^^^^^
E       UnicodeDecodeError: 'utf-8' codec can't decode byte 0x90 in position 40: invalid start byte

azure-cli/src/azure-cli-testsdk/azure/cli/testsdk/utilities.py:53: UnicodeDecodeError
```

https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=127765187&view=logs&j=b162b355-d59d-5864-ce0f-0a70f12dd28b&t=dc59ccd1-231f-538b-777f-33a592c7ca57&l=2729

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
