### PR TITLE
[ACR] `az acr check-health`: Remove notary functionality from ACR health check

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/check_health.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/check_health.py
@@ -23,8 +23,6 @@ ERROR_MSG_DEEP_LINK = "\nPlease refer to https://aka.ms/acr/errors#{} for more i
 MIN_HELM_VERSION = "2.11.0"
 HELM_VERSION_REGEX = re.compile(r'(SemVer|Version):"v([.\d]+)"')
 ACR_CHECK_HEALTH_MSG = "Try running 'az acr check-health -n {} --yes' to diagnose this issue."
-RECOMMENDED_NOTARY_VERSION = "0.6.0"
-NOTARY_VERSION_REGEX = re.compile(r'Version:\s+([.\d]+)')
 DOCKER_PULL_WRONG_PLATFORM = 'cannot be used on this platform'
 
 
@@ -164,46 +162,6 @@ def _get_helm_version(ignore_errors):
         obsolete_ver_error = HELM_VERSION_ERROR.set_error_message(
             "Current Helm client version is not recommended. Please upgrade your Helm client to at least version {}."
             .format(MIN_HELM_VERSION))
-        _handle_error(obsolete_ver_error, ignore_errors)
-
-
-def _get_notary_version(ignore_errors):
-    from ._errors import NOTARY_VERSION_ERROR
-    from .notary import get_notary_command
-    from packaging.version import parse  # pylint: disable=import-error,no-name-in-module
-
-    # Notary command check
-    notary_command, error = get_notary_command(is_diagnostics_context=True)
-
-    if error:
-        _handle_error(error, ignore_errors)
-        return
-
-    # Notary version check
-    output, warning, stderr, succeeded = _subprocess_communicate([notary_command, "version"])
-
-    if not succeeded:
-        _handle_error(NOTARY_VERSION_ERROR.append_error_message(stderr), ignore_errors)
-        return
-
-    if warning:
-        logger.warning(warning)
-
-    # Retrieve the notary version if regex pattern is found
-    match_obj = NOTARY_VERSION_REGEX.search(output)
-    if match_obj:
-        output = match_obj.group(1)
-
-    logger.warning("Notary version: %s", output)
-
-    # Display error if the current version does not match the recommended version
-    if match_obj and parse(output) != parse(RECOMMENDED_NOTARY_VERSION):
-        version_msg = "upgrade"
-        if parse(output) > parse(RECOMMENDED_NOTARY_VERSION):
-            version_msg = "downgrade"
-        obsolete_ver_error = NOTARY_VERSION_ERROR.set_error_message(
-            "Current notary version is not recommended. Please {} your notary client to version {}."
-            .format(version_msg, RECOMMENDED_NOTARY_VERSION))
         _handle_error(obsolete_ver_error, ignore_errors)
 
 
@@ -468,6 +426,5 @@ def acr_check_health(cmd,  # pylint: disable useless-return
 
     if not in_cloud_console:
         _get_helm_version(ignore_errors)
-        _get_notary_version(ignore_errors)
 
     logger.warning(FAQ_MESSAGE)


### PR DESCRIPTION
**Related command**
`az acr check-health`

**Description**
This PR removes the deprecated notary functionality from the Azure Container Registry health check command. The changes include:

- Removed `RECOMMENDED_NOTARY_VERSION` and `NOTARY_VERSION_REGEX` constants
- Removed the entire `_get_notary_version()` function (40+ lines of notary-specific code)
- Removed the call to `_get_notary_version(ignore_errors)` from the main health check workflow

This streamlines the ACR health check by eliminating dependencies on the deprecated notary tool while maintaining all other essential functionality including Docker, Helm, registry connectivity, and authentication checks.

**Testing Guide**
Test the ACR health check command to verify notary checks are removed:

```bash
# Test basic health check - should complete without notary version check
az acr check-health -n <registry-name>

# Test with ignore errors flag
az acr check-health -n <registry-name> --ignore-errors

# Test with repository parameter
az acr check-health -n <registry-name> --repository <repo-name>

# Test with private endpoint
az acr check-health -n <registry-name> --vnet <vnet-name>

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
