### PR TITLE
{CI} rm _vendor/bin from setuptools for rpm

### DIFF
--- a/scripts/release/rpm/azure-cli.spec
+++ b/scripts/release/rpm/azure-cli.spec
@@ -57,6 +57,10 @@ deactivate
 for d in %{buildroot}%{cli_lib_dir}/bin/*; do perl -p -i -e "s#%{buildroot}##g" $d; done;
 rm %{buildroot}%{cli_lib_dir}/pyvenv.cfg
 
+# Remove vendored binaries with foreign shebangs that cause RPM dependency issues
+# Use || true to not fail if path doesn't exist
+rm -rf %{buildroot}%{cli_lib_dir}/lib/python*/site-packages/setuptools/_vendor/bin || true
+
 # Create executable (entry script)
 
 # For PYTHONPATH:


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Addressing issue that surfaced [here](https://dev.azure.com/azclitools/public/_build/results?buildId=292722&view=logs&j=1ef531ff-da39-56ef-4b6e-e80dda062c0a&t=25c46730-3e0b-56cf-a8c6-a5b37a8d9315) in azure-cli `batched CI` pipelines. 

Output of error from pipelines:
```
1.080 Error: 
1.080  Problem: conflicting requests
1.080   - nothing provides /Users/jaraco/code/pypa/setuptools/.tox/vendor/bin/python3 needed by azure-cli-2.82.0-1.el9.x86_64 from @commandline
1.081 (try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
------
ubi.dockerfile:31
```

File in question was added to setuptools [here](https://github.com/pypa/setuptools/pull/5139/changes#diff-0bc3b78522d7d476745abe9653b98f3745d5ff7409b045cb801bc4541413fa62R1)

Note, GH issue has been lodged with `setuptools` repo: https://github.com/pypa/setuptools/issues/5159
This PR may not be necessary if a fix is applied on setuptools within the next few days, otherwise we may need the workaround in this PR. 

Update: looks like maintainers may update with a fix: https://github.com/pypa/setuptools/pull/5166, hopefully it is released soon. 

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
