### PR TITLE
{NetAppFiles} Remove --endpoint-type

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/netappfiles/_breaking_change.py
+++ b/src/azure-cli/azure/cli/command_modules/netappfiles/_breaking_change.py
@@ -2,6 +2,3 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
-from azure.cli.core.breaking_change import register_argument_deprecate
-register_argument_deprecate('netappfiles volume create', '--endpoint-type')
-register_argument_deprecate('netappfiles volume update', '--endpoint-type')

--- a/src/azure-cli/azure/cli/command_modules/netappfiles/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/netappfiles/custom.py
@@ -315,15 +315,6 @@ class VolumeCreate(_VolumeCreate):
             minimum=50
         )
 
-        # Removed in API is not needed, added here for backwards compatibility will be removed in breaking change window
-        args_schema.endpoint_type = AAZStrArg(
-            options=["--endpoint-type"],
-            arg_group="Replication",
-            help="Indicates whether the local volume is the source or destination for the Volume Replication",
-            nullable=True,
-            enum={"dst": "dst", "src": "src"},
-        )
-
         # The API does only support setting Basic and Standard
         args_schema.network_features.enum = AAZArgEnum({"Basic": "Basic", "Standard": "Standard"}, case_sensitive=False)
 
@@ -418,15 +409,6 @@ class VolumeUpdate(_VolumeUpdate):
             arg_group="Properties",
             help="Name or Resource ID of the vnet. If you want to use a vnet in other resource group or subscription, please provide the Resource ID instead of the name of the vnet.",
             required=False,
-        )
-
-        # Removed in API is not needed, added here for backwards compatibility will be removed in breaking change window
-        args_schema.endpoint_type = AAZStrArg(
-            options=["--endpoint-type"],
-            arg_group="Replication",
-            help="Indicates whether the local volume is the source or destination for the Volume Replication",
-            nullable=True,
-            enum={"dst": "dst", "src": "src"},
         )
 
         args_schema.usage_threshold._fmt = AAZIntArgFormat(


### PR DESCRIPTION
**Related command**
az netappfiles

**Description**<!--Mandatory-->
Removes deprecated argument --endpoint-type from az netappfiles volume create and update

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[NetAppFiles] BREAKING CHANGE: `az netappfiles volume create`: Remove deprecated argument `--endpoint-type`, this property is readOnly
[NetAppFiles] BREAKING CHANGE: `az netappfiles volume update`: Remove deprecated argument `--endpoint-type`, this property is readOnly

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
