### PR TITLE
{AKS} `az aks enable-addons --addon monitoring`: handle existing linked resource in AMPLS gracefully

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/addonconfiguration.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/addonconfiguration.py
@@ -736,8 +736,10 @@ def create_ampls_scope(cmd, ampls_resource_id, dce_endpoint_name, dce_resource_i
             )
             error = None
             break
-        except Exception as e:
-            if "Scoped resource with same linked resource id already exists" in str(e):
+        except CLIError as e:
+            error = e
+        except HttpResponseError as e:
+            if e.status_code == 409 and "Scoped resource with same linked resource id already exists" in str(e):
                 logger.info("Scoped resource with same linked resource id already exists, skipping")
                 return
             error = e

--- a/src/azure-cli/azure/cli/command_modules/acs/addonconfiguration.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/addonconfiguration.py
@@ -736,7 +736,10 @@ def create_ampls_scope(cmd, ampls_resource_id, dce_endpoint_name, dce_resource_i
             )
             error = None
             break
-        except CLIError as e:
+        except Exception as e:
+            if "Scoped resource with same linked resource id already exists" in str(e):
+                logger.info("Scoped resource with same linked resource id already exists, skipping")
+                return
             error = e
     else:
         raise error

--- a/src/azure-cli/azure/cli/command_modules/acs/addonconfiguration.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/addonconfiguration.py
@@ -754,8 +754,7 @@ def is_ampls_scoped_exist(cmd, ampls_resource_id, scoped_resource_id):
             # Compare case-insensitively since Azure resource IDs can have case variations
             if linked_resource_id.lower() == scoped_resource_id.lower():
                 print(f"DEBUG: MATCH FOUND! Resource already scoped.")
-                logger.info("Resource already scoped in AMPLS. Scoped resource name: %s, LinkedResourceId: %s", 
-                           scoped_resource_name, linked_resource_id)
+                print("Resource already scoped in AMPLS. Scoped resource name: %s, LinkedResourceId: %s", scoped_resource_name, linked_resource_id)
                 return True
         
         print(f"DEBUG: No matching linkedResourceId found. Resource is not yet scoped.")

--- a/src/azure-cli/azure/cli/command_modules/acs/addonconfiguration.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/addonconfiguration.py
@@ -435,21 +435,21 @@ def ensure_container_insights_for_monitoring(
         ingestionDataCollectionEndpointName = f"MSCI-ingest-{location}-{cluster_name}"
         # Max length of the DCE name is 44 chars
         ingestionDataCollectionEndpointName = _trim_suffix_if_needed(ingestionDataCollectionEndpointName[0:43])
-        ingestion_scoped_resource_id = None
+        ingestion_dce_resource_id = None
 
         # config DCE MUST be in cluster region
         configDataCollectionEndpointName = f"MSCI-config-{cluster_region}-{cluster_name}"
         # Max length of the DCE name is 44 chars
         configDataCollectionEndpointName = _trim_suffix_if_needed(configDataCollectionEndpointName[0:43])
-        config_scoped_resource_id = None
+        config_dce_resource_id = None
 
         # create ingestion DCE if high log scale mode enabled
         if enable_high_log_scale_mode:
-            ingestion_scoped_resource_id = create_data_collection_endpoint(cmd, cluster_subscription, cluster_resource_group_name, location, ingestionDataCollectionEndpointName, is_use_ampls)
+            ingestion_dce_resource_id = create_data_collection_endpoint(cmd, cluster_subscription, cluster_resource_group_name, location, ingestionDataCollectionEndpointName, is_use_ampls)
 
         # create config DCE if AMPLS resource specified
         if is_use_ampls:
-            config_scoped_resource_id = create_data_collection_endpoint(cmd, cluster_subscription, cluster_resource_group_name, cluster_region, configDataCollectionEndpointName, is_use_ampls)
+            config_dce_resource_id = create_data_collection_endpoint(cmd, cluster_subscription, cluster_resource_group_name, cluster_region, configDataCollectionEndpointName, is_use_ampls)
 
         if create_dcr:
             # first get the association between region display names and region IDs (because for some reason
@@ -534,7 +534,7 @@ def ensure_container_insights_for_monitoring(
                                 }
                             ]
                         },
-                        "dataCollectionEndpointId": ingestion_scoped_resource_id
+                        "dataCollectionEndpointId": ingestion_dce_resource_id
                     },
                 }
             )
@@ -615,7 +615,7 @@ def ensure_container_insights_for_monitoring(
                                 }
                             ]
                         },
-                        "dataCollectionEndpointId": ingestion_scoped_resource_id
+                        "dataCollectionEndpointId": ingestion_dce_resource_id
                     },
                 }
             )
@@ -647,22 +647,22 @@ def ensure_container_insights_for_monitoring(
             create_or_delete_dcr_association(cmd, cluster_region, remove_monitoring, cluster_resource_id, dcr_resource_id)
             if is_use_ampls:
                 # associate config DCE to the cluster
-                create_dce_association(cmd, cluster_region, cluster_resource_id, config_scoped_resource_id)
+                create_dce_association(cmd, cluster_region, cluster_resource_id, config_dce_resource_id)
                 # link config DCE to AMPLS
-                create_ampls_scope(cmd, ampls_resource_id, configDataCollectionEndpointName, config_scoped_resource_id)
+                create_ampls_scope(cmd, ampls_resource_id, configDataCollectionEndpointName, config_dce_resource_id)
                 # link workspace to AMPLS
                 create_ampls_scope(cmd, ampls_resource_id, workspace_name, workspace_resource_id)
                 # link ingest DCE to AMPLS
                 if enable_high_log_scale_mode:
-                    create_ampls_scope(cmd, ampls_resource_id, ingestionDataCollectionEndpointName, ingestion_scoped_resource_id)
+                    create_ampls_scope(cmd, ampls_resource_id, ingestionDataCollectionEndpointName, ingestion_dce_resource_id)
 
 
-def create_dce_association(cmd, cluster_region, cluster_resource_id, config_scoped_resource_id):
+def create_dce_association(cmd, cluster_region, cluster_resource_id, config_dce_resource_id):
     association_body = json.dumps(
         {
             "location": cluster_region,
             "properties": {
-                "dataCollectionEndpointId": config_scoped_resource_id,
+                "dataCollectionEndpointId": config_dce_resource_id,
                 "description": "associates config dataCollectionEndpoint to AKS cluster resource",
             },
         }

--- a/src/azure-cli/azure/cli/command_modules/acs/addonconfiguration.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/addonconfiguration.py
@@ -725,7 +725,7 @@ def is_ampls_scoped_exist(cmd, ampls_resource_id, scoped_resource_id):
         cmd: Command context
         ampls_resource_id: Full resource ID of the AMPLS
         scoped_resource_id: Full resource ID of the resource to be linked
-        
+
     Returns:
         bool: True if the resource is already scoped to the AMPLS, False otherwise
     """
@@ -734,7 +734,7 @@ def is_ampls_scoped_exist(cmd, ampls_resource_id, scoped_resource_id):
         ampls_scoped_resources_url = f"{cmd.cli_ctx.cloud.endpoints.resource_manager}{ampls_resource_id}/scopedresources?api-version=2021-07-01-preview"
         response = send_raw_request(cmd.cli_ctx, "GET", ampls_scoped_resources_url)
         scoped_resources_data = json.loads(response.text)
-        
+
         # Check if any scoped resource has the same linkedResourceId
         for scoped_resource in scoped_resources_data.get('value', []):
             properties = scoped_resource.get('properties', {})

--- a/src/azure-cli/azure/cli/command_modules/acs/addonconfiguration.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/addonconfiguration.py
@@ -736,7 +736,7 @@ def is_ampls_scoped_exist(cmd, ampls_resource_id, scoped_resource_id):
         scoped_resources_data = json.loads(response.text)
                 
         # Check if any scoped resource has the same linkedResourceId
-        for i, scoped_resource in enumerate(scoped_resources_data.get('value', [])):
+        for scoped_resource in scoped_resources_data.get('value', []):
             properties = scoped_resource.get('properties', {})
             linked_resource_id = properties.get('linkedResourceId', '')
             scoped_resource_name = scoped_resource.get('name', 'unknown')
@@ -747,10 +747,11 @@ def is_ampls_scoped_exist(cmd, ampls_resource_id, scoped_resource_id):
 
         logger.info("No matching linkedResourceId found. Resource is not yet scoped.")
         return False
-        
-    except Exception as e:
+
+    except CLIError as e:
         logger.warning("Error checking AMPLS scoped resources: %s", str(e))
         return False
+
 
 def create_ampls_scope(cmd, ampls_resource_id, scoped_resource_name, scoped_resource_id):
     # Check if the resource is already scoped to the AMPLS

--- a/src/azure-cli/azure/cli/command_modules/acs/addonconfiguration.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/addonconfiguration.py
@@ -720,7 +720,7 @@ def create_or_delete_dcr_association(cmd, cluster_region, remove_monitoring, clu
 def is_ampls_scoped_exist(cmd, ampls_resource_id, scoped_resource_id):
     """
     Check if the specified resource is already scoped (linked) to the AMPLS by iterating through all scoped resources.
-    
+
     Args:
         cmd: Command context
         ampls_resource_id: Full resource ID of the AMPLS
@@ -734,7 +734,7 @@ def is_ampls_scoped_exist(cmd, ampls_resource_id, scoped_resource_id):
         ampls_scoped_resources_url = f"{cmd.cli_ctx.cloud.endpoints.resource_manager}{ampls_resource_id}/scopedresources?api-version=2021-07-01-preview"
         response = send_raw_request(cmd.cli_ctx, "GET", ampls_scoped_resources_url)
         scoped_resources_data = json.loads(response.text)
-                
+        
         # Check if any scoped resource has the same linkedResourceId
         for scoped_resource in scoped_resources_data.get('value', []):
             properties = scoped_resource.get('properties', {})
@@ -757,7 +757,7 @@ def create_ampls_scope(cmd, ampls_resource_id, scoped_resource_name, scoped_reso
     # Check if the resource is already scoped to the AMPLS
     if is_ampls_scoped_exist(cmd, ampls_resource_id, scoped_resource_id):
         return
-    
+
     scoped_resource_ampls_body = json.dumps(
         {
             "properties": {


### PR DESCRIPTION
**Related command**
az aks enable-addons --addon monitoring

**Description**<!--Mandatory-->
if the workspace already exists in the ampls, when enable container insights addon with amplsId for the first time, there will be an resource conflict error.

**Testing Guide**
1. add a workspace to ampls.
2. then run the
`
az aks enable-addons --addon monitoring --name {cluster-name} --resource-group {resource-group-name} --workspace-resource-id {law-id} --ampls-resource-id {ampls-id}
`
# commit: e507960375692e423803ddec83e7de86a7f709f7
- without this fix, there will be following error, and container insights feature can't be enabled.

---

(azure-cli-dev-env-dev-fork) <User>azureuser</User>@<Host>jumpbox-vm</Host>:/azure-cli-dev-fork$ deactivate
<User>azureuser</User>@<Host>jumpbox-vm</Host>:~/azure-cli-dev-fork$ az aks enable-addons \
  --addon monitoring \
  --name <ClusterName>private-aks3</ClusterName> \
  --resource-group <ResourceGroup>private-rg3</ResourceGroup> \
  --workspace-resource-id "/subscriptions/<SubscriptionID>/resourceGroups/<ResourceGroup>/providers/Microsoft.OperationalInsights/workspaces/<WorkspaceName>bug-fix-1</WorkspaceName>" \
  --ampls-resource-id "/subscriptions/<SubscriptionID>/resourceGroups/<ResourceGroup>/providers/microsoft.insights/privateLinkScopes/<AMPLSName>private-aks3-ampls</AMPLSName>"

Conflict({
  "error": {
    "code": "Conflict",
    "message": "Scoped resource with same linked resource id already exists in this private link scope",
    "innererror": {
      "trace": [
        "Microsoft.AppInsights.Nexus.ResourceStore.ResourceStoreException"
      ]
    }
  }
})
---

- with this fix:
error is gone. logs can stream to log analytics workspace

---
<User>azureuser</User>@<Host>jumpbox-vm</Host>:/azure-cli-dev-fork$ source azure-cli-dev-env-dev-fork/bin/activate
(azure-cli-dev-env-dev-fork) <User>azureuser</User>@<Host>jumpbox-vm</Host>:~/azure-cli-dev-fork$ az aks enable-addons \
  --addon monitoring \
  --name <ClusterName>private-aks3</ClusterName> \
  --resource-group <ResourceGroup>private-rg3</ResourceGroup> \
  --workspace-resource-id "/subscriptions/<SubscriptionID>/resourceGroups/<ResourceGroup>/providers/Microsoft.OperationalInsights/workspaces/<WorkspaceName>bug-fix-1</WorkspaceName>" \
  --ampls-resource-id "/subscriptions/<SubscriptionID>/resourceGroups/<ResourceGroup>/providers/microsoft.insights/privateLinkScopes/<AMPLSName>private-aks3-ampls</AMPLSName>"

/home/<User>azureuser</User>/azure-cli-dev-fork/azure-cli-dev-env-dev-fork/bin/az:4: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
  __import__('pkg_resources').require('azure-cli==2.76.0')

 / InProgress ..
 ...
 ...
   "workloadAutoScalerProfile": {
    "keda": null,
    "verticalPodAutoscaler": null
  }
}
---

- query heartbeat in law

---
<User>azureuser</User>@<Host>jumpbox-vm</Host>:~/azure-cli-dev-fork$ az monitor log-analytics query \
  --workspace "<WorkspaceID>" \
  --analytics-query "Heartbeat | where TimeGenerated > ago(30m)" \
  --timespan "PT30M"

[
  {
    "Category": "Azure Monitor Agent",
    "Computer": "<NodeName>aks-userpool-xxxxxxx-vmss000001</NodeName>",
    "ComputerEnvironment": "Non-Azure",
    "ComputerIP": "<IPv6>fd40:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx</IPv6>",
    "ComputerPrivateIPs": "[\"<IPv4>10.xxx.xxx.xxx</IPv4>\"]",
    "OSName": "Common Base Linux Mariner",
    "OSType": "Linux",
    "Resource": "<ClusterName>private-aks3</ClusterName>",
    "ResourceGroup": "<ResourceGroup>private-rg3</ResourceGroup>",
    "ResourceId": "/subscriptions/<SubscriptionID>/resourceGroups/<ResourceGroup>/providers/Microsoft.ContainerService/managedClusters/<ClusterName>private-aks3</ClusterName>",
    "SubscriptionId": "<SubscriptionID>",
    "TenantId": "<TenantID>",
    "TimeGenerated": "2025-08-01T05:16:23.8004461Z",
    "_ResourceId": "/subscriptions/<SubscriptionID>/resourcegroups/<ResourceGroup>/providers/microsoft.containerservice/managedclusters/<ClusterName>private-aks3</ClusterName>"
  }
]
---

- query containerV2 log in law

----
~/Docker-Provider/test/scenario$ az monitor log-analytics query \
  --workspace "<REDACTED_WORKSPACE_ID>" \
  --analytics-query "ContainerLogV2 | where TimeGenerated > ago(30m)" \
  --timespan "PT2M"

/path/to/az:4: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
  __import__('pkg_resources').require('azure-cli==2.76.0')

[
  {
    "Computer": "<REDACTED_COMPUTER_NAME>",
    "ContainerId": "<REDACTED_CONTAINER_ID>",
    "ContainerName": "second-log-app",
    "KubernetesMetadata": "None",
    "LogLevel": "unknown",
    "LogMessage": "281",
    "LogSource": "stdout",
    "PodName": "second-log-app-5474ff74c-sfpbm",
    "PodNamespace": "windows-log-ltsc2022",
    "SourceSystem": "",
    "TableName": "PrimaryResult",
    "TenantId": "<REDACTED_TENANT_ID>",
    "TimeGenerated": "2025-08-01T17:16:23.8465413Z",
    "Type": "ContainerLogV2",
    "_ResourceId": "/subscriptions/<REDACTED_SUBSCRIPTION_ID>/resourcegroups/<REDACTED_RG>/providers/microsoft.containerservice/managedclusters/<REDACTED_CLUSTER>"
  },
  {
    "Computer": "<REDACTED_COMPUTER_NAME>",
    "ContainerId": "<REDACTED_CONTAINER_ID>",
    "ContainerName": "second-log-app",
    "KubernetesMetadata": "None",
    "LogLevel": "unknown",
    "LogMessage": "282",
    "LogSource": "stdout",
    "PodName": "second-log-app-5474ff74c-sfpbm",
    "PodNamespace": "windows-log-ltsc2022",
    "SourceSystem": "",
    "TableName": "PrimaryResult",
    "TenantId": "<REDACTED_TENANT_ID>",
    "TimeGenerated": "2025-08-01T17:16:24.8573817Z",
    "Type": "ContainerLogV2",
    "_ResourceId": "/subscriptions/<REDACTED_SUBSCRIPTION_ID>/resourcegroups/<REDACTED_RG>/providers/microsoft.containerservice/managedclusters/<REDACTED_CLUSTER>"
  }
]


----


**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

{AKS} `az aks enable-addons --addon monitoring`: handle existing linked resource in AMPLS gracefully

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).


----------------------------------
# commit: d1e446ab52cf7a6871a9d1ef4249c54bcbc67227

az monitor log-analytics query \
  --workspace "<workspace-id>" \
  --analytics-query "ContainerLogV2 | where TimeGenerated > ago(5m)" \
  --timespan "PT30M"
/home/<user>/azure-cli-dev-env/bin/az:4: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
  __import__('pkg_resources').require('azure-cli==2.76.0')
[
  {
    "Computer": "<computer-name>",
    "ContainerId": "<container-id>",
    "ContainerName": "second-log-app",
    "KubernetesMetadata": "None",
    "LogLevel": "unknown",
    "LogMessage": "20664",
    "LogSource": "stdout",
    "PodName": "second-log-app-<pod-id>",
    "PodNamespace": "windows-log-ltsc2022",
    "SourceSystem": "",
    "TableName": "PrimaryResult",
    "TenantId": "<tenant-id>",
    "TimeGenerated": "2025-08-01T22:58:45.4967915Z",
    "Type": "ContainerLogV2",
    "_ResourceId": "/subscriptions/<subscription-id>/resourcegroups/<resource-group>/providers/microsoft.containerservice/managedclusters/<cluster-name>"
  },
  {
    "Computer": "<computer-name>",
    "ContainerId": "<container-id>",
    "ContainerName": "second-log-app",
    "KubernetesMetadata": "None",
    "LogLevel": "unknown",
    "LogMessage": "20665",
    "LogSource": "stdout",
    "PodName": "second-log-app-<pod-id>",
    "PodNamespace": "windows-log-ltsc2022",
    "SourceSystem": "",
    "TableName": "PrimaryResult",
    "TenantId": "<tenant-id>",
    "TimeGenerated": "2025-08-01T22:58:46.5169425Z",
    "Type": "ContainerLogV2",
    "_ResourceId": "/subscriptions/<subscription-id>/resourcegroups/<resource-group>/providers/microsoft.containerservice/managedclusters/<cluster-name>"
  }
]





