### PR TITLE
{LTS} Add history notes for 2.66.1

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -3,6 +3,12 @@
 Release History
 ===============
 
+2.66.1
+++++++
+
+* Resolve CVE-2024-50602 (#30567)
+* Resolve CVE-2024-12797 (#30819)
+
 2.66.0
 ++++++
 * `aaz`: Support managed identity (#29953)

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -3,6 +3,13 @@
 Release History
 ===============
 
+2.66.1
+++++++
+
+**Profile**
+
+* BREAKING CHANGE: `az login`: `--password` no longer accepts a service principal certificate. Use `--certificate` to pass a service principal certificate (#30540)
+
 2.66.0
 ++++++
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
Add history notes for 2.66.1.

This PR should have been part of https://github.com/Azure/azure-cli/pull/30848

The history notes are copied from https://github.com/Azure/azure-cli/releases/tag/azure-cli-2.66.1
