### PR TITLE
{ACR} `az acr build`: Exclude .venv directories from build

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_archive_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_archive_utils.py
@@ -213,7 +213,7 @@ def _archive_file_recursively(tar, name, arcname, parent_ignored, parent_matchin
 
     # Even if a dir is ignored by .dockerignore, its children might still be included (Docker semantics),
     # so we continue scanning unless it is in our build_ignore_dirs set (performance skip list).
-    if tarinfo.isdir() and not (os.path.basename(tarinfo.name) in build_ignore_dirs):
+    if tarinfo.isdir() and os.path.basename(tarinfo.name) not in build_ignore_dirs:
         for f in os.listdir(name):
             _archive_file_recursively(tar, os.path.join(name, f), os.path.join(arcname, f),
                                       parent_ignored=ignored, parent_matching_rule_index=matching_rule_index,


### PR DESCRIPTION
Add exclusion for .venv directories to improve performance.

**Related command**
az acr build

**Description**<!--Mandatory-->
Az acr build parses all files in repo even if excluded in .dockerignore. This PR targets .venv directories from getting processed thus reducing the unnecessarily long build time.

**History Notes**
Issue raised here: https://github.com/Azure/azure-cli/issues/31250

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
