### PR TITLE
{Core} Bump MSAL to 1.35.0b1

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -55,8 +55,8 @@ DEPENDENCIES = [
     'knack~=0.11.0',
     'microsoft-security-utilities-secret-masker~=1.0.0b4',
     'msal-extensions==1.2.0',
-    'msal[broker]==1.34.0b1; sys_platform == "win32"',
-    'msal==1.34.0b1; sys_platform != "win32"',
+    'msal[broker]==1.35.0b1; sys_platform == "win32"',
+    'msal==1.35.0b1; sys_platform != "win32"',
     'packaging>=20.9',
     'pkginfo>=1.5.0.1',
     # psutil can't install on cygwin: https://github.com/Azure/azure-cli/issues/9399

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -109,7 +109,7 @@ jmespath==0.9.5
 jsondiff==2.0.0
 knack==0.11.0
 msal-extensions==1.2.0
-msal==1.34.0b1
+msal==1.35.0b1
 msrest==0.7.1
 oauthlib==3.2.2
 packaging==25.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -110,7 +110,7 @@ jmespath==0.9.5
 jsondiff==2.0.0
 knack==0.11.0
 msal-extensions==1.2.0
-msal==1.34.0b1
+msal==1.35.0b1
 msrest==0.7.1
 oauthlib==3.2.2
 packaging==25.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -109,7 +109,7 @@ jmespath==0.9.5
 jsondiff==2.0.0
 knack==0.11.0
 msal-extensions==1.2.0
-msal[broker]==1.34.0b1
+msal[broker]==1.35.0b1
 msrest==0.7.1
 oauthlib==3.2.2
 packaging==25.0


### PR DESCRIPTION
Fix https://github.com/Azure/azure-cli/issues/31900, IcM 700647529

**Related command**
`az login`

**Description**<!--Mandatory-->
Bump MSAL to [1.35.0b1](https://github.com/AzureAD/microsoft-authentication-library-for-python/releases/tag/1.35.0b1) to pick up new changes, especially the removal of `getfqdn()` for managed identity flow (https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/859), so that `az login` doesn't hang (https://github.com/Azure/azure-cli/issues/31900) or fail (IcM 700647529) with misconfigured network setup.

**History Notes**
[Profile] `az login`: For managed identity authentication, no longer retrieve the FQDN of the machine, bypassing hanging or error caused by misconfigured network setup.
