### PR TITLE
Add support to use AZD as token credential provider

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -45,6 +45,7 @@ CLASSIFIERS = [
 DEPENDENCIES = [
     'argcomplete~=2.0',
     'azure-cli-telemetry==1.0.8.*',
+    'azure-identity>=1.12.0',
     'azure-mgmt-core>=1.2.0,<2',
     'cryptography',
     # On Linux, the distribution (Ubuntu, Debian, etc) and version are logged in telemetry
@@ -53,7 +54,7 @@ DEPENDENCIES = [
     'jmespath',
     'knack~=0.10.1',
     'msal-extensions~=1.0.0',
-    'msal[broker]==1.20.0',
+    'msal[broker]>=1.20.0,<2.0.0',
     'msrestazure~=0.6.4',
     'packaging>=20.9',
     'paramiko>=2.0.8,<4.0.0',

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -9,6 +9,7 @@ azure-cli-telemetry==1.0.8
 azure-cli==2.48.1
 azure-common==1.1.22
 azure-core==1.26.0
+azure-identity==1.15.0
 azure-cosmos==3.2.0
 azure-data-tables==12.4.0
 azure-datalake-store==0.0.49

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -9,6 +9,7 @@ azure-cli-telemetry==1.0.8
 azure-cli==2.48.1
 azure-common==1.1.22
 azure-core==1.26.0
+azure-identity==1.15.0
 azure-cosmos==3.2.0
 azure-data-tables==12.4.0
 azure-datalake-store==0.0.49

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -9,6 +9,7 @@ azure-cli-telemetry==1.0.8
 azure-cli==2.48.1
 azure-common==1.1.22
 azure-core==1.26.0
+azure-identity==1.15.0
 azure-cosmos==3.2.0
 azure-data-tables==12.4.0
 azure-datalake-store==0.0.49


### PR DESCRIPTION
This PR makes it possible to set `AZ_USE_AZD_AUTH` env var to make `az` to use `azd` to generate the access tokens.

By having this feature, AZD will be able to call AZ and set the ENV VAR as part of the process invocation, effectively re-using AZD's current authentication for AZ.
For example, using az inside azd's hooks would no longer require folks to login az and azd, enhancing the user experience.

This change should have no effect if the ENV VAR is not set.
