### PR TITLE
{Auth} Do not show re-authentication message for service principal and managed identity

### DIFF
--- a/src/azure-cli-core/azure/cli/core/auth/util.py
+++ b/src/azure-cli-core/azure/cli/core/auth/util.py
@@ -44,7 +44,7 @@ def aad_error_handler(error, tenant=None, scopes=None, claims_challenge=None):
     recommendation = None
     if error_codes and 7000215 in error_codes:
         recommendation = PASSWORD_CERTIFICATE_WARNING
-    else:
+    elif tenant or scopes or claims_challenge:
         login_command = _generate_login_command(tenant=tenant, scopes=scopes, claims_challenge=claims_challenge)
         login_message = ('Run the command below to authenticate interactively; '
                          'additional arguments may be added as needed:\n'


### PR DESCRIPTION
**Description**<!--Mandatory-->
Currently, the re-authentication message is also shown for service principals:

```
> az login --service-principal --username aaa --password bbb --tenant 54826b22-38d6-4fb2-bad9-b7b93a3e9c5a
AADSTS700016: Application with identifier 'aaa' was not found in the directory 'AzureSDKTeam'. This can happen if the application has not been installed by the administrator of the tenant or consented to by any user in the tenant. You may have sent your authentication request to the wrong tenant. Trace ID: 7314ce0e-cf06-46cd-a37d-ec0549841f00 Correlation ID: b279ed29-07ef-4bce-907a-40ae377e50a4 Timestamp: 2025-07-01 09:47:03Z
Interactive authentication is needed. Please run:
az login
```

and managed identity:

```
> az login --identity --client-id xxx
Identity not found
Interactive authentication is needed. Please run:
az login
```

This is incorrect and meaningless.

This PR changes behavior so that the re-authentication message with a bare `az login` is not shown for service principal:

```
> az login --service-principal --username aaa --password bbb --tenant 54826b22-38d6-4fb2-bad9-b7b93a3e9c5a
AADSTS700016: Application with identifier 'aaa' was not found in the directory 'AzureSDKTeam'. This can happen if the application has not been installed by the administrator of the tenant or consented to by any user in the tenant. You may have sent your authentication request to the wrong tenant. Trace ID: dc386116-460c-4e36-8235-a12e5a762900 Correlation ID: cc78e339-9d82-4c18-9af8-d47802edab6b Timestamp: 2025-07-01 09:50:11Z
```

or managed identity:

```
> az login --identity --client-id xxx
Identity not found
```

For Cloud Shell, we still show the re-authentication message as a fallback (explicit login) in case of failure:

https://github.com/Azure/azure-cli/blob/4177017389d93ae665909f4907762ce00d667297/src/azure-cli-core/azure/cli/core/auth/msal_credentials.py#L132
