### PR TITLE
[lab] Fix #7903 Help updated (`az lab vm`): Add double quotes with escape character to `--expand`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/lab/aaz/latest/lab/vm/_list.py
+++ b/src/azure-cli/azure/cli/command_modules/lab/aaz/latest/lab/vm/_list.py
@@ -56,7 +56,7 @@ class List(AAZCommand):
         )
         _args_schema.expand = AAZStrArg(
             options=["--expand"],
-            help="Specify the $expand query. Example: 'properties($expand=artifacts,computeVm,networkInterface,applicableSchedule)'",
+            help="Specify the $expand query. Example: '\"properties($expand=artifacts,computeVm,networkInterface,applicableSchedule)\"'",
         )
         _args_schema.filters = AAZStrArg(
             options=["--filters"],

--- a/src/azure-cli/azure/cli/command_modules/lab/aaz/latest/lab/vm/_show.py
+++ b/src/azure-cli/azure/cli/command_modules/lab/aaz/latest/lab/vm/_show.py
@@ -59,7 +59,7 @@ class Show(AAZCommand):
         )
         _args_schema.expand = AAZStrArg(
             options=["--expand"],
-            help="Specify the $expand query. Example: 'properties($expand=artifacts,computeVm,networkInterface,applicableSchedule)'",
+            help="Specify the $expand query. Example: '\"properties($expand=artifacts,computeVm,networkInterface,applicableSchedule)\"'",
         )
         return cls._args_schema
 

--- a/src/azure-cli/azure/cli/command_modules/lab/aaz/latest/lab/vm/_wait.py
+++ b/src/azure-cli/azure/cli/command_modules/lab/aaz/latest/lab/vm/_wait.py
@@ -57,7 +57,7 @@ class Wait(AAZWaitCommand):
         )
         _args_schema.expand = AAZStrArg(
             options=["--expand"],
-            help="Specify the $expand query. Example: 'properties($expand=artifacts,computeVm,networkInterface,applicableSchedule)'",
+            help="Specify the $expand query. Example: '\"properties($expand=artifacts,computeVm,networkInterface,applicableSchedule)\"'",
         )
         return cls._args_schema
 


### PR DESCRIPTION
Add double quotes with escape character, to avoid issue with documentation when user copy/paste the command.

**Related command**

- `az lab vm show --help`
- `az lab vm list --help`
- `az lab vm wait --help`

**Description**<!--Mandatory-->
This PR is here to fix this issue:
[Using az lab vm show to view artifacts doesn't work](https://github.com/Azure/azure-cli/issues/7903)
The `--expand` help text have been updated with double quotes to help people when they copy/paste it into their terminal.

**Testing Guide**
Run these commands and look at the output displayed:

- `az lab vm show --help`
- `az lab vm list --help`
- `az lab vm wait --help`

_Before:_
`--expand              : Specify the $expand query. Example:
                            'properties($expand=artifacts,computeVm,networkInterface,applicableSched
                            ule)'.`

_After:_
`--expand            : Specify the $expand query. Example:
                          '"properties($expand=artifacts,computeVm,networkInterface,applicableSchedu
                          le)"'.`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
