### PR TITLE
{Compute} `az create vm`: Remove preview flag for CapacityReservationGroup parameter

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_params.py
@@ -1259,7 +1259,7 @@ def load_arguments(self, _):
                        help='The maximum price (in US Dollars) you are willing to pay for a Spot VM/VMSS. -1 indicates that the Spot VM/VMSS should not be evicted for price reasons')
             c.argument('capacity_reservation_group', options_list=['--capacity-reservation-group', '--crg'],
                        help='The ID or name of the capacity reservation group that is used to allocate. Pass in "None" to disassociate the capacity reservation group. Please note that if you want to delete a VM/VMSS that has been associated with capacity reservation group, you need to disassociate the capacity reservation group first.',
-                       min_api='2021-04-01', is_preview=True)
+                       min_api='2021-04-01')
             c.argument('v_cpus_available', type=int, min_api='2021-11-01', help='Specify the number of vCPUs available')
             c.argument('v_cpus_per_core', type=int, min_api='2021-11-01', help='Specify the ratio of vCPU to physical core. Setting this property to 1 also means that hyper-threading is disabled.')
             c.argument('disk_controller_type', disk_controller_type)


### PR DESCRIPTION
**Related command**
az vm create --capacity-reservation-group;
az vm update --capacity-reservation-group;
az vmss create --capacity-reservation-group;
az vmss update --capacity-reservation-group;

**Description**
The capacity reservation group has been a GA-ed feature for a while. A customer noticed the preview feature warning when using the CLI and reported it. The flag must have been missed from being cleaned up during the GA preparation for Capacity reservation feature. This PR is to remove the is_preview flag from the capacity reservation group parameter in azure cli vm commands.

**Testing Guide**
az vm create --capacity-reservation-group executes without preview feature warning message

**History Notes**


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
