### PR TITLE
{RDBMS} `az postgres flexible-server create, az postgres server, az postgres db, az postgres server-logs`: Add upcoming breaking change announcements

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/_breaking_change.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_breaking_change.py
@@ -1,0 +1,24 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from azure.cli.core.breaking_change import register_logic_breaking_change, \
+    register_argument_deprecate, register_other_breaking_change
+
+register_logic_breaking_change('postgres flexible-server create', 'Update default value of "--version"',
+                               detail='The default value will be changed from "17" to a '
+                               'supported version based on regional capabilities.')
+register_argument_deprecate('postgres flexible-server create', '--create-default-database',
+                            message='Please use command group "postgres flexible-server db" for database creation.')
+register_argument_deprecate('postgres flexible-server create', '--database-name',
+                            message='Please use command group "postgres flexible-server db" for database creation.')
+register_other_breaking_change('postgres server',
+                               message='Azure Database for PostgreSQL Single Server is deprecated. '
+                               'Please migrate to Flexible Server for new deployments.')
+register_other_breaking_change('postgres db',
+                               message='Azure Database for PostgreSQL Single Server is deprecated. '
+                               'Please migrate to Flexible Server for new deployments.')
+register_other_breaking_change('postgres server-logs',
+                               message='Azure Database for PostgreSQL Single Server is deprecated. '
+                               'Please migrate to Flexible Server for new deployments.')

--- a/src/azure-cli/azure/cli/command_modules/rdbms/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_help.py
@@ -818,7 +818,7 @@ short-summary: Manage Azure Database for PostgreSQL servers.
 
 helps['postgres db'] = """
 type: group
-short-summary: Manage PostgreSQL databases on a server. Is scheduled to retire by March 28, 2025
+short-summary: Manage PostgreSQL databases on a server. Is deprecated, please migrate to Azure Database for PostgreSQL flexible server.
 """
 
 helps['postgres db create'] = """
@@ -857,7 +857,7 @@ examples:
 
 helps['postgres server'] = """
 type: group
-short-summary: Manage Azure Database for PostgreSQL Single Server. Is scheduled to retire by March 28, 2025. You can migrate to the Azure Database for PostgreSQL flexible server.
+short-summary: Manage Azure Database for PostgreSQL Single Server. Is deprecated, please migrate to Azure Database for PostgreSQL flexible server.
 """
 
 helps['postgres server configuration'] = """
@@ -1097,7 +1097,7 @@ short-summary: Wait for server to satisfy certain conditions.
 
 helps['postgres server-logs'] = """
 type: group
-short-summary: Manage server logs. Is scheduled to retire by March 28, 2025
+short-summary: Manage server logs. Is deprecated, please migrate to Azure Database for PostgreSQL flexible server.
 """
 
 helps['postgres server-logs download'] = """


### PR DESCRIPTION
**Related command**
az postgres flexible-server create
az postgres server
az postgres db
az postgres server-logs

**Description**<!--Mandatory-->
All commands under the Postgres server removed.
PG default version Currently 'PG17'. Remove hardcoded value being set for version, instead utilize capabilities API.
Last breaking change we removed having a database be created as default for every server. Can we now remove the argument '--create-default-database' and stick to having customers use the 'az postgres flexible-server database' group, if they want to create any databases.


**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
{RDBMS} `az postgres flexible-server create, az postgres server, az postgres db, az postgres server-logs`: Add upcoming breaking change announcements
