### PR TITLE
[Profile] `az login`: Add `--get-subscriptions` to limit the subscriptions that are retrieved

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -147,6 +147,7 @@ class Profile:
               password,
               is_service_principal,
               tenant,
+              get_subscriptions=None,
               scopes=None,
               use_device_code=False,
               allow_no_subscriptions=False,
@@ -199,7 +200,8 @@ class Profile:
             credential = identity.get_service_principal_credential(username)
 
         if tenant:
-            subscriptions = subscription_finder.find_using_specific_tenant(tenant, credential)
+            subscriptions = subscription_finder.find_using_specific_tenant(tenant, credential,
+                                                                           get_subscriptions=get_subscriptions)
         else:
             subscriptions = subscription_finder.find_using_common_tenant(username, credential)
 
@@ -841,14 +843,21 @@ class SubscriptionFinder:
                 logger.warning("%s", t.tenant_id_name)
         return all_subscriptions
 
-    def find_using_specific_tenant(self, tenant, credential, tenant_id_description=None):
+    def find_using_specific_tenant(self, tenant, credential, tenant_id_description=None, get_subscriptions=None):
         """List subscriptions that can be accessed from a specific tenant.
         If called from find_using_common_tenant, tenant_id_description is TenantIdDescription retrieved from
         'Tenants - List' REST API. If directly called, tenant_id_description is None.
         """
         client = self._create_subscription_client(credential)
         # https://learn.microsoft.com/en-us/rest/api/resources/subscriptions/list
-        subscriptions = client.subscriptions.list()
+
+        subscriptions = []
+        if get_subscriptions:
+            for s in get_subscriptions:
+                subscriptions.append(client.subscriptions.get(s))
+        else:
+            subscriptions = client.subscriptions.list()
+
         all_subscriptions = []
         for s in subscriptions:
             _attach_token_tenant(s, tenant, tenant_id_description=tenant_id_description)

--- a/src/azure-cli/azure/cli/command_modules/profile/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/__init__.py
@@ -50,6 +50,10 @@ class ProfileCommandsLoader(AzCommandsLoader):
                        help='User password or service principal secret. Will prompt if not given.')
             c.argument('tenant', options_list=['--tenant', '-t'], validator=validate_tenant,
                        help='The Microsoft Entra tenant, must be provided when using a service principal.')
+            c.argument('get_subscriptions', nargs='+',
+                       help='Space-separated list of subscriptions to retrieve. '
+                            'This argument must be used together with --tenant. '
+                            'Without this argument, all subscriptions will be retrieved.')
             c.argument('scopes', options_list=['--scope'], nargs='+',
                        help='Used in the /authorize request. It can cover only one static resource.')
             c.argument('allow_no_subscriptions', action='store_true',

--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -121,7 +121,9 @@ def account_clear(cmd):
 
 
 # pylint: disable=too-many-branches, too-many-locals
-def login(cmd, username=None, password=None, tenant=None, scopes=None, allow_no_subscriptions=False,
+def login(cmd, username=None, password=None,
+          tenant=None, get_subscriptions=None,
+          scopes=None, allow_no_subscriptions=False,
           claims_challenge=None,
           # Device code flow
           use_device_code=False,
@@ -132,6 +134,8 @@ def login(cmd, username=None, password=None, tenant=None, scopes=None, allow_no_
     """Log in to access Azure subscriptions"""
 
     # quick argument usage check
+    if get_subscriptions and not tenant:
+        raise CLIError("usage error: --get-subscription must be used together with --tenant")
     if any([password, service_principal, tenant]) and identity:
         raise CLIError("usage error: '--identity' is not applicable with other arguments")
     if identity and username:
@@ -195,6 +199,7 @@ def login(cmd, username=None, password=None, tenant=None, scopes=None, allow_no_
         password,
         service_principal,
         tenant,
+        get_subscriptions=get_subscriptions,
         scopes=scopes,
         use_device_code=use_device_code,
         allow_no_subscriptions=allow_no_subscriptions,


### PR DESCRIPTION
**Related command**
`az login`

**Description**<!--Mandatory-->
Resolve #31939
Partially resolve #14933

If `--tenant` and `--get-subscriptions` are specified, CLI calls [Subscriptions - Get](https://docs.microsoft.com/en-us/rest/api/resources/subscriptions/get) to retrieve information for the specified subscriptions without calling [Subscriptions - List](https://docs.microsoft.com/en-us/rest/api/resources/subscriptions/list) API.

**Testing Guide**
```
az login --tenant xxx --get-subscription xxx xxx
```

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
