### PR TITLE
{LTS} Pin azdev to lts version

### DIFF
--- a/.azure-pipelines/templates/azdev_setup.yml
+++ b/.azure-pipelines/templates/azdev_setup.yml
@@ -15,8 +15,7 @@ steps:
       python -m venv env
       chmod +x env/bin/activate
       . env/bin/activate
-      python -m pip install -U pip
-      pip install azdev==0.1.90 setuptools==70.0.0
+      pip install https://github.com/Azure/azure-cli-dev-tools/archive/refs/heads/lts-2.66.zip
       azdev --version
 
       if [ -z "$CLI_EXT_REPO_PATH" ]; then


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
azdev is pinned to 0.1.90 in https://github.com/Azure/azure-cli/pull/30874. Now azdev 0.1.90 is broken too, see https://github.com/Azure/azure-cli-dev-tools/pull/536

This pr installs azdev from the https://github.com/Azure/azure-cli-dev-tools/tree/lts-2.66 branch.

PS: Although I've fixed the azdev pipeline, I doubt we can fix azdev CI and release old version within the next five years. Installing from GitHub prevents us from releasing it to PyPI and reduces the effort to fix CI.