### PR TITLE
Fix: FutureWarning functools.partial will be a method descriptor in future Python versions; wrap it in staticmethod() if you want to preserve the old behavior

### DIFF
--- a/src/azure-cli-core/azure/cli/core/aaz/_command.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_command.py
@@ -329,7 +329,9 @@ def register_command_group(
         if is_preview:
             cls.AZ_PREVIEW_INFO = staticmethod(partial(PreviewItem, target=f'az {name}', object_type='command group'))
         if is_experimental:
-            cls.AZ_EXPERIMENTAL_INFO = staticmethod(partial(ExperimentalItem, target=f'az {name}', object_type='command group'))
+            cls.AZ_EXPERIMENTAL_INFO = staticmethod(
+                partial(ExperimentalItem, target=f'az {name}', object_type='command group')
+            )
         if deprecated_info:
             cls.AZ_DEPRECATE_INFO = staticmethod(
                 partial(
@@ -377,7 +379,9 @@ def register_command(
         if is_preview:
             cls.AZ_PREVIEW_INFO = staticmethod(partial(PreviewItem, target=f'az {name}', object_type='command'))
         if is_experimental:
-            cls.AZ_EXPERIMENTAL_INFO = staticmethod(partial(ExperimentalItem, target=f'az {name}', object_type='command'))
+            cls.AZ_EXPERIMENTAL_INFO = staticmethod(
+                partial(ExperimentalItem, target=f'az {name}', object_type='command')
+            )
         if deprecated_info:
             cls.AZ_DEPRECATE_INFO = staticmethod(
                 partial(


### PR DESCRIPTION
**Related command**

Everything, including `az login`

**Description**

This removes the warning script error message:

```
python3.13-azure-cli-core-2.75.0/lib/python3.13/site-packages/azure/cli/core/aaz/_command.py:132: FutureWarning: functools.partial will be a method descriptor in future Python versions; wrap it in staticmethod() if you want to preserve the old behavior
  if self.AZ_PREVIEW_INFO:
python3.13-azure-cli-core-2.75.0/lib/python3.13/site-packages/azure/cli/core/aaz/_command.py:133: FutureWarning: functools.partial will be a method descriptor in future Python versions; wrap it in staticmethod() if you want to preserve the old behavior
  self.preview_info = self.AZ_PREVIEW_INFO(cli_ctx=self.cli_ctx)
python3.13-azure-cli-core-2.75.0/lib/python3.13/site-packages/azure/cli/core/aaz/_command.py:50: FutureWarning: functools.partial will be a method descriptor in future Python versions; wrap it in staticmethod() if you want to preserve the old behavior
  if self.AZ_PREVIEW_INFO:
python3.13-azure-cli-core-2.75.0/lib/python3.13/site-packages/azure/cli/core/aaz/_command.py:51: FutureWarning: functools.partial will be a method descriptor in future Python versions; wrap it in staticmethod() if you want to preserve the old behavior
  self.group_kwargs['preview_info'] = self.AZ_PREVIEW_INFO(cli_ctx=self.cli_ctx)
```

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
