### PR TITLE
[Profile] `az login`: Add `--subscription`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/profile/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/__init__.py
@@ -50,6 +50,9 @@ class ProfileCommandsLoader(AzCommandsLoader):
                        help='User password or service principal secret. Will prompt if not given.')
             c.argument('tenant', options_list=['--tenant', '-t'], validator=validate_tenant,
                        help='The Microsoft Entra tenant, must be provided when using a service principal.')
+            c.argument('subscription',
+                       help='The subscription ID that will be used as the default. '
+                            'Specifying this argument will bypass the interactive subscription selector.')
             c.argument('scopes', options_list=['--scope'], nargs='+',
                        help='Used in the /authorize request. It can cover only one static resource.')
             c.argument('allow_no_subscriptions', action='store_true',

--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -121,7 +121,9 @@ def account_clear(cmd):
 
 
 # pylint: disable=too-many-branches, too-many-locals
-def login(cmd, username=None, password=None, tenant=None, scopes=None, allow_no_subscriptions=False,
+def login(cmd, username=None, password=None,
+          tenant=None, subscription=None,
+          scopes=None, allow_no_subscriptions=False,
           claims_challenge=None,
           # Device code flow
           use_device_code=False,
@@ -187,7 +189,8 @@ def login(cmd, username=None, password=None, tenant=None, scopes=None, allow_no_
     from azure.cli.core.telemetry import set_login_experience_v2
     set_login_experience_v2(login_experience_v2)
 
-    select_subscription = interactive and sys.stdin.isatty() and sys.stdout.isatty() and login_experience_v2
+    select_subscription = (not subscription and
+                           interactive and sys.stdin.isatty() and sys.stdout.isatty() and login_experience_v2)
 
     subscriptions = profile.login(
         interactive,
@@ -214,6 +217,9 @@ def login(cmd, username=None, password=None, tenant=None, scopes=None, allow_no_
         print(LOGIN_ANNOUNCEMENT)
         logger.warning(LOGIN_OUTPUT_WARNING)
         return
+
+    if subscription:
+        profile.set_active_subscription(subscription)
 
     all_subscriptions = list(subscriptions)
     for sub in all_subscriptions:

--- a/src/azure-cli/azure/cli/command_modules/profile/tests/latest/test_profile_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/tests/latest/test_profile_custom.py
@@ -11,7 +11,7 @@ from azure.cli.command_modules.profile.custom import (
 
 from azure.cli.core.mock import DummyCli
 from knack.util import CLIError
-
+from azure.cli.testsdk.scenario_tests.const import MOCKED_TENANT_ID, MOCKED_SUBSCRIPTION_ID
 
 class ProfileCommandTest(unittest.TestCase):
     @mock.patch('azure.cli.core.api.load_subscriptions', autospec=True)
@@ -106,6 +106,27 @@ class ProfileCommandTest(unittest.TestCase):
 
         # assert
         self.assertTrue(invoked)
+
+    @mock.patch('sys.stdin.isatty', return_value=True)
+    @mock.patch('sys.stdout.isatty', return_value=True)
+    @mock.patch('azure.cli.command_modules.profile._subscription_selector.SubscriptionSelector')
+    @mock.patch('azure.cli.core._profile.Profile.set_active_subscription')
+    @mock.patch('azure.cli.core._profile.Profile.login')
+    def test_login_with_subscription(self, login_mock, set_active_subscription_mock, subscription_selector_mock, *_):
+        cmd = mock.MagicMock()
+        login_mock.return_value = [{
+            'environmentName': 'AzureCloud',
+            'homeTenantId': MOCKED_TENANT_ID,
+            'id': MOCKED_SUBSCRIPTION_ID,
+            'isDefault': False,
+            'managedByTenants': [],
+            'name': 'test subscription name',
+            'state': 'Enabled',
+            'tenantId': MOCKED_TENANT_ID,
+            'user': {'name': 'test@microsoft.com', 'type': 'user'}}]
+        login(cmd, subscription=MOCKED_SUBSCRIPTION_ID)
+        subscription_selector_mock.assert_not_called()
+        set_active_subscription_mock.assert_called_with(MOCKED_SUBSCRIPTION_ID)
 
     def test_login_validate_tenant(self):
         from azure.cli.command_modules.profile._validators import validate_tenant


### PR DESCRIPTION
**Related command**
`az login`

**Description**<!--Mandatory-->
Partially resolve https://github.com/Azure/azure-cli/issues/14933

This PR adds `--subscription` argument to bypass the interactive subscription selector (#28910).

This PR cannot solve https://github.com/Azure/azure-cli/issues/31939 because `--subscription` merely selects the default subscription. [Subscriptions - List](https://docs.microsoft.com/en-us/rest/api/resources/subscriptions/list) API is still called to list all subscriptions. If we replace [Subscriptions - List](https://docs.microsoft.com/en-us/rest/api/resources/subscriptions/list) with a [Subscriptions - Get](https://docs.microsoft.com/en-us/rest/api/resources/subscriptions/get) API call, cross-tenant authentication will break as Azure CLI has no information of the auxiliary subscription.

**Testing Guide**
```
az login --subscription xxx
```

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
