### PR TITLE
{Auth} Remove `broker_error` detection for re-authentication message

### DIFF
--- a/src/azure-cli-core/azure/cli/core/auth/util.py
+++ b/src/azure-cli-core/azure/cli/core/auth/util.py
@@ -45,11 +45,7 @@ def aad_error_handler(error, **kwargs):
         recommendation = PASSWORD_CERTIFICATE_WARNING
     else:
         login_command = _generate_login_command(**kwargs)
-        recommendation = (
-            # Cloud Shell uses IMDS-like interface for implicit login. If getting token/cert failed,
-            # we let the user explicitly log in to AAD with MSAL.
-            "Please explicitly log in with:\n{}" if error.get('error') == 'broker_error'
-            else "Interactive authentication is needed. Please run:\n{}").format(login_command)
+        recommendation = "Interactive authentication is needed. Please run:\n{}".format(login_command)
 
     from azure.cli.core.azclierror import AuthenticationError
     raise AuthenticationError(error_description, msal_error=error, recommendation=recommendation)


### PR DESCRIPTION
**Related command**
`az login`

**Description**<!--Mandatory-->
Previously, `broker_error` is dedicated to denote **getting VM SSH certificate error in Cloud Shell** (#22162) and the re-authentication message (error recommendation) is:

> Please explicitly log in with:

This is because in Cloud Shell, Azure CLI is _implicitly_ authenticated and no explicit `az login --identity` is required.

On a local machine, the re-authentication message for Entra errors is

> Interactive authentication is needed. Please run:

After supporting Windows broker (#23828), an Entra error such as `AADSTS50076` is also returned as `broker_error` in the `error` property of the MSAL result, making it impossible to tell if the error is from Cloud Shell or Entra. The re-authentication message for Entra errors is also

> Please explicitly log in with:

which is inaccurate.

This PR drops the `broker_error` detection logic and unifies the re-authentication message.

As it has been years since Cloud Shell supported getting VM SSH certificate, the error is not likely to happen anymore.

**Testing Guide**
```
> az account get-access-token --tenant 54826b22-38d6-4fb2-bad9-b7b93a3e9c5a
SubError: basic_action V2Error: invalid_grant AADSTS50076: Due to a configuration change made by your administrator, or because you moved to a new location, you must use multi-factor authentication to access '797f4846-ba00-4fd7-ba43-dac1f8f63013'. Trace ID: 5e7a55fa-d403-4c80-be59-20df17111400 Correlation ID: 632c9066-f581-4a21-b44d-8484adafe70c Timestamp: 2025-07-01 08:52:40Z. Status: Response_Status.Status_InteractionRequired, Error code: 3399614476, Tag: 557973645
Interactive authentication is needed. Please run:
az login --scope https://management.core.windows.net//.default
```
