### PR TITLE
{Auth} Drop `data` keyword argument from `get_token`

### DIFF
--- a/src/azure-cli-core/azure/cli/core/auth/credential_adaptor.py
+++ b/src/azure-cli-core/azure/cli/core/auth/credential_adaptor.py
@@ -57,10 +57,6 @@ def _prepare_msal_kwargs(options=None):
     # Both get_token's kwargs and get_token_info's options are accepted as their schema is the same (at least for now).
     msal_kwargs = {}
     if options:
-        # For VM SSH. 'data' support is a CLI-specific extension.
-        # SDK doesn't support 'data': https://github.com/Azure/azure-sdk-for-python/pull/16397
-        if 'data' in options:
-            msal_kwargs['data'] = options['data']
         # For CAE
         if 'claims' in options:
             msal_kwargs['claims_challenge'] = options['claims']

--- a/src/azure-cli-core/azure/cli/core/auth/tests/test_credential_adaptor.py
+++ b/src/azure-cli-core/azure/cli/core/auth/tests/test_credential_adaptor.py
@@ -11,11 +11,6 @@ from ..credential_adaptor import CredentialAdaptor
 
 
 MOCK_ACCESS_TOKEN = "mock_access_token"
-MOCK_DATA = {
-    'key_id': 'test',
-    'req_cnf': 'test',
-    'token_type': 'ssh-cert'
-}
 MOCK_CLAIMS = {"test_claims": "value2"}
 
 class MsalCredentialStub:
@@ -44,7 +39,7 @@ def _now_timestamp_mock():
 
 class TestCredentialAdaptor(unittest.TestCase):
 
-    @mock.patch('azure.cli.core.auth.util._now_timestamp', new=_now_timestamp_mock)
+    @mock.patch('azure.cli.core.auth.util.now_timestamp', new=_now_timestamp_mock)
     def test_get_token(self):
         msal_cred = MsalCredentialStub()
         sdk_cred = CredentialAdaptor(msal_cred)
@@ -56,15 +51,11 @@ class TestCredentialAdaptor(unittest.TestCase):
         assert access_token.token == MOCK_ACCESS_TOKEN
         assert access_token.expires_on == 1630920323
 
-        # Note that SDK doesn't support 'data'. This is a CLI-specific extension.
-        sdk_cred.get_token('https://management.core.windows.net//.default', data=MOCK_DATA)
-        assert msal_cred.acquire_token_kwargs['data'] == MOCK_DATA
-
         sdk_cred.get_token('https://management.core.windows.net//.default', claims=MOCK_CLAIMS)
         assert msal_cred.acquire_token_claims_challenge == MOCK_CLAIMS
 
 
-    @mock.patch('azure.cli.core.auth.util._now_timestamp', new=_now_timestamp_mock)
+    @mock.patch('azure.cli.core.auth.util.now_timestamp', new=_now_timestamp_mock)
     def test_get_token_info(self):
         msal_cred = MsalCredentialStub()
         sdk_cred = CredentialAdaptor(msal_cred)
@@ -77,10 +68,6 @@ class TestCredentialAdaptor(unittest.TestCase):
         assert access_token_info.token_type == 'Bearer'
 
         assert msal_cred.acquire_token_scopes == ['https://management.core.windows.net//.default']
-
-        # Note that SDK doesn't support 'data'. If 'data' were supported, it should be tested with:
-        sdk_cred.get_token_info('https://management.core.windows.net//.default', options={'data': MOCK_DATA})
-        assert msal_cred.acquire_token_kwargs['data'] == MOCK_DATA
 
         sdk_cred.get_token_info('https://management.core.windows.net//.default', options={'claims': MOCK_CLAIMS})
         assert msal_cred.acquire_token_claims_challenge == MOCK_CLAIMS


### PR DESCRIPTION
**Description**<!--Mandatory-->
Python SDK's `get_token` protocol does not support `data` keyword argument and will not support in the future (https://github.com/Azure/azure-sdk-for-python/pull/16397), so Azure CLI supports `data` in `get_token` as CLI-specific extension.

With the full migration to `acquire_token`, it is no longer necessary to expose `data` in `get_token`.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
