### PR TITLE
{Backup}  Add northeastus5 region mapping to backup module

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/backup/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom.py
@@ -87,6 +87,7 @@ secondary_region_map = {
     "koreasouth": "koreacentral",
     "malaysiasouth": "japanwest",
     "northcentralus": "southcentralus",
+    "northeastus5": "centralus",
     "northeurope": "westeurope",
     "norwayeast": "norwaywest",
     "norwaywest": "norwayeast",


### PR DESCRIPTION
**Related command**
az backup

**Description**

The PR is adding mapping to secondary region for paired regions. this is needed for all new regions. this PR is for upcoming region Northeast US 5

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
