### PR TITLE
{Network} Fix `--sku` argument to accept `StandardV2` value

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_params.py
@@ -613,7 +613,7 @@ def load_arguments(self, _):
 
     with self.argument_context('network public-ip create') as c:
         c.argument('name', completer=None)
-        c.argument('sku', help='Name of a public IP address SKU', arg_type=get_enum_type(["Basic", "Standard"]), default="Standard")
+        c.argument('sku', help='Name of a public IP address SKU', arg_type=get_enum_type(["Basic", "Standard", "StandardV2"]), default="Standard")
         c.argument('tier', help='Tier of a public IP address SKU and Global tier is only supported for standard SKU public IP addresses', arg_type=get_enum_type(["Regional", "Global"]))
         c.ignore('dns_name_type')
         c.argument('edge_zone', edge_zone)

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/nat/gateway/_create.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/nat/gateway/_create.py
@@ -84,6 +84,12 @@ class Create(AAZCommand):
             help="A reference to the source virtual network using this nat gateway resource.",
         )
         cls._build_args_sub_resource_create(_args_schema.source_vnet)
+        _args_schema.sku = AAZStrArg(
+            options=["--sku"],
+            help="Name of Nat Gateway SKU.",
+            default="Standard",
+            enum={"Standard": "Standard", "StandardV2": "StandardV2"},
+        )
         _args_schema.tags = AAZDictArg(
             options=["--tags"],
             help="Space-separated tags: key[=value] [key[=value] ...].",
@@ -126,20 +132,6 @@ class Create(AAZCommand):
         zone.Element = AAZStrArg()
 
         # define Arg Group "Parameters"
-
-        _args_schema = cls._args_schema
-        _args_schema.sku = AAZObjectArg(
-            options=["--sku"],
-            arg_group="Parameters",
-            help="The nat gateway SKU.",
-        )
-
-        sku = cls._args_schema.sku
-        sku.name = AAZStrArg(
-            options=["name"],
-            help="Name of Nat Gateway SKU.",
-            enum={"Standard": "Standard", "StandardV2": "StandardV2"},
-        )
         return cls._args_schema
 
     _args_sub_resource_create = None
@@ -268,7 +260,7 @@ class Create(AAZCommand):
             )
             _builder.set_prop("location", AAZStrType, ".location")
             _builder.set_prop("properties", AAZObjectType, typ_kwargs={"flags": {"client_flatten": True}})
-            _builder.set_prop("sku", AAZObjectType, ".sku")
+            _builder.set_prop("sku", AAZObjectType)
             _builder.set_prop("tags", AAZDictType, ".tags")
             _builder.set_prop("zones", AAZListType, ".zone")
 
@@ -307,7 +299,7 @@ class Create(AAZCommand):
 
             sku = _builder.get(".sku")
             if sku is not None:
-                sku.set_prop("name", AAZStrType, ".name")
+                sku.set_prop("name", AAZStrType, ".sku")
 
             tags = _builder.get(".tags")
             if tags is not None:

--- a/src/azure-cli/azure/cli/command_modules/network/operations/nat.py
+++ b/src/azure-cli/azure/cli/command_modules/network/operations/nat.py
@@ -37,7 +37,6 @@ class GatewayCreate(_GatewayCreate):
         )
         args_schema.pip_addresses._registered = False
         args_schema.pip_prefixes._registered = False
-        args_schema.sku._registered = False
         return args_schema
 
     def pre_operations(self):


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az network nat gateway create`
`az network public-ip create`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix parameter enum, now accepts `StandardV2`.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Network] `az network nat gateway create`: `--sku` argument now accepts `StandardV2` value.
[Network] `az network public-ip create`: `--sku` argument now accepts `StandardV2` value.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
