### PR TITLE
{LTS} Backport #31170: Increase `TestExtensionsLoading` timeout to 80 minutes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -569,7 +569,7 @@ jobs:
 - job: TestExtensionsLoading
   displayName: Test Extensions Loading
   condition: succeeded()
-  timeoutInMinutes: 40
+  timeoutInMinutes: 80
 
   pool:
     name: ${{ variables.ubuntu_pool }}


### PR DESCRIPTION
**Description**<!--Mandatory-->
Part of https://github.com/Azure/azure-cli/issues/32053

Backport https://github.com/Azure/azure-cli/pull/31170

```
git cherry-pick -x 15c9554d9c8c69d5f9393c4ac00ae8e188fe3ecc
```

CI task `TestExtensionsLoading` keeps failing:

<img width="3302" height="663" alt="image" src="https://github.com/user-attachments/assets/92322f72-98dc-4c1a-8de8-1325195539c7" />

> ##[error]The job running on agent pool-ubuntu-2204 6 ran longer than the maximum time of 40 minutes. For more information, see https://go.microsoft.com/fwlink/?linkid=2077134

This PR doubles the timeout to 80 minutes.