### PR TITLE
[App Service] `az webapp list runtimes`: Update logic to include missing Java versions and remove hardcoded lists

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -6407,10 +6407,6 @@ class _StackRuntimeHelper(_AbstractStackRuntimeHelper):
     def _parse_major_version_windows(self, major_version, parsed_results, config_mappings):
         java_container_minor_versions = self._get_valid_minor_versions(major_version, linux=False, java=True)
         if java_container_minor_versions:
-            # Limit to 3 containers for display
-            if len(java_container_minor_versions) > 0:
-                leng = len(java_container_minor_versions) if len(java_container_minor_versions) < 3 else 3
-                java_container_minor_versions = java_container_minor_versions[:leng]
             for container in java_container_minor_versions:
                 container_settings = container.stack_settings.windows_container_settings
                 java_container = container_settings.java_container
@@ -6429,10 +6425,6 @@ class _StackRuntimeHelper(_AbstractStackRuntimeHelper):
                     parsed_results.append(runtime)
         else:
             minor_versions = self._get_valid_minor_versions(major_version, linux=False, java=False)
-            if "Java" in major_version.display_text:
-                if len(minor_versions) > 0:
-                    leng = len(minor_versions) if len(minor_versions) < 3 else 3
-                    minor_versions = minor_versions[1:leng]
             for minor_version in minor_versions:
                 settings = minor_version.stack_settings.windows_runtime_settings
                 if "Java" not in minor_version.display_text:
@@ -6495,13 +6487,10 @@ class _StackRuntimeHelper(_AbstractStackRuntimeHelper):
             se_containers = [minor_java_container_versions[0]] if minor_java_container_versions else []
             for java in java_versions:
                 se_java_containers = [c for c in minor_java_container_versions if c.value.startswith(java)]
-                se_containers = se_containers + se_java_containers[:min(len(se_java_containers), 2)]
+                se_containers = se_containers + se_java_containers
             minor_java_container_versions = se_containers
         if minor_java_container_versions:
-            leng = len(minor_java_container_versions) if \
-                len(minor_java_container_versions) < 3 else 3 if \
-                "SE" not in major_version.display_text else len(minor_java_container_versions)
-            for minor in minor_java_container_versions[:leng]:
+            for minor in minor_java_container_versions:
                 linux_container_settings = minor.stack_settings.linux_container_settings
                 # Dynamically get all Java runtimes from container settings
                 runtimes = self._get_java_runtimes_from_container_settings(linux_container_settings)


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az webapp list-runtimes

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix list-runtimes to dynamically discover Java versions including Java 25

- Remove hardcoded Java version lists that were missing Java 25
- Add dynamic parsing of Java versions from API's runtimes array
- Add _get_java_versions_from_minor_versions() for Linux Java SE containers
- Add _get_java_versions_from_windows_container() for Windows containers
- Add _get_java_runtimes_from_container_settings() for Linux container runtimes
- Add deduplication to prevent duplicate runtime entries (e.g., JBOSSEAP)
- Future-proof: new Java versions will automatically appear without code changes

**Testing Guide**
<!--Example commands with explanations.-->
`az webapp list-runtimes` should now show Java 25 

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
