### PR TITLE
{Packaging} Bump cffi to 1.17.1

### DIFF
--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -93,7 +93,7 @@ azure-synapse-managedprivateendpoints==0.4.0
 azure-synapse-spark==0.7.0
 bcrypt==3.2.0
 certifi==2024.7.4
-cffi==1.16.0
+cffi==1.17.1
 chardet==5.2.0
 colorama==0.4.6
 cryptography==44.0.1

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -93,7 +93,7 @@ azure-synapse-managedprivateendpoints==0.4.0
 azure-synapse-spark==0.7.0
 bcrypt==3.2.0
 certifi==2024.7.4
-cffi==1.16.0
+cffi==1.17.1
 chardet==5.2.0
 colorama==0.4.6
 cryptography==44.0.1

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -93,7 +93,7 @@ azure-synapse-managedprivateendpoints==0.4.0
 azure-synapse-spark==0.7.0
 bcrypt==3.2.0
 certifi==2024.7.4
-cffi==1.16.0
+cffi==1.17.1
 chardet==5.2.0
 colorama==0.4.6
 cryptography==44.0.1


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Cffi raises this error: `ERROR: Error loading command module 'iot': /opt/hostedtoolcache/Python/3.13.5/x64/lib/python3.13/site-packages/_cffi_backend.cpython-313-x86_64-linux-gnu.so: undefined symbol: _PyErr_WriteUnraisableMsg`, which is a known issue: https://github.com/python-cffi/cffi/issues/23#issuecomment-2209670861.

Update it to latest version.