### PR TITLE
{LTS} Backport #31973: Wrap `functools.partial` in `staticmethod()` to remove FutureWarning

### DIFF
--- a/src/azure-cli-core/azure/cli/core/aaz/_command.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_command.py
@@ -327,12 +327,15 @@ def register_command_group(
         helps[name] = yaml.safe_dump(cls.AZ_HELP)
 
         if is_preview:
-            cls.AZ_PREVIEW_INFO = partial(PreviewItem, target=f'az {name}', object_type='command group')
+            cls.AZ_PREVIEW_INFO = staticmethod(partial(PreviewItem,
+                                                       target=f'az {name}', object_type='command group'))
         if is_experimental:
-            cls.AZ_EXPERIMENTAL_INFO = partial(ExperimentalItem, target=f'az {name}', object_type='command group')
+            cls.AZ_EXPERIMENTAL_INFO = staticmethod(partial(ExperimentalItem,
+                                                            target=f'az {name}', object_type='command group'))
         if deprecated_info:
-            cls.AZ_DEPRECATE_INFO = partial(Deprecated, target=f'az {name}', object_type='command group',
-                                            **deprecated_info)
+            cls.AZ_DEPRECATE_INFO = staticmethod(partial(Deprecated,
+                                                         target=f'az {name}', object_type='command group',
+                                                         **deprecated_info))
         return cls
 
     return decorator
@@ -369,11 +372,13 @@ def register_command(
         if confirmation:
             cls.AZ_CONFIRMATION = confirmation
         if is_preview:
-            cls.AZ_PREVIEW_INFO = partial(PreviewItem, target=f'az {name}', object_type='command')
+            cls.AZ_PREVIEW_INFO = staticmethod(partial(PreviewItem, target=f'az {name}', object_type='command'))
         if is_experimental:
-            cls.AZ_EXPERIMENTAL_INFO = partial(ExperimentalItem, target=f'az {name}', object_type='command')
+            cls.AZ_EXPERIMENTAL_INFO = staticmethod(partial(ExperimentalItem,
+                                                            target=f'az {name}', object_type='command'))
         if deprecated_info:
-            cls.AZ_DEPRECATE_INFO = partial(Deprecated, target=f'az {name}', object_type='command', **deprecated_info)
+            cls.AZ_DEPRECATE_INFO = staticmethod(partial(Deprecated, target=f'az {name}',
+                                                         object_type='command', **deprecated_info))
         return cls
 
     return decorator


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Backport
- https://github.com/Azure/azure-cli/pull/31973