### PR TITLE
{Keyvault} `az keyvault key sign`: Document base64 requirement for digest

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/keyvault/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_help.py
@@ -379,7 +379,7 @@ short-summary: Create a signature from a digest using a key that is stored in a 
 examples:
   - name: Create a signature from a digest using keyvault's key.
     text: |
-        az keyvault key sign --name mykey --vault-name myvault --algorithm RS256 --digest "12345678901234567890123456789012"
+        az keyvault key sign --name mykey --vault-name myvault --algorithm RS256 --digest "rsBwZF/lPuOzdjBZN2E08FjMM3JHyXit0Xi2zN+wAZ8="
 """
 
 helps['keyvault key verify'] = """
@@ -388,7 +388,7 @@ short-summary: Verify a signature using the key that is stored in a Vault or HSM
 examples:
   - name: Verify a signature using keyvault's key.
     text: |
-        az keyvault key verify --name mykey --vault-name myvault --algorithm RS256 --digest "12345678901234567890123456789012" --signature XXXYYYZZZ
+        az keyvault key verify --name mykey --vault-name myvault --algorithm RS256 --digest "rsBwZF/lPuOzdjBZN2E08FjMM3JHyXit0Xi2zN+wAZ8=" --signature XXXYYYZZZ
 """
 
 helps['keyvault key backup'] = """

--- a/src/azure-cli/azure/cli/command_modules/keyvault/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_params.py
@@ -426,7 +426,7 @@ def load_arguments(self, _):
         with self.argument_context('keyvault key {}'.format(scope)) as c:
             c.argument('algorithm', options_list=['--algorithm', '-a'], arg_type=get_enum_type(SignatureAlgorithm),
                        help='Algorithm identifier')
-            c.argument('digest', help='The value to sign')
+            c.argument('digest', help='The value to sign (base64 encoded)')
             c.argument('signature', help='signature to verify')
 
     with self.argument_context('keyvault key random') as c:


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az keyvault key sign`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Document that the digest arg to `sign` and `verify` must be base64 encoded. Spent a little while figuring that out. The error messages are confusing if the input is not encoded correctly too, so it's important to have clear docs.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [tick ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ tick] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ tick] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
