### PR TITLE
{Role} `az role`: Bump `azure-mgmt-authorization` to single-API SDK

### DIFF
--- a/src/azure-cli-core/azure/cli/core/profiles/_shared.py
+++ b/src/azure-cli-core/azure/cli/core/profiles/_shared.py
@@ -187,10 +187,7 @@ AZURE_API_PROFILES = {
         ResourceType.MGMT_RESOURCE_MANAGEDAPPLICATIONS: '2019-07-01',
         ResourceType.MGMT_NETWORK_PRIVATEDNS: None,
         ResourceType.MGMT_KEYVAULT: None,
-        ResourceType.MGMT_AUTHORIZATION: SDKProfile('2022-04-01', {
-            'role_definitions': '2022-05-01-preview',
-            'provider_operations_metadata': '2018-01-01-preview'
-        }),
+        ResourceType.MGMT_AUTHORIZATION: None,
         ResourceType.MGMT_CONTAINERREGISTRY: SDKProfile('2025-03-01-preview', {
             'agent_pools': '2025-03-01-preview',
             'tasks': '2025-03-01-preview',

--- a/src/azure-cli/azure/cli/command_modules/acs/_roleassignments.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_roleassignments.py
@@ -93,21 +93,9 @@ def add_role_assignment_executor(cmd, role, assignee, resource_group_name=None,
         mod="models",
         operation_group="role_assignments",
     )
-    if cmd.supported_api_version(min_api="2018-01-01-preview", resource_type=ResourceType.MGMT_AUTHORIZATION):
-        parameters = RoleAssignmentCreateParameters(role_definition_id=role_id, principal_id=object_id,
-                                                    principal_type=assignee_principal_type)
-        return assignments_client.create(scope, assignment_name, parameters, headers=custom_headers)
-
-    # for backward compatibility
-    RoleAssignmentProperties = get_sdk(
-        cmd.cli_ctx,
-        ResourceType.MGMT_AUTHORIZATION,
-        "RoleAssignmentProperties",
-        mod="models",
-        operation_group="role_assignments",
-    )
-    properties = RoleAssignmentProperties(role_definition_id=role_id, principal_id=object_id)
-    return assignments_client.create(scope, assignment_name, properties, headers=custom_headers)
+    parameters = RoleAssignmentCreateParameters(role_definition_id=role_id, principal_id=object_id,
+                                                principal_type=assignee_principal_type)
+    return assignments_client.create(scope, assignment_name, parameters, headers=custom_headers)
 
 
 def add_role_assignment(cmd, role, service_principal_msi_id, is_service_principal=True,
@@ -271,11 +259,9 @@ def delete_role_assignments_executor(
 def subnet_role_assignment_exists(cmd, scope):
     factory = get_auth_management_client(cmd.cli_ctx, scope)
     assignments_client = factory.role_assignments
-
-    if cmd.supported_api_version(min_api='2018-01-01-preview', resource_type=ResourceType.MGMT_AUTHORIZATION):
-        for i in assignments_client.list_for_scope(scope=scope, filter='atScope()'):
-            if i.scope == scope and i.role_definition_id.endswith(CONST_NETWORK_CONTRIBUTOR_ROLE_ID):
-                return True
+    for i in assignments_client.list_for_scope(scope=scope, filter='atScope()'):
+        if i.scope == scope and i.role_definition_id.endswith(CONST_NETWORK_CONTRIBUTOR_ROLE_ID):
+            return True
     return False
 
 

--- a/src/azure-cli/azure/cli/command_modules/aro/tests/latest/recordings/test_aro_public_cluster.yaml
+++ b/src/azure-cli/azure/cli/command_modules/aro/tests/latest/recordings/test_aro_public_cluster.yaml
@@ -1280,7 +1280,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.65.0 azsdk-python-core/1.31.0 Python/3.11.9 (macOS-14.7-x86_64-i386-64bit)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_aro000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/permissions?api-version=2015-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_aro000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/permissions?api-version=2022-05-01-preview
   response:
     body:
       string: '{"value":[{"actions":["*/read","Microsoft.Authorization/*","Microsoft.Support/*"],"notActions":[]},{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write","Microsoft.Authorization/elevateAccess/Action","Microsoft.Blueprint/blueprintAssignments/write","Microsoft.Blueprint/blueprintAssignments/delete","Microsoft.Compute/galleries/share/action","Microsoft.Purview/consents/write","Microsoft.Purview/consents/delete","Microsoft.Resources/deploymentStacks/manageDenySetting/action"]}]}'
@@ -2117,7 +2117,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.65.0 azsdk-python-core/1.31.0 Python/3.11.9 (macOS-14.7-x86_64-i386-64bit)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_aro000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/permissions?api-version=2015-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_aro000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/permissions?api-version=2022-05-01-preview
   response:
     body:
       string: '{"value":[{"actions":["*/read","Microsoft.Authorization/*","Microsoft.Support/*"],"notActions":[]},{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write","Microsoft.Authorization/elevateAccess/Action","Microsoft.Blueprint/blueprintAssignments/write","Microsoft.Blueprint/blueprintAssignments/delete","Microsoft.Compute/galleries/share/action","Microsoft.Purview/consents/write","Microsoft.Purview/consents/delete","Microsoft.Resources/deploymentStacks/manageDenySetting/action"]}]}'

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -3119,10 +3119,7 @@ def list_provider_permissions(cmd, resource_provider_namespace):
 
 
 def show_provider_operations(cmd, resource_provider_namespace):
-    version = getattr(get_api_version(cmd.cli_ctx, ResourceType.MGMT_AUTHORIZATION), 'provider_operations_metadata')
     auth_client = _authorization_management_client(cmd.cli_ctx)
-    if version == '2015-07-01':
-        return auth_client.provider_operations_metadata.get(resource_provider_namespace, api_version=version)
     return auth_client.provider_operations_metadata.get(resource_provider_namespace)
 
 

--- a/src/azure-cli/azure/cli/command_modules/role/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_params.py
@@ -340,9 +340,9 @@ def load_arguments(self, _):
                         "the logged-in account has no permission or the machine has no network access to query "
                         "Microsoft Graph.")
         c.argument('ids', nargs='+', help='space-separated role assignment ids')
-        c.argument('description', is_preview=True, min_api='2020-04-01-preview', help='Description of role assignment.')
-        c.argument('condition', is_preview=True, min_api='2020-04-01-preview', help='Condition under which the user can be granted permission.')
-        c.argument('condition_version', is_preview=True, min_api='2020-04-01-preview', help='Version of the condition syntax. If --condition is specified without --condition-version, default to 2.0.')
+        c.argument('description', is_preview=True, help='Description of role assignment.')
+        c.argument('condition', is_preview=True, help='Condition under which the user can be granted permission.')
+        c.argument('condition_version', is_preview=True, help='Version of the condition syntax. If --condition is specified without --condition-version, default to 2.0.')
         c.argument('assignment_name', name_arg_type,
                    help='A GUID for the role assignment. It must be unique and different for each role assignment. If omitted, a new GUID is generated.')
 
@@ -379,7 +379,7 @@ def load_arguments(self, _):
             service_principal = "ServicePrincipal"
             foreign_group = "ForeignGroup"
 
-        c.argument('assignee_principal_type', min_api='2018-09-01-preview', arg_type=get_enum_type(PrincipalType),
+        c.argument('assignee_principal_type', arg_type=get_enum_type(PrincipalType),
                    help='use with --assignee-object-id to avoid errors caused by propagation latency in Microsoft Graph')
 
     with self.argument_context('role assignment update') as c:

--- a/src/azure-cli/azure/cli/command_modules/role/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/role/commands.py
@@ -75,7 +75,7 @@ def load_command_table(self, _):
         g.custom_command('delete', 'delete_role_assignments', validator=process_assignment_namespace)
         g.custom_command('list', 'list_role_assignments', validator=process_assignment_namespace, table_transformer=transform_assignment_list)
         g.custom_command('create', 'create_role_assignment', validator=process_assignment_namespace)
-        g.custom_command('update', 'update_role_assignment', min_api='2020-04-01-preview')
+        g.custom_command('update', 'update_role_assignment')
         g.custom_command('list-changelogs', 'list_role_assignment_change_logs')
 
     with self.command_group('ad app', client_factory=get_graph_client, exception_handler=graph_err_handler) as g:

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -22,7 +22,7 @@ azure-mgmt-apimanagement==4.0.0
 azure-mgmt-appconfiguration==5.0.0
 azure-mgmt-appcontainers==2.0.0
 azure-mgmt-applicationinsights==1.0.0
-azure-mgmt-authorization==4.0.0
+azure-mgmt-authorization==5.0.0b1
 azure-mgmt-batch==17.3.0
 azure-mgmt-batchai==7.0.0b1
 azure-mgmt-billing==6.0.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -22,7 +22,7 @@ azure-mgmt-apimanagement==4.0.0
 azure-mgmt-appconfiguration==5.0.0
 azure-mgmt-appcontainers==2.0.0
 azure-mgmt-applicationinsights==1.0.0
-azure-mgmt-authorization==4.0.0
+azure-mgmt-authorization==5.0.0b1
 azure-mgmt-batch==17.3.0
 azure-mgmt-batchai==7.0.0b1
 azure-mgmt-billing==6.0.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -22,7 +22,7 @@ azure-mgmt-apimanagement==4.0.0
 azure-mgmt-appconfiguration==5.0.0
 azure-mgmt-appcontainers==2.0.0
 azure-mgmt-applicationinsights==1.0.0
-azure-mgmt-authorization==4.0.0
+azure-mgmt-authorization==5.0.0b1
 azure-mgmt-batch==17.3.0
 azure-mgmt-batchai==7.0.0b1
 azure-mgmt-billing==6.0.0

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -67,7 +67,7 @@ DEPENDENCIES = [
     'azure-mgmt-appconfiguration==5.0.0',
     'azure-mgmt-appcontainers==2.0.0',
     'azure-mgmt-applicationinsights~=1.0.0',
-    'azure-mgmt-authorization~=4.0.0',
+    'azure-mgmt-authorization==5.0.0b1',
     'azure-mgmt-batchai==7.0.0b1',
     'azure-mgmt-batch~=17.3.0',
     'azure-mgmt-billing==6.0.0',


### PR DESCRIPTION
**Related command**
`az role`

**Description**<!--Mandatory-->
Similar to https://github.com/Azure/azure-cli/pull/31526, https://github.com/Azure/azure-cli/pull/31801, this PR bumps `azure-mgmt-authorization` to single-API SDK.

A [private package](https://github.com/Azure/azure-sdk-for-python/pull/42095#issuecomment-3100727491) generated from [package-2024-09-01-preview](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/authorization/resource-manager/readme.md#tag-package-2024-09-01-preview) has been tested. It contains all necessary API versions CLI declares:

https://github.com/Azure/azure-cli/blob/a7e596e3826fe1fda81d99a1f899801bd6779113/src/azure-cli-core/azure/cli/core/profiles/_shared.py#L195-L197

Luckily, no API version bump is introduced, so there is no need to record tests again.