### PR TITLE
[App Service] Added a command to switch between sitecontainers and cl…

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -2343,6 +2343,16 @@ examples:
     text: az webapp sitecontainers log --name MyWebApp --resource-group MyResourceGroup --container-name MyContainer
 """
 
+helps['webapp sitecontainers convert'] = """
+type: command
+short-summary: Convert a webapp from a webapp from sitecontainers to a classic custom container and vice versa.
+examples:
+  - name: Convert a webapp to classic custom container from sitecontainers
+    text: az webapp sitecontainers convert --mode classic --name MyWebApp --resource-group MyResourceGroup
+  - name: Convert a webapp to sitecontainers from classic custom container
+    text: az webapp sitecontainers convert --mode sitecontainers --name MyWebApp --resource-group MyResourceGroup
+"""
+
 
 helps['webapp up'] = """
 type: command

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -203,6 +203,9 @@ subscription than the app service environment, please use the resource ID for --
     with self.argument_context("webapp sitecontainers list") as c:
         c.argument('name', arg_type=webapp_name_arg_type, id_part=None, help='Name of the linux webapp')
 
+    with self.argument_context("webapp sitecontainers convert") as c:
+        c.argument('mode', options_list=['--mode'], help='Mode for conversion. Allowed values: classic, sitecontainers.', choices=['classic', 'sitecontainers'])
+
     with self.argument_context('webapp show') as c:
         c.argument('name', arg_type=webapp_name_arg_type)
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -150,6 +150,7 @@ def load_command_table(self, _):
         g.custom_command('list', 'list_webapp_sitecontainers')
         g.custom_command('status', 'get_webapp_sitecontainers_status')
         g.custom_command('log', 'get_webapp_sitecontainer_log')
+        g.custom_command('convert', 'convert_webapp_sitecontainers')
 
     with self.command_group('webapp traffic-routing') as g:
         g.custom_command('set', 'set_traffic_routing')

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -1353,6 +1353,157 @@ def get_webapp_sitecontainer_log(cmd, name, resource_group, container_name, slot
         raise AzureInternalError("Failed to fetch sitecontainer logs. Error: {}".format(str(ex)))
 
 
+def convert_webapp_sitecontainers(cmd, name, resource_group, mode, slot=None):
+    """
+    Convert a webapp between classic and sitecontainers mode.
+
+    :param cmd: CLI command context
+    :param name: Name of the webapp
+    :param resource_group: Resource group of the webapp
+    :param mode: Target mode, either 'classic' or 'sitecontainers'
+    :param slot: Optional deployment slot
+    """
+    client = web_client_factory(cmd.cli_ctx)
+    if mode not in ['classic', 'sitecontainers']:
+        raise InvalidArgumentValueError(
+            "Invalid mode '{}'. Allowed values: classic, sitecontainers.".format(mode)
+        )
+
+    site_config = get_site_configs(cmd, resource_group, name, slot)
+    linux_fx_version = getattr(site_config, "linux_fx_version", None)
+ 
+    if mode == 'sitecontainers':
+        if linux_fx_version and not linux_fx_version.startswith('DOCKER|'):
+            raise ValidationError("Cannot convert to sitecontainers mode as site is not a classic custom container app.")
+        acr_use_managed_identity_creds = getattr(site_config, "acr_use_managed_identity_creds", None)
+        acr_user_managed_identity_id = getattr(site_config, "acr_user_managed_identity_id", None)
+
+        acr_user_name = None
+        acr_user_password = None
+
+        from azure.cli.core.commands.client_factory import get_subscription_id
+        subscription_id = get_subscription_id(cmd.cli_ctx)
+        url = (
+            f"/subscriptions/{subscription_id}/resourceGroups/{resource_group}/"
+            f"providers/Microsoft.Web/sites/{name}/config/appsettings/list?api-version=2023-12-01"
+            )
+        request_url = cmd.cli_ctx.cloud.endpoints.resource_manager + url
+        response = send_raw_request(cmd.cli_ctx, "POST", request_url)
+        app_settings_raw = response.json()
+        app_settings = app_settings_raw.get("properties", {})
+
+        acr_user_password = app_settings.get("DOCKER_REGISTRY_SERVER_PASSWORD", None)
+        acr_user_name = app_settings.get("DOCKER_REGISTRY_SERVER_USERNAME", None)
+        websites_port = app_settings.get("WEBSITES_PORT", None) or app_settings.get("PORT", None)
+
+        # Get docker image from linux_fx_version
+        docker_image = linux_fx_version.replace("DOCKER|", "", 1)
+        sidecarmainname = "main"
+        startup_cmd = getattr(site_config, "app_command_line", None)
+
+        # Prepare parameters for sitecontainers create
+        sitecontainer_kwargs = {
+            "name": name,
+            "resource_group": resource_group,
+            "slot": slot,
+            "container_name": sidecarmainname,
+            "image": docker_image,
+            "target_port": websites_port,
+            "startup_cmd": startup_cmd,
+            "is_main": True,
+        }
+
+        if acr_use_managed_identity_creds:
+            if acr_user_managed_identity_id:
+                # ACR with User-Assigned Managed Identity
+                logger.warning("Site is using User-Assigned Managed Identity for ACR authentication.")
+                sitecontainer_kwargs["user_assigned_identity"] = acr_user_managed_identity_id
+            else:
+                # ACR with System-Assigned Managed Identity
+                logger.warning("Site is using System-Assigned Managed Identity for ACR authentication.")
+                sitecontainer_kwargs["system_assigned_identity"] = True
+        else: 
+            if acr_user_name and acr_user_password:
+                # ACR with User Credentials
+                logger.warning("Site is using User Credentials for ACR authentication.")
+                sitecontainer_kwargs["registry_username"] = acr_user_name
+                sitecontainer_kwargs["registry_password"] = acr_user_password
+            else:
+                # No ACR authentication, using anonymous access
+                logger.warning("Site is using anonymous access for ACR authentication.")
+        response = create_webapp_sitecontainers(cmd, **sitecontainer_kwargs)
+        if response is None:
+            raise AzureInternalError("Failed to create sitecontainer for conversion to sitecontainers mode.")
+        
+        # Set linuxFxVersion to SITECONTAINERS
+        logger.warning("Setting linuxFxVersion to SITECONTAINERS")
+        update_site_configs(cmd, resource_group, name, slot=slot, linux_fx_version="SITECONTAINERS")
+        logger.warning("Webapp '%s' converted to sitecontainers mode.", name)
+        return {"result": "success", "mode": mode}
+    else:  # mode == 'classic'
+        if linux_fx_version and not linux_fx_version.lower().startswith('sitecontainers'):
+            raise ValidationError("Cannot convert to classic mode as site is not a SITECONTAINERS app.")
+
+        # Get the main sitecontainer
+        sitecontainers = list_webapp_sitecontainers(cmd, name, resource_group, slot)
+        main_container = next((c for c in sitecontainers if getattr(c, "is_main", False)), None)
+        if not main_container:
+            raise ResourceNotFoundError("No main sitecontainer found. Cannot convert to classic mode.")
+
+        main_container = update_webapp_sitecontainer(cmd, name, resource_group, main_container.name, slot=slot,
+                                    image=main_container.image, target_port=main_container.target_port, is_main=main_container.is_main)
+
+        # Prepare new linux_fx_version
+        docker_image = getattr(main_container, "image", None)
+        if not docker_image:
+            raise ValidationError("Main sitecontainer does not have an image specified.")
+
+        linux_fx_version = _format_fx_version(docker_image)
+
+        # Prepare app settings for registry credentials if needed
+        settings = []
+        if main_container.auth_type == AuthType.USER_CREDENTIALS:
+            if main_container.user_name:
+                settings.append(f"DOCKER_REGISTRY_SERVER_USERNAME={main_container.user_name}")
+            if main_container.password_secret:
+                settings.append(f"DOCKER_REGISTRY_SERVER_PASSWORD={main_container.password_secret}")
+            if main_container.target_port:
+                settings.append(f"WEBSITES_PORT={main_container.target_port}")
+        elif main_container.auth_type == AuthType.SYSTEM_IDENTITY:
+            configs = get_site_configs(cmd, resource_group, name, slot)
+            setattr(configs, 'acr_use_managed_identity_creds', True)
+            setattr(configs, 'acr_user_managed_identity_id', "")
+            _generic_site_operation(cmd.cli_ctx, resource_group, name, 'update_configuration', slot, configs)
+        elif main_container.auth_type == AuthType.USER_ASSIGNED:
+            app = client.web_apps.get_slot(resource_group, name, slot) if slot else client.web_apps.get(resource_group, name)
+            if app.identity and app.identity.user_assigned_identities:
+                # Find the managed identity key whose client_id matches main_container.user_managed_identity_client_id
+                matched_key = None
+                for key, identity in app.identity.user_assigned_identities.items():
+                    if identity.client_id == main_container.user_managed_identity_client_id:
+                        matched_key = key
+                        break
+                if not matched_key:
+                    raise ResourceNotFoundError(
+                        f"Could not find a user-assigned identity with client_id '{main_container.user_managed_identity_client_id}' assigned to the app."
+                    )
+            update_site_configs(cmd, resource_group, name, slot=slot, acr_identity=matched_key)
+        elif main_container.auth_type == AuthType.Anonymous:
+            update_site_configs(cmd, resource_group, name, slot=slot, acr_use_identity=False)
+
+        logger.warning("Deleting all sitecontainers before converting to classic mode.")
+        # Remove all sitecontainers
+        for c in sitecontainers:
+            delete_webapp_sitecontainer(cmd, name, resource_group, c.name, slot)
+
+        # Set linuxFxVersion to classic custom container
+        update_site_configs(cmd, resource_group, name, slot=slot, linux_fx_version=linux_fx_version)
+        if settings:
+            update_app_settings(cmd, resource_group, name, settings, slot)
+        logger.warning("Webapp '%s' converted to classic custom container mode.", name)
+        return {"result": "success", "mode": mode}
+
+
 # for generic updater
 def get_webapp(cmd, resource_group_name, name, slot=None):
     return _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'get', slot)
@@ -2181,7 +2332,7 @@ def update_site_configs(cmd, resource_group_name, name, slot=None, number_of_wor
             _update_webapp_current_stack_property_if_needed(cmd, resource_group_name, name, current_stack)
 
     if linux_fx_version:
-        if linux_fx_version.strip().lower().startswith('docker|'):
+        if linux_fx_version.strip().lower().startswith('docker|') or linux_fx_version.strip().lower().startswith('sitecontainers'):
             if ('WEBSITES_ENABLE_APP_SERVICE_STORAGE' not in app_settings.properties or
                     app_settings.properties['WEBSITES_ENABLE_APP_SERVICE_STORAGE'] != 'true'):
                 update_app_settings(cmd, resource_group_name, name, ["WEBSITES_ENABLE_APP_SERVICE_STORAGE=false"])


### PR DESCRIPTION
[App Service] Added a command to switch between sitecontainers and classic custom containers

**Related command**
az webapp sitecontainers convert --mode classic --name MyWebApp --resource-group MyResourceGroup
Convert a webapp to classic custom container from sitecontainers

az webapp sitecontainers convert --mode sitecontainers --name MyWebApp --resource-group MyResourceGroup
Convert a webapp to sitecontainers from classic custom container

**Description**<!--Mandatory-->
This change add a new command to az webapp sitecontainers, which can be used to switch between sitecontainers and classic custom containers

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
