### PR TITLE
[az aks mesh] update test files to reflect istio lts support

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/recordings/test_aks_azure_service_mesh_canary_upgrade.yaml
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/recordings/test_aks_azure_service_mesh_canary_upgrade.yaml
@@ -22,16 +22,24 @@ interactions:
         ,\n   \"name\": \"istio\",\n   \"type\": \"Microsoft.ContainerService/locations/meshRevisionProfiles\"\
         ,\n   \"properties\": {\n    \"meshRevisions\": [\n     {\n      \"revision\"\
         : \"asm-1-20\",\n      \"upgrades\": [\n       \"asm-1-21\"\n      ],\n  \
-        \    \"compatibleWith\": [\n       {\n        \"name\": \"kubernetes\",\n\
+        \    \"compatibleWith\": [\n       {\n        \"name\": \"KubernetesOfficial\",\n\
         \        \"versions\": [\n         \"1.25\",\n         \"1.26\",\n       \
-        \  \"1.27\",\n         \"1.28\",\n         \"1.29\"\n        ]\n       }\n\
+        \  \"1.27\",\n         \"1.28\",\n         \"1.29\"\n        ]\n       },\n\
+        \       {\n        \"name\": \"AKSLongTermSupport\",\n        \"versions\": [\n\
+        \         \"1.25\",\n         \"1.26\",\n         \"1.27\",\n         \"1.28\",\n\
+        \         \"1.29\"\n        ]\n       }\n\
         \      ]\n     },\n     {\n      \"revision\": \"asm-1-21\",\n      \"upgrades\"\
         : [\n       \"asm-1-22\"\n      ],\n      \"compatibleWith\": [\n       {\n\
-        \        \"name\": \"kubernetes\",\n        \"versions\": [\n         \"1.26\"\
+        \        \"name\": \"KubernetesOfficial\",\n        \"versions\": [\n         \"1.26\"\
+        ,\n         \"1.27\",\n         \"1.28\",\n         \"1.29\",\n         \"\
+        1.30\"\n        ]\n       },\n       {\n\
+        \        \"name\": \"AKSLongTermSupport\",\n        \"versions\": [\n         \"1.26\"\
         ,\n         \"1.27\",\n         \"1.28\",\n         \"1.29\",\n         \"\
         1.30\"\n        ]\n       }\n      ]\n     },\n     {\n      \"revision\"\
         : \"asm-1-22\",\n      \"compatibleWith\": [\n       {\n        \"name\":\
-        \ \"kubernetes\",\n        \"versions\": [\n         \"1.27\",\n         \"\
+        \ \"KubernetesOfficial\",\n        \"versions\": [\n         \"1.27\",\n         \"\
+        1.28\",\n         \"1.29\",\n         \"1.30\"\n        ]\n       },\n       {\n        \"name\":\
+        \ \"AKSLongTermSupport\",\n        \"versions\": [\n         \"1.27\",\n         \"\
         1.28\",\n         \"1.29\",\n         \"1.30\"\n        ]\n       }\n    \
         \  ]\n     }\n    ]\n   }\n  }\n ]\n}"
     headers:
@@ -890,7 +898,10 @@ interactions:
         ,\n   \"name\": \"istio\",\n   \"type\": \"Microsoft.ContainerService/managedClusters/meshUpgradeProfiles\"\
         ,\n   \"properties\": {\n    \"revision\": \"asm-1-20\",\n    \"upgrades\"\
         : [\n     \"asm-1-21\"\n    ],\n    \"compatibleWith\": [\n     {\n      \"\
-        name\": \"kubernetes\",\n      \"versions\": [\n       \"1.25\",\n       \"\
+        name\": \"KubernetesOfficial\",\n      \"versions\": [\n       \"1.25\",\n       \"\
+        1.26\",\n       \"1.27\",\n       \"1.28\",\n       \"1.29\"\n      ]\n  \
+        \   },\n     {\n      \"\
+        name\": \"AKSLongTermSupport\",\n      \"versions\": [\n       \"1.25\",\n       \"\
         1.26\",\n       \"1.27\",\n       \"1.28\",\n       \"1.29\"\n      ]\n  \
         \   }\n    ]\n   }\n  }\n ]\n}"
     headers:
@@ -1616,16 +1627,24 @@ interactions:
         ,\n   \"name\": \"istio\",\n   \"type\": \"Microsoft.ContainerService/locations/meshRevisionProfiles\"\
         ,\n   \"properties\": {\n    \"meshRevisions\": [\n     {\n      \"revision\"\
         : \"asm-1-20\",\n      \"upgrades\": [\n       \"asm-1-21\"\n      ],\n  \
-        \    \"compatibleWith\": [\n       {\n        \"name\": \"kubernetes\",\n\
+        \    \"compatibleWith\": [\n       {\n        \"name\": \"KubernetesOfficial\",\n\
         \        \"versions\": [\n         \"1.25\",\n         \"1.26\",\n       \
-        \  \"1.27\",\n         \"1.28\",\n         \"1.29\"\n        ]\n       }\n\
+        \  \"1.27\",\n         \"1.28\",\n         \"1.29\"\n        ]\n       },\n\
+        \       {\n        \"name\": \"AKSLongTermSupport\",\n        \"versions\": [\n\
+        \         \"1.25\",\n         \"1.26\",\n         \"1.27\",\n         \"1.28\",\n\
+        \         \"1.29\"\n        ]\n       }\n\
         \      ]\n     },\n     {\n      \"revision\": \"asm-1-21\",\n      \"upgrades\"\
         : [\n       \"asm-1-22\"\n      ],\n      \"compatibleWith\": [\n       {\n\
-        \        \"name\": \"kubernetes\",\n        \"versions\": [\n         \"1.26\"\
+        \        \"name\": \"KubernetesOfficial\",\n        \"versions\": [\n         \"1.26\"\
+        ,\n         \"1.27\",\n         \"1.28\",\n         \"1.29\",\n         \"\
+        1.30\"\n        ]\n       },\n       {\n\
+        \        \"name\": \"AKSLongTermSupport\",\n        \"versions\": [\n         \"1.26\"\
         ,\n         \"1.27\",\n         \"1.28\",\n         \"1.29\",\n         \"\
         1.30\"\n        ]\n       }\n      ]\n     },\n     {\n      \"revision\"\
         : \"asm-1-22\",\n      \"compatibleWith\": [\n       {\n        \"name\":\
-        \ \"kubernetes\",\n        \"versions\": [\n         \"1.27\",\n         \"\
+        \ \"KubernetesOfficial\",\n        \"versions\": [\n         \"1.27\",\n         \"\
+        1.28\",\n         \"1.29\",\n         \"1.30\"\n        ]\n       },\n       {\n        \"name\":\
+        \ \"AKSLongTermSupport\",\n        \"versions\": [\n         \"1.27\",\n         \"\
         1.28\",\n         \"1.29\",\n         \"1.30\"\n        ]\n       }\n    \
         \  ]\n     }\n    ]\n   }\n  }\n ]\n}"
     headers:
@@ -2765,16 +2784,24 @@ interactions:
         ,\n   \"name\": \"istio\",\n   \"type\": \"Microsoft.ContainerService/locations/meshRevisionProfiles\"\
         ,\n   \"properties\": {\n    \"meshRevisions\": [\n     {\n      \"revision\"\
         : \"asm-1-20\",\n      \"upgrades\": [\n       \"asm-1-21\"\n      ],\n  \
-        \    \"compatibleWith\": [\n       {\n        \"name\": \"kubernetes\",\n\
+        \    \"compatibleWith\": [\n       {\n        \"name\": \"KubernetesOfficial\",\n\
         \        \"versions\": [\n         \"1.25\",\n         \"1.26\",\n       \
-        \  \"1.27\",\n         \"1.28\",\n         \"1.29\"\n        ]\n       }\n\
+        \  \"1.27\",\n         \"1.28\",\n         \"1.29\"\n        ]\n       },\n\
+        \       {\n        \"name\": \"AKSLongTermSupport\",\n        \"versions\": [\n\
+        \         \"1.25\",\n         \"1.26\",\n         \"1.27\",\n         \"1.28\",\n\
+        \         \"1.29\"\n        ]\n       }\n\
         \      ]\n     },\n     {\n      \"revision\": \"asm-1-21\",\n      \"upgrades\"\
         : [\n       \"asm-1-22\"\n      ],\n      \"compatibleWith\": [\n       {\n\
-        \        \"name\": \"kubernetes\",\n        \"versions\": [\n         \"1.26\"\
+        \        \"name\": \"KubernetesOfficial\",\n        \"versions\": [\n         \"1.26\"\
+        ,\n         \"1.27\",\n         \"1.28\",\n         \"1.29\",\n         \"\
+        1.30\"\n        ]\n       },\n       {\n\
+        \        \"name\": \"AKSLongTermSupport\",\n        \"versions\": [\n         \"1.26\"\
         ,\n         \"1.27\",\n         \"1.28\",\n         \"1.29\",\n         \"\
         1.30\"\n        ]\n       }\n      ]\n     },\n     {\n      \"revision\"\
         : \"asm-1-22\",\n      \"compatibleWith\": [\n       {\n        \"name\":\
-        \ \"kubernetes\",\n        \"versions\": [\n         \"1.27\",\n         \"\
+        \ \"KubernetesOfficial\",\n        \"versions\": [\n         \"1.27\",\n         \"\
+        1.28\",\n         \"1.29\",\n         \"1.30\"\n        ]\n       },\n       {\n        \"name\":\
+        \ \"AKSLongTermSupport\",\n        \"versions\": [\n         \"1.27\",\n         \"\
         1.28\",\n         \"1.29\",\n         \"1.30\"\n        ]\n       }\n    \
         \  ]\n     }\n    ]\n   }\n  }\n ]\n}"
     headers:

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/recordings/test_aks_azure_service_mesh_enable_disable.yaml
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/recordings/test_aks_azure_service_mesh_enable_disable.yaml
@@ -22,16 +22,24 @@ interactions:
         ,\n   \"name\": \"istio\",\n   \"type\": \"Microsoft.ContainerService/locations/meshRevisionProfiles\"\
         ,\n   \"properties\": {\n    \"meshRevisions\": [\n     {\n      \"revision\"\
         : \"asm-1-20\",\n      \"upgrades\": [\n       \"asm-1-21\"\n      ],\n  \
-        \    \"compatibleWith\": [\n       {\n        \"name\": \"kubernetes\",\n\
+        \    \"compatibleWith\": [\n       {\n        \"name\": \"KubernetesOfficial\",\n\
         \        \"versions\": [\n         \"1.25\",\n         \"1.26\",\n       \
-        \  \"1.27\",\n         \"1.28\",\n         \"1.29\"\n        ]\n       }\n\
+        \  \"1.27\",\n         \"1.28\",\n         \"1.29\"\n        ]\n       },\n\
+        \       {\n        \"name\": \"AKSLongTermSupport\",\n        \"versions\": [\n\
+        \         \"1.25\",\n         \"1.26\",\n         \"1.27\",\n         \"1.28\",\n\
+        \         \"1.29\"\n        ]\n       }\n\
         \      ]\n     },\n     {\n      \"revision\": \"asm-1-21\",\n      \"upgrades\"\
         : [\n       \"asm-1-22\"\n      ],\n      \"compatibleWith\": [\n       {\n\
-        \        \"name\": \"kubernetes\",\n        \"versions\": [\n         \"1.26\"\
+        \        \"name\": \"KubernetesOfficial\",\n        \"versions\": [\n         \"1.26\"\
+        ,\n         \"1.27\",\n         \"1.28\",\n         \"1.29\",\n         \"\
+        1.30\"\n        ]\n       },\n       {\n\
+        \        \"name\": \"AKSLongTermSupport\",\n        \"versions\": [\n         \"1.26\"\
         ,\n         \"1.27\",\n         \"1.28\",\n         \"1.29\",\n         \"\
         1.30\"\n        ]\n       }\n      ]\n     },\n     {\n      \"revision\"\
         : \"asm-1-22\",\n      \"compatibleWith\": [\n       {\n        \"name\":\
-        \ \"kubernetes\",\n        \"versions\": [\n         \"1.27\",\n         \"\
+        \ \"KubernetesOfficial\",\n        \"versions\": [\n         \"1.27\",\n         \"\
+        1.28\",\n         \"1.29\",\n         \"1.30\"\n        ]\n       },\n       {\n        \"name\":\
+        \ \"AKSLongTermSupport\",\n        \"versions\": [\n         \"1.27\",\n         \"\
         1.28\",\n         \"1.29\",\n         \"1.30\"\n        ]\n       }\n    \
         \  ]\n     }\n    ]\n   }\n  }\n ]\n}"
     headers:
@@ -918,16 +926,24 @@ interactions:
         ,\n   \"name\": \"istio\",\n   \"type\": \"Microsoft.ContainerService/locations/meshRevisionProfiles\"\
         ,\n   \"properties\": {\n    \"meshRevisions\": [\n     {\n      \"revision\"\
         : \"asm-1-20\",\n      \"upgrades\": [\n       \"asm-1-21\"\n      ],\n  \
-        \    \"compatibleWith\": [\n       {\n        \"name\": \"kubernetes\",\n\
+        \    \"compatibleWith\": [\n       {\n        \"name\": \"KubernetesOfficial\",\n\
         \        \"versions\": [\n         \"1.25\",\n         \"1.26\",\n       \
-        \  \"1.27\",\n         \"1.28\",\n         \"1.29\"\n        ]\n       }\n\
+        \  \"1.27\",\n         \"1.28\",\n         \"1.29\"\n        ]\n       },\n\
+        \       {\n        \"name\": \"AKSLongTermSupport\",\n        \"versions\": [\n\
+        \         \"1.25\",\n         \"1.26\",\n         \"1.27\",\n         \"1.28\",\n\
+        \         \"1.29\"\n        ]\n       }\n\
         \      ]\n     },\n     {\n      \"revision\": \"asm-1-21\",\n      \"upgrades\"\
         : [\n       \"asm-1-22\"\n      ],\n      \"compatibleWith\": [\n       {\n\
-        \        \"name\": \"kubernetes\",\n        \"versions\": [\n         \"1.26\"\
+        \        \"name\": \"KubernetesOfficial\",\n        \"versions\": [\n         \"1.26\"\
+        ,\n         \"1.27\",\n         \"1.28\",\n         \"1.29\",\n         \"\
+        1.30\"\n        ]\n       },\n       {\n\
+        \        \"name\": \"AKSLongTermSupport\",\n        \"versions\": [\n         \"1.26\"\
         ,\n         \"1.27\",\n         \"1.28\",\n         \"1.29\",\n         \"\
         1.30\"\n        ]\n       }\n      ]\n     },\n     {\n      \"revision\"\
         : \"asm-1-22\",\n      \"compatibleWith\": [\n       {\n        \"name\":\
-        \ \"kubernetes\",\n        \"versions\": [\n         \"1.27\",\n         \"\
+        \ \"KubernetesOfficial\",\n        \"versions\": [\n         \"1.27\",\n         \"\
+        1.28\",\n         \"1.29\",\n         \"1.30\"\n        ]\n       },\n       {\n        \"name\":\
+        \ \"AKSLongTermSupport\",\n        \"versions\": [\n         \"1.27\",\n         \"\
         1.28\",\n         \"1.29\",\n         \"1.30\"\n        ]\n       }\n    \
         \  ]\n     }\n    ]\n   }\n  }\n ]\n}"
     headers:

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/recordings/test_aks_azure_service_mesh_get_revisions.yaml
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/recordings/test_aks_azure_service_mesh_get_revisions.yaml
@@ -22,16 +22,24 @@ interactions:
         ,\n   \"name\": \"istio\",\n   \"type\": \"Microsoft.ContainerService/locations/meshRevisionProfiles\"\
         ,\n   \"properties\": {\n    \"meshRevisions\": [\n     {\n      \"revision\"\
         : \"asm-1-20\",\n      \"upgrades\": [\n       \"asm-1-21\"\n      ],\n  \
-        \    \"compatibleWith\": [\n       {\n        \"name\": \"kubernetes\",\n\
+        \    \"compatibleWith\": [\n       {\n        \"name\": \"KubernetesOfficial\",\n\
         \        \"versions\": [\n         \"1.25\",\n         \"1.26\",\n       \
-        \  \"1.27\",\n         \"1.28\",\n         \"1.29\"\n        ]\n       }\n\
+        \  \"1.27\",\n         \"1.28\",\n         \"1.29\"\n        ]\n       },\n\
+        \       {\n        \"name\": \"AKSLongTermSupport\",\n        \"versions\": [\n\
+        \         \"1.25\",\n         \"1.26\",\n         \"1.27\",\n         \"1.28\",\n\
+        \         \"1.29\"\n        ]\n       }\n\
         \      ]\n     },\n     {\n      \"revision\": \"asm-1-21\",\n      \"upgrades\"\
         : [\n       \"asm-1-22\"\n      ],\n      \"compatibleWith\": [\n       {\n\
-        \        \"name\": \"kubernetes\",\n        \"versions\": [\n         \"1.26\"\
+        \        \"name\": \"KubernetesOfficial\",\n        \"versions\": [\n         \"1.26\"\
+        ,\n         \"1.27\",\n         \"1.28\",\n         \"1.29\",\n         \"\
+        1.30\"\n        ]\n       },\n       {\n\
+        \        \"name\": \"AKSLongTermSupport\",\n        \"versions\": [\n         \"1.26\"\
         ,\n         \"1.27\",\n         \"1.28\",\n         \"1.29\",\n         \"\
         1.30\"\n        ]\n       }\n      ]\n     },\n     {\n      \"revision\"\
         : \"asm-1-22\",\n      \"compatibleWith\": [\n       {\n        \"name\":\
-        \ \"kubernetes\",\n        \"versions\": [\n         \"1.27\",\n         \"\
+        \ \"KubernetesOfficial\",\n        \"versions\": [\n         \"1.27\",\n         \"\
+        1.28\",\n         \"1.29\",\n         \"1.30\"\n        ]\n       },\n       {\n        \"name\":\
+        \ \"AKSLongTermSupport\",\n        \"versions\": [\n         \"1.27\",\n         \"\
         1.28\",\n         \"1.29\",\n         \"1.30\"\n        ]\n       }\n    \
         \  ]\n     }\n    ]\n   }\n  }\n ]\n}"
     headers:

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/recordings/test_aks_azure_service_mesh_get_upgrades.yaml
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/recordings/test_aks_azure_service_mesh_get_upgrades.yaml
@@ -22,16 +22,24 @@ interactions:
         ,\n   \"name\": \"istio\",\n   \"type\": \"Microsoft.ContainerService/locations/meshRevisionProfiles\"\
         ,\n   \"properties\": {\n    \"meshRevisions\": [\n     {\n      \"revision\"\
         : \"asm-1-20\",\n      \"upgrades\": [\n       \"asm-1-21\"\n      ],\n  \
-        \    \"compatibleWith\": [\n       {\n        \"name\": \"kubernetes\",\n\
+        \    \"compatibleWith\": [\n       {\n        \"name\": \"KubernetesOfficial\",\n\
         \        \"versions\": [\n         \"1.25\",\n         \"1.26\",\n       \
-        \  \"1.27\",\n         \"1.28\",\n         \"1.29\"\n        ]\n       }\n\
+        \  \"1.27\",\n         \"1.28\",\n         \"1.29\"\n        ]\n       },\n\
+        \       {\n        \"name\": \"AKSLongTermSupport\",\n        \"versions\": [\n\
+        \         \"1.25\",\n         \"1.26\",\n         \"1.27\",\n         \"1.28\",\n\
+        \         \"1.29\"\n        ]\n       }\n\
         \      ]\n     },\n     {\n      \"revision\": \"asm-1-21\",\n      \"upgrades\"\
         : [\n       \"asm-1-22\"\n      ],\n      \"compatibleWith\": [\n       {\n\
-        \        \"name\": \"kubernetes\",\n        \"versions\": [\n         \"1.26\"\
+        \        \"name\": \"KubernetesOfficial\",\n        \"versions\": [\n         \"1.26\"\
+        ,\n         \"1.27\",\n         \"1.28\",\n         \"1.29\",\n         \"\
+        1.30\"\n        ]\n       },\n       {\n\
+        \        \"name\": \"AKSLongTermSupport\",\n        \"versions\": [\n         \"1.26\"\
         ,\n         \"1.27\",\n         \"1.28\",\n         \"1.29\",\n         \"\
         1.30\"\n        ]\n       }\n      ]\n     },\n     {\n      \"revision\"\
         : \"asm-1-22\",\n      \"compatibleWith\": [\n       {\n        \"name\":\
-        \ \"kubernetes\",\n        \"versions\": [\n         \"1.27\",\n         \"\
+        \ \"KubernetesOfficial\",\n        \"versions\": [\n         \"1.27\",\n         \"\
+        1.28\",\n         \"1.29\",\n         \"1.30\"\n        ]\n       },\n       {\n        \"name\":\
+        \ \"AKSLongTermSupport\",\n        \"versions\": [\n         \"1.27\",\n         \"\
         1.28\",\n         \"1.29\",\n         \"1.30\"\n        ]\n       }\n    \
         \  ]\n     }\n    ]\n   }\n  }\n ]\n}"
     headers:
@@ -1008,16 +1016,24 @@ interactions:
         ,\n   \"name\": \"istio\",\n   \"type\": \"Microsoft.ContainerService/locations/meshRevisionProfiles\"\
         ,\n   \"properties\": {\n    \"meshRevisions\": [\n     {\n      \"revision\"\
         : \"asm-1-20\",\n      \"upgrades\": [\n       \"asm-1-21\"\n      ],\n  \
-        \    \"compatibleWith\": [\n       {\n        \"name\": \"kubernetes\",\n\
+        \    \"compatibleWith\": [\n       {\n        \"name\": \"KubernetesOfficial\",\n\
         \        \"versions\": [\n         \"1.25\",\n         \"1.26\",\n       \
-        \  \"1.27\",\n         \"1.28\",\n         \"1.29\"\n        ]\n       }\n\
+        \  \"1.27\",\n         \"1.28\",\n         \"1.29\"\n        ]\n       },\n\
+        \       {\n        \"name\": \"AKSLongTermSupport\",\n        \"versions\": [\n\
+        \         \"1.25\",\n         \"1.26\",\n         \"1.27\",\n         \"1.28\",\n\
+        \         \"1.29\"\n        ]\n       }\n\
         \      ]\n     },\n     {\n      \"revision\": \"asm-1-21\",\n      \"upgrades\"\
         : [\n       \"asm-1-22\"\n      ],\n      \"compatibleWith\": [\n       {\n\
-        \        \"name\": \"kubernetes\",\n        \"versions\": [\n         \"1.26\"\
+        \        \"name\": \"KubernetesOfficial\",\n        \"versions\": [\n         \"1.26\"\
+        ,\n         \"1.27\",\n         \"1.28\",\n         \"1.29\",\n         \"\
+        1.30\"\n        ]\n       },\n       {\n\
+        \        \"name\": \"AKSLongTermSupport\",\n        \"versions\": [\n         \"1.26\"\
         ,\n         \"1.27\",\n         \"1.28\",\n         \"1.29\",\n         \"\
         1.30\"\n        ]\n       }\n      ]\n     },\n     {\n      \"revision\"\
         : \"asm-1-22\",\n      \"compatibleWith\": [\n       {\n        \"name\":\
-        \ \"kubernetes\",\n        \"versions\": [\n         \"1.27\",\n         \"\
+        \ \"KubernetesOfficial\",\n        \"versions\": [\n         \"1.27\",\n         \"\
+        1.28\",\n         \"1.29\",\n         \"1.30\"\n        ]\n       },\n       {\n        \"name\":\
+        \ \"AKSLongTermSupport\",\n        \"versions\": [\n         \"1.27\",\n         \"\
         1.28\",\n         \"1.29\",\n         \"1.30\"\n        ]\n       }\n    \
         \  ]\n     }\n    ]\n   }\n  }\n ]\n}"
     headers:

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/recordings/test_aks_azure_service_mesh_with_ingress_gateway.yaml
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/recordings/test_aks_azure_service_mesh_with_ingress_gateway.yaml
@@ -22,16 +22,24 @@ interactions:
         ,\n   \"name\": \"istio\",\n   \"type\": \"Microsoft.ContainerService/locations/meshRevisionProfiles\"\
         ,\n   \"properties\": {\n    \"meshRevisions\": [\n     {\n      \"revision\"\
         : \"asm-1-20\",\n      \"upgrades\": [\n       \"asm-1-21\"\n      ],\n  \
-        \    \"compatibleWith\": [\n       {\n        \"name\": \"kubernetes\",\n\
+        \    \"compatibleWith\": [\n       {\n        \"name\": \"KubernetesOfficial\",\n\
         \        \"versions\": [\n         \"1.25\",\n         \"1.26\",\n       \
-        \  \"1.27\",\n         \"1.28\",\n         \"1.29\"\n        ]\n       }\n\
+        \  \"1.27\",\n         \"1.28\",\n         \"1.29\"\n        ]\n       },\n\
+        \       {\n        \"name\": \"AKSLongTermSupport\",\n        \"versions\": [\n\
+        \         \"1.25\",\n         \"1.26\",\n         \"1.27\",\n         \"1.28\",\n\
+        \         \"1.29\"\n        ]\n       }\n\
         \      ]\n     },\n     {\n      \"revision\": \"asm-1-21\",\n      \"upgrades\"\
         : [\n       \"asm-1-22\"\n      ],\n      \"compatibleWith\": [\n       {\n\
-        \        \"name\": \"kubernetes\",\n        \"versions\": [\n         \"1.26\"\
+        \        \"name\": \"KubernetesOfficial\",\n        \"versions\": [\n         \"1.26\"\
+        ,\n         \"1.27\",\n         \"1.28\",\n         \"1.29\",\n         \"\
+        1.30\"\n        ]\n       },\n       {\n\
+        \        \"name\": \"AKSLongTermSupport\",\n        \"versions\": [\n         \"1.26\"\
         ,\n         \"1.27\",\n         \"1.28\",\n         \"1.29\",\n         \"\
         1.30\"\n        ]\n       }\n      ]\n     },\n     {\n      \"revision\"\
         : \"asm-1-22\",\n      \"compatibleWith\": [\n       {\n        \"name\":\
-        \ \"kubernetes\",\n        \"versions\": [\n         \"1.27\",\n         \"\
+        \ \"KubernetesOfficial\",\n        \"versions\": [\n         \"1.27\",\n         \"\
+        1.28\",\n         \"1.29\",\n         \"1.30\"\n        ]\n       },\n       {\n        \"name\":\
+        \ \"AKSLongTermSupport\",\n        \"versions\": [\n         \"1.27\",\n         \"\
         1.28\",\n         \"1.29\",\n         \"1.30\"\n        ]\n       }\n    \
         \  ]\n     }\n    ]\n   }\n  }\n ]\n}"
     headers:
@@ -1029,16 +1037,24 @@ interactions:
         ,\n   \"name\": \"istio\",\n   \"type\": \"Microsoft.ContainerService/locations/meshRevisionProfiles\"\
         ,\n   \"properties\": {\n    \"meshRevisions\": [\n     {\n      \"revision\"\
         : \"asm-1-20\",\n      \"upgrades\": [\n       \"asm-1-21\"\n      ],\n  \
-        \    \"compatibleWith\": [\n       {\n        \"name\": \"kubernetes\",\n\
+        \    \"compatibleWith\": [\n       {\n        \"name\": \"KubernetesOfficial\",\n\
         \        \"versions\": [\n         \"1.25\",\n         \"1.26\",\n       \
-        \  \"1.27\",\n         \"1.28\",\n         \"1.29\"\n        ]\n       }\n\
+        \  \"1.27\",\n         \"1.28\",\n         \"1.29\"\n        ]\n       },\n\
+        \       {\n        \"name\": \"AKSLongTermSupport\",\n        \"versions\": [\n\
+        \         \"1.25\",\n         \"1.26\",\n         \"1.27\",\n         \"1.28\",\n\
+        \         \"1.29\"\n        ]\n       }\n\
         \      ]\n     },\n     {\n      \"revision\": \"asm-1-21\",\n      \"upgrades\"\
         : [\n       \"asm-1-22\"\n      ],\n      \"compatibleWith\": [\n       {\n\
-        \        \"name\": \"kubernetes\",\n        \"versions\": [\n         \"1.26\"\
+        \        \"name\": \"KubernetesOfficial\",\n        \"versions\": [\n         \"1.26\"\
+        ,\n         \"1.27\",\n         \"1.28\",\n         \"1.29\",\n         \"\
+        1.30\"\n        ]\n       },\n       {\n\
+        \        \"name\": \"AKSLongTermSupport\",\n        \"versions\": [\n         \"1.26\"\
         ,\n         \"1.27\",\n         \"1.28\",\n         \"1.29\",\n         \"\
         1.30\"\n        ]\n       }\n      ]\n     },\n     {\n      \"revision\"\
         : \"asm-1-22\",\n      \"compatibleWith\": [\n       {\n        \"name\":\
-        \ \"kubernetes\",\n        \"versions\": [\n         \"1.27\",\n         \"\
+        \ \"KubernetesOfficial\",\n        \"versions\": [\n         \"1.27\",\n         \"\
+        1.28\",\n         \"1.29\",\n         \"1.30\"\n        ]\n       },\n       {\n        \"name\":\
+        \ \"AKSLongTermSupport\",\n        \"versions\": [\n         \"1.27\",\n         \"\
         1.28\",\n         \"1.29\",\n         \"1.30\"\n        ]\n       }\n    \
         \  ]\n     }\n    ]\n   }\n  }\n ]\n}"
     headers:
@@ -1743,16 +1759,24 @@ interactions:
         ,\n   \"name\": \"istio\",\n   \"type\": \"Microsoft.ContainerService/locations/meshRevisionProfiles\"\
         ,\n   \"properties\": {\n    \"meshRevisions\": [\n     {\n      \"revision\"\
         : \"asm-1-20\",\n      \"upgrades\": [\n       \"asm-1-21\"\n      ],\n  \
-        \    \"compatibleWith\": [\n       {\n        \"name\": \"kubernetes\",\n\
+        \    \"compatibleWith\": [\n       {\n        \"name\": \"KubernetesOfficial\",\n\
         \        \"versions\": [\n         \"1.25\",\n         \"1.26\",\n       \
-        \  \"1.27\",\n         \"1.28\",\n         \"1.29\"\n        ]\n       }\n\
+        \  \"1.27\",\n         \"1.28\",\n         \"1.29\"\n        ]\n       },\n\
+        \       {\n        \"name\": \"AKSLongTermSupport\",\n        \"versions\": [\n\
+        \         \"1.25\",\n         \"1.26\",\n         \"1.27\",\n         \"1.28\",\n\
+        \         \"1.29\"\n        ]\n       }\n\
         \      ]\n     },\n     {\n      \"revision\": \"asm-1-21\",\n      \"upgrades\"\
         : [\n       \"asm-1-22\"\n      ],\n      \"compatibleWith\": [\n       {\n\
-        \        \"name\": \"kubernetes\",\n        \"versions\": [\n         \"1.26\"\
+        \        \"name\": \"KubernetesOfficial\",\n        \"versions\": [\n         \"1.26\"\
+        ,\n         \"1.27\",\n         \"1.28\",\n         \"1.29\",\n         \"\
+        1.30\"\n        ]\n       },\n       {\n\
+        \        \"name\": \"AKSLongTermSupport\",\n        \"versions\": [\n         \"1.26\"\
         ,\n         \"1.27\",\n         \"1.28\",\n         \"1.29\",\n         \"\
         1.30\"\n        ]\n       }\n      ]\n     },\n     {\n      \"revision\"\
         : \"asm-1-22\",\n      \"compatibleWith\": [\n       {\n        \"name\":\
-        \ \"kubernetes\",\n        \"versions\": [\n         \"1.27\",\n         \"\
+        \ \"KubernetesOfficial\",\n        \"versions\": [\n         \"1.27\",\n         \"\
+        1.28\",\n         \"1.29\",\n         \"1.30\"\n        ]\n       },\n       {\n        \"name\":\
+        \ \"AKSLongTermSupport\",\n        \"versions\": [\n         \"1.27\",\n         \"\
         1.28\",\n         \"1.29\",\n         \"1.30\"\n        ]\n       }\n    \
         \  ]\n     }\n    ]\n   }\n  }\n ]\n}"
     headers:

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/recordings/test_aks_azure_service_mesh_with_pluginca.yaml
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/recordings/test_aks_azure_service_mesh_with_pluginca.yaml
@@ -22,16 +22,24 @@ interactions:
         ,\n   \"name\": \"istio\",\n   \"type\": \"Microsoft.ContainerService/locations/meshRevisionProfiles\"\
         ,\n   \"properties\": {\n    \"meshRevisions\": [\n     {\n      \"revision\"\
         : \"asm-1-20\",\n      \"upgrades\": [\n       \"asm-1-21\"\n      ],\n  \
-        \    \"compatibleWith\": [\n       {\n        \"name\": \"kubernetes\",\n\
+        \    \"compatibleWith\": [\n       {\n        \"name\": \"KubernetesOfficial\",\n\
         \        \"versions\": [\n         \"1.25\",\n         \"1.26\",\n       \
-        \  \"1.27\",\n         \"1.28\",\n         \"1.29\"\n        ]\n       }\n\
+        \  \"1.27\",\n         \"1.28\",\n         \"1.29\"\n        ]\n       },\n\
+        \       {\n        \"name\": \"AKSLongTermSupport\",\n        \"versions\": [\n\
+        \         \"1.25\",\n         \"1.26\",\n         \"1.27\",\n         \"1.28\",\n\
+        \         \"1.29\"\n        ]\n       }\n\
         \      ]\n     },\n     {\n      \"revision\": \"asm-1-21\",\n      \"upgrades\"\
         : [\n       \"asm-1-22\"\n      ],\n      \"compatibleWith\": [\n       {\n\
-        \        \"name\": \"kubernetes\",\n        \"versions\": [\n         \"1.26\"\
+        \        \"name\": \"KubernetesOfficial\",\n        \"versions\": [\n         \"1.26\"\
+        ,\n         \"1.27\",\n         \"1.28\",\n         \"1.29\",\n         \"\
+        1.30\"\n        ]\n       },\n       {\n\
+        \        \"name\": \"AKSLongTermSupport\",\n        \"versions\": [\n         \"1.26\"\
         ,\n         \"1.27\",\n         \"1.28\",\n         \"1.29\",\n         \"\
         1.30\"\n        ]\n       }\n      ]\n     },\n     {\n      \"revision\"\
         : \"asm-1-22\",\n      \"compatibleWith\": [\n       {\n        \"name\":\
-        \ \"kubernetes\",\n        \"versions\": [\n         \"1.27\",\n         \"\
+        \ \"KubernetesOfficial\",\n        \"versions\": [\n         \"1.27\",\n         \"\
+        1.28\",\n         \"1.29\",\n         \"1.30\"\n        ]\n       },\n       {\n        \"name\":\
+        \ \"AKSLongTermSupport\",\n        \"versions\": [\n         \"1.27\",\n         \"\
         1.28\",\n         \"1.29\",\n         \"1.30\"\n        ]\n       }\n    \
         \  ]\n     }\n    ]\n   }\n  }\n ]\n}"
     headers:
@@ -1519,16 +1527,24 @@ interactions:
         ,\n   \"name\": \"istio\",\n   \"type\": \"Microsoft.ContainerService/locations/meshRevisionProfiles\"\
         ,\n   \"properties\": {\n    \"meshRevisions\": [\n     {\n      \"revision\"\
         : \"asm-1-20\",\n      \"upgrades\": [\n       \"asm-1-21\"\n      ],\n  \
-        \    \"compatibleWith\": [\n       {\n        \"name\": \"kubernetes\",\n\
+        \    \"compatibleWith\": [\n       {\n        \"name\": \"KubernetesOfficial\",\n\
         \        \"versions\": [\n         \"1.25\",\n         \"1.26\",\n       \
-        \  \"1.27\",\n         \"1.28\",\n         \"1.29\"\n        ]\n       }\n\
+        \  \"1.27\",\n         \"1.28\",\n         \"1.29\"\n        ]\n       },\n\
+        \       {\n        \"name\": \"AKSLongTermSupport\",\n        \"versions\": [\n\
+        \         \"1.25\",\n         \"1.26\",\n         \"1.27\",\n         \"1.28\",\n\
+        \         \"1.29\"\n        ]\n       }\n\
         \      ]\n     },\n     {\n      \"revision\": \"asm-1-21\",\n      \"upgrades\"\
         : [\n       \"asm-1-22\"\n      ],\n      \"compatibleWith\": [\n       {\n\
-        \        \"name\": \"kubernetes\",\n        \"versions\": [\n         \"1.26\"\
+        \        \"name\": \"KubernetesOfficial\",\n        \"versions\": [\n         \"1.26\"\
+        ,\n         \"1.27\",\n         \"1.28\",\n         \"1.29\",\n         \"\
+        1.30\"\n        ]\n       },\n       {\n\
+        \        \"name\": \"AKSLongTermSupport\",\n        \"versions\": [\n         \"1.26\"\
         ,\n         \"1.27\",\n         \"1.28\",\n         \"1.29\",\n         \"\
         1.30\"\n        ]\n       }\n      ]\n     },\n     {\n      \"revision\"\
         : \"asm-1-22\",\n      \"compatibleWith\": [\n       {\n        \"name\":\
-        \ \"kubernetes\",\n        \"versions\": [\n         \"1.27\",\n         \"\
+        \ \"KubernetesOfficial\",\n        \"versions\": [\n         \"1.27\",\n         \"\
+        1.28\",\n         \"1.29\",\n         \"1.30\"\n        ]\n       },\n       {\n        \"name\":\
+        \ \"AKSLongTermSupport\",\n        \"versions\": [\n         \"1.27\",\n         \"\
         1.28\",\n         \"1.29\",\n         \"1.30\"\n        ]\n       }\n    \
         \  ]\n     }\n    ]\n   }\n  }\n ]\n}"
     headers:


### PR DESCRIPTION
**Related command**
az aks mesh get-revisions
az aks mesh get-upgrades

**Description**<!--Mandatory-->
To support AKS LTS versions, istio add-on api will return two items in the `compatiableWith` array for each revision. One entry is the Kubernetes versions this revision supports, the other the AKS LTS versions. `compatiableWith` has always been an array and the current cli implementation supports this change, so this pr just updates the testcases to reflect the api response change.

**Testing Guide**
`az aks mesh get-revisions` returns 

```
Revision    Upgrades   CompatibleWith       CompatibleVersions
asm-1-23    asm-1-24   KubernetesOfficial   1.23, 1.24, 1.25
asm-1-23    asm-1-24   AKSLongTermSupport   1.22, 1.23, 1.24, 1.25
asm-1-24    asm-1-25   KubernetesOfficial   1.24, 1.25, 1.26
asm-1-24    asm-1-25   AKSLongTermSupport   1.23, 1.24, 1.25, 1.26
```

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
