### PR TITLE
[App Service] `az webapp create`: Update this and similar commands to use new Site-level outboundVnetRouting property

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -3199,16 +3199,20 @@ def update_site_configs(cmd, resource_group_name, name, slot=None, number_of_wor
             setattr(configs, 'function_app_scale_limit', max_replicas)
         return update_configuration_polling(cmd, resource_group_name, name, slot, configs)
 
+    # Update SiteConfig first
+    result = _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'update_configuration', slot, configs)
+
     # Handle vnet_route_all_enabled separately using Site-level outbound_vnet_routing property
+    # This is done after SiteConfig update to ensure the Site-level property is not overwritten
     if vnet_route_all_enabled is not None:
         from azure.mgmt.web.models import OutboundVnetRouting
         client = web_client_factory(cmd.cli_ctx)
         app = _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'get', slot, client=client)
-        app.outbound_vnet_routing = OutboundVnetRouting(application_traffic=(vnet_route_all_enabled == 'true'))
+        app.outbound_vnet_routing = OutboundVnetRouting(application_traffic=vnet_route_all_enabled == 'true')
         _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'begin_create_or_update', slot,
                                 client=client, extra_parameter=app)
 
-    return _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'update_configuration', slot, configs)
+    return result
 
 
 def update_configuration_polling(cmd, resource_group_name, name, slot, configs):

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands.py
@@ -3444,7 +3444,7 @@ class FunctionappNetworkConnectionTests(ScenarioTest):
 
         self.cmd('functionapp create -g {} -n {} -s {} -p {} --functions-version 4 --vnet {} --subnet {}'.format(resource_group, functionapp_name, storage_account, ep_plan_name, vnet_name, subnet_name)).assert_with_checks([
             JMESPathCheck('vnetContentShareEnabled', True),
-            JMESPathCheck('vnetRouteAllEnabled', True),
+            JMESPathCheck('outboundVnetRouting.applicationTraffic', True),
             JMESPathCheck('virtualNetworkSubnetId', subnet_id)
         ])
 


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az webapp create
az webapp config set
az webapp vnet-integration add
az functionapp create
az functionapp vnet-integration add

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Update webapp and functionapp commands to use the new Site-level outboundVnetRouting property instead of the deprecated SiteConfig vnetRouteAllEnabled property for API version 2024-11-01.

The vnetRouteAllEnabled property on SiteConfig is no longer honored by the API. This PR migrates to the new OutboundVnetRouting model with application_traffic=True to maintain backward compatibility and the same user-facing behavior.

az webapp create - Use outbound_vnet_routing on Site object
az functionapp create - Use outbound_vnet_routing on Site object
az webapp vnet-integration add - Use outbound_vnet_routing on Site object
az functionapp vnet-integration add - Use outbound_vnet_routing on Site object
az webapp config set --vnet-route-all-enabled - Now updates Site-level outbound_vnet_routing property instead of SiteConfig

**Testing Guide**
<!--Example commands with explanations.-->
# Test webapp create with vnet integration
az webapp create -g <rg> -p <plan> -n <name> --vnet <vnet> --subnet <subnet>
az webapp show -g <rg> -n <name> --query "outboundVnetRouting"
# Expected: applicationTraffic: true

# Test webapp config set
az webapp config set -g <rg> -n <name> --vnet-route-all-enabled false
az webapp show -g <rg> -n <name> --query "outboundVnetRouting.applicationTraffic"
# Expected: false

az webapp config set -g <rg> -n <name> --vnet-route-all-enabled true
az webapp show -g <rg> -n <name> --query "outboundVnetRouting.applicationTraffic"
# Expected: true


**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[App Service] `az webapp create/config set`: Fix vnet routing to use site-level outbound vnet routing property for API version `2024-11-01`
[App Service] `az webapp vnet-integration add`: Fix vnet routing to use site-level outbound vnet routing property for API version `2024-11-01`
[App Service] `az functionapp create/vnet-integration add`: Fix vnet routing to use site-level outbound vnet routing property for API version `2024-11-01`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
