### PR TITLE
{Misc.} Remove unreachable code for creating SSL context

### DIFF
--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -1164,12 +1164,6 @@ ConfiguredDefaultSetter = ScopedConfig
 
 
 def _ssl_context():
-    if sys.version_info < (3, 4) or (in_cloud_console() and platform.system() == 'Windows'):
-        try:
-            return ssl.SSLContext(ssl.PROTOCOL_TLS)  # added in python 2.7.13 and 3.6
-        except AttributeError:
-            return ssl.SSLContext(ssl.PROTOCOL_TLSv1)
-
     return ssl.create_default_context()
 
 

--- a/src/azure-cli/azure/cli/command_modules/acr/helm.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/helm.py
@@ -10,7 +10,7 @@ from urllib.request import urlopen
 from knack.util import CLIError
 from knack.log import get_logger
 
-from azure.cli.core.util import in_cloud_console, user_confirmation
+from azure.cli.core.util import user_confirmation
 
 from ._docker_utils import (
     get_access_credentials,
@@ -366,15 +366,7 @@ def _get_helm_package_name(client_version):
 
 
 def _ssl_context():
-    import sys
     import ssl
-
-    if sys.version_info < (3, 4) or (in_cloud_console() and platform.system() == 'Windows'):
-        try:
-            return ssl.SSLContext(ssl.PROTOCOL_TLS)  # added in python 2.7.13 and 3.6
-        except AttributeError:
-            return ssl.SSLContext(ssl.PROTOCOL_TLSv1)
-
     return ssl.create_default_context()
 
 

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -2218,13 +2218,6 @@ def k8s_install_kubelogin(cmd, client_version='latest', install_location=None, s
 
 
 def _ssl_context():
-    if sys.version_info < (3, 4) or (in_cloud_console() and platform.system() == 'Windows'):
-        try:
-            # added in python 2.7.13 and 3.6
-            return ssl.SSLContext(ssl.PROTOCOL_TLS)
-        except AttributeError:
-            return ssl.SSLContext(ssl.PROTOCOL_TLSv1)
-
     return ssl.create_default_context()
 
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -41,7 +41,7 @@ from azure.mgmt.web import WebSiteManagementClient
 
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.commands import LongRunningOperation
-from azure.cli.core.util import in_cloud_console, shell_safe_json_parse, open_page_in_browser, get_json_object, \
+from azure.cli.core.util import shell_safe_json_parse, open_page_in_browser, get_json_object, \
     ConfiguredDefaultSetter, sdk_no_wait
 from azure.cli.core.util import get_az_user_agent, send_raw_request, get_file_json
 from azure.cli.core.profiles import ResourceType, get_sdk
@@ -2676,12 +2676,6 @@ def _redact_storage_accounts(properties):
 
 
 def _ssl_context():
-    if sys.version_info < (3, 4) or (in_cloud_console() and sys.platform.system() == 'Windows'):
-        try:
-            return ssl.SSLContext(ssl.PROTOCOL_TLS)  # added in python 2.7.13 and 3.6
-        except AttributeError:
-            return ssl.SSLContext(ssl.PROTOCOL_TLSv1)
-
     return ssl.create_default_context()
 
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
Azure CLI now only supports Python 3.9+:

https://github.com/Azure/azure-cli/blob/d7e8a34a277107b4de5d53b7f36e5aa0c1dc0592/src/azure-cli-core/setup.py#L85

and there is no Windows Cloud Shell, so this piece of code will never be hit.

For code cleanness, this PR removes the unreachable code.
