### PR TITLE
[MySQL] `az mysql flexible-server upgrade`: Add new version 8.4

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/mysql/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/mysql/_params.py
@@ -216,7 +216,7 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
     )
 
     mysql_version_upgrade_arg_type = CLIArgumentType(
-        arg_type=get_enum_type(['8']),
+        arg_type=get_enum_type(['8', '8.4']),
         options_list=['--version', '-v'],
         help='Server major version.'
     )


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az mysql flexible-server upgrade --version
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Add new version option 8.4 to upgrade command
**Testing Guide**
<!--Example commands with explanations.-->
az mysql flexible-server upgrade --version 8.4
**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
