### PR TITLE
[Profile] `az account get-access-token`: Allow specifying `--tenant` with the current tenant

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -360,17 +360,20 @@ class Profile:
 
         managed_identity_type, managed_identity_id = Profile._parse_managed_identity_account(account)
 
+        non_current_tenant_template = ("For {} account, getting access token for non-current tenants is not "
+                                       "supported. The specified tenant must be the current tenant "
+                                       f"{account[_TENANT_ID]}")
         if in_cloud_console() and account[_USER_ENTITY].get(_CLOUD_SHELL_ID):
             # Cloud Shell
-            if tenant:
-                raise CLIError("Tenant shouldn't be specified for Cloud Shell account")
+            if tenant and tenant != account[_TENANT_ID]:
+                raise CLIError(non_current_tenant_template.format('Cloud Shell'))
             from .auth.msal_credentials import CloudShellCredential
             cred = CloudShellCredential()
 
         elif managed_identity_type:
             # managed identity
-            if tenant:
-                raise CLIError("Tenant shouldn't be specified for managed identity account")
+            if tenant and tenant != account[_TENANT_ID]:
+                raise CLIError(non_current_tenant_template.format('managed identity'))
             cred = ManagedIdentityAuth.credential_factory(managed_identity_type, managed_identity_id)
             if credential_out:
                 credential_out['credential'] = cred


### PR DESCRIPTION
**Related command**
`az account get-access-token`

**Description**<!--Mandatory-->
Resolve https://github.com/Azure/azure-sdk-for-python/issues/41875

#11798 forbids passing `--tenant` to `az account get-access-token`.

However, when Key Vault data-plane SDK receives a challenge, it will always pass the `tenant_id` to `AzureCliCredential` and `az account get-access-token`. If the current account is a Cloud Shell or managed identity account, `az account get-access-token` will fail:

https://github.com/Azure/azure-cli/blob/bc6c4d9769729f3a8e64e2c2c55c87c881fdd731/src/azure-cli-core/azure/cli/core/_profile.py#L370-L373

As it is impossible for SDK to know which account type is used by Azure CLI and pass `--tenant` conditionally, it is better for CLI to allow `--tenant` with the current tenant.

This PR allows specifying `--tenant` with the current tenant for Cloud Shell or managed identity account, but still raises error when getting access token for a non-current tenant.

**Testing Guide**
```sh
# Success
az account get-access-token
az account get-access-token --tenant CURRENT_TENANT

# Error
az account get-access-token --tenant 00000000-0000-0000-0000-000000000000
```

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Profile] `az account get-access-token`: Specifying `--tenant` with the current tenant is now allowed for Cloud Shell and managed identity account