### PR TITLE
[Network] az network private-endpoint-connection: Update provider Microsoft.Security/privateLinks

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/private_link_resource_and_endpoint_connections/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/private_link_resource_and_endpoint_connections/custom.py
@@ -86,7 +86,7 @@ def register_providers():
     _register_one_provider('Microsoft.App/managedEnvironments', '2024-02-02-preview', True)
     _register_one_provider('Microsoft.FluidRelay/fluidRelayServers', '2025-03-10-preview', True)
     _register_one_provider('Microsoft.VideoIndexer/accounts', '2025-04-01', True)
-    _register_one_provider('Microsoft.Security/privateLinks', '2025-09-01-preview', True)
+    _register_one_provider('Microsoft.Security/privateLinks', '2026-01-01', True)
     _register_one_provider('Microsoft.Maps/accounts', '2023-12-01-preview', True)
 
 

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/private_endpoint_arm_templates/security_privatelinks_template.json
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/private_endpoint_arm_templates/security_privatelinks_template.json
@@ -11,7 +11,7 @@
   "resources": [
       {
           "type": "Microsoft.Security/privateLinks",
-          "apiVersion": "2025-09-01-preview",
+          "apiVersion": "2026-01-01",
           "name": "[parameters('target_resource_name')]",
           "location": "global",
           "properties": {}


### PR DESCRIPTION
Related command
az network private-endpoint create
az network private-endpoint-connection show/approve/list/reject

Description
This PR update the Microsoft.Security/privateLinks RP to use 2026-01-01 stable api-version.

Testing Guide
Updated the SecurityPrivateLinksNetworkARMTemplateBasedScenarioTest class that can be run using azdev test SecurityPrivateLinksNetworkARMTemplateBasedScenarioTest.

History Notes
N/A