### PR TITLE
[RDBMS] `az postgres flexible-server create`: Extend EOL to PG 11 and 12

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/validators.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/validators.py
@@ -515,9 +515,9 @@ def _pg_version_validator(version, versions):
         if version not in versions:
             raise CLIError('Incorrect value for --version. Allowed values : {}'.format(sorted(versions)))
         if version in ('11', '12'):
-            logger.warning("Support for PostgreSQL {} has officially ended. "
+            logger.warning("Support for PostgreSQL %s has officially ended. "
                            "We recommend selecting PostgreSQL 14 or a later version for "
-                           "all future operations.".format(version))
+                           "all future operations.", str(version))
         if version == '13':
             logger.warning("PostgreSQL version 13 will reach end-of-life (EOL) soon. "
                            "Upgrade to PostgreSQL 14 or later as soon as possible to "


### PR DESCRIPTION
**Related command**
az postgres flexible-server create

**Description**<!--Mandatory-->
Extended EOL to PG 11 and 12

**Testing Guide**
![image (7)](https://github.com/user-attachments/assets/7baceb5c-5836-4b27-ab19-9aafb6b0d076)

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[RDBMS] `az postgres flexible-server create`: Extend EOL to PG 11 and 12

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
