### PR TITLE
[AKS] `az aks create`: Fix the issue where enabling v1 container storage does not fail if the VM SKU field is left empty

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/azurecontainerstorage/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azurecontainerstorage/_validators.py
@@ -661,7 +661,7 @@ def _validate_nodepools(  # pylint: disable=too-many-branches,too-many-locals
                         'and retry the Azure Container Storage operation.'
                     )
             vm_size = agentpool.get("vm_size")
-            if vm_size is not None:
+            if vm_size is not None and vm_size != "":
                 cpu_value, nvme_enabled = get_vm_sku_details(vm_size.lower())
                 if cpu_value is None or nvme_enabled is None:
                     raise UnknownError(

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -8825,7 +8825,7 @@ class AKSManagedClusterUpdateDecorator(BaseAKSManagedClusterDecorator):
             except Exception as ex:
                 raise UnknownError(
                     f"An error occurred while checking the version of Azure Container Storage"
-                    f"extension installed on the cluster: {str(ex)}"
+                    f" extension installed on the cluster: {str(ex)}"
                 ) from ex
 
             disable_azure_container_storage_v1 = disable_azure_container_storage_param is not None and is_container_storage_v1_extension_installed


### PR DESCRIPTION


**Related command**
az aks create

**Description**<!--Mandatory-->
This PR makes minor fixes on "az aks create --enable-azure-container-storage <pooltype> --container-storage-version 1" to not fail when vm_sku was empty.

**Testing Guide**
az aks create -g test-rg -n test-cluster --enable-azure-container-storage azureDisk --container-storage-version 1

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
