### PR TITLE
{LTS} Backport #31158: Use Ubuntu 24.04 on ARM agent

### DIFF
--- a/scripts/ci/install_docker.sh
+++ b/scripts/ci/install_docker.sh
@@ -5,11 +5,8 @@ if [[ $(dpkg --print-architecture) == "amd64" ]]; then
     echo "Docker is already installed on AMD64"
     exit 0
 fi
-# https://docs.docker.com/engine/security/rootless/
-/bin/bash -c "$(curl -fsSL https://get.docker.com)"
-sudo apt-get install -y uidmap
-dockerd-rootless-setuptool.sh install
-export XDG_RUNTIME_DIR=/home/cloudtest/.docker/run
-PATH=/usr/bin:/sbin:/usr/sbin:$PATH dockerd-rootless.sh &
-sleep 5
-docker context use rootless
+
+# https://docs.docker.com/engine/install/ubuntu/#install-using-the-convenience-script
+curl -fsSL https://get.docker.com -o get-docker.sh
+sudo sh ./get-docker.sh
+sudo chmod 666 /var/run/docker.sock


### PR DESCRIPTION
**Description**<!--Mandatory-->
Part of https://github.com/Azure/azure-cli/issues/32053

Backport https://github.com/Azure/azure-cli/pull/31158

```
git cherry-pick -x 2fa70b03fda01027a87e7efd5ed1d52c93bb2609
```

https://github.com/Azure/azure-cli/pull/30996 already bumped `ubuntu_arm64_pool` to `pool-ubuntu-latest-arm64`, but got reverted to `ubuntu-arm64-2004-pool` by https://github.com/Azure/azure-cli/pull/31123 due to failure in `scripts/ci/install_docker.sh`.

Later, https://github.com/Azure/azure-cli/pull/31158 fixed `scripts/ci/install_docker.sh` and bumped `ubuntu_arm64_pool` back to `pool-ubuntu-latest-arm64`, so there is no need to update `ubuntu_arm64_pool` to `pool-ubuntu-latest-arm64` again.
