### PR TITLE
[RDBMS] `az postgres flexible-server update/fabric-mirroring`: Allow high availability enabled servers to start fabric mirroring if PG version 17+

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
@@ -471,7 +471,7 @@ def flexible_server_update_custom_func(cmd, client, instance,
             high_availability_param.standby_availability_zone = standby_availability_zone
 
         # PG 11 and 12 will never receive fabric mirroring support. Ignite 2025 Fabric mirroring supported on 17. Skip this check for servers of these versions
-        if high_availability.lower() != "disabled" and str(instance.version) not in ["11", "12", "17"]:
+        if high_availability.lower() != "disabled" and str(instance.version) not in ["11", "12", "17", "18"]:
             config_client = cf_postgres_flexible_config(cmd.cli_ctx, '_')
             fabric_mirror_status = config_client.get(resource_group_name, server_name, 'azure.fabric_mirror_enabled')
             if (fabric_mirror_status and fabric_mirror_status.value.lower() == 'on'):
@@ -1585,7 +1585,7 @@ def flexible_server_fabric_mirroring_start(cmd, client, resource_group_name, ser
     flexible_servers_client = cf_postgres_flexible_servers(cmd.cli_ctx, '_')
     server = flexible_servers_client.get(resource_group_name, server_name)
 
-    if server.high_availability.mode != "Disabled" and server.version not in ["17"]:
+    if server.high_availability.mode != "Disabled" and server.version not in ["17", "18"]:
         # disable fabric mirroring on HA server
         raise CLIError("Fabric mirroring is not supported on servers with high availability enabled.")
 
@@ -1615,7 +1615,7 @@ def flexible_server_fabric_mirroring_stop(cmd, client, resource_group_name, serv
     flexible_servers_client = cf_postgres_flexible_servers(cmd.cli_ctx, '_')
     server = flexible_servers_client.get(resource_group_name, server_name)
 
-    if server.high_availability.mode != "Disabled" and server.version not in ["17"]:
+    if server.high_availability.mode != "Disabled" and server.version not in ["17", "18"]:
         # disable fabric mirroring on HA server
         raise CLIError("Fabric mirroring is not supported on servers with high availability enabled.")
 
@@ -1637,7 +1637,7 @@ def flexible_server_fabric_mirroring_update_databases(cmd, client, resource_grou
     flexible_servers_client = cf_postgres_flexible_servers(cmd.cli_ctx, '_')
     server = flexible_servers_client.get(resource_group_name, server_name)
 
-    if server.high_availability.mode != "Disabled" and server.version not in ["17"]:
+    if server.high_availability.mode != "Disabled" and server.version not in ["17", "18"]:
         # disable fabric mirroring on HA server
         raise CLIError("Fabric mirroring is not supported on servers with high availability enabled.")
 


### PR DESCRIPTION
**Related command**
`az postgres flexible-server update`
`az postgres flexible-server update/fabric-mirroring`

**Description**<!--Mandatory-->
Starting with Ignite, Fabric mirroring shall be supported on PG17+ servers with HA setup as well.

**Testing Guide**
Manual

az postgres flexible-server fabric-mirroring start -g nascrunner25 -s nasc-new-ha-919 --database-names postgres --yes
Enabling system assigned managed identity on the server.
Updating necessary server parameters.
{
  "allowedValues": ".*",
  "dataType": "String",
  "defaultValue": "",
  "description": "Specifies the list of databases for which to enable mirroring.",
  "documentationLink": "https://go.microsoft.com/fwlink/?linkid=2285682",
  "id": "/subscriptions/ac0271d6-426b-4b0d-b88d-0d0e4bd693ae/resourceGroups/nascrunner25/providers/Microsoft.DBforPostgreSQL/flexibleServers/nasc-new-ha-919/configurations/azure.mirror_databases",
  "isConfigPendingRestart": false,
  "isDynamicConfig": true,
  "isReadOnly": false,
  "name": "azure.mirror_databases",
  "resourceGroup": "nascrunner25",
  "source": "user-override",
  "systemData": null,
  "type": "Microsoft.DBforPostgreSQL/flexibleServers/configurations",
  "unit": null,
  "value": "postgres"
}

**History Notes**
[RDBMS] `az postgres flexible-server update/fabric-mirroring`: Allow high availability enabled servers to start fabric mirroring if PG version 17+