### PR TITLE
{Core} Fix bug in deprecation register when action argument is missing

### DIFF
--- a/src/azure-cli-core/azure/cli/core/breaking_change.py
+++ b/src/azure-cli-core/azure/cli/core/breaking_change.py
@@ -266,7 +266,7 @@ class BreakingChange(abc.ABC):
                 if not arg:
                     continue
                 arg.deprecate_info = self.appended_status_tag(cli_ctx, arg.deprecate_info, self.to_tag(cli_ctx))
-                arg.action = _argument_breaking_change_action(cli_ctx, arg.deprecate_info, arg.options['action'])
+                arg.action = _argument_breaking_change_action(cli_ctx, arg.deprecate_info, arg.options.get('action'))
         elif self.is_command_group(cli_ctx):
             command_group = cli_ctx.invocation.commands_loader.command_group_table[self.command_name]
             if not command_group:


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
This PR addresses a `KeyError` that occurred when registering an upcoming breaking change on an argument with an implicit action. The issue is resolved by using the `.get()` method to safely return `None` if the key does not exist.

Additionally, `_argument_breaking_change_action` accepts `None` as a valid action. In such cases, the base action class defaults to `argparse.Action`, which raises a `NotImplementedError` when its `__call__` method is invoked. The `ArgumentBreakingChangeAction` class catches this exception and falls back to behaving like a store action.

This behavior aligns with the implementation in Knack:
https://github.com/microsoft/knack/blob/fb5699615a3c8b93c6bf8068306709af1c37a079/knack/arguments.py#L163-L216.

This will resolve the comments in code in https://github.com/Azure/azure-cli/pull/32070.
```
# Add action=None to work around an error registering a breaking change for this argument
```

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
