### PR TITLE
{Packaging} Bump `azure-mgmt-core` to 1.6.0 and `azure-core` to 1.35.0

### DIFF
--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -8,7 +8,7 @@ azure-cli-core==2.75.0
 azure-cli-telemetry==1.1.0
 azure-cli==2.75.0
 azure-common==1.1.22
-azure-core==1.31.0
+azure-core==1.35.0
 azure-cosmos==3.2.0
 azure-data-tables==12.4.0
 azure-datalake-store==1.0.1
@@ -33,7 +33,7 @@ azure-mgmt-compute==34.1.0
 azure-mgmt-containerinstance==10.2.0b1
 azure-mgmt-containerregistry==14.1.0b1
 azure-mgmt-containerservice==37.0.0
-azure-mgmt-core==1.5.0
+azure-mgmt-core==1.6.0
 azure-mgmt-cosmosdb==9.8.0
 azure-mgmt-databoxedge==1.0.0
 azure-mgmt-datalake-nspkg==3.0.1

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -8,7 +8,7 @@ azure-cli-core==2.75.0
 azure-cli-telemetry==1.1.0
 azure-cli==2.75.0
 azure-common==1.1.22
-azure-core==1.31.0
+azure-core==1.35.0
 azure-cosmos==3.2.0
 azure-data-tables==12.4.0
 azure-datalake-store==1.0.1
@@ -33,7 +33,7 @@ azure-mgmt-compute==34.1.0
 azure-mgmt-containerinstance==10.2.0b1
 azure-mgmt-containerregistry==14.1.0b1
 azure-mgmt-containerservice==37.0.0
-azure-mgmt-core==1.5.0
+azure-mgmt-core==1.6.0
 azure-mgmt-cosmosdb==9.8.0
 azure-mgmt-databoxedge==1.0.0
 azure-mgmt-datalake-nspkg==3.0.1

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -8,7 +8,7 @@ azure-cli-core==2.75.0
 azure-cli-telemetry==1.1.0
 azure-cli==2.75.0
 azure-common==1.1.22
-azure-core==1.31.0
+azure-core==1.35.0
 azure-cosmos==3.2.0
 azure-data-tables==12.4.0
 azure-datalake-store==1.0.1
@@ -33,7 +33,7 @@ azure-mgmt-compute==34.1.0
 azure-mgmt-containerinstance==10.2.0b1
 azure-mgmt-containerregistry==14.1.0b1
 azure-mgmt-containerservice==37.0.0
-azure-mgmt-core==1.5.0
+azure-mgmt-core==1.6.0
 azure-mgmt-cosmosdb==9.8.0
 azure-mgmt-databoxedge==1.0.0
 azure-mgmt-datalake-nspkg==3.0.1


### PR DESCRIPTION
**Description**<!--Mandatory-->
Changes in this PR were part of #31699, because #31699 requires `azure-mgmt-core==1.6.0`:

> `ARMChallengeAuthenticationPolicy` adopt `on_challenge` in `BearerTokenCredentialPolicy` of `azure-core` to support complete CAE challenges.

However, `azure-mgmt-core` 1.6.0 depends on `azure-core>=1.32.0` and bumping `azure-core` is a big change, so this PR is created as a separate one.

