### PR TITLE
[LTS] Backport #32315: Bump embedded Python to 3.13.9

### DIFF
--- a/build_scripts/windows/scripts/build.cmd
+++ b/build_scripts/windows/scripts/build.cmd
@@ -30,7 +30,7 @@ if "%ARCH%"=="x86" (
     echo Please set ARCH to "x86" or "x64"
     goto ERROR
 )
-set PYTHON_VERSION=3.13.7
+set PYTHON_VERSION=3.13.9
 
 set WIX_DOWNLOAD_URL="https://azurecliprod.blob.core.windows.net/msi/wix310-binaries-mirror.zip"
 set PYTHON_DOWNLOAD_URL="https://www.python.org/ftp/python/%PYTHON_VERSION%/python-%PYTHON_VERSION%-embed-%PYTHON_ARCH%.zip"

--- a/scripts/release/debian/build.sh
+++ b/scripts/release/debian/build.sh
@@ -15,7 +15,7 @@ set -exv
 ls -Rl /mnt/artifacts
 
 WORKDIR=`cd $(dirname $0); cd ../../../; pwd`
-PYTHON_VERSION="3.13.7"
+PYTHON_VERSION="3.13.9"
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Update APT packages


### PR DESCRIPTION
Backport
- https://github.com/Azure/azure-cli/pull/32315

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Core] Resolve CVE-2025-9230
[Core] Resolve CVE-2025-9232