### PR TITLE
{CI} Fix ignore logic

### DIFF
--- a/scripts/ci/test_extensions.sh
+++ b/scripts/ci/test_extensions.sh
@@ -33,7 +33,7 @@ set +e
 for ext in $output; do
     echo
     # Use regex to detect if $ext is in $ignore_list
-    if [[ $ignore_list =~ $ext ]]; then
+    if [[ " $ignore_list " =~ " $ext " ]]; then
         echo "Ignore extension: $ext"
         continue
     fi


### PR DESCRIPTION
Currently, load extension task skips ml test:
![image](https://github.com/user-attachments/assets/94656694-ffb1-4686-8b53-0f4aeec310dd)

Add spaces around extension names for exact matching
![image](https://github.com/user-attachments/assets/b2334f40-f436-4499-aeea-777f2081c2aa)


**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
