### PR TITLE
{LTS} Skip homebrew task in LTS

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -591,7 +591,7 @@ jobs:
   displayName: Build Homebrew Formula
 
   dependsOn: BuildPythonWheel
-  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual', 'Schedule'))
+  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual', 'Schedule'), not(contains(variables['Build.SourceBranch'], 'lts')))
   pool:
     name: ${{ variables.ubuntu_pool }}
   steps:


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Homebrew task fails in LTS CI, which has been fixed in dev branch: https://github.com/Azure/azure-cli/pull/32162/

However, LTS does not need homebrew, so skip homebrew task.