### PR TITLE
{Test} Skip email replacer if the request body is not string

### DIFF
--- a/src/azure-cli-testsdk/azure/cli/testsdk/utilities.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/utilities.py
@@ -223,8 +223,12 @@ class EmailAddressReplacer(RecordingProcessor):
     def process_request(self, request):
         request.uri = self._replace_email_address(request.uri)
         if request.body:
-            body = _byte_to_str(request.body)
-            request.body = self._replace_email_address(body)
+            try:
+                body = _byte_to_str(request.body)
+                request.body = self._replace_email_address(body)
+            except UnicodeDecodeError:
+                # If the body is not a string, we cannot decode it, so we skip the replacement
+                pass
         return request
 
     def process_response(self, response):


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
There could be some cases that request body is not string (for example a zip file). EmailReplacer will fail on `_byte_to_str` with `UnicodeDecodeError`. In such case, there's no need to replace anything so skipping EmailReplacer directly

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
