### PR TITLE
{Packaging} Bump `packaging` to 25.0

### DIFF
--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -109,7 +109,7 @@ msal-extensions==1.2.0
 msal==1.34.0b1
 msrest==0.7.1
 oauthlib==3.2.2
-packaging==24.2
+packaging==25.0
 paramiko==3.5.0
 pbr==5.3.1
 pkginfo==1.8.2

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -110,7 +110,7 @@ msal-extensions==1.2.0
 msal==1.34.0b1
 msrest==0.7.1
 oauthlib==3.2.2
-packaging==24.2
+packaging==25.0
 paramiko==3.5.0
 pbr==5.3.1
 pkginfo==1.8.2

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -109,7 +109,7 @@ msal-extensions==1.2.0
 msal[broker]==1.34.0b1
 msrest==0.7.1
 oauthlib==3.2.2
-packaging==24.2
+packaging==25.0
 paramiko==3.5.0
 pbr==5.3.1
 pkginfo==1.8.2


### PR DESCRIPTION
**Description**<!--Mandatory-->
Bump `packaging` to 25.0 to fix CI error

https://dev.azure.com/azclitools/public/_build/results?buildId=269015&view=logs&j=01b4a72e-3869-52eb-110d-7f0d8b784d9a&t=eabdfe33-575f-55d9-45e8-de3a854831ca&l=947

```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
tox 4.29.0 requires packaging>=25, but you have packaging 24.2 which is incompatible.
pyproject-api 1.9.1 requires packaging>=25, but you have packaging 24.2 which is incompatible.
```

Luckily, this error is not causing any functionality error.