### PR TITLE
{LTS} Backport #32008: Update SBOM task conditions to trigger on release branches only

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -224,6 +224,7 @@ jobs:
 
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'SBOM'
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/release')
     inputs:
       BuildDropPath: 'build_scripts/windows/out/'
 
@@ -268,6 +269,7 @@ jobs:
 
     - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
       displayName: 'SBOM'
+      condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/release')
       inputs:
         BuildDropPath: 'build_scripts/windows/out/'
 
@@ -374,6 +376,7 @@ jobs:
 
     - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
       displayName: 'SBOM'
+      condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/release')
       inputs:
         BuildDropPath: $(Build.ArtifactStagingDirectory)
         DockerImagesToScan: 'clibuild$BUILD_BUILDNUMBER:latest'
@@ -458,6 +461,7 @@ jobs:
 
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'SBOM'
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/release')
     inputs:
       BuildDropPath: $(Build.ArtifactStagingDirectory)
 
@@ -628,6 +632,7 @@ jobs:
 
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'SBOM'
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/release')
     inputs:
       BuildDropPath: $(Build.ArtifactStagingDirectory)
 
@@ -743,6 +748,7 @@ jobs:
 
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'SBOM'
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/release')
     inputs:
       BuildDropPath: $(Build.ArtifactStagingDirectory)
 
@@ -837,6 +843,7 @@ jobs:
       filePath: scripts/release/rpm/pipeline.sh
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'SBOM'
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/release')
     inputs:
       BuildDropPath: $(Build.ArtifactStagingDirectory)
   - task: PublishPipelineArtifact@0
@@ -956,6 +963,7 @@ jobs:
 
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'SBOM'
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/release')
     inputs:
       BuildDropPath: $(Build.ArtifactStagingDirectory)
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
Backport 

- #32008

Cherry-picked the commit 008f1c280a808b85fae27cebc40fc22acd3aac89 with

```
git cherry-pick -x 008f1c280a808b85fae27cebc40fc22acd3aac89
```

and solved the merge conflict caused by https://github.com/Azure/azure-cli/pull/31994.

