### PR TITLE
{Core} Adopt serialization func from azure-core for CLI's `todict` formatting

### DIFF
--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -633,7 +633,7 @@ def todict(obj, post_processor=None):
     """
     from datetime import date, time, datetime, timedelta
     from enum import Enum
-    from azure.core.serialization import is_generated_model, attribute_list
+    from azure.core.serialization import attribute_list
     if isinstance(obj, dict):
         result = {k: todict(v, post_processor) for (k, v) in obj.items()}
         return post_processor(obj, result) if post_processor else result
@@ -647,10 +647,12 @@ def todict(obj, post_processor=None):
         return str(obj)
     # This is the only difference with knack.util.todict because for typespec generated SDKs
     # The base model stores data in obj.__dict__['_data'] instead of in obj.__dict__
+    # The way to detect if it's a typespec generated model is to check the private `_is_model` attribute
     # azure-core provided new function `attribute_list` to list all attribute names
     # so that we don't need to use raw __dict__ directly
-    if hasattr(obj, 'as_dict') and not hasattr(obj, '_attribute_map'):
-        result = {to_camel_case(attr): todict(getattr(obj, attr), post_processor) for attr in attribute_list(obj) if hasattr(obj, attr)}
+    if getattr(obj, "_is_model", False):
+        result = {to_camel_case(attr): todict(getattr(obj, attr), post_processor)
+                  for attr in attribute_list(obj) if hasattr(obj, attr)}
         return post_processor(obj, result) if post_processor else result
     if hasattr(obj, '_asdict'):
         return todict(obj._asdict(), post_processor)

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -633,6 +633,7 @@ def todict(obj, post_processor=None):
     """
     from datetime import date, time, datetime, timedelta
     from enum import Enum
+    from azure.core.serialization import is_generated_model, attribute_list
     if isinstance(obj, dict):
         result = {k: todict(v, post_processor) for (k, v) in obj.items()}
         return post_processor(obj, result) if post_processor else result
@@ -644,11 +645,14 @@ def todict(obj, post_processor=None):
         return obj.isoformat()
     if isinstance(obj, timedelta):
         return str(obj)
-    # This is the only difference with knack.util.todict because for typespec generated SDKs
-    # The base model stores data in obj.__dict__['_data'] instead of in obj.__dict__
-    # We need to call obj.as_dict() to extract data for this kind of model
-    if hasattr(obj, 'as_dict') and not hasattr(obj, '_attribute_map'):
-        result = {to_camel_case(k): todict(v, post_processor) for k, v in obj.as_dict().items()}
+    # This is the only difference with knack.util.todict
+    # azure-core has provided
+    #   - `is_generated_model` to identify auto generated SDK models
+    #   - `attribute_list` to list all attribute names
+    # no matter it's track1/track2/swagger generated/typespec generated SDKs
+    # no matter what transformation (renaming/formatting/...) the attribute has during auto generation
+    if is_generated_model(obj):
+        result = {to_camel_case(attr): todict(getattr(obj, attr), post_processor) for attr in attribute_list(obj)}
         return post_processor(obj, result) if post_processor else result
     if hasattr(obj, '_asdict'):
         return todict(obj._asdict(), post_processor)

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -652,7 +652,10 @@ def todict(obj, post_processor=None):
     # no matter it's track1/track2/swagger generated/typespec generated SDKs
     # no matter what transformation (renaming/formatting/...) the attribute has during auto generation
     if is_generated_model(obj):
-        result = {to_camel_case(attr): todict(getattr(obj, attr), post_processor) for attr in attribute_list(obj)}
+        result = {}
+        for attr in attribute_list(obj):
+            if hasattr(obj, attr):
+                result[to_camel_case(attr)] = todict(getattr(obj, attr), post_processor)
         return post_processor(obj, result) if post_processor else result
     if hasattr(obj, '_asdict'):
         return todict(obj._asdict(), post_processor)


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
All cli commands

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Previously we added dict transformation for typespec generated SDK models in https://github.com/Azure/azure-cli/pull/30339, we called typespec generated SDK model's `as_dict` func to get each attribute name and attribute value. But this still causes issues like https://github.com/Azure/azure-cli/issues/31529 reported when
- the attribute is renamed during SDK generation
- the attribute has some formatter defined in the SDK model


We can take the `expired` attribute from [Keyvault SDK](https://github.com/Azure/azure-sdk-for-python/blob/d85023107fade43aa9a05f46ce4c1ae8b73597ed/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_generated/models/_models.py#L410-L412) as an example:
```Python
    expires: Optional[datetime.datetime] = rest_field(
        name="exp", visibility=["read", "create", "update", "delete", "query"], format="unix-timestamp"
    )
```
The `expires` is **renamed** from `exp` in http response and has `unix-timestamp` **time format**. By calling `as_dict`
- we are expecting to get `{'expires': '2027-05-28T16:43:07+00:00'}` (from **swagger** generated SDK model)
- but we actually get `{'exp': 1811522587}` (from **typespec** generated SDK model).

**The renaming and formatting was not applied to `as_dict` and this behavior applies for all typespec generated SDK models.**

To resolve this breaking change, SDK team added related serialization support in azure-core with https://github.com/Azure/azure-sdk-for-python/pull/41445, https://github.com/Azure/azure-sdk-for-python/pull/41571. They now have two functions to handle both **swagger** generated SDK and **typespec** generated SDK:
- `is_generated_model` to identify auto generated SDK models
- `attribute_list` to list all attribute names which are after renaming
- we can call `getattr(obj, attr)` for the attribute we get from `attribute_list` to get the attribute value which is after formatting

This PR changes the dict formatting for typespec generated SDK models with new `attribute_list` func. We didn't adopt `is_generated_model` because we don't want to change swagger generated SDK models' dict formatting to avoid any regressions.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
