### PR TITLE
{LTS} Backport #32362: Delete Failing Function App Test

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands.py
@@ -1836,19 +1836,6 @@ class FunctionAppOnLinux(ScenarioTest):
 
     @ResourceGroupPreparer(location=LINUX_ASP_LOCATION_FUNCTIONAPP)
     @StorageAccountPreparer()
-    def test_functionapp_on_linux_consumption_python_39(self, resource_group, storage_account):
-        functionapp = self.create_random_name(
-            prefix='functionapp-linux', length=24)
-        self.cmd('functionapp create -g {} -n {} -c {} -s {} --os-type linux --runtime python --functions-version 4 --runtime-version 3.9'
-                 .format(resource_group, functionapp, LINUX_ASP_LOCATION_FUNCTIONAPP, storage_account), checks=[
-                     JMESPathCheck('name', functionapp)
-                 ])
-
-        self.cmd('functionapp config show -g {} -n {}'.format(resource_group, functionapp), checks=[
-            JMESPathCheck('linuxFxVersion', 'Python|3.9')])
-
-    @ResourceGroupPreparer(location=LINUX_ASP_LOCATION_FUNCTIONAPP)
-    @StorageAccountPreparer()
     def test_functionapp_on_linux_functions_version(self, resource_group, storage_account):
         plan = self.create_random_name(prefix='funcapplinplan', length=24)
         functionapp = self.create_random_name(


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Backport
- #32362 


```
self = <azure.cli.command_modules.appservice.custom._FunctionAppStackRuntimeHelper object at 0x7f00aea3cf20>
runtime = 'python', version = '3.9'

    def validate_end_of_life_date(self, runtime, version):
        from dateutil.relativedelta import relativedelta
        today = datetime.datetime.now(datetime.timezone.utc)
        six_months = today + relativedelta(months=+6)
        runtimes_eol = [r for r in self.end_of_life_dates if runtime == r.name]
        matched_runtime_eol = next((r for r in runtimes_eol if r.version == version), None)
        if matched_runtime_eol:
            eol = matched_runtime_eol.eol
            runtime_deprecation_link = matched_runtime_eol.deprecation_link or ''
    
            if eol < today:
>               raise ValidationError('{} has reached EOL on {} and is no longer supported. {}'
                                      .format(runtime, eol.date(), runtime_deprecation_link))
E               azure.cli.core.azclierror.ValidationError: python has reached EOL on 2025-10-31 and is no longer supported.
```