### PR TITLE
{CI} Fix Codegen Coverage task

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1178,6 +1178,9 @@ jobs:
       pip install msrestazure markupsafe==2.0.1
       # Some extension will change the dependence, so run `azdev setup` again after all extensions installed.
       azdev setup -c ./s -r ./azure-cli-extensions
+      
+      # Force install this version to be compatible with numpy 2.0
+      pip install deepdiff==8.6.1
 
       mkdir -p /tmp/module_stats
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

azdev has update the deepdiff dependency to 8.6.1 at https://github.com/Azure/azure-cli-dev-tools/pull/531

The Codegen Coverage fails with:
```
    from azdev.params import load_arguments
  File "/mnt/vss/_work/1/s/env/lib/python3.11/site-packages/azdev/params.py", line 14, in <module>
    from azdev.operations.command_change import diff_export_format_choices
  File "/mnt/vss/_work/1/s/env/lib/python3.11/site-packages/azdev/operations/command_change/__init__.py", line 12, in <module>
    import azure_cli_diff_tool
  File "/mnt/vss/_work/1/s/env/lib/python3.11/site-packages/azure_cli_diff_tool/__init__.py", line 15, in <module>
    from deepdiff import DeepDiff
  File "/mnt/vss/_work/1/s/env/lib/python3.11/site-packages/deepdiff/__init__.py", line 10, in <module>
    from .diff import DeepDiff
  File "/mnt/vss/_work/1/s/env/lib/python3.11/site-packages/deepdiff/diff.py", line 18, in <module>
    from deepdiff.helper import (strings, bytes_type, numbers, uuids, times, ListItemRemovedOrAdded, notpresent,
  File "/mnt/vss/_work/1/s/env/lib/python3.11/site-packages/deepdiff/helper.py", line 63, in <module>
    np_float_ = np.float_
                ^^^^^^^^^
  File "/mnt/vss/_work/1/s/env/lib/python3.11/site-packages/numpy/__init__.py", line 781, in __getattr__
    raise AttributeError(
AttributeError: `np.float_` was removed in the NumPy 2.0 release. Use `np.float64` instead.
```
The installed deepdiff is 6.3.3 and is not compatible with numpy 2.0. By checking the index.json in extension, confcom depends on deepdiff 6.3.3: https://github.com/Azure/azure-cli-extensions/blob/de110edc4faa6464bfa82fe8dc64f46c34ad1d77/src/confcom/setup.py#L43

Force install deepdiff 8.6.1 to fix the CI.

**This PR can be reverted once `confcom` updates its dependency to the latest deepdiff.**

Ref: https://dev.azure.com/azclitools/public/_build/results?buildId=277501&view=logs&jobId=9345cfb0-d7b9-509c-bf97-03248f55543a&j=9345cfb0-d7b9-509c-bf97-03248f55543a&t=e1a1fdd4-b888-5743-66dc-7bbee1ce278e