### PR TITLE
{CI} Disable `partnercenter` extension test

### DIFF
--- a/scripts/ci/test_extensions.sh
+++ b/scripts/ci/test_extensions.sh
@@ -26,7 +26,8 @@ exit_code=0
 # hybridaks is going to be deprecated: https://github.com/Azure/azure-cli/pull/29838
 # db-up is going to be deprecated: https://github.com/Azure/azure-cli/pull/29887
 # serviceconnector-passwordless's dependency is not compatible with 3.13 https://github.com/Azure/azure-cli/pull/31895
-ignore_list='azure-cli-ml fzf arcappliance arcdata connectedk8s k8s-extension alias hybridaks db-up serviceconnector-passwordless'
+# partnercenter is not compatible with latest pydantic: https://github.com/Azure/azure-cli/pull/31967
+ignore_list='azure-cli-ml fzf arcappliance arcdata connectedk8s k8s-extension alias hybridaks db-up serviceconnector-passwordless partnercenter'
 
 # Does not exit if az extension add fails until all extensions have been tested
 set +e


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
In latest `aks-preview` extension, it adds dependency `holmesgpt==0.12.4`, which installs latest `pydantic`.
https://github.com/Azure/azure-cli-extensions/commit/fb7fc37b18c5f53e25ddc8b3026e50babd7c8a01#diff-f03813f1ac4bc03269805bd456fdb6b2260a6b6009d9416d8c0ccc440cea22b5R27

However, `partnercenter` is not compatible with `pydantic` 2.11.7 in Test Extensions Loading task:
```
  File "/opt/az/azcliextensions/partnercenter/azext_partnercenter/operations/marketplace_offer_plan_technicalconfiguration/custom.py", line 7, in <module>
    from azext_partnercenter.vendored_sdks.production_ingestion.models import (ContainerCnabPlanTechnicalConfigurationProperties, CnabReference)
  File "/opt/az/azcliextensions/partnercenter/azext_partnercenter/vendored_sdks/production_ingestion/models/__init__.py", line 7, in <module>
    from ._models import *
  File "/opt/az/azcliextensions/partnercenter/azext_partnercenter/vendored_sdks/production_ingestion/models/_models.py", line 17, in <module>
    class DurableId(BaseModel):
  File "/opt/az/azcliextensions/aks-preview/pydantic/_internal/_model_construction.py", line 112, in __new__
    private_attributes = inspect_namespace(
                         ^^^^^^^^^^^^^^^^^^
  File "/opt/az/azcliextensions/aks-preview/pydantic/_internal/_model_construction.py", line 402, in inspect_namespace
    raise TypeError("To define root models, use `pydantic.RootModel` rather than a field called '__root__'")
TypeError: To define root models, use `pydantic.RootModel` rather than a field called '__root__'
```

Disable this extension test to unblock CI.

Ref: https://dev.azure.com/azclitools/5147fa83-336e-44ef-bbe0-c86b8ae86cbb/_build/results?buildId=266927&view=logs&jobId=01af1841-5e1e-55ad-41dc-1e6c21da8745