### PR TITLE
[ACS] `az aks create`: Pre-announce `--no-ssh-key` default behaviour breaking change

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_breaking_change.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_breaking_change.py
@@ -1,4 +1,13 @@
 # --------------------------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
-# --------
+# --------------------------------------------------------------------------------------------
+
+from azure.cli.core.breaking_change import register_logic_breaking_change
+
+# Breaking change: change default SSH key handling in `az aks create`
+register_logic_breaking_change(
+    'aks create',
+    summary="Default SSH key behavior will change. When no SSH key parameters are provided, "
+            "the command will behave as if '--no-ssh-key' was passed instead of failing"
+)


### PR DESCRIPTION
**Related command**
`az aks create`

**Description**<!--Mandatory-->
This PR adds a breaking change pre-announcement for az aks create.
* Current behavior: If no SSH key–related parameters are provided, the command fails.
* Planned behavior (effective November 2025): If no SSH key parameters are provided, the command will behave as if --no-ssh-key was passed.

This pre-announcement ensures customers are warned ahead of time and have the opportunity to adjust their scripts or workflows before the November 2025 breaking change release.

**Testing Guide**
* Can be tested using `az aks create` with the required parameters and omitting all ssh related parameters

<img width="1345" height="682" alt="image" src="https://github.com/user-attachments/assets/94dc08a8-7733-43ad-9bda-23e888758e3b" />

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
