### PR TITLE
[ACR] `az acr login`: Fix login status code when command fails

### DIFF
--- a/doc/how_to_introduce_breaking_changes.md
+++ b/doc/how_to_introduce_breaking_changes.md
@@ -319,13 +319,13 @@ This way, the pre-announcement wouldn't be displayed unless running into the bra
 Before you publish the breaking changes, you need to make sure that the announcement is ready for the Upcoming Breaking Change Documentation. To do that, run this command:
 
 ```commandline
-azdev genereate-breaking-change-report
+azdev generate-breaking-change-report
 ```
 
 If your breaking change is not for the next breaking change window, you can see all the announcements by using `--target-version None` like this:
 
 ```commandline
-azdev genereate-breaking-change-report --target-version None
+azdev generate-breaking-change-report --target-version None
 ```
 
 The output should be a JSON object including the pre-announcement you made.
@@ -347,5 +347,5 @@ The Upcoming Breaking Change Documentation includes:
 The documentation is generated through `azdev` tool. You can preview the documentation locally through the following command.
 
 ```commandline
-azdev genereate-breaking-change-report CLI --output-format markdown
+azdev generate-breaking-change-report CLI --output-format markdown
 ```

--- a/src/azure-cli/azure/cli/command_modules/acr/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/custom.py
@@ -355,7 +355,7 @@ def acr_login(cmd,
     _, stderr = p.communicate()
     return_code = p.returncode
 
-    if stderr:
+    if stderr or return_code != 0:  # when docker command process returns non-zero
         if b'error storing credentials' in stderr and b'stub received bad data' in stderr \
            and _check_wincred(login_server):
             # Retry once after disabling wincred


### PR DESCRIPTION
**Related command**
az acr login

**Description**<!--Mandatory-->
When az acr login fails for docker login, the command should return a non-zero status code.
Why wasn't this the case? the check was if stderr is not empty. In the case docker is not running, stderr is empty and the error is written to stdout:

```
The command 'docker' could not be found in this WSL 2 distro.
We recommend to activate the WSL integration in Docker Desktop settings.

For details about using Docker Desktop with WSL 2, visit:

https://docs.docker.com/go/wsl2/
```

fixes #27907 

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
