### PR TITLE
{Core}: add support for None in supported_api_version comparison

### DIFF
--- a/src/azure-cli-core/azure/cli/core/profiles/_shared.py
+++ b/src/azure-cli-core/azure/cli/core/profiles/_shared.py
@@ -427,6 +427,8 @@ def supported_api_version(api_profile, resource_type, min_api=None, max_api=None
     Returns True if current API version for the resource type satisfies min/max range.
     To compare profile versions, set resource type to None.
     Can return a tuple<operation_group, bool> if the resource_type supports SDKProfile.
+    note: if the api_version for the given profile is None (inherrited from the SDK), returns True
+    as there is no easy way to extract the api version.
     note: Currently supports YYYY-MM-DD, YYYY-MM-DD-preview, YYYY-MM-DD-profile
     or YYYY-MM-DD-profile-preview  formatted strings.
     """
@@ -438,6 +440,8 @@ def supported_api_version(api_profile, resource_type, min_api=None, max_api=None
         if isinstance(resource_type, (ResourceType, CustomResourceType)) else api_profile
     if isinstance(api_version_obj, SDKProfile):
         api_version_obj = api_version_obj.profile.get(operation_group or '', api_version_obj.default_api_version)
+    if not api_version_obj:
+        return True
     return _validate_api_version(api_version_obj, min_api, max_api)
 
 

--- a/src/azure-cli-core/azure/cli/core/tests/test_api_profiles.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_api_profiles.py
@@ -133,6 +133,13 @@ class TestAPIProfiles(unittest.TestCase):
         with mock.patch('azure.cli.core.profiles._shared.AZURE_API_PROFILES', test_profile):
             self.assertTrue(supported_api_version(cli, ResourceType.MGMT_KEYVAULT, min_api='2016-06-04'))
 
+    def test_supported_api_version_min_constraint_none(self):
+        cli = DummyCli()
+        cli.cloud = Cloud('TestCloud', profile='2017-01-01-profile')
+        test_profile = {'2017-01-01-profile': {ResourceType.MGMT_STORAGE: None}}
+        with mock.patch('azure.cli.core.profiles._shared.AZURE_API_PROFILES', test_profile):
+            self.assertTrue(supported_api_version(cli, ResourceType.MGMT_STORAGE, min_api='2000-01-01'))
+
     def test_supported_api_version_max_constraint(self):
         cli = DummyCli()
         cli.cloud = Cloud('TestCloud', profile='2017-01-01-profile')
@@ -154,6 +161,13 @@ class TestAPIProfiles(unittest.TestCase):
         with mock.patch('azure.cli.core.profiles._shared.AZURE_API_PROFILES', test_profile):
             self.assertTrue(supported_api_version(cli, ResourceType.MGMT_KEYVAULT, max_api='8.0'))
 
+    def test_supported_api_version_max_constraint_none(self):
+        cli = DummyCli()
+        cli.cloud = Cloud('TestCloud', profile='2017-01-01-profile')
+        test_profile = {'2017-01-01-profile': {ResourceType.MGMT_STORAGE: None}}
+        with mock.patch('azure.cli.core.profiles._shared.AZURE_API_PROFILES', test_profile):
+            self.assertTrue(supported_api_version(cli, ResourceType.MGMT_STORAGE, max_api='2021-01-01'))
+
     def test_supported_api_version_min_max_constraint(self):
         cli = DummyCli()
         cli.cloud = Cloud('TestCloud', profile='2017-01-01-profile')
@@ -169,6 +183,14 @@ class TestAPIProfiles(unittest.TestCase):
         with mock.patch('azure.cli.core.profiles._shared.AZURE_API_PROFILES', test_profile):
             self.assertTrue(
                 supported_api_version(cli, ResourceType.MGMT_KEYVAULT, min_api='6.0', max_api='8.0'))
+
+    def test_supported_api_version_min_max_constraint_none(self):
+        cli = DummyCli()
+        cli.cloud = Cloud('TestCloud', profile='2017-01-01-profile')
+        test_profile = {'2017-01-01-profile': {ResourceType.MGMT_STORAGE: None}}
+        with mock.patch('azure.cli.core.profiles._shared.AZURE_API_PROFILES', test_profile):
+            self.assertTrue(
+                supported_api_version(cli, ResourceType.MGMT_STORAGE, min_api='2000-01-01', max_api='2021-01-01'))
 
     def test_supported_api_version_max_constraint_not_supported(self):
         cli = DummyCli()


### PR DESCRIPTION
**Related command**

**Description**<!--Mandatory-->
Even though this is mostly written with an issue seen in the IoT CLI extension, this can apply to other services too.

There is a push to remove the reliance on multi-api SDKs and allow the SDK to determine the API version by setting the profile API versions to None. However, this will break comparisons for minimum and maximum APIs since the None is not comparable. In particular, if there is a minimum or maximum api, the code fails to convert the current profile api (None) via _SemVerAPIFormat and _DateAPIFormat since these two expect strings.

Extension fails to load:
<img width="1134" height="60" alt="image" src="https://github.com/user-attachments/assets/147ac1e5-03db-4927-8711-06481152addb" />
with debug:
<img width="1122" height="278" alt="image" src="https://github.com/user-attachments/assets/88249d9f-8c2a-40a0-b76a-7e8072efb61c" />

<img width="1163" height="267" alt="image" src="https://github.com/user-attachments/assets/1183b9cb-20e9-4494-9430-8933c42af1da" />


The IoT CLI extension has two references for `min_api` ([first](https://github.com/Azure/azure-iot-cli-extension/blob/1d5e3e488363ca6df975c1b5b5d0174476bff499/azext_iot/iothub/command_map.py#L96) and [second](https://github.com/Azure/azure-iot-cli-extension/blob/1d5e3e488363ca6df975c1b5b5d0174476bff499/azext_iot/iothub/command_map.py#L128)). Although these can be removed, it means that if the [IoT Hub API Profile](https://github.com/Azure/azure-cli/blob/dev/src/azure-cli-core/azure/cli/core/profiles/_shared.py#L221) is set to None, **any iot cli extension version before this change would break with the latest Azure CLI**. 

This means there are 3 options:
1. accept the breaking change.
2. keep the latest API profile as a specific value.
3. update the api comparison code to allow for None.

This PR explores option 3, in which `supported_api_version` just returns True if the `api_version_obj` taken from the API Profiles is None (since you cannot compare a version to None, you assume that the SDK version works). This should help other services avoid the same issue if they have their own extensions that have set `min_api` or `max_api`.

I have tried to extract the api version from the azure-mgmt-iothub 5.0.0b1, but this value is not set as a constant anywhere and cannot be extracted unless the client is imported and initialized or the docstrings are parsed. I do believe importing and initializing the client or parsing the docstrings is overkill, especially if the client has a possibility of not being used and another generation of the client could change the format of the docstrings.

Relevant PRs:
Storage with the latest profile being set to None:
https://github.com/Azure/azure-cli/pull/31526/files#diff-817dfb662b344e1666b95ab3ad0b614a2f042217b02a20e572738e824d35b32b
IoT Hub PR to set the api profiles to None:
https://github.com/Azure/azure-cli/pull/31955

**Testing Guide**
Added unit tests for supported_api_version + have manually tested that the extension would work with this change and setting the IoT Hub profile to None.

**History Notes**

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
