### PR TITLE
{Packaging} Add `azure-core` dependency to `azure-cli-core`

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -45,6 +45,7 @@ CLASSIFIERS = [
 DEPENDENCIES = [
     'argcomplete~=3.5.2',
     'azure-cli-telemetry==1.1.0.*',
+    'azure-core~=1.35.0',
     'azure-mgmt-core>=1.2.0,<2',
     'cryptography',
     # On Linux, the distribution (Ubuntu, Debian, etc) and version are logged in telemetry


### PR DESCRIPTION
**Description**<!--Mandatory-->
Fix https://github.com/Azure/azure-cli/issues/31915

`azure.core.serialization.attribute_list` was added by https://github.com/Azure/azure-sdk-for-python/pull/41571 and released in `azure-core` 1.35.0. https://github.com/Azure/azure-cli/pull/31775 created a dependency on `azure.core.serialization.attribute_list` but didn't declare the dependency.

https://github.com/Azure/azure-cli/pull/31763 bumped `azure-core` to 1.35.0, but only in `src/azure-cli/requirements.py3.*.txt`.

If `azure-cli` is installed via `pip`, `azure-core` < 1.35.0 will cause error:

```
  File "/local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.12/site-packages/azure/cli/core/util.py", line 647, in todict
    from azure.core.serialization import attribute_list
ImportError: cannot import name 'attribute_list' from 'azure.core.serialization' (/databricks/python/lib/python3.12/site-packages/azure/core/serialization.py)
```

This PR adds `azure-core~=1.35.0` dependency to `azure-cli-core`.
