### PR TITLE
{ACR} `az acr show-usage`: Add examples for MaximumStorageCapacity and Size query

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_help.py
@@ -901,7 +901,7 @@ examples:
   - name: Get the current amount of storage used by the registry based on the included storage of its SKU (in bytes).
     text: >
         az acr show-usage -n myregistry --query "value[?name=='Size'] | [0]"
-  - name: Get the current amount of storage used by the registry based on maximum storage capacity allowed.
+  - name: Get the current amount of storage used by the registry and the maximum storage capacity allowed.
     text: >
         az acr show-usage -n myregistry --query "value[?name=='MaximumStorageCapacity'] | [0]"
 """


### PR DESCRIPTION
**Related command**
az acr show-usage

**Description**<!--Mandatory-->
We are adding a new listUsage entity to our API to expose "MaximumStorageCapacity". This will allow us to show the maximum storage capacity of the registry without altering the existing structure of the API.

The update to the help command helps users under the different between the "Size" and "MaximumStorageCapacity" listUsages entities and how to query them.

**Testing Guide**
Example of `az acr show-usage --help`
```ps1
Command
    az acr show-usage : Get the storage usage for an Azure Container Registry.

Arguments
    --name -n [Required] : The name of the container registry. It should be specified in lower case.
                           You can configure the default registry name using `az configure
                           --defaults acr=<registry name>`.
    --resource-group -g  : Name of resource group. You can configure the default group using `az
                           configure --defaults group=<name>`.

Global Arguments
    --debug              : Increase logging verbosity to show all debug logs.
    --help -h            : Show this help message and exit.
    --only-show-errors   : Only show errors, suppressing warnings.
    --output -o          : Output format.  Allowed values: json, jsonc, none, table, tsv, yaml,
                           yamlc.  Default: json.
    --query              : JMESPath query string. See http://jmespath.org/ for more information and
                           examples.
    --subscription       : Name or ID of subscription. You can configure the default subscription
                           using `az account set -s NAME_OR_ID`.
    --verbose            : Increase logging verbosity. Use --debug for full debug logs.

Examples
    Get the storage usage for an Azure Container Registry.
        az acr show-usage -n myregistry
    Get the current amount of storage used by the registry (in bytes). 
        az acr show-usage -n myregistry --query "value[?name=='Size'] | [0]" 
    Get the maximum storage limit allowed for the registry based on its SKU.
        az acr show-usage -n myregistry --query "value[?name=='MaximumStorageCapacity'] | [0]" 

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
