### PR TITLE
[Backup] `az backup restore restore-azurefileshare`: Fix a bug where the source storage account is deleted and the required sourceResourceId property is missing from the restore request payload

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/backup/custom_afs.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom_afs.py
@@ -199,12 +199,15 @@ def restore_AzureFileShare(cmd, client, resource_group_name, vault_name, rp_name
         if not afs_restore_request.source_resource_id:
             raise CLIError("Source resource ID is null or empty after retrieval from storage account.")
     except (CLIError) as e:
-        logger.warning("Failed to get storage account ID: %s. Falling back to source resource ID from protected item.", str(e))
+        logger.warning(
+            "Failed to get storage account ID: %s. Falling back to source resource ID from protected item.",
+            str(e))
         source_resource_id = _get_source_resource_id_from_item(item)
         if source_resource_id:
             afs_restore_request.source_resource_id = source_resource_id
         else:
-            raise CLIError("Unable to retrieve source resource ID. The storage account might have been deleted and no fallback source resource ID is available.")
+            raise CLIError(
+                "Unable to retrieve source resource ID. The storage account might have been deleted and no fallback source resource ID is available.")
 
     afs_restore_request.restore_request_type = restore_request_type
 
@@ -428,10 +431,11 @@ def _get_storage_account_id(cli_ctx, storage_account_name, storage_account_rg):
         storage_account = resources_client.get(storage_account_rg, classic_storage_resource_namespace,
                                                parent_resource_path, resource_type, storage_account_name,
                                                classic_api_version)
-    except:  # pylint: disable=bare-except
+    except BaseException:  # pylint: disable=bare-except
         storage_account = resources_client.get(storage_account_rg, storage_resource_namespace, parent_resource_path,
                                                resource_type, storage_account_name, api_version)
     return storage_account.id
+
 
 def _get_source_resource_id_from_item(item):
     """
@@ -441,6 +445,7 @@ def _get_source_resource_id_from_item(item):
     if item and hasattr(item, 'properties') and hasattr(item.properties, 'source_resource_id'):
         return item.properties.source_resource_id
     return None
+
 
 def set_policy(cmd, client, resource_group_name, vault_name, policy, policy_name, tenant_id=None,
                is_critical_operation=False, yes=False):

--- a/src/azure-cli/azure/cli/command_modules/backup/custom_afs.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom_afs.py
@@ -198,7 +198,7 @@ def restore_AzureFileShare(cmd, client, resource_group_name, vault_name, rp_name
         # Check if source_resource_id is null or empty after assignment
         if not afs_restore_request.source_resource_id:
             raise CLIError("Source resource ID is null or empty after retrieval from storage account.")
-    except Exception as e:
+    except (CLIError) as e:
         logger.warning("Failed to get storage account ID: %s. Falling back to source resource ID from protected item.", str(e))
         source_resource_id = _get_source_resource_id_from_item(item)
         if source_resource_id:

--- a/src/azure-cli/azure/cli/command_modules/backup/custom_afs.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom_afs.py
@@ -207,7 +207,8 @@ def restore_AzureFileShare(cmd, client, resource_group_name, vault_name, rp_name
             afs_restore_request.source_resource_id = source_resource_id
         else:
             raise CLIError(
-                "Unable to retrieve source resource ID. The storage account might have been deleted and no fallback source resource ID is available.")
+                "Unable to retrieve source resource ID. The storage account might have been deleted "
+                "and no fallback source resource ID is available.") from e
 
     afs_restore_request.restore_request_type = restore_request_type
 
@@ -431,7 +432,7 @@ def _get_storage_account_id(cli_ctx, storage_account_name, storage_account_rg):
         storage_account = resources_client.get(storage_account_rg, classic_storage_resource_namespace,
                                                parent_resource_path, resource_type, storage_account_name,
                                                classic_api_version)
-    except BaseException:  # pylint: disable=bare-except
+    except:  # pylint: disable=bare-except
         storage_account = resources_client.get(storage_account_rg, storage_resource_namespace, parent_resource_path,
                                                resource_type, storage_account_name, api_version)
     return storage_account.id

--- a/src/azure-cli/azure/cli/command_modules/backup/custom_afs.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom_afs.py
@@ -432,7 +432,7 @@ def _get_storage_account_id(cli_ctx, storage_account_name, storage_account_rg):
         storage_account = resources_client.get(storage_account_rg, classic_storage_resource_namespace,
                                                parent_resource_path, resource_type, storage_account_name,
                                                classic_api_version)
-    except BaseException:  # pylint: disable=bare-except
+    except:  # pylint: disable=bare-except
         storage_account = resources_client.get(storage_account_rg, storage_resource_namespace, parent_resource_path,
                                                resource_type, storage_account_name, api_version)
     return storage_account.id


### PR DESCRIPTION
**Related command**
az backup restore restore-azurefileshare



**Description**<!--Mandatory-->
Implementing fix to handle cases where the source storage account is deleted & required sourceResourceId property is missing for restore request payload.

**Testing Guide**
Tested restore where AFS source storage account was deleted before changes were made to reproduce bug.
Tested restore where AFS source storage account was deleted after changes were made to validate fix. 

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
