### PR TITLE
[Service Fabric] Fix #5180: `az sf cluster create`: Change behavior to read cluster_name from parameters file if provided

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/servicefabric/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/servicefabric/custom.py
@@ -75,6 +75,7 @@ DEFAULT_BACKEND_PORT = 3389
 SERVICE_FABRIC_WINDOWS_NODE_EXT_NAME = "servicefabricnode"
 SERVICE_FABRIC_LINUX_NODE_EXT_NAME = "servicefabriclinuxnode"
 
+CLUSTER_NAME_VALUE = "clusterName"
 SOURCE_VAULT_VALUE = "sourceVaultValue"
 CERTIFICATE_THUMBPRINT = "certificateThumbprint"
 CERTIFICATE_URL_VALUE = "certificateUrlValue"
@@ -134,7 +135,7 @@ def new_cluster(cmd,
                 'when \'--secret-identifier\' is specified')
     if parameter_file or template_file:
         if parameter_file is None or template_file is None:
-            raise CLIError('If using customize template to deploy,both \'--parameter-file\' and \'--template-file\' can not be None ' + '\n For example:\n az sf cluster create --resource-group myRg --location westus --certificate-subject-name test.com --parameter-file c:\\parameter.json --template-file c:\\template.json' +
+            raise CLIError('If using customize template to deploy, neither \'--parameter-file\' and \'--template-file\' can be None ' + '\n For example:\n az sf cluster create --resource-group myRg --location westus --certificate-subject-name test.com --parameter-file c:\\parameter.json --template-file c:\\template.json' +
                            '\n az sf cluster create --resource-group myRg --location westus --parameter-file c:\\parameter.json --template-file c:\\template.json --certificate_file c:\\test.pfx' + '\n az sf cluster create --resource-group myRg --location westus --certificate-subject-name test.com --parameter-file c:\\parameter.json --template-file c:\\template.json --certificate-output-folder c:\\certoutput')
         if cluster_size or vm_sku or vm_user_name:
             raise CLIError('\'cluster_size\',\'vm_sku\',\'vm_os\',\'vm_user_name\' can not be specified when using customize template deployment')
@@ -218,18 +219,19 @@ def new_cluster(cmd,
                                                           os_type=vm_os,
                                                           linux=linux)
     else:
-        parameters, output_file = _set_parameters_for_customize_template(cmd,
-                                                                         cli_ctx,
-                                                                         resource_group_name,
-                                                                         certificate_file,
-                                                                         certificate_password,
-                                                                         vault_name,
-                                                                         vault_resource_group_name,
-                                                                         certificate_output_folder,
-                                                                         certificate_subject_name,
-                                                                         secret_identifier,
-                                                                         parameter_file)
+        parameters, output_file = _set_parameters_for_customize_template(cmd=cmd,
+                                                                         cli_ctx=cli_ctx,
+                                                                         resource_group_name=resource_group_name,
+                                                                         certificate_file=certificate_file,
+                                                                         certificate_password=certificate_password,
+                                                                         vault_name=vault_name,
+                                                                         vault_resource_group_name=vault_resource_group_name,
+                                                                         certificate_output_folder=certificate_output_folder,
+                                                                         certificate_subject_name=certificate_subject_name,
+                                                                         secret_identifier=secret_identifier,
+                                                                         parameter_file=parameter_file)
 
+        cluster_name = parameters[CLUSTER_NAME_VALUE]['value']
         vault_id = parameters[SOURCE_VAULT_VALUE]['value']
         certificate_uri = parameters[CERTIFICATE_URL_VALUE]['value']
         cert_thumbprint = parameters[CERTIFICATE_THUMBPRINT]['value']


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az sf cluster create`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fixes https://github.com/Azure/azure-cli/issues/5180 where at the end of a deployment using a template, the client attempts to poll for the cluster status at end of creation with assumption that `--cluster_name` == `--resource_group_name` if `--cluster-name` is not provided. Changed code to read `--cluster_name` parameter from parameter file.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->
{Service Fabric} `az sf cluster create`: Change behavior to read cluster_name from parameters file if provided to fix issue #5180

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
