### PR TITLE
[ACR] `az acr config content-trust update`, `az acr check-health`: Add breaking changes announcement 

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_breaking_change.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_breaking_change.py
@@ -3,7 +3,10 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from azure.cli.core.breaking_change import register_command_group_deprecate
+from azure.cli.core.breaking_change import (
+    register_command_group_deprecate,
+    register_logic_breaking_change
+)
 
 helm_bc_msg = 'In November 2020, Helm 2 reached end of life. ' \
               'Starting on March 30th, 2025 Azure Container Registry will no longer support Helm 2. ' \
@@ -28,3 +31,13 @@ register_command_group_deprecate(command_group='acr helm', redirect='Helm v3 com
                                  target_version='Sept 30th, 2025')
 
 register_command_group_deprecate(command_group='acr config content-trust', message=content_trust_bc_msg)
+
+register_logic_breaking_change('acr check-health', 'Remove Notary client version validation',
+                               detail='The Notary client version check will no longer be performed as part of the '
+                                      'check-health command due to Docker Content Trust deprecation.',
+                               doc_link='https://aka.ms/acr/dctdeprecation')
+
+register_logic_breaking_change('acr config content-trust update', 'Remove content-trust enabled configuration',
+                               detail='The `--status enabled` parameter will no longer be accepted and will result in '
+                                      'an error due to Docker Content Trust deprecation.',
+                               doc_link='https://aka.ms/acr/dctdeprecation')


### PR DESCRIPTION
**Related command**
`az acr config content-trust update`
`az acr check-health`

**Description**<!--Mandatory-->
Azure Container Registry will retire [Docker Content Trust](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-content-trust) on March 31, 2028. For more details, refer to https://aka.ms/acr/dctdeprecation.

- Add a breaking change announcement for `az acr config content-trust update` stating that the `enabled` status value will no longer be accepted in the next breaking change release.
- Add a breaking change announcement for `az acr check-health` stating that the Notary client check will be removed in the next breaking change release.

**Testing Guide**
<img width="1610" height="450" alt="image" src="https://github.com/user-attachments/assets/5045bf11-840b-4082-a7d8-3532159a3d38" />
<img width="1668" height="592" alt="image" src="https://github.com/user-attachments/assets/63d819f5-403f-4ae4-b2a1-e988bbd52f6d" />

**History Notes**
[ACR] `az acr config content-trust update`: Add breaking changes announcement that `enabled` status will no longer be accepted
[ACR] `az acr check-health`: Add breaking change announcement that Notary client check will be removed


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
