### PR TITLE
[PACKAGING] Fix: Use PEP 440 compliant version specifier for azure-cli-telemetry

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -44,7 +44,7 @@ CLASSIFIERS = [
 
 DEPENDENCIES = [
     'argcomplete~=3.5.2',
-    'azure-cli-telemetry==1.1.0.*',
+    'azure-cli-telemetry>=1.1.0,<1.1.1',
     'azure-core~=1.35.0',
     'azure-mgmt-core>=1.2.0,<2',
     'cryptography',


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

This PR changes the version specifier for `azure-cli-telemetry`. Previously, it used the `==X.Y.Z.*` schema, which is a discouraged edge case of PEP 440.
- Find the PEP [here](https://peps.python.org/pep-0440/#version-matching).
- Find the discussion on the edge case [here](https://discuss.python.org/t/pep-440-clarification-on-prefix-version-matching-with-pre-release-post-release-segments/16622)

To quote one of the PEP's authors (see [here](https://discuss.python.org/t/pep-440-clarification-on-prefix-version-matching-with-pre-release-post-release-segments/16622/5)):

> I don’t think myself or Nick considered at all the idea of something like ==1.1.0.post0.* for the PEP to have a thought one way or the other. I think that disallowing them makes the most sense though.

This PR replaces the version specifier with `>=X.Y.Z,<X.Y.Z+1`.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).