### PR TITLE
[RDBMS] `az postgres flexible-server upgrade`: Allow major version upgrade to PostgreSQL Version 18

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/_helptext_pg.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_helptext_pg.py
@@ -40,7 +40,7 @@ examples:
         az postgres flexible-server create --location northeurope --resource-group testGroup \\
           --name testserver --admin-user username --admin-password password \\
           --sku-name Standard_D2s_v3 --tier GeneralPurpose --public-access 153.24.26.117 --storage-size 128 \\
-          --tags "key=value" --version 17 --zonal-resiliency Enabled --zone 1 \\
+          --tags "key=value" --version 18 --zonal-resiliency Enabled --zone 1 \\
           --standby-zone 3
   - name: >
       Create server with high availability feature enabled that allows primary and standby in the same zone when multi-zone capacity is unavailable.
@@ -910,8 +910,8 @@ helps['postgres flexible-server upgrade'] = """
 type: command
 short-summary: Upgrade the major version of a flexible server.
 examples:
-  - name: Upgrade server 'testsvr' to PostgreSQL major version 17.
-    text: az postgres flexible-server upgrade -g testgroup -n testsvr -v 17
+  - name: Upgrade server 'testsvr' to PostgreSQL major version 18.
+    text: az postgres flexible-server upgrade -g testgroup -n testsvr -v 18
 """
 
 helps['postgres flexible-server identity'] = """

--- a/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
@@ -472,7 +472,7 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
         )
 
         pg_version_upgrade_arg_type = CLIArgumentType(
-            arg_type=get_enum_type(['13', '14', '15', '16', '17']),
+            arg_type=get_enum_type(['13', '14', '15', '16', '17', '18']),
             options_list=['--version', '-v'],
             help='Server major version.'
         )


### PR DESCRIPTION
**Related command**
`az postgres flexible-server upgrade`

**Description**<!--Mandatory-->
Perform in-place major version upgrades from PostgreSQL 11–17 with no endpoint or connection string changes.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
