### PR TITLE
{Auth} Show raw MSAL error in debug log

### DIFF
--- a/src/azure-cli-core/azure/cli/core/auth/util.py
+++ b/src/azure-cli-core/azure/cli/core/auth/util.py
@@ -29,6 +29,8 @@ def aad_error_handler(error, **kwargs):
     # To trigger this function for testing, simply provide an invalid scope:
     # az account get-access-token --scope https://my-invalid-scope
 
+    logger.debug('MSAL error: %r', error)
+
     from azure.cli.core.util import in_cloud_console
     if in_cloud_console():
         import socket


### PR DESCRIPTION
**Description**<!--Mandatory-->
This change was part of https://github.com/Azure/azure-cli/pull/28954, but was postponed.

Showing the MSAL error in the debug log can be very helpful for troubleshooting, especially in a managed identity or Cloud Shell environment where changing the source code is difficult (https://github.com/Azure/azure-cli/pull/31743#discussion_r2177112870).

As confirmed with MSAL team, the MSAL error will only contain PII but not any credentials. Azure CLI doesn't send debug log to telemetry, so it is safe to display the MSAL error in the debug log.

**Testing Guide**
```
> az account get-access-token --scope https://my-invalid-scope --debug
...
cli.azure.cli.core.auth.util: MSAL error: {'error': 'invalid_scope', 'error_description': "AADSTS70011: The provided request must include a 'scope' input parameter. The provided value for the input parameter 'scope' is not valid. The scope https://my-invalid-scope offline_access openid profile is not valid. The scope format is invalid. Scope must be in a valid URI form <https://example/scope> or a valid Guid <guid/scope>.
```

