### PR TITLE
[MySQL] `az mysql flexible-server mirroring enable/disable`: Support fabric mirroring

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/mysql/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/mysql/_client_factory.py
@@ -141,6 +141,10 @@ def private_dns_link_client_factory(cli_ctx, subscription_id=None):
                                    subscription_id=subscription_id).virtual_network_links
 
 
+def cf_mysql_flexible_fabric_mirroring_settings(cli_ctx, _):
+    return get_mysql_flexible_management_client(cli_ctx).fabric_mirroring_settings
+
+
 # Operations for single server
 def cf_mysql_servers(cli_ctx, _):
     return get_mysql_management_client(cli_ctx).servers

--- a/src/azure-cli/azure/cli/command_modules/mysql/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/mysql/_help.py
@@ -902,3 +902,33 @@ examples:
   - name: Create a export backup for 'testsvr' with backup name 'testbackup'.
     text: az mysql flexible-server export create -g testgroup -n testsvr -b testbackup -u destsasuri
 """
+
+helps['mysql flexible-server mirroring'] = """
+type: group
+short-summary: Manage Microsoft Fabric Mirroring for Azure Database for MySQL Flexible Server.
+long-summary: |
+  Fabric Mirroring allows continuous data replication from MySQL Flexible Server into Microsoft Fabric for analytics and reporting.
+"""
+
+helps['mysql flexible-server mirroring enable'] = """
+type: command
+short-summary: Enable Fabric Mirroring for a MySQL Flexible Server.
+long-summary: |
+  Configures the server for Fabric Mirroring.
+  Requires a User Assigned Managed Identity (UAMI) resource ID with appropriate permissions.
+examples:
+  - name: Enable Fabric Mirroring for server 'testsvr' using a User Assigned Managed Identity.
+    text: >
+      az mysql flexible-server mirroring enable -g testgroup -n testsvr \
+        --identity-resource-id /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<name>
+"""
+
+helps['mysql flexible-server mirroring disable'] = """
+type: command
+short-summary: Disable Fabric Mirroring for a MySQL Flexible Server.
+long-summary: |
+  Removes Fabric Mirroring configuration from the server.
+examples:
+  - name: Disable Fabric Mirroring for server 'testsvr'.
+    text: az mysql flexible-server mirroring disable -g testgroup -n testsvr
+"""

--- a/src/azure-cli/azure/cli/command_modules/mysql/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/mysql/_params.py
@@ -736,3 +736,10 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
             elif scope == "check-name-availability":
                 c.argument('migration_name', arg_type=migration_id_arg_type, options_list=['--migration-name'],
                            help='Name of the migration.')
+
+    with self.argument_context('mysql flexible-server mirroring enable') as c:
+        c.argument('server_name', id_part=None, arg_type=server_name_arg_type)
+        c.argument('uami', options_list=['--identity-resource-id'], help='Resource ID of the User Assigned Managed Identity (UAMI) used for Fabric Mirroring. Example: /subscriptions/{sub-id}/resourceGroups/{rg}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identity-name}')
+
+    with self.argument_context('mysql flexible-server mirroring disable') as c:
+        c.argument('server_name', id_part=None, arg_type=server_name_arg_type)

--- a/src/azure-cli/azure/cli/command_modules/mysql/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/mysql/commands.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
-
 from azure.cli.core.commands import CliCommandType
 from azure.cli.command_modules.mysql._client_factory import (
     cf_mysql_advanced_threat_protection,
@@ -17,7 +16,8 @@ from azure.cli.command_modules.mysql._client_factory import (
     cf_mysql_flexible_backups,
     cf_mysql_flexible_adadmin,
     cf_mysql_flexible_export,
-    cf_mysql_flexible_maintenances)
+    cf_mysql_flexible_maintenances,
+    cf_mysql_flexible_fabric_mirroring_settings)
 from ._transformers import (
     table_transform_output,
     table_transform_output_list_servers,
@@ -93,6 +93,11 @@ def load_command_table(self, _):
     mysql_flexible_maintenance_sdk = CliCommandType(
         operations_tmpl='azure.mgmt.mysqlflexibleservers.operations#MaintenancesOperations.{}',
         client_factory=cf_mysql_flexible_maintenances
+    )
+
+    mysql_flexible_fabric_mirroring_settings_sdk = CliCommandType(
+        operations_tmpl='azure.mgmt.rdbms.mysql_flexibleservers.operations#FabricMirroringSettingsOperations.{}',
+        client_factory=cf_mysql_flexible_fabric_mirroring_settings
     )
 
     # MERU COMMANDS
@@ -236,3 +241,10 @@ def load_command_table(self, _):
         g.custom_command('reschedule', 'flexible_server_maintenance_reschedule')
         g.custom_command('list', 'flexible_server_maintenance_list')
         g.custom_show_command('show', 'flexible_server_maintenance_show')
+
+    with self.command_group('mysql flexible-server mirroring',
+                            mysql_flexible_fabric_mirroring_settings_sdk,
+                            custom_command_type=mysql_custom,
+                            client_factory=cf_mysql_flexible_fabric_mirroring_settings) as g:
+        g.custom_command('enable', 'flexible_server_mirroring_enable')
+        g.custom_command('disable', 'flexible_server_mirroring_disable')

--- a/src/azure-cli/azure/cli/command_modules/mysql/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/mysql/custom.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # --------------------------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
@@ -2021,6 +2022,49 @@ def migrate_firewall_rules_from_single_to_flex(db_context, cmd, source_server_id
                              start_ip=rule.start_ip_address,
                              end_ip=rule.end_ip_address,
                              firewall_rule_name=rule.name)
+
+
+def _fm_settings_payload(state, uami=None):
+    """
+    Build the flattened payload expected by the SDK for FabricMirroringSettings.
+    Because of x-ms-client-flatten, we set properties at the top level.
+    """
+    # Most recent autorest will let us pass state/identityResourceId directly on the Settings model
+    return mysql_models.FabricMirroringSettings(
+        state=state,
+        identity_resource_id=uami  # optional when disabling
+    )
+
+
+def flexible_server_mirroring_enable(cmd, client, resource_group_name, server_name, identity_resource_id):
+    """
+    'Enable' translates to PUT the 'Default' FabricMirroringSettings with state=Enabled and UAMI.
+    The Swagger limits settings name to 'Default'.
+    """
+    if not identity_resource_id:
+        raise RequiredArgumentMissingError(
+            "Parameter --identity-resource-id is required when enabling fabric mirroring."
+        )
+
+    payload = _fm_settings_payload(state='Enabled', uami=identity_resource_id)
+
+    # Long-running operation
+    poller = (getattr(client, 'begin_create_or_update', None) or getattr(client, 'begin_put'))(
+        resource_group_name, server_name, 'Default', payload
+    )
+    return resolve_poller(poller, cmd.cli_ctx, 'Enable Fabric mirroring')
+
+
+def flexible_server_mirroring_disable(cmd, client, resource_group_name, server_name):
+    """
+    'Disable' translates to PUT the 'Default' FabricMirroringSettings with state=Disabled.
+    identityResourceId can be omitted when disabling<97>service will deactivate/clean bindings.
+    """
+    payload = _fm_settings_payload(state='Disabled', uami=None)
+    poller = (getattr(client, 'begin_create_or_update', None) or getattr(client, 'begin_put'))(
+        resource_group_name, server_name, 'Default', payload
+    )
+    return resolve_poller(poller, cmd.cli_ctx, 'Disable Fabric mirroring')
 
 
 # pylint: disable=too-many-instance-attributes, too-few-public-methods

--- a/src/azure-cli/azure/cli/command_modules/mysql/tests/latest/test_mysql_scenario.py
+++ b/src/azure-cli/azure/cli/command_modules/mysql/tests/latest/test_mysql_scenario.py
@@ -2351,3 +2351,41 @@ class MySQLExportTest(ScenarioTest):
 
         # deletion of single server created
         self.cmd('{} flexible-server delete -g {} -n {} --yes'.format(database_engine, resource_group, server), checks=NoneCheck())
+
+
+class MySQLFabricMirroringEnableDisableTest(ScenarioTest):
+    """Scenario tests for Fabric Mirroring enable/disable commands."""
+
+    @AllowLargeResponse()
+    @ResourceGroupPreparer(location='eastus2euap')
+    def test_mysql_fabric_mirroring_enable_disable(self, resource_group):
+        # Arrange
+        server_name = self.create_random_name(SERVER_NAME_PREFIX, SERVER_NAME_MAX_LENGTH)
+        identity_name = self.create_random_name('identity', 24)
+        location = 'eastus2euap'
+
+        # Create server (GeneralPurpose tier required for Fabric Mirroring, using Standard_D2ads_v5 valid in eastus2euap)
+        create_result = self.cmd('mysql flexible-server create -l {} -g {} -n {} --public-access {} --tier GeneralPurpose --sku-name {}'
+                                 .format(location, resource_group, server_name, '0.0.0.0', 'Standard_D2ads_v5')).get_output_in_json()
+
+        # Verify server was created by checking the host contains the server name
+        self.assertIn(server_name, create_result['host'])
+
+        # Set binlog_row_image to 'noblob' as required for Fabric Mirroring
+        self.cmd('mysql flexible-server parameter set -g {} -s {} -n binlog_row_image -v noblob'
+                 .format(resource_group, server_name))
+
+        # Create User Assigned Managed Identity
+        identity_result = self.cmd('identity create -g {} -n {}'.format(resource_group, identity_name)).get_output_in_json()
+        identity_id = identity_result['id']
+
+        # Enable Fabric Mirroring
+        self.cmd('mysql flexible-server mirroring enable -g {} -n {} --identity-resource-id {}'
+                 .format(resource_group, server_name, identity_id))
+
+        # Disable Fabric Mirroring
+        self.cmd('mysql flexible-server mirroring disable -g {} -n {}'
+                 .format(resource_group, server_name))
+
+        # Cleanup
+        self.cmd('mysql flexible-server delete -g {} -n {} --yes'.format(resource_group, server_name))


### PR DESCRIPTION
To enable fabric mirroring on the server:
az mysql flexible-server mirroring enable --resource-group <resource-group-name> --name <server-name> --identity-resource-id <uami-resource-id>

To disable fabric mirroring on the server:
az mysql flexible-server mirroring disable --resource-group <resource-group-name> --name <server-name>


**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[MySQL] `az mysql flexible-server mirroring enable/disable`: Support fabric mirroring

<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ❌ Action needed

| Breaking Changes | Tests |
| :--: | :--: |
| ⚠️ None | ❌ 128/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Warning" summary="None" -->
<!-- AzureCLI-BreakingChangeTest --><details>
<summary>⚠️AzureCLI-BreakingChangeTest</summary>

><details>
> <summary>⚠️mysql</summary>
>
>|rule|cmd_name|rule_message|suggest_message|
>|---|---|---|---|
>|⚠️ [1011 - SubgroupAdd](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1011.md)|mysql flexible-server mirroring|sub group `mysql flexible-server mirroring` added||
>
></details>
</details>

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Failed" summary="128/130" -->
<details>
<summary>❌AzureCLI-FullTest</summary>

><details>
> <summary>️✔️acr</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️acs</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️advisor</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️ams</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️apim</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️appconfig</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️appservice</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️aro</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️backup</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️batch</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️batchai</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️billing</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️botservice</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️cloud</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️cognitiveservices</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️compute_recommender</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️computefleet</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️config</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️configure</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️consumption</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️container</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️containerapp</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️core</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️cosmosdb</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️databoxedge</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️dls</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️dms</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️eventgrid</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️eventhubs</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️feedback</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️find</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️hdinsight</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️identity</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️iot</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️keyvault</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️lab</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️managedservices</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️maps</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️marketplaceordering</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️monitor</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>❌mysql</summary>
>
>><details>
>> <summary>❌latest</summary>
>>
>>><details>
>>> <summary>❌3.12</summary>
>>>
>>>|Type|Test Case|Error Message|Line|
>>>|---|---|---|---|
>>>|Failed|test_mysql_fabric_mirroring_enable_disable|self&nbsp;=&nbsp;<azure.cli.testsdk.base.ExecutionResult&nbsp;object&nbsp;at&nbsp;0x7f63ed9e1d00><br>cli_ctx&nbsp;=&nbsp;<azure.cli.core.mock.DummyCli&nbsp;object&nbsp;at&nbsp;0x7f63edf2e480><br>command&nbsp;=&nbsp;'group&nbsp;create&nbsp;--location&nbsp;eastus2euap&nbsp;--name&nbsp;clitest.rgflddjbhlfipw62hrqam2jrmmkkbryir5po2ksfnje3lbjavke4kh4zv5xopxulgs...=azurecli&nbsp;cause=automation&nbsp;test&nbsp;date=2026-07-23T06:42:54Z&nbsp;test=test_mysql_fabric_mirroring_enable_disable&nbsp;module=mysql'<br>expect_failure&nbsp;=&nbsp;False<br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;_in_process_execute(self,&nbsp;cli_ctx,&nbsp;command,&nbsp;expect_failure=False):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;io&nbsp;import&nbsp;StringIO<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;vcr.errors&nbsp;import&nbsp;CannotOverwriteExistingCassetteException<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;command.startswith('az&nbsp;'):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;command&nbsp;=&nbsp;command[3:]<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stdout_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;logging_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;try:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;issue:&nbsp;stderr&nbsp;cannot&nbsp;be&nbsp;redirect&nbsp;in&nbsp;this&nbsp;form,&nbsp;as&nbsp;a&nbsp;result&nbsp;some&nbsp;failure&nbsp;information<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;is&nbsp;lost&nbsp;when&nbsp;command&nbsp;fails.<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.exit_code&nbsp;=&nbsp;cli_ctx.invoke(shlex.split(command),&nbsp;out_file=stdout_buf)&nbsp;or&nbsp;0<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br><br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:303:&nbsp;<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br>env/lib/python3.12/site-packages/knack/cli.py:245:&nbsp;in&nbsp;invoke<br>&nbsp;&nbsp;&nbsp;&nbsp;exit_code&nbsp;=&nbsp;self.exception_handler(ex)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/__init__.py:153:&nbsp;in&nbsp;exception_handler<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;handle_exception(ex)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br><br>ex&nbsp;=&nbsp;CLIError("Please&nbsp;run&nbsp;'az&nbsp;login'&nbsp;to&nbsp;setup&nbsp;account."),&nbsp;args&nbsp;=&nbsp;(),&nbsp;kwargs&nbsp;=&nbsp;{}<br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;_handle_main_exception(ex,&nbsp;*args,&nbsp;**kwargs):&nbsp;&nbsp;#&nbsp;pylint:&nbsp;disable=unused-argument<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;isinstance(ex,&nbsp;CannotOverwriteExistingCassetteException):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;This&nbsp;exception&nbsp;usually&nbsp;caused&nbsp;by&nbsp;a&nbsp;no&nbsp;match&nbsp;HTTP&nbsp;request.&nbsp;This&nbsp;is&nbsp;a&nbsp;product&nbsp;error<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;that&nbsp;is&nbsp;caused&nbsp;by&nbsp;change&nbsp;of&nbsp;SDK&nbsp;invocation.<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;ex<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;CliExecutionError(ex)<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;azure.cli.testsdk.exceptions.CliExecutionError:&nbsp;The&nbsp;CLI&nbsp;throws&nbsp;exception&nbsp;CLIError&nbsp;during&nbsp;execution&nbsp;and&nbsp;fails&nbsp;the&nbsp;command.<br><br>src/azure-cli-testsdk/azure/cli/testsdk/patches.py:35:&nbsp;CliExecutionError<br><br>During&nbsp;handling&nbsp;of&nbsp;the&nbsp;above&nbsp;exception,&nbsp;another&nbsp;exception&nbsp;occurred:<br>src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/decorators.py:40:&nbsp;in&nbsp;_preparer_wrapper<br>&nbsp;&nbsp;&nbsp;&nbsp;fn(test_class_instance,&nbsp;**kwargs)<br>src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/preparers.py:39:&nbsp;in&nbsp;_preparer_wrapper<br>&nbsp;&nbsp;&nbsp;&nbsp;parameter_update&nbsp;=&nbsp;self.create_resource(<br>src/azure-cli-testsdk/azure/cli/testsdk/preparers.py:99:&nbsp;in&nbsp;create_resource<br>&nbsp;&nbsp;&nbsp;&nbsp;self.live_only_execute(self.cli_ctx,&nbsp;template.format(self.location,&nbsp;name))<br>src/azure-cli-testsdk/azure/cli/testsdk/preparers.py:39:&nbsp;in&nbsp;live_only_execute<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;self._raw_execute(cli_ctx,&nbsp;command,&nbsp;expect_failure)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:252:&nbsp;in&nbsp;__init__<br>&nbsp;&nbsp;&nbsp;&nbsp;self._in_process_execute(cli_ctx,&nbsp;command,&nbsp;expect_failure=expect_failure)<br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:315:&nbsp;in&nbsp;_in_process_execute<br>&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;ex.exception<br>env/lib/python3.12/site-packages/knack/cli.py:233:&nbsp;in&nbsp;invoke<br>&nbsp;&nbsp;&nbsp;&nbsp;cmd_result&nbsp;=&nbsp;self.invocation.execute(args)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:677:&nbsp;in&nbsp;execute<br>&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;ex<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:820:&nbsp;in&nbsp;_run_jobs_serially<br>&nbsp;&nbsp;&nbsp;&nbsp;results.append(self._run_job(expanded_arg,&nbsp;cmd_copy))<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:789:&nbsp;in&nbsp;_run_job<br>&nbsp;&nbsp;&nbsp;&nbsp;result&nbsp;=&nbsp;cmd_copy(params)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:335:&nbsp;in&nbsp;__call__<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;self.handler(*args,&nbsp;**kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/command_operation.py:120:&nbsp;in&nbsp;handler<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;op(**command_args)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^<br>src/azure-cli/azure/cli/command_modules/resource/custom.py:1641:&nbsp;in&nbsp;create_resource_group<br>&nbsp;&nbsp;&nbsp;&nbsp;rcf&nbsp;=&nbsp;_resource_client_factory(cmd.cli_ctx)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli/azure/cli/command_modules/resource/_client_factory.py:10:&nbsp;in&nbsp;_resource_client_factory<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;get_mgmt_service_client(cli_ctx,&nbsp;ResourceType.MGMT_RESOURCE_RESOURCES)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/client_factory.py:83:&nbsp;in&nbsp;get_mgmt_service_client<br>&nbsp;&nbsp;&nbsp;&nbsp;client,&nbsp;_&nbsp;=&nbsp;_get_mgmt_service_client(cli_ctx,&nbsp;client_type,&nbsp;subscription_id=subscription_id,<br>src/azure-cli-core/azure/cli/core/commands/client_factory.py:234:&nbsp;in&nbsp;_get_mgmt_service_client<br>&nbsp;&nbsp;&nbsp;&nbsp;credential,&nbsp;subscription_id,&nbsp;_&nbsp;=&nbsp;profile.get_login_credentials(<br>src/azure-cli-core/azure/cli/core/_profile.py:342:&nbsp;in&nbsp;get_login_credentials<br>&nbsp;&nbsp;&nbsp;&nbsp;account&nbsp;=&nbsp;self.get_subscription(subscription_id)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br><br>self&nbsp;=&nbsp;<azure.cli.core._profile.Profile&nbsp;object&nbsp;at&nbsp;0x7f63ed14deb0><br>subscription&nbsp;=&nbsp;None<br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;get_subscription(self,&nbsp;subscription=None):&nbsp;&nbsp;#&nbsp;take&nbsp;id&nbsp;or&nbsp;name<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;subscriptions&nbsp;=&nbsp;self.load_cached_subscriptions()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;not&nbsp;subscriptions:<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;CLIError(_AZ_LOGIN_MESSAGE)<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;knack.util.CLIError:&nbsp;Please&nbsp;run&nbsp;'az&nbsp;login'&nbsp;to&nbsp;setup&nbsp;account.<br><br>src/azure-cli-core/azure/cli/core/_profile.py:608:&nbsp;CLIError|azure/cli/command_modules/mysql/tests/latest/test_mysql_scenario.py:2381|
>>>
>>></details>
>>><details>
>>> <summary>❌3.14</summary>
>>>
>>>|Type|Test Case|Error Message|Line|
>>>|---|---|---|---|
>>>|Failed|test_mysql_fabric_mirroring_enable_disable|self&nbsp;=&nbsp;<azure.cli.testsdk.base.ExecutionResult&nbsp;object&nbsp;at&nbsp;0x7f8a0aae2660><br>cli_ctx&nbsp;=&nbsp;<azure.cli.core.mock.DummyCli&nbsp;object&nbsp;at&nbsp;0x7f8a0a77a350><br>command&nbsp;=&nbsp;'group&nbsp;create&nbsp;--location&nbsp;eastus2euap&nbsp;--name&nbsp;clitest.rgxyb7h6jdexjn4idqxvsf6nsvnzydzoakx734jvv3kj6o6hcetmlkxpvjwrvmxvkq...=azurecli&nbsp;cause=automation&nbsp;test&nbsp;date=2026-07-23T06:42:47Z&nbsp;test=test_mysql_fabric_mirroring_enable_disable&nbsp;module=mysql'<br>expect_failure&nbsp;=&nbsp;False<br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;_in_process_execute(self,&nbsp;cli_ctx,&nbsp;command,&nbsp;expect_failure=False):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;io&nbsp;import&nbsp;StringIO<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;from&nbsp;vcr.errors&nbsp;import&nbsp;CannotOverwriteExistingCassetteException<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;command.startswith('az&nbsp;'):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;command&nbsp;=&nbsp;command[3:]<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stdout_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;logging_buf&nbsp;=&nbsp;StringIO()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;try:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;issue:&nbsp;stderr&nbsp;cannot&nbsp;be&nbsp;redirect&nbsp;in&nbsp;this&nbsp;form,&nbsp;as&nbsp;a&nbsp;result&nbsp;some&nbsp;failure&nbsp;information<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;is&nbsp;lost&nbsp;when&nbsp;command&nbsp;fails.<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;self.exit_code&nbsp;=&nbsp;cli_ctx.invoke(shlex.split(command),&nbsp;out_file=stdout_buf)&nbsp;or&nbsp;0<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br><br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:303:&nbsp;<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br>env/lib/python3.14/site-packages/knack/cli.py:245:&nbsp;in&nbsp;invoke<br>&nbsp;&nbsp;&nbsp;&nbsp;exit_code&nbsp;=&nbsp;self.exception_handler(ex)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/__init__.py:153:&nbsp;in&nbsp;exception_handler<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;handle_exception(ex)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br><br>ex&nbsp;=&nbsp;CLIError("Please&nbsp;run&nbsp;'az&nbsp;login'&nbsp;to&nbsp;setup&nbsp;account."),&nbsp;args&nbsp;=&nbsp;(),&nbsp;kwargs&nbsp;=&nbsp;{}<br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;_handle_main_exception(ex,&nbsp;*args,&nbsp;**kwargs):&nbsp;&nbsp;#&nbsp;pylint:&nbsp;disable=unused-argument<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;isinstance(ex,&nbsp;CannotOverwriteExistingCassetteException):<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;This&nbsp;exception&nbsp;usually&nbsp;caused&nbsp;by&nbsp;a&nbsp;no&nbsp;match&nbsp;HTTP&nbsp;request.&nbsp;This&nbsp;is&nbsp;a&nbsp;product&nbsp;error<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;that&nbsp;is&nbsp;caused&nbsp;by&nbsp;change&nbsp;of&nbsp;SDK&nbsp;invocation.<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;ex<br>&nbsp;&nbsp;&nbsp;&nbsp;<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;CliExecutionError(ex)<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;azure.cli.testsdk.exceptions.CliExecutionError:&nbsp;The&nbsp;CLI&nbsp;throws&nbsp;exception&nbsp;CLIError&nbsp;during&nbsp;execution&nbsp;and&nbsp;fails&nbsp;the&nbsp;command.<br><br>src/azure-cli-testsdk/azure/cli/testsdk/patches.py:35:&nbsp;CliExecutionError<br><br>During&nbsp;handling&nbsp;of&nbsp;the&nbsp;above&nbsp;exception,&nbsp;another&nbsp;exception&nbsp;occurred:<br>src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/decorators.py:40:&nbsp;in&nbsp;_preparer_wrapper<br>&nbsp;&nbsp;&nbsp;&nbsp;fn(test_class_instance,&nbsp;**kwargs)<br>src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/preparers.py:39:&nbsp;in&nbsp;_preparer_wrapper<br>&nbsp;&nbsp;&nbsp;&nbsp;parameter_update&nbsp;=&nbsp;self.create_resource(<br>src/azure-cli-testsdk/azure/cli/testsdk/preparers.py:99:&nbsp;in&nbsp;create_resource<br>&nbsp;&nbsp;&nbsp;&nbsp;self.live_only_execute(self.cli_ctx,&nbsp;template.format(self.location,&nbsp;name))<br>src/azure-cli-testsdk/azure/cli/testsdk/preparers.py:39:&nbsp;in&nbsp;live_only_execute<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;self._raw_execute(cli_ctx,&nbsp;command,&nbsp;expect_failure)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:252:&nbsp;in&nbsp;__init__<br>&nbsp;&nbsp;&nbsp;&nbsp;self._in_process_execute(cli_ctx,&nbsp;command,&nbsp;expect_failure=expect_failure)<br>src/azure-cli-testsdk/azure/cli/testsdk/base.py:315:&nbsp;in&nbsp;_in_process_execute<br>&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;ex.exception<br>env/lib/python3.14/site-packages/knack/cli.py:233:&nbsp;in&nbsp;invoke<br>&nbsp;&nbsp;&nbsp;&nbsp;cmd_result&nbsp;=&nbsp;self.invocation.execute(args)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:677:&nbsp;in&nbsp;execute<br>&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;ex<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:820:&nbsp;in&nbsp;_run_jobs_serially<br>&nbsp;&nbsp;&nbsp;&nbsp;results.append(self._run_job(expanded_arg,&nbsp;cmd_copy))<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:789:&nbsp;in&nbsp;_run_job<br>&nbsp;&nbsp;&nbsp;&nbsp;result&nbsp;=&nbsp;cmd_copy(params)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/__init__.py:335:&nbsp;in&nbsp;__call__<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;self.handler(*args,&nbsp;**kwargs)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/command_operation.py:120:&nbsp;in&nbsp;handler<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;op(**command_args)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^<br>src/azure-cli/azure/cli/command_modules/resource/custom.py:1641:&nbsp;in&nbsp;create_resource_group<br>&nbsp;&nbsp;&nbsp;&nbsp;rcf&nbsp;=&nbsp;_resource_client_factory(cmd.cli_ctx)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli/azure/cli/command_modules/resource/_client_factory.py:10:&nbsp;in&nbsp;_resource_client_factory<br>&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;get_mgmt_service_client(cli_ctx,&nbsp;ResourceType.MGMT_RESOURCE_RESOURCES)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>src/azure-cli-core/azure/cli/core/commands/client_factory.py:83:&nbsp;in&nbsp;get_mgmt_service_client<br>&nbsp;&nbsp;&nbsp;&nbsp;client,&nbsp;_&nbsp;=&nbsp;_get_mgmt_service_client(cli_ctx,&nbsp;client_type,&nbsp;subscription_id=subscription_id,<br>src/azure-cli-core/azure/cli/core/commands/client_factory.py:234:&nbsp;in&nbsp;_get_mgmt_service_client<br>&nbsp;&nbsp;&nbsp;&nbsp;credential,&nbsp;subscription_id,&nbsp;_&nbsp;=&nbsp;profile.get_login_credentials(<br>src/azure-cli-core/azure/cli/core/_profile.py:342:&nbsp;in&nbsp;get_login_credentials<br>&nbsp;&nbsp;&nbsp;&nbsp;account&nbsp;=&nbsp;self.get_subscription(subscription_id)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<br>_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;_&nbsp;<br><br>self&nbsp;=&nbsp;<azure.cli.core._profile.Profile&nbsp;object&nbsp;at&nbsp;0x7f8a0f917cb0><br>subscription&nbsp;=&nbsp;None<br><br>&nbsp;&nbsp;&nbsp;&nbsp;def&nbsp;get_subscription(self,&nbsp;subscription=None):&nbsp;&nbsp;#&nbsp;take&nbsp;id&nbsp;or&nbsp;name<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;subscriptions&nbsp;=&nbsp;self.load_cached_subscriptions()<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;not&nbsp;subscriptions:<br>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raise&nbsp;CLIError(_AZ_LOGIN_MESSAGE)<br>E&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;knack.util.CLIError:&nbsp;Please&nbsp;run&nbsp;'az&nbsp;login'&nbsp;to&nbsp;setup&nbsp;account.<br><br>src/azure-cli-core/azure/cli/core/_profile.py:608:&nbsp;CLIError|azure/cli/command_modules/mysql/tests/latest/test_mysql_scenario.py:2381|
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️netappfiles</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️network</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️policyinsights</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️postgresql</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️privatedns</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️profile</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️rdbms</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️redis</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️relay</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️resource</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️role</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️search</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️security</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️servicebus</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️serviceconnector</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️servicefabric</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️signalr</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️sql</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️sqlvm</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️storage</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️synapse</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️telemetry</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️util</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
><details>
> <summary>️✔️vm</summary>
>
>><details>
>> <summary>️✔️latest</summary>
>>
>>><details>
>>> <summary>️✔️3.12</summary>
>>>
>>>
>>></details>
>>><details>
>>> <summary>️✔️3.14</summary>
>>>
>>>
>>></details>
>></details>
></details>
</details>

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->