### PR TITLE
{LTS} Bump `packaging` to 25.0

### DIFF
--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -108,7 +108,7 @@ msal[broker]==1.31.0
 msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2
-packaging==23.2
+packaging==25.0
 paramiko==3.4.0
 pbr==5.3.1
 pkginfo==1.8.2

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -109,7 +109,7 @@ msal[broker]==1.31.0
 msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2
-packaging==23.2
+packaging==25.0
 paramiko==3.4.0
 pbr==5.3.1
 pkginfo==1.8.2

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -108,7 +108,7 @@ msal[broker]==1.31.0
 msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2
-packaging==23.2
+packaging==25.0
 paramiko==3.4.0
 pbr==5.3.1
 pkginfo==1.8.2


### PR DESCRIPTION
**Description**<!--Mandatory-->
Bump `packaging` to 25.0 to fix CI error

https://dev.azure.com/azclitools/public/_build/results?buildId=268859&view=logs&j=168ccbe3-da49-5c0b-6478-08f7016e4bf5&t=5102475c-9f36-53bb-ee2b-856291a96d5a&l=979

```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
pyproject-api 1.9.1 requires packaging>=25, but you have packaging 23.2 which is incompatible.
tox 4.29.0 requires packaging>=25, but you have packaging 23.2 which is incompatible.
```
