### PR TITLE
{MySQL} Hide backup export command

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/mysql/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/mysql/commands.py
@@ -202,7 +202,9 @@ def load_command_table(self, _):
 
     with self.command_group('mysql flexible-server export', mysql_flexible_export_sdk,
                             custom_command_type=mysql_custom,
-                            client_factory=cf_mysql_flexible_export, is_preview=True) as g:
+                            client_factory=cf_mysql_flexible_export, 
+                            is_preview=True,
+                            deprecate_info=self.deprecate(..., hide=True)) as g:
         g.custom_command('create', 'flexible_server_export_create')
 
     with self.command_group('mysql flexible-server identity', mysql_flexible_servers_sdk,

--- a/src/azure-cli/azure/cli/command_modules/mysql/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/mysql/commands.py
@@ -204,7 +204,7 @@ def load_command_table(self, _):
                             custom_command_type=mysql_custom,
                             client_factory=cf_mysql_flexible_export, 
                             is_preview=True,
-                            deprecate_info=self.deprecate(..., hide=True)) as g:
+                            deprecate_info=self.deprecate(hide=True)) as g:
         g.custom_command('create', 'flexible_server_export_create')
 
     with self.command_group('mysql flexible-server identity', mysql_flexible_servers_sdk,

--- a/src/azure-cli/azure/cli/command_modules/mysql/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/mysql/commands.py
@@ -202,7 +202,7 @@ def load_command_table(self, _):
 
     with self.command_group('mysql flexible-server export', mysql_flexible_export_sdk,
                             custom_command_type=mysql_custom,
-                            client_factory=cf_mysql_flexible_export, 
+                            client_factory=cf_mysql_flexible_export,
                             is_preview=True,
                             deprecate_info=self.deprecate(hide=True)) as g:
         g.custom_command('create', 'flexible_server_export_create')


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az mysql flexible-server export
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
The feature export backup is no longer supported in Azure DB for MySQL flexible server. We need to hide this command for now.
**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
