### PR TITLE
[ACR] Fix #31572 az acr check_health crashes when the registry is not found

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/check_health.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/check_health.py
@@ -345,7 +345,7 @@ def _check_registry_health(cmd, registry_name, repository, ignore_errors):
     status_validated = _get_registry_status(login_server, registry_name, ignore_errors)
     if status_validated:
         RoleAssignmentMode = cmd.get_models('RoleAssignmentMode')
-        registry_abac_enabled = registry.role_assignment_mode == RoleAssignmentMode.ABAC_REPOSITORY_PERMISSIONS
+        registry_abac_enabled = registry and registry.role_assignment_mode == RoleAssignmentMode.ABAC_REPOSITORY_PERMISSIONS
         _get_endpoint_and_token_status(cmd, login_server, registry_abac_enabled, repository, ignore_errors)
 
     if cmd.supported_api_version(min_api='2020-11-01-preview', resource_type=ResourceType.MGMT_CONTAINERREGISTRY):  # pylint: disable=too-many-nested-blocks


### PR DESCRIPTION
Fixes exception described in #31752 ; see the bug for details

**Related command**
az acr check_health

**Description**<!--Mandatory-->
In _check_registry_health, get_registry_by_name may return `None` for the registry. But not all references to the registry check for this first, resulting in exception when it checks whether ABAC is enabled. This PR checks whether the registry is non-None before it checks `registry.role_assignment_mode` for ABAC repository permissions.

**Testing Guide**
see bug for repro instructions. you might need to use a registry that doesn't exist, or one that responds intermittently, since that's the problem I had when I hit this bug.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
