### PR TITLE
{Auth} Add `--claims-challenge` to the re-authentication message

### DIFF
--- a/src/azure-cli-core/azure/cli/core/auth/msal_credentials.py
+++ b/src/azure-cli-core/azure/cli/core/auth/msal_credentials.py
@@ -51,8 +51,7 @@ class UserCredential:  # pylint: disable=too-few-public-methods
                      scopes, claims_challenge, kwargs)
 
         if claims_challenge:
-            logger.warning('Acquiring new access token silently for tenant %s with claims challenge: %s',
-                           self._msal_app.authority.tenant, claims_challenge)
+            logger.info('Acquiring new access token silently with claims challenge: %s', claims_challenge)
         result = self._msal_app.acquire_token_silent_with_error(
             scopes, self._account, claims_challenge=claims_challenge, **kwargs)
 

--- a/src/azure-cli-core/azure/cli/core/auth/tests/test_util.py
+++ b/src/azure-cli-core/azure/cli/core/auth/tests/test_util.py
@@ -68,6 +68,15 @@ class TestUtil(unittest.TestCase):
         assert actual == ('az login --tenant "21987a97-4e85-47c5-9a13-9dc3e11b2a9a" '
                           '--scope "https://management.core.windows.net//.default"')
 
+        # tenant, scopes and claims_challenge
+        actual = _generate_login_command(
+            tenant='21987a97-4e85-47c5-9a13-9dc3e11b2a9a',
+            scopes=["https://management.core.windows.net//.default"],
+            claims_challenge='{"access_token":{"acrs":{"essential":true,"values":["p1"]}}}')
+        assert actual == ('az logout\n'
+                          'az login --tenant "21987a97-4e85-47c5-9a13-9dc3e11b2a9a" '
+                          '--scope "https://management.core.windows.net//.default" '
+                          '--claims-challenge "eyJhY2Nlc3NfdG9rZW4iOnsiYWNycyI6eyJlc3NlbnRpYWwiOnRydWUsInZhbHVlcyI6WyJwMSJdfX19"')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Related command**
`az login`

**Description**<!--Mandatory-->
https://github.com/Azure/azure-cli/pull/31778 added `--claims-challenge` to `az login`.

When a `PUT` or `DELETE` request is blocked by MFA policy with a `401` response, `ARMChallengeAuthenticationPolicy` will trigger silent re-authentication. If silent re-authentication fails, Azure CLI shows re-authentication message with `--claims-challenge` and base64-encoded value. Running this `az login --claims-challenge xxx` command will trigger the MFA process.

The JSON value of the claims challenge is base64-encoded to avoid quoting issue (https://github.com/Azure/azure-cli/issues/15529). Even though base64-encoded string may contain `+/-_=` characters, they will not be interpreted by shell.

Below is a test in PowerShell 7.5.2:

```
> az login --claims-challenge eyJhY2Nlc3NfdG9rZW4iOnsiYWNycyI6eyJlc3NlbnRpYWwiOnRydWUsInZhbHVlcyI6WyJwMSJdfX19+/-_= --debug
cli.knack.cli: Command arguments: ['login', '--claims-challenge', 'eyJhY2Nlc3NfdG9rZW4iOnsiYWNycyI6eyJlc3NlbnRpYWwiOnRydWUsInZhbHVlcyI6WyJwMSJdfX19+/-_=', '--debug']
```

and Bash:

```
$ az login --claims-challenge eyJhY2Nlc3NfdG9rZW4iOnsiYWNycyI6eyJlc3NlbnRpYWwiOnRydWUsInZhbHVlcyI6WyJwMSJdfX19+/-_= --debug
cli.knack.cli: Command arguments: ['login', '--claims-challenge', 'eyJhY2Nlc3NfdG9rZW4iOnsiYWNycyI6eyJlc3NlbnRpYWwiOnRydWUsInZhbHVlcyI6WyJwMSJdfX19+/-_=', '--debug']
```

so quoting the base64-encoded claims challenge is not necessary, but there could be unknown shells that do interpret these characters, so we quote it to follow the best practice.

**Testing Guide**
```
> az keyvault create -g testpolicy1 -n testkv
Run the command below to authenticate interactively; additional arguments may be added as needed:
az logout
az login --tenant "3f145493-536c-40aa-8a6d-ca91dd64cd3b" --scope "https://management.core.windows.net//.default" --claims-challenge "eyJhY2Nlc3NfdG9rZW4iOnsiYWNycyI6eyJlc3NlbnRpYWwiOnRydWUsInZhbHVlcyI6WyJwMSJdfX19"
(RequestDisallowedByPolicy) Resource 'testkv' was disallowed by policy. ...
Code: RequestDisallowedByPolicy
Message: Resource 'testkv' was disallowed by policy. ...
Target: testkv
```

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Core] Provide actionable error recommendation when a command fails because of Multi-Factor Authentication (MFA) policy violation

