### PR TITLE
[Profile] `az login`: Support `--claims-challenge` in device code flow

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -172,7 +172,7 @@ class Profile:
                 use_device_code = True
 
             if use_device_code:
-                user_identity = identity.login_with_device_code(scopes=scopes)
+                user_identity = identity.login_with_device_code(scopes=scopes, claims_challenge=claims_challenge)
             else:
                 user_identity = identity.login_with_auth_code(scopes=scopes, claims_challenge=claims_challenge)
         else:

--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -171,14 +171,14 @@ class Identity:  # pylint: disable=too-many-instance-attributes
             claims_challenge=claims_challenge)
         return check_result(result)
 
-    def login_with_device_code(self, scopes):
-        flow = self._msal_app.initiate_device_flow(scopes)
+    def login_with_device_code(self, scopes, claims_challenge=None):
+        flow = self._msal_app.initiate_device_flow(scopes, claims_challenge=claims_challenge)
         if "user_code" not in flow:
             raise ValueError(
                 "Fail to create device flow. Err: %s" % json.dumps(flow, indent=4))
         from azure.cli.core.style import print_styled_text, Style
         print_styled_text((Style.WARNING, flow["message"]), file=sys.stderr)
-        result = self._msal_app.acquire_token_by_device_flow(flow)  # By default it will block
+        result = self._msal_app.acquire_token_by_device_flow(flow, claims_challenge=claims_challenge)
         return check_result(result)
 
     def login_with_username_password(self, username, password, scopes):

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -55,8 +55,8 @@ DEPENDENCIES = [
     'knack~=0.11.0',
     'microsoft-security-utilities-secret-masker~=1.0.0b4',
     'msal-extensions==1.2.0',
-    'msal[broker]==1.33.0b1; sys_platform == "win32"',
-    'msal==1.33.0b1; sys_platform != "win32"',
+    'msal[broker]==1.34.0b1; sys_platform == "win32"',
+    'msal==1.34.0b1; sys_platform != "win32"',
     'packaging>=20.9',
     'pkginfo>=1.5.0.1',
     # psutil can't install on cygwin: https://github.com/Azure/azure-cli/issues/9399

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -106,7 +106,7 @@ jmespath==0.9.5
 jsondiff==2.0.0
 knack==0.11.0
 msal-extensions==1.2.0
-msal==1.33.0b1
+msal==1.34.0b1
 msrest==0.7.1
 oauthlib==3.2.2
 packaging==24.2

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -107,7 +107,7 @@ jmespath==0.9.5
 jsondiff==2.0.0
 knack==0.11.0
 msal-extensions==1.2.0
-msal==1.33.0b1
+msal==1.34.0b1
 msrest==0.7.1
 oauthlib==3.2.2
 packaging==24.2

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -106,7 +106,7 @@ jmespath==0.9.5
 jsondiff==2.0.0
 knack==0.11.0
 msal-extensions==1.2.0
-msal[broker]==1.33.0b1
+msal[broker]==1.34.0b1
 msrest==0.7.1
 oauthlib==3.2.2
 packaging==24.2


### PR DESCRIPTION
**Related command**
`az login --use-device-code`

**Description**<!--Mandatory-->
https://github.com/Azure/azure-cli/pull/31778 didn't add `--claims-challenge` for device code flow because of MSAL limitation https://github.com/AzureAD/microsoft-authentication-library-for-python/issues/834.

After MSAL fixes it in https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/839, this PR adds `--claims-challenge` for device code flow.

**Testing Guide**
```
az login --use-device-code --tenant 3f145493-536c-40aa-8a6d-ca91dd64cd3b --claims-challenge eyJhY2Nlc3NfdG9rZW4iOnsiYWNycyI6eyJlc3NlbnRpYWwiOnRydWUsInZhbHVlcyI6WyJwMSJdfX19
az account get-access-token
```

Then verify the access token's `amr` (Authentication Methods Reference) claim contains `mfa`:

```
  "amr": [
    "fido",
    "mfa"
  ],
```

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
