### PR TITLE
{Compute} `az disk-encryption-set update`: Set source vault to None when `--source-vault` is not input

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/operations/disk_encryption_set.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/operations/disk_encryption_set.py
@@ -65,3 +65,8 @@ class DiskEncryptionSetUpdate(_DiskEncryptionSetUpdate):
         if has_value(args.source_vault):
             vault = args.source_vault.to_serialized_data()
             args.source_vault = vault if is_valid_resource_id(vault) else KV_RID_TEMPLATE.format(self.ctx.subscription_id, args.resource_group, vault)
+
+    def pre_instance_update(self, instance):
+        args = self.ctx.args
+        if not has_value(args.source_vault):
+            instance.properties.active_key.source_vault = None


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

 `az disk-encryption-set update`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Fix IcM: 638240702

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
