### PR TITLE
[App Config] `az appconfig kv export`: Escape keys only when exporting to properties file

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appconfig/_kv_export_helpers.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/_kv_export_helpers.py
@@ -125,7 +125,8 @@ def __write_kv_and_features_to_file(
                     exported_keyvalues, fp, sort_keys=False, width=float("inf")
                 )
             elif format_ == "properties":
-                javaproperties.dump(exported_keyvalues, fp)
+                for key, value in exported_keyvalues.items():
+                    fp.write('{}={}\n'.format(javaproperties.escape(key), value))
     except Exception as exception:
         raise FileOperationError(
             "Failed to export key-values to file. " + str(exception)


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az appconfig export

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
This PR fixes this issue - https://github.com/Azure/azure-cli/issues/25325

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
