### PR TITLE
[AKS] `az aks update`: Fix typo on validation error for disabling azurecontainerstorage

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/azurecontainerstorage/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azurecontainerstorage/_validators.py
@@ -509,7 +509,7 @@ def validate_disable_azure_container_storage_params(
     if storage_pool_type is not None and not isinstance(storage_pool_type, bool):
         raise InvalidArgumentValueError(
             'The latest version of Azure Container Storage only supports ephemeral nvme storage and does not '
-            'require or support a storage-pool-type value for --enable-azure-container-storage parameter. '
+            'require or support a storage-pool-type value for --disable-azure-container-storage parameter. '
             f'Please remove {storage_pool_type} from the command and try again.'
         )
 

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_validators.py
@@ -1588,7 +1588,7 @@ class TestValidateDisableAzureContainerStorage(unittest.TestCase):
             )
         err = (
             'The latest version of Azure Container Storage only supports ephemeral nvme storage and does not '
-            'require or support a storage-pool-type value for --enable-azure-container-storage parameter. '
+            'require or support a storage-pool-type value for --disable-azure-container-storage parameter. '
             f'Please remove {storage_pool_type} from the command and try again.'
         )
         self.assertEqual(str(cm.exception), err)


### PR DESCRIPTION


**Related command**
az aks update

**Description**<!--Mandatory-->
Fixes a typo in the validation errors 

**Testing Guide**
az aks update --disable-azure-container-storage all

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
