### PR TITLE
{LTS} Backport #30284: Bump paramiko to 3.5.0

### DIFF
--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -109,7 +109,7 @@ msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2
 packaging==25.0
-paramiko==3.4.0
+paramiko==3.5.0
 pbr==5.3.1
 pkginfo==1.8.2
 portalocker==2.3.2

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -110,7 +110,7 @@ msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2
 packaging==25.0
-paramiko==3.4.0
+paramiko==3.5.0
 pbr==5.3.1
 pkginfo==1.8.2
 portalocker==2.3.2

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -109,7 +109,7 @@ msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2
 packaging==25.0
-paramiko==3.4.0
+paramiko==3.5.0
 pbr==5.3.1
 pkginfo==1.8.2
 portalocker==2.3.2


### PR DESCRIPTION
Backport
- https://github.com/Azure/azure-cli/pull/30284

Error:
```
_ ERROR collecting azure/cli/command_modules/iot/tests/latest/test_iot_certificate_commands.py _
ImportError while importing test module '/mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/iot/tests/latest/test_iot_certificate_commands.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/hostedtoolcache/Python/3.13.9/x64/lib/python3.13/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
src/azure-cli/azure/cli/command_modules/iot/tests/latest/test_iot_certificate_commands.py:9: in <module>
    from azure.cli.command_modules.iot.tests.latest._test_utils import (
src/azure-cli/azure/cli/command_modules/iot/tests/latest/_test_utils.py:9: in <module>
    from cryptography import x509
env/lib/python3.13/site-packages/cryptography/x509/__init__.py:7: in <module>
    from cryptography.x509 import certificate_transparency, verification
env/lib/python3.13/site-packages/cryptography/x509/certificate_transparency.py:8: in <module>
    from cryptography.hazmat.bindings._rust import x509 as rust_x509
E   ImportError: /mnt/vss/_work/1/s/env/lib/python3.13/site-packages/_cffi_backend.cpython-313-x86_64-linux-gnu.so: undefined symbol: _PyErr_WriteUnraisableMsg
_ ERROR collecting azure/cli/command_modules/iot/tests/latest/test_iot_dps_commands.py _
ImportError while importing test module '/mnt/vss/_work/1/s/src/azure-cli/azure/cli/command_modules/iot/tests/latest/test_iot_dps_commands.py'.
```

Ref: https://dev.azure.com/azclitools/public/_build/results?buildId=284330&view=logs&jobId=e1e9f901-9daf-582d-5d69-e30a01dc5263&j=e1e9f901-9daf-582d-5d69-e30a01dc5263&t=f8406c5f-88d4-529e-9985-1bf82372cf9b