### PR TITLE
{CI} Fix cli login issue for regression test pipeline

### DIFF
--- a/scripts/regression_test/extension_regression_test.yml
+++ b/scripts/regression_test/extension_regression_test.yml
@@ -21,7 +21,13 @@ jobs:
       inputs:
         versionSpec: '3.12'
         displayName: "Use Python 3.12"
-    - bash: |
+    - task: AzureCLI@2
+      displayName: 'checkout branch'
+      inputs:
+        connectedServiceNameARM: $(azure-cli-live-test-msft-connected-service)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
           set -ev
           pwd
           git clone https://github.com/Azure/azure-cli-extensions.git
@@ -34,7 +40,6 @@ jobs:
           git remote add azclibot https://azclibot:${GITHUB_TOKEN}@github.com/azclibot/azure-cli-extensions.git
           git checkout -b regression_test_$(Build.BuildId)
           git push --set-upstream azclibot regression_test_$(Build.BuildId)
-      displayName: 'checkout branch'
 
 - job: CLIExtensionRegressionTest
   displayName: CLI Extension Regression Test
@@ -74,7 +79,13 @@ jobs:
     inputs:
       versionSpec: '3.12'
       displayName: "Use Python 3.12"
-  - bash: |
+  - task: AzureCLI@2
+    displayName: 'checkout cli and extension repo'
+    inputs:
+      connectedServiceNameARM: $(azure-cli-live-test-msft-connected-service)
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
         set -ev
         pwd
         if [[ -n "$(CUSTOM_CLI_REPO)" && -n "$(CUSTOM_CLI_BRANCH)" ]]; then
@@ -94,7 +105,6 @@ jobs:
 
         git fetch azclibot
         git checkout -b regression_test_$(Build.BuildId) azclibot/regression_test_$(Build.BuildId)
-    displayName: 'checkout cli and extension repo'
   - template: ../../.azure-pipelines/templates/azdev_setup.yml
     parameters:
       CLIExtensionRepoPath: ./azure-cli-extensions
@@ -153,7 +163,13 @@ jobs:
   pool:
     name: ${{ variables.ubuntu_pool }}
   steps:
-    - bash: |
+    - task: AzureCLI@2
+      displayName: 'Result Summary'
+      inputs:
+        connectedServiceNameARM: $(azure-cli-live-test-msft-connected-service)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
           set -ev
 
           # git config
@@ -195,4 +211,3 @@ jobs:
 
             sleep 5
           done
-      displayName: 'Result Summary'

--- a/scripts/regression_test/regression_test.yml
+++ b/scripts/regression_test/regression_test.yml
@@ -22,7 +22,13 @@ jobs:
       inputs:
         versionSpec: '3.12'
         displayName: "Use Python 3.12"
-    - bash: |
+    - task: AzureCLI@2
+      displayName: 'update version'
+      inputs:
+        connectedServiceNameARM: $(azure-cli-live-test-msft-connected-service)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
           set -ev
 
           # git config
@@ -53,7 +59,6 @@ jobs:
           git add .
           git commit -m "update version"
           git push --set-upstream azclibot regression_test_$(Build.BuildId)
-      displayName: 'update version'
 
 - job: RerunTests
   displayName: CLI Regression tests
@@ -86,7 +91,13 @@ jobs:
       inputs:
         versionSpec: '3.12'
         displayName: "Use Python 3.12"
-    - bash: |
+    - task: AzureCLI@2
+      displayName: 'Checkout Target Branch'
+      inputs:
+        connectedServiceNameARM: $(azure-cli-live-test-msft-connected-service)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
           set -ev
           # git config
           if [[ -n "$(CUSTOM_REPO)" && -n "$(CUSTOM_BRANCH)" && -n "$(CUSTOM_GITHUB_TOKEN)" ]]; then
@@ -104,7 +115,6 @@ jobs:
           git fetch ${GITHUB_REPO} ${GITHUB_BRANCH}
 
           git checkout -b ${GITHUB_BRANCH} ${GITHUB_REPO}/${GITHUB_BRANCH}
-      displayName: 'Checkout Target Branch'
     - template: ../../.azure-pipelines/templates/azdev_setup.yml
     - task: AzureCLI@2
       displayName: 'Rerun tests'
@@ -137,7 +147,13 @@ jobs:
   pool:
     name: ${{ variables.ubuntu_pool }}
   steps:
-    - bash: |
+    - task: AzureCLI@2
+      displayName: 'Create PR'
+      inputs:
+        connectedServiceNameARM: $(azure-cli-live-test-msft-connected-service)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
           set -ev
           # git config
           if [[ -n "$(CUSTOM_REPO)" && -n "$(CUSTOM_BRANCH)" && -n "$(CUSTOM_GITHUB_TOKEN)" ]]; then


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
In https://github.com/Azure/azure-cli/pull/31760, some CLI tasks were mistakenly updated to simple bash tasks. Actually there's `az keyvault secret show` within the bash script to fetch github token which needs CLI environment. This PR will fix the issue

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
