### PR TITLE
[Service Fabric] `az sf cluster create`: Add more options for parameter `--vm-os`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/servicefabric/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/servicefabric/custom.py
@@ -84,6 +84,11 @@ SEC_CERTIFICATE_URL_VALUE = "secCertificateUrlValue"
 
 os_dic = {'WindowsServer2012R2Datacenter': '2012-R2-Datacenter',
           'UbuntuServer1604': '16.04-LTS',
+          'UbuntuServer1804': '18.04-LTS',
+          'UbuntuServer1804Gen2': '18_04-LTS-Gen2',
+          'UbuntuServer2004': '20_04-LTS',
+          'UbuntuServer2204': '22_04-LTS',
+          'UbuntuServer2204Gen2': '22_04-LTS-Gen2',
           'WindowsServer2016DatacenterwithContainers': '2016-Datacenter-with-Containers',
           'WindowsServer2016Datacenter': '2016-Datacenter',
           'WindowsServer1709': "Datacenter-Core-1709-smalldisk",
@@ -91,7 +96,13 @@ os_dic = {'WindowsServer2012R2Datacenter': '2012-R2-Datacenter',
           'WindowsServer1803withContainers': "Datacenter-Core-1803-with-Containers-smalldisk",
           'WindowsServer1809withContainers': "Datacenter-Core-1809-with-Containers-smalldisk",
           'WindowsServer2019Datacenter': "2019-Datacenter",
-          'WindowsServer2019DatacenterwithContainers': "2019-Datacenter-Core-with-Containers"}
+          'WindowsServer2019DatacenterGen2': "2019-Datacenter-gensecond",
+          'WindowsServer2019DatacenterwithContainers': "2019-Datacenter-Core-with-Containers",
+          'WindowsServer2022Datacenter': "2022-Datacenter",
+          'WindowsServer2022DatacenterGen2': "2022-Datacenter-G2",
+          'WindowsServer2022DatacenterAzureEdition': "2022-Datacenter-Azure-Edition",
+          'WindowsServer2022DatacenterCoreSmallDisk': "2022-Datacenter-Core-SmallDisk",
+          'WindowsServer2022DatacenterGS': "2022-Datacenter-GS"}
 
 
 def list_cluster(client, resource_group_name=None):
@@ -183,7 +194,6 @@ def new_cluster(cmd,
     cert_thumbprint = None
     output_file = None
     if parameter_file is None:
-        vm_os = os_dic[vm_os]
         reliability_level = _get_reliability_level(cluster_size)
         result = _create_certificate(cmd,
                                      cli_ctx,
@@ -201,8 +211,9 @@ def new_cluster(cmd,
         output_file = result[3]
 
         linux = None
-        if vm_os == '16.04-LTS':
+        if vm_os.startswith('Ubuntu'):
             linux = True
+        vm_os = os_dic[vm_os]
         template = _modify_template(linux)
         parameters = _set_parameters_for_default_template(cluster_location=location,
                                                           cluster_name=cluster_name,


### PR DESCRIPTION
**Related command**
`az sf cluster create`

**Description**<!--Mandatory-->
`az sf cluster create`: add more options for parameter `--vm-os` to fix https://github.com/Azure/azure-cli/issues/30381

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->
[Service Fabric] `az sf cluster create`: Add more options for parameter `--vm-os`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
