### PR TITLE
PI filter fix

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/backup/custom_wl.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom_wl.py
@@ -326,7 +326,7 @@ def show_protectable_instance(items, server_name, protectable_item_type, instanc
                       item.properties.server_name.lower() == server_name.lower()]
     # Instance Name filter, if it is passed
     if instance_name:
-        filtered_items = [item for item in items if item.name.lower() == instance_name.lower()]
+        filtered_items = [item for item in filtered_items if item.name.lower() == instance_name.lower()]
 
     return cust_help.get_none_one_or_many(filtered_items)
 


### PR DESCRIPTION
**Related command**
az backup recoveryconfig show `
  --container-name "asehacontainer;ha3-cluster0" `
  --item-name "SAPAseDatabase;ha3-cluster0;ha3" `
  --resource-group ase-portal-test-rg `
  --vault-name ase-ea-can-portal-test-vault `
  --restore-mode AlternateWorkloadRestore `
  --rp-name "2266265719745537152" `
  --target-container-name "VMAppContainer;Compute;ase-portal-test-rg;ha3db1" `
  --target-instance-name "VMAppContainer;Compute;ase-portal-test-rg;ha3db2" `
  --target-resource-group "ase-portal-test-rg" `
  --target-subscription-id "40449e6d-a5d2-40f1-a151-0b76f21a48c0" `
  --target-item-name "SAPAseDatabase;ha3db1;ha3" `
  --target-server-name "ha3db1" `
  --target-server-type "SAPAseDatabase" `
  --workload-type SAPAseDatabase `
  --output json > alr-recovery-config.json --debug

**Description**<!--Mandatory-->
Fix for filtering protectable items based on instance name, impacts filtered list of Protectable items returned 

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az backup recoverypoint list`: Check added for multiple target item or empty target item

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ *] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ *] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ *] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
