### PR TITLE
[EventHubs] Fix #31108, #32073: `az eventhubs`: Regex updated for commands with `--namespace-name` arguments

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/eventhub/_create.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/eventhub/_create.py
@@ -55,7 +55,7 @@ class Create(AAZCommand):
             help="The Namespace name",
             required=True,
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$",
+                pattern="^[a-zA-Z][a-zA-Z0-9-]{4,48}[a-zA-Z0-9]$",
                 max_length=50,
                 min_length=6,
             ),

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/eventhub/_delete.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/eventhub/_delete.py
@@ -57,7 +57,7 @@ class Delete(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$",
+                pattern="^[a-zA-Z][a-zA-Z0-9-]{4,48}[a-zA-Z0-9]$",
                 max_length=50,
                 min_length=6,
             ),

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/eventhub/_list.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/eventhub/_list.py
@@ -47,7 +47,7 @@ class List(AAZCommand):
             help="The Namespace name",
             required=True,
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$",
+                pattern="^[a-zA-Z][a-zA-Z0-9-]{4,48}[a-zA-Z0-9]$",
                 max_length=50,
                 min_length=6,
             ),

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/eventhub/_show.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/eventhub/_show.py
@@ -57,7 +57,7 @@ class Show(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$",
+                pattern="^[a-zA-Z][a-zA-Z0-9-]{4,48}[a-zA-Z0-9]$",
                 max_length=50,
                 min_length=6,
             ),

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/eventhub/_update.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/eventhub/_update.py
@@ -59,7 +59,7 @@ class Update(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$",
+                pattern="^[a-zA-Z][a-zA-Z0-9-]{4,48}[a-zA-Z0-9]$",
                 max_length=50,
                 min_length=6,
             ),

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/namespace/_create.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/namespace/_create.py
@@ -53,7 +53,7 @@ class Create(AAZCommand):
             help="The Namespace name",
             required=True,
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$",
+                pattern="^[a-zA-Z][a-zA-Z0-9-]{4,48}[a-zA-Z0-9]$",
                 max_length=50,
                 min_length=6,
             ),

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/namespace/_delete.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/namespace/_delete.py
@@ -51,7 +51,7 @@ class Delete(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$",
+                pattern="^[a-zA-Z][a-zA-Z0-9-]{4,48}[a-zA-Z0-9]$",
                 max_length=50,
                 min_length=6,
             ),

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/namespace/_failover.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/namespace/_failover.py
@@ -48,7 +48,7 @@ class Failover(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$",
+                pattern="^[a-zA-Z][a-zA-Z0-9-]{4,48}[a-zA-Z0-9]$",
                 max_length=50,
                 min_length=6,
             ),

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/namespace/_show.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/namespace/_show.py
@@ -50,7 +50,7 @@ class Show(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$",
+                pattern="^[a-zA-Z][a-zA-Z0-9-]{4,48}[a-zA-Z0-9]$",
                 max_length=50,
                 min_length=6,
             ),

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/namespace/_update.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/namespace/_update.py
@@ -53,7 +53,7 @@ class Update(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$",
+                pattern="^[a-zA-Z][a-zA-Z0-9-]{4,48}[a-zA-Z0-9]$",
                 max_length=50,
                 min_length=6,
             ),

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/namespace/_wait.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/namespace/_wait.py
@@ -46,7 +46,7 @@ class Wait(AAZWaitCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$",
+                pattern="^[a-zA-Z][a-zA-Z0-9-]{4,48}[a-zA-Z0-9]$",
                 max_length=50,
                 min_length=6,
             ),

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/namespace/nsp_configuration/_list.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/namespace/nsp_configuration/_list.py
@@ -46,7 +46,7 @@ class List(AAZCommand):
             help="The Namespace name",
             required=True,
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$",
+                pattern="^[a-zA-Z][a-zA-Z0-9-]{4,48}[a-zA-Z0-9]$",
                 max_length=50,
                 min_length=6,
             ),

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/namespace/nsp_configuration/_show.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/namespace/nsp_configuration/_show.py
@@ -47,7 +47,7 @@ class Show(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$",
+                pattern="^[a-zA-Z][a-zA-Z0-9-]{4,48}[a-zA-Z0-9]$",
                 max_length=50,
                 min_length=6,
             ),


### PR DESCRIPTION
**Related command**
`az eventhubs eventhub create`
`az eventhubs eventhub delete`
`az eventhubs eventhub list`
`az eventhubs eventhub show`
`az eventhubs eventhub update`
`az eventhubs namespace create`
`az eventhubs namespace delete`
`az eventhubs namespace failover`
`az eventhubs namespace show`
`az eventhubs namespace update`
`az eventhubs namespace wait`
`az eventhubs namespace nsp-configuration list`
`az eventhubs namespace nsp-configuration show`

**Description**<!--Mandatory-->
2 issues have been reported (#31108 and #32073) regarding the argument `--namespace-name`. This argument has a min length defined at  6 and max at 50. But the regular expression provided to the pattern property doesn't match the min and max lengths.

For example with a `--namespace-name` value with a length equals to 7:
`az eventhubs namespace nsp-configuration list --namespace-name abc1234`
`InvalidArgumentValue: --namespace-name: Invalid format: 'abc1234' does not fully match regular expression pattern '^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$'`

The current regular expression min length is 8 and max 52.

Before:
```
fmt=AAZStrArgFormat(
                pattern="^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$",
                max_length=50,
                min_length=6,
            ),
```

To fix it, I modified it to have at the end a min at 6 and max at 50.

After:
```
fmt=AAZStrArgFormat(
                pattern="^[a-zA-Z][a-zA-Z0-9-]{4,48}[a-zA-Z0-9]$",
                max_length=50,
                min_length=6,
            ),
```

**Testing Guide**

There are 3 tests to perform:
- with a `--namespace-name` value length less than 6.
- with a `--namespace-name` value length equals to 6.
- a `--namespace-name` value length more than 6.

_Before fix, with a `--namespace-name` value length equals to 6:_
`az eventhubs eventhub list --namespace-name abc123`
`InvalidArgumentValue: --namespace-name: Invalid format: 'abc123' does not fully match regular expression pattern '^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$'`

_After fix, with a `--namespace-name` value length equals to 6 (message expected because this resource doesn't exist):_
`az eventhubs eventhub list --namespace-name abc123`
`(ParentResourceNotFound) Failed to perform 'read' on resource(s) of type 'namespaces/eventhubs', because the parent resource '/subscriptions/.../resourceGroups/.../providers/Microsoft.EventHub/namespaces/abc123' could not be found.
Code: ParentResourceNotFound
Message: Failed to perform 'read' on resource(s) of type 'namespaces/eventhubs', because the parent resource '/subscriptions/.../resourceGroups/.../providers/Microsoft.EventHub/namespaces/abc123' could not be found.`

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[EventHubs] Fix #31108, #32073: `az eventhubs`: Regex updated for commands with `--namespace-name` arguments

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
