### PR TITLE
{LTS} Backport #31503: Bump embedded Python to 3.12.10

### DIFF
--- a/build_scripts/windows/scripts/build.cmd
+++ b/build_scripts/windows/scripts/build.cmd
@@ -30,7 +30,7 @@ if "%ARCH%"=="x86" (
     echo Please set ARCH to "x86" or "x64"
     goto ERROR
 )
-set PYTHON_VERSION=3.12.8
+set PYTHON_VERSION=3.12.10
 
 set WIX_DOWNLOAD_URL="https://azurecliprod.blob.core.windows.net/msi/wix310-binaries-mirror.zip"
 set PYTHON_DOWNLOAD_URL="https://www.python.org/ftp/python/%PYTHON_VERSION%/python-%PYTHON_VERSION%-embed-%PYTHON_ARCH%.zip"

--- a/scripts/release/debian/build.sh
+++ b/scripts/release/debian/build.sh
@@ -15,7 +15,7 @@ set -exv
 ls -Rl /mnt/artifacts
 
 WORKDIR=`cd $(dirname $0); cd ../../../; pwd`
-PYTHON_VERSION="3.12.8"
+PYTHON_VERSION="3.12.10"
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Update APT packages


### PR DESCRIPTION
**Description**<!--Mandatory-->
Backport 

- #31503

Commands used to create this PR:

```sh
# Switch to the LTS dev branch
git switch dev-lts-2.66

# Make sure the branch is up to date
git pull

# Create a new branch for backporting
git switch --create backport-31503

# Cherry-pick the commit from PR #31503. -x appends the commit hash to the commit message
git cherry-pick -x 106221b5aab04eb8cec4592d6da50e1aa83f0cfe

# Push the branch to your fork
git push origin --set-upstream
```

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Core] Resolve CVE-2024-13176
[Core] Resolve CVE-2024-9143
