### PR TITLE
{Batch} Pin azure-batch in setup.py

### DIFF
--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -53,7 +53,7 @@ CLASSIFIERS = [
 DEPENDENCIES = [
     "antlr4-python3-runtime~=4.13.1",
     'azure-appconfiguration~=1.7.1',
-    'azure-batch~=15.0.0b1',
+    'azure-batch==15.0.0b1',
     'azure-cli-core=={}'.format(VERSION),
     'azure-cosmos~=3.0,>=3.0.2',
     'azure-data-tables==12.4.0',


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
`azure-batch` released new version 15.0.0b3, which is not compatible with previous version.

When install azure-cli from PyPI, Integration Test against Profiles Python312 failed with this error:
```
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/site-packages/azure/cli/command_modules/batch/custom.py", line 22, in <module>
    from azure.batch.models import (AffinityInfo, BatchPoolResizeContent, BatchStartTask, BatchTaskConstraints, BatchTask,
ImportError: cannot import name 'AffinityInfo' from 'azure.batch.models' (/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/site-packages/azure/batch/models/__init__.py). Did you mean: 'BatchAffinityInfo'?
```
Pin the version to `15.0.0b1`, matching requirements.txt.

Related PR: https://github.com/Azure/azure-cli/pull/30501

Ref: https://dev.azure.com/azclitools/public/_build/results?buildId=276835&view=logs&jobId=918eca13-e87f-5234-76ca-b0a0c5383642&j=918eca13-e87f-5234-76ca-b0a0c5383642&t=7158aeab-8c89-5857-4851-ee2901405347