### PR TITLE
[Packaging] Drop Python 3.9 support

### DIFF
--- a/doc/command_guidelines.md
+++ b/doc/command_guidelines.md
@@ -426,7 +426,7 @@ Follow the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/d
 
 ## Coding Practices
 
-- All code must support Python 3.9 ~ 3.13
+- All code must support Python 3.10 ~ 3.13
 - PRs to Azure/azure-cli and Azure/azure-cli-extensions must pass CI
 - Code must pass style checks with pylint and pep8
 - (*) All commands should have tests

--- a/doc/debug/debug_in_vs_code.md
+++ b/doc/debug/debug_in_vs_code.md
@@ -4,7 +4,7 @@
 
 * Visual Studio Code [Link](http://code.visualstudio.com/)
 * Visual Studio Code Python Extension [Link](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
-* Python 3.9+
+* Python 3.10+
 * Set up development environment [Link](https://github.com/Azure/azure-cli/blob/master/doc/configuring_your_machine.md)
 
 ## Quick start

--- a/doc/extensions/authoring.md
+++ b/doc/extensions/authoring.md
@@ -130,9 +130,9 @@ See [Extension Metadata](metadata.md) for more information.
 
 ### Test your extension on Python 3
 
-- The Azure CLI supports Python 3.9 ~ 3.13 so verify that your extension does the same.
+- The Azure CLI supports Python 3.10 ~ 3.13 so verify that your extension does the same.
 - You can create virtual environments for different versions and run your extension in them.
-- e.g. `python3.9 -m venv env38` and `python3.10 -m venv env310`.
+- e.g. `python3.13 -m venv env313`.
 
 
 Also, see the [FAQ](faq.md).

--- a/doc/install_linux_prerequisites.md
+++ b/doc/install_linux_prerequisites.md
@@ -6,7 +6,7 @@ Some native Linux packages are required when installing the CLI with:
 - Interactive installation script
 - `pip`
 
-Current supported Python versions are Python 3.9 ~ 3.13.
+Current supported Python versions are Python 3.10 ~ 3.13.
 
 The commands to run to install the dependencies for some common distributions are listed below.
 
@@ -16,7 +16,7 @@ sudo apt-get update && sudo apt-get install -y libssl-dev libffi-dev python-dev 
 ```
 
 ### RHEL 8, CentOS Stream 8, RHEL 9, CentOS Stream 9
-Install the latest Python 3.9 available in the software repo.
+Install the latest Python 3.12 available in the software repo.
 ```
-sudo dnf install -y gcc libffi-devel python39-devel openssl-devel
+sudo dnf install -y gcc libffi-devel python312-devel openssl-devel
 ```

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -98,7 +98,6 @@ CLASSIFIERS = [
     'Intended Audience :: Developers',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -35,7 +35,6 @@ CLASSIFIERS = [
     'Intended Audience :: System Administrators',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
@@ -84,6 +83,6 @@ setup(
     classifiers=CLASSIFIERS,
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests", "azure", "azure.cli"]),
     install_requires=DEPENDENCIES,
-    python_requires='>=3.9.0',
+    python_requires='>=3.10.0',
     package_data={'azure.cli.core': ['auth/landing_pages/*.html']}
 )

--- a/src/azure-cli-telemetry/setup.py
+++ b/src/azure-cli-telemetry/setup.py
@@ -16,7 +16,6 @@ CLASSIFIERS = [
     'Intended Audience :: System Administrators',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',

--- a/src/azure-cli-testsdk/setup.py
+++ b/src/azure-cli-testsdk/setup.py
@@ -15,7 +15,6 @@ CLASSIFIERS = [
     'Intended Audience :: Developers',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -42,7 +42,6 @@ CLASSIFIERS = [
     'Intended Audience :: System Administrators',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
@@ -180,7 +179,7 @@ setup(
     ],
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests", "azure", "azure.cli"]),
     install_requires=DEPENDENCIES,
-    python_requires='>=3.9.0',
+    python_requires='>=3.10.0',
     package_data={
         'azure.cli.command_modules.acr': ['*.json'],
         'azure.cli.command_modules.botservice': ['*.json', '*.config'],


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Drop Python 3.9 as it reaches EOL on 2025-10-31: https://devguide.python.org/versions/

Related PR:
- #30225