### PR TITLE
[Service Fabric] BREAKING CHANGE: `az sf managed-application update`: Remove argument options to fix `--help` formatting

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/servicefabric/_breaking_change.py
+++ b/src/azure-cli/azure/cli/command_modules/servicefabric/_breaking_change.py
@@ -1,0 +1,7 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from azure.cli.core.breaking_change import register_other_breaking_change
+
+register_other_breaking_change('sf managed-application update', 'Options list has changed, run help command to see allowed options')

--- a/src/azure-cli/azure/cli/command_modules/servicefabric/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/servicefabric/_params.py
@@ -178,11 +178,11 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
         c.argument('maximum_nodes', arg_type=maximum_nodes)
         c.argument('force_restart', arg_type=get_three_state_flag(),
                    help='Indicates that the service host restarts even if the upgrade is a configuration-only change.')
-        c.argument('service_type_health_policy_map', options_list=['--service-type-health-policy-map', '--service-type-policy'],
+        c.argument('service_type_health_policy_map', options_list=['--service-type-health-policy-map'],
                    help='Specify the map of the health policy to use for different service types as a hash table in the following format: {\"ServiceTypeName\" : \"MaxPercentUnhealthyPartitionsPerService,MaxPercentUnhealthyReplicasPerPartition,MaxPercentUnhealthyServices\"}. For example: @{ \"ServiceTypeName01\" = \"5,10,5\"; \"ServiceTypeName02\" = \"5,5,5\" }')
 
     with self.argument_context('sf application update', arg_group='Upgrade description') as c:
-        c.argument('upgrade_replica_set_check_timeout', options_list=['--upgrade-replica-set-check-timeout', '--replica-check-timeout', '--rep-check-timeout'],
+        c.argument('upgrade_replica_set_check_timeout', options_list=['--replica-check-timeout', '--rep-check-timeout'],
                    help='Specify the maximum time, in seconds, that Service Fabric waits for a service to reconfigure into a safe state, if not already in a safe state, before Service Fabric proceeds with the upgrade.')
         c.argument('failure_action', arg_type=get_enum_type(['Rollback', 'Manual']),
                    help='Specify the action to take if the monitored upgrade fails. The acceptable values for this parameter are Rollback or Manual.')
@@ -198,13 +198,13 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
                    help='Specify the maximum time, in seconds, that Service Fabric takes for the entire upgrade. After this period, the upgrade fails.')
         c.argument('consider_warning_as_error', options_list=['--warning-as-error', '--consider-warning-as-error'], arg_type=get_three_state_flag(),
                    help='Indicates whether to treat a warning health event as an error event during health evaluation.')
-        c.argument('default_service_type_max_percent_unhealthy_partitions_per_service', options_list=['--max-porcent-unhealthy-partitions', '--max-unhealthy-parts'],
+        c.argument('default_service_type_max_percent_unhealthy_partitions_per_service', options_list=['--max-unhealthy-parts'],
                    help='Specify the maximum percent of unhelthy partitions per service allowed by the health policy for the default service type to use for the monitored upgrade. Allowed values are form 0 to 100.')
-        c.argument('default_service_type_max_percent_unhealthy_replicas_per_partition', options_list=['--max-porcent-unhealthy-replicas', '--max-unhealthy-reps'],
+        c.argument('default_service_type_max_percent_unhealthy_replicas_per_partition', options_list=['--max-unhealthy-reps'],
                    help='Specify the maximum percent of unhelthy replicas per service allowed by the health policy for the default service type to use for the monitored upgrade. Allowed values are form 0 to 100.')
-        c.argument('default_service_type_max_percent_unhealthy_services', options_list=['--max-porcent-unhealthy-services', '--max-unhealthy-servs'],
+        c.argument('default_service_type_max_percent_unhealthy_services', options_list=['--max-unhealthy-servs'],
                    help='Specify the maximum percent of unhelthy services allowed by the health policy for the default service type to use for the monitored upgrade. Allowed values are form 0 to 100.')
-        c.argument('max_percent_unhealthy_deployed_applications', options_list=['--max-porcent-unhealthy-apps', '--max-unhealthy-apps'],
+        c.argument('max_percent_unhealthy_deployed_applications', options_list=['--max-unhealthy-apps'],
                    help='Specify the maximum percentage of the application instances deployed on the nodes in the cluster that have a health state of error before the application health state for the cluster is error. Allowed values are form 0 to 100.')
 
     with self.argument_context('sf application create', validator=validate_create_application) as c:
@@ -368,7 +368,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
 
     # managed-application
     service_type_health_policy_map = CLIArgumentType(
-        options_list=['--service-type-health-policy-map', '--service-type-policy'],
+        options_list=['--service-type-health-policy-map'],
         action=AddServiceTypeHealthPolicyAction,
         nargs='*',
         help='Specify the map of the health policy to use for different service types as key/value pairs in the following format: \"ServiceTypeName\"=\"MaxPercentUnhealthyPartitionsPerService,MaxPercentUnhealthyReplicasPerPartition,MaxPercentUnhealthyServices\". '
@@ -387,9 +387,9 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
                    help='Indicates that the service host restarts even if the upgrade is a configuration-only change.')
         c.argument('recreate_application', arg_type=get_three_state_flag(),
                    help='Determines whether the application should be recreated on update. If value=true, the rest of the upgrade policy parameters are not allowed.')
-        c.argument('upgrade_replica_set_check_timeout', options_list=['--upgrade-replica-set-check-timeout', '--replica-check-timeout', '--rep-check-timeout'],
+        c.argument('upgrade_replica_set_check_timeout', options_list=['--replica-check-timeout', '--rep-check-timeout'],
                    help='Specify the maximum time, in seconds, that Service Fabric waits for a service to reconfigure into a safe state, if not already in a safe state, before Service Fabric proceeds with the upgrade.')
-        c.argument('instance_close_delay_duration', options_list=['--instance-close-delay-duration', '--instance-close-duration', '--close-duration'],
+        c.argument('instance_close_delay_duration', options_list=['--instance-close-delay-duration'],
                    help='Specify the duration in seconds, to wait before a stateless instance is closed, to allow the active requests to drain gracefully. This would be effective when the instance is closing during the application/cluster upgrade, only for those instances which have a non-zero delay duration configured in the service description.')
         c.argument('failure_action', arg_type=get_enum_type(FailureAction),
                    help='Specify the action to take if the monitored upgrade fails. The acceptable values for this parameter are Rollback or Manual.')
@@ -405,16 +405,16 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
                    help='Specify the maximum time, in seconds, that Service Fabric takes to upgrade a single upgrade domain. After this period, the upgrade fails.')
         c.argument('upgrade_timeout',
                    help='Specify the maximum time, in seconds, that Service Fabric takes for the entire upgrade. After this period, the upgrade fails.')
-        c.argument('consider_warning_as_error', options_list=['--warning-as-error', '--consider-warning-as-error'], arg_type=get_three_state_flag(),
+        c.argument('consider_warning_as_error', options_list=['--warning-as-error'], arg_type=get_three_state_flag(),
                    help='Indicates whether to treat a warning health event as an error event during health evaluation.')
-        c.argument('default_service_type_max_percent_unhealthy_partitions_per_service', options_list=['--max-percent-unhealthy-partitions', '--max-unhealthy-parts'],
+        c.argument('default_service_type_max_percent_unhealthy_partitions_per_service', options_list=['--max-unhealthy-parts'],
                    help='Specify the maximum percent of unhelthy partitions per service allowed by the health policy for the default service type to use for the monitored upgrade. Allowed values are from 0 to 100.')
-        c.argument('default_service_type_max_percent_unhealthy_replicas_per_partition', options_list=['--max-percent-unhealthy-replicas', '--max-unhealthy-reps'],
+        c.argument('default_service_type_max_percent_unhealthy_replicas_per_partition', options_list=['--max-unhealthy-reps'],
                    help='Specify the maximum percent of unhelthy replicas per service allowed by the health policy for the default service type to use for the monitored upgrade. Allowed values are from 0 to 100.')
-        c.argument('default_service_type_max_percent_unhealthy_services', options_list=['--max-percent-unhealthy-services', '--max-unhealthy-servs'],
+        c.argument('default_service_type_max_percent_unhealthy_services', options_list=['--max-unhealthy-servs'],
                    help='Specify the maximum percent of unhelthy services allowed by the health policy for the default service type to use for the monitored upgrade. Allowed values are from 0 to 100.')
         c.argument('service_type_health_policy_map', arg_type=service_type_health_policy_map)
-        c.argument('max_percent_unhealthy_deployed_applications', options_list=['--max-percent-unhealthy-deployed-applications', '--max-percent-unhealthy-apps', '--max-unhealthy-apps'],
+        c.argument('max_percent_unhealthy_deployed_applications', options_list=['--max-unhealthy-apps'],
                    help='Specify the maximum percentage of the application instances deployed on the nodes in the cluster that have a health state of error before the application health state for the cluster is error. Allowed values are form 0 to 100.')
 
     with self.argument_context('sf managed-application create', validator=validate_create_managed_application) as c:


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
 `az sf managed-application update`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix for issues https://github.com/Azure/azure-cli/issues/28574 and https://github.com/Azure/azure-cli/issues/31750. Removed argument options to decrease the width of the arguments column and increase the width of the description column.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Service Fabric] BREAKING CHANGE: `az sf managed-application update`: Remove argument options `--service-type-policy`,  `--upgrade-replica-set-check-timeout`, `--max-porcent-unhealthy-partitions`, `--max-porcent-unhealthy-replicas`, `--max-porcent-unhealthy-services`, `--max-porcent-unhealthy-apps`, `--service-type-policy`, `--upgrade-replica-set-check-timeout`, `--instance-close-duration`, `--consider-warning-as-error`, `--max-percent-unhealthy-partitions`. `--max-percent-unhealthy-replicas`, `--max-percent-unhealthy-replicas`, `--max-percent-unhealthy-deployed-applications` to fix `--help` formatting

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
 