### PR TITLE
[ARM] `az resource list`: Include `provisioningState` property in table output

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/commands.py
@@ -67,7 +67,7 @@ def transform_resource_list(result):
     for r in result:
         res = OrderedDict([('Name', r['name']), ('ResourceGroup', r['resourceGroup']), ('Location', r['location']), ('Type', r['type'])])
         try:
-            res['Status'] = r['properties']['provisioningStatus']
+            res['Status'] = r['provisioningState']
         except TypeError:
             res['Status'] = ' '
         transformed.append(res)


### PR DESCRIPTION
**Related command**
`az resource list`

**Description**<!--Mandatory-->
The `az resource list -o table` output previously wouldn't populate the `Status` field which corresponds to provisioningState.  With this change, the table output now contains the provisioning state of the resource. 

Note: the resources API is not returning the correct provisioning state for resources, this change does not fix this.  I will open an ICM to the ARM team to address this.  

**Testing Guide**
Before the change
```
$ az resource list -g kipp-miwi-bicep --resource-type Microsoft.RedHatOpenShift/openshiftClusters  -o table
Name             ResourceGroup    Location       Type                                         Status
---------------  ---------------  -------------  -------------------------------------------  --------
kipp-miwi-bicep  kipp-miwi-bicep  southeastasia  Microsoft.RedHatOpenShift/OpenShiftClusters
```

after the change
```
$ az resource list -g kipp-miwi-bicep --resource-type Microsoft.RedHatOpenShift/openshiftClusters  -o table
Name             ResourceGroup    Location       Type                                         Status
---------------  ---------------  -------------  -------------------------------------------  ---------
kipp-miwi-bicep  kipp-miwi-bicep  southeastasia  Microsoft.RedHatOpenShift/OpenShiftClusters  Succeeded
```

**History Notes**

[resource] Populate the provisioningState as Status on table output for resource list
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
