### PR TITLE
[rdbms] `az postgresql flexible-server create`: Handle failed IP address check

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_virtual_network.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_virtual_network.py
@@ -455,12 +455,10 @@ def prepare_private_dns_zone(db_context, resource_group, server_name, private_dn
 def prepare_public_network(public_access, yes):
     if public_access is None:
         try:
-            '''
-            In USSec and USNat, the IP address checker is not available as the public Internet is not accessible.  
-            When the user does not provide a public IP address or does not disble public access, 
-            the `az cli postgres flexible-server create` command will fail with the error
-            HTTPSConnectionPool(host='api.ipify.org', port443): Max retries excceeded with url
-            '''
+            # In USSec and USNat, the IP address checker is not available as the public Internet is not accessible.
+            # When the user does not provide a public IP address or does not disble public access,
+            # the `az cli postgres flexible-server create` command will fail with the error
+            # HTTPSConnectionPool(host='api.ipify.org', port443): Max retries excceeded with url
             ip_address = get(IP_ADDRESS_CHECKER).text
         except Exception as ex:
             raise CLIError("Unable to detect your current IP address. Please provide a valid IP address or CIDR range for --public-access parameter or set --public-access Disabled. Error: {}".format(ex))

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_virtual_network.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_virtual_network.py
@@ -454,7 +454,17 @@ def prepare_private_dns_zone(db_context, resource_group, server_name, private_dn
 
 def prepare_public_network(public_access, yes):
     if public_access is None:
-        ip_address = get(IP_ADDRESS_CHECKER).text
+        try:
+            '''
+            In USSec and USNat, the IP address checker is not available as the public Internet is not accessible.  
+            When the user does not provide a public IP address or does not disble public access, 
+            the `az cli postgres flexible-server create` command will fail with the error
+            HTTPSConnectionPool(host='api.ipify.org', port443): Max retries excceeded with url
+            '''
+            ip_address = get(IP_ADDRESS_CHECKER).text
+        except Exception as ex:
+            raise CLIError("Unable to detect your current IP address. Please provide a valid IP address or CIDR range for --public-access parameter or set --public-access Disabled. Error: {}".format(ex))
+
         logger.warning("Detected current client IP : %s", ip_address)
         if yes:
             return ip_address, ip_address


### PR DESCRIPTION
**Related command**
az postgresql flexible-server create

**Description**<!--Mandatory-->
If the IP address check to ipify.org fails, the server creation command fails with no explanation of how to resolve it.  This will fail 100% of the time in USSec and USNat if the server is not VNet, the user does not provide an IP address or IP range, or the user does not specify that public access is disabled.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
