### PR TITLE
[network] Add: `az network nic create`: created new --ip-config-name …

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -4333,6 +4333,7 @@ class NICCreate(_NICCreate):
         args_schema.ip_config_name = AAZStrArg(
             options=["--ip-config-name"],
             help="Name of the Ip configuration",
+            default="ipconfig1",
             required=False
         )
         args_schema.extended_location._registered = False

--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -4330,6 +4330,11 @@ class NICCreate(_NICCreate):
                          "/networkSecurityGroups/{}",
             ),
         )
+        args_schema.ip_config_name = AAZStrArg(
+            options=["--ip-config-name"],
+            help="Name of the Ip configuration",
+            required=False
+        )
         args_schema.extended_location._registered = False
         args_schema.ip_configurations._registered = False
         args_schema.nsg._registered = False
@@ -4343,7 +4348,7 @@ class NICCreate(_NICCreate):
             args.extended_location.name = args.edge_zone
             args.extended_location.type = "EdgeZone"
         ip_configuration = {
-            "name": "ipconfig1",
+            "name": args.ip_config_name,
             "private_ip_address": args.private_ip_address,
             "private_ip_address_version": args.private_ip_address_version,  # when address doesn't exist, version should be ipv4 (default)
             "private_ip_allocation_method": "Static" if has_value(args.private_ip_address) else "Dynamic",


### PR DESCRIPTION
**Related command**

`az network nic create`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

- This PR exists because it is useful to be able to configure the network interface card ip configuration name at creation time. Currently it is fixed at "ipconfig1"
- The effect is the ability to be able to be able to customise the ip configuration name upon creation of the  network interface card. Changes to the codebase itself are minimal (as customisation is placed in **azure-cli/azure/cli/command_modules/network/custom.py**) and the change itself is just send a simple string along the request.
- The impact is that for services which rely on ip configuration name (for example: azure load balancer when adding a backend nic to the pool) you can have assurance to be able to add the nic by a name determined by you (e.g `az network nic ip-config address-pool add --resource-group {rg} --nic-name {nic} --lb-name {lb} --ip-config-name {ip_config_name} --address-pool {backend_pool_name}` instead of hardcoding "ipconfig1" into the --ip-config-name parameter).

**Testing Guide**
To test the command run:

`az network nic create --resource-group {rg} --name {nic} --subnet {subnet_id} --ip-config-name {ip_config_name}`

I tested this in practice by updating the file: **azure-cli/azure/cli/command_modules/network/custom.py** and running the command with the new parameter and it worked.

But I wasn't sure how to integrate it fully into the testing framework provided. After trying my best to read through the code base I **think** the way to test this is to:
1. Add properties to the **azure-cli/azure/cli/command_modules/network/aaz/latest/network/nic/_create.py** (i.e something like `properties.set_prop("ipConfigName", AAZStrType, ".ip_config_name")`
1. Add a line to the **azure-cli/azure/cli/command_modules/network/test/latest/test_network_commands.py** (i.e something like `self.check('NewNIC.ipConfigName", {ip_config_name})` (where `{ip_config_name}` is obtained by the following code also in the same file):
```
        self.kwargs.update({
            'nic': 'cli-test-nic',
            'rt': 'Microsoft.Network/networkInterfaces',
            'subnet': 'mysubnet',
            'vnet': 'myvnet',
            'nsg1': 'mynsg',
            'nsg2': 'myothernsg',
            'lb': 'mylb',
            'pri_ip': '10.0.0.15',
            'pub_ip': 'publicip1',
            'ip_config_name': 'myipconfig1'
        })
```
But I'm not sure how to run the tests themselves. Any help on this would be appreciated!

**PR Checklist**

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
