### PR TITLE
[ACR] `az acr task create`: Fix error message when `--context` is not provided

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/task.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/task.py
@@ -114,7 +114,7 @@ def acr_task_create(cmd,  # pylint: disable=too-many-locals
             raise CLIError(e)
 
     if not context_path:
-        raise CLIError("If the task is not a System Task, --context-path must be provided.")
+        raise CLIError("If the task is not a System Task, --context must be provided.")
 
     if context_path.lower() == ACR_NULL_CONTEXT:
         context_path = None


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az acr task create`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
The error message "If the task is not a System Task, --context-path must be provided". This should be "If the task if not a System Task, --context must be provided" instead. 

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
