### PR TITLE
{LTS} Pin `setuptools` to 70.0.0

### DIFF
--- a/.azure-pipelines/templates/azdev_setup.yml
+++ b/.azure-pipelines/templates/azdev_setup.yml
@@ -16,7 +16,7 @@ steps:
       chmod +x env/bin/activate
       . env/bin/activate
       python -m pip install -U pip
-      pip install azdev==0.1.90
+      pip install azdev==0.1.90 setuptools==70.0.0
       azdev --version
 
       if [ -z "$CLI_EXT_REPO_PATH" ]; then


### PR DESCRIPTION
**Description**<!--Mandatory-->
Azure CLI's editable installation doesn't work with setuptools 80.9.0: 

```
No module named azure.cli.__main__; 'azure.cli' is a package and cannot be directly executed
```

More details: 
- https://github.com/Azure/azure-cli/issues/32042

This PR follows the same approach as https://github.com/Azure/azure-cli-dev-tools/pull/524 to pin `setuptools` to 70.0.0.
