### PR TITLE
[IoT] BREAKING CHANGE: Migrate `az iot hub devicestream` command group to CLI extension

### DIFF
--- a/src/azure-cli-core/azure/cli/core/profiles/_shared.py
+++ b/src/azure-cli-core/azure/cli/core/profiles/_shared.py
@@ -233,10 +233,6 @@ AZURE_API_PROFILES = {
 # We should avoid using ad hoc API versions,
 # use the version in a profile as much as possible.
 AD_HOC_API_VERSIONS = {
-    ResourceType.MGMT_IOTHUB: {
-        # src/azure-cli/azure/cli/command_modules/iot/custom.py#iot_hub_devicestream_show
-        'iot_hub_resource': '2019-07-01-preview',
-    },
     ResourceType.MGMT_APPSERVICE: {
         # src/azure-cli/azure/cli/command_modules/appservice/_constants.py:68
         'app_service_certificate_orders': '2022-09-01'

--- a/src/azure-cli/azure/cli/command_modules/iot/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/_help.py
@@ -427,21 +427,6 @@ examples:
     crafted: true
 """
 
-helps['iot hub devicestream'] = """
-type: group
-short-summary: Manage device streams of an IoT hub.
-"""
-
-helps['iot hub devicestream show'] = """
-type: command
-short-summary: Get IoT Hub's device streams endpoints.
-long-summary: Get IoT Hub's device streams endpoints.
-examples:
-  - name: Get all the device streams from "MyIotHub" IoT Hub.
-    text: >
-        az iot hub devicestream show -n MyIotHub
-"""
-
 helps['iot hub identity'] = """
 type: group
 short-summary: Manage identities of an Azure IoT hub.

--- a/src/azure-cli/azure/cli/command_modules/iot/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/commands.py
@@ -191,11 +191,6 @@ def load_command_table(self, _):  # pylint: disable=too-many-statements
         g.custom_command('update', 'iot_hub_route_update', transform=RouteUpdateResultTransform(self.cli_ctx))
         g.custom_command('test', 'iot_hub_route_test')
 
-    # iot hub device stream commands
-    with self.command_group('iot hub devicestream', client_factory=iot_hub_service_factory,
-                            min_api="2019-07-01-preview", is_preview=True) as g:
-        g.custom_show_command('show', 'iot_hub_devicestream_show')
-
     # iot central commands
     with self.command_group('iot central app', iot_central_sdk, client_factory=iot_central_service_factory) as g:
         g.custom_command('create', 'iot_central_app_create', supports_no_wait=True)

--- a/src/azure-cli/azure/cli/command_modules/iot/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/custom.py
@@ -1210,15 +1210,6 @@ def iot_message_enrichment_list(cmd, client, hub_name, resource_group_name=None)
     return hub.properties.routing.enrichments
 
 
-def iot_hub_devicestream_show(cmd, client, hub_name, resource_group_name=None):
-    from azure.cli.core.commands.client_factory import get_mgmt_service_client
-    resource_group_name = _ensure_hub_resource_group_name(client, resource_group_name, hub_name)
-    # DeviceStreams property is still in preview, so until GA we need to use a preview API-version
-    client = get_mgmt_service_client(cmd.cli_ctx, ResourceType.MGMT_IOTHUB, api_version='2019-07-01-preview')
-    hub = client.iot_hub_resource.get(resource_group_name, hub_name)
-    return hub.properties.device_streams
-
-
 def iot_hub_manual_failover(cmd, client, hub_name, resource_group_name=None, no_wait=False):
     hub = iot_hub_get(cmd, client, hub_name, resource_group_name)
     resource_group_name = hub.additional_properties['resourcegroup']

--- a/src/azure-cli/azure/cli/command_modules/iot/tests/latest/test_iot_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/tests/latest/test_iot_commands.py
@@ -388,9 +388,6 @@ class IoTHubTest(ScenarioTest):
                          self.check('length(serviceBusTopics[*])', 0),
                          self.check('length(storageContainers[*])', 1)])
 
-        # Test 'az iot hub devicestream show'
-        self.cmd('iot hub devicestream show -n {0} -g {1}'.format(hub, rg), checks=self.is_empty())
-
         # Test 'az iot hub message-enrichment create'
         real_endpoints = 'events'
         fake_endpoints = 'events fake_endpoint'
@@ -768,17 +765,16 @@ class IoTHubTest(ScenarioTest):
 
         # File upload - add connection string and containername - keybased
         updated_hub = self.cmd('iot hub update -n {0} -g {1} --fc {2} --fcs {3}'
-                 .format(hub, rg, containerName, storageConnectionString)).get_output_in_json()
+                               .format(hub, rg, containerName, storageConnectionString)).get_output_in_json()
         assert not updated_hub['properties']['storageEndpoints']['$default']['authenticationType']
         assert storage_cs_pattern in updated_hub['properties']['storageEndpoints']['$default']['connectionString']
         assert updated_hub['properties']['storageEndpoints']['$default']['containerName'] == containerName
 
         updated_hub = self.cmd('iot hub update -n {0} -g {1} --fsa {2}'
-                 .format(hub, rg, key_based_auth)).get_output_in_json()
+                               .format(hub, rg, key_based_auth)).get_output_in_json()
         assert updated_hub['properties']['storageEndpoints']['$default']['authenticationType'] == key_based_auth
         assert storage_cs_pattern in updated_hub['properties']['storageEndpoints']['$default']['connectionString']
         assert updated_hub['properties']['storageEndpoints']['$default']['containerName'] == containerName
-
 
         # Change to identity-based (with no identity) - fail
         self.cmd('iot hub update -n {0} -g {1} --fsa identitybased'.format(hub, rg), expect_failure=True)


### PR DESCRIPTION
**Related command**
az iot hub devicestream

**Description**<!--Mandatory-->
Removes the `az iot hub devicestream` command group from this code base. The commands are moved to the azure-iot extension with the same functionality (https://github.com/Azure/azure-iot-cli-extension/pull/748)

This way we can keep one version of the IoT Hub API in this repository.

**Testing Guide**
Removed the command from test_iot_hub, ran the recorded tests, and ran the tests live. The recorded tests did not change.

**History Notes**
[IoT] Remove `az iot hub devicestream`. To use this command, please install the latest version of the extension azure-iot.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
