### PR TITLE
{CI} Fix homebrew formula test by creating dummy homebrew tap

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -668,7 +668,12 @@ jobs:
       brew uninstall azure-cli
       
       echo == Install azure-cli.rb formula ==
-      brew install --build-from-source $SYSTEM_ARTIFACTSDIRECTORY/homebrew/azure-cli.rb
+      # Need to create a dummy homebrew tap to install the formula
+      git config --global user.email "you@example.com"
+      git config --global user.name "Your Name"
+      brew tap-new dev/azure-cli
+      cp $SYSTEM_ARTIFACTSDIRECTORY/homebrew/azure-cli.rb $(brew --repository)/Library/Taps/dev/homebrew-azure-cli/Formula/
+      brew install --build-from-source dev/homebrew-azure-cli/azure-cli
       
       echo == Az Version ==
       az --version


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Test Homebrew Formula task fails with
```
== Install azure-cli.rb formula ==
Error: Homebrew requires formulae to be in a tap, rejecting:
  /Users/runner/work/1/a/homebrew/azure-cli.rb (/Users/runner/work/1/a/homebrew/azure-cli.rb)

To create a tap, run e.g.
  brew tap-new <user|org>/<repository>
To create a formula in a tap run e.g.
  brew create <url> --tap=<user|org>/<repository>
```

Homebrew 4.6.0 prohibits installing formula from path, see https://github.com/Homebrew/brew/issues/20521. Need to create a dummy tap then install it.

**Testing Guide**
<!--Example commands with explanations.-->
Task passed at 
https://dev.azure.com/azclitools/public/_build/results?buildId=273283&view=logs&jobId=ebe8970d-a8af-5d7e-4086-8f4ce0be006b&j=ebe8970d-a8af-5d7e-4086-8f4ce0be006b&t=3f22f999-770c-5d06-3bb8-1a936f5d8384