### PR TITLE
{Core} Add discernable telemetry for `--help` commands

### DIFF
--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -186,6 +186,7 @@ class AzCliCommandParser(CLICommandParser):
 
         telemetry.set_command_details(
             command=self.prog[3:],
+            parameters=['--help'],
             extension_name=extension_name,
             extension_version=extension_version)
         telemetry.set_success(summary='show help')


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Previously, there was no way in telemetry to query commands from the `--help` family. This PR add `--help` to the telemetry payload (using the `Params` property). 

Tested conditions:

- [x] Top-level `az help`
- [x] Top-level `az --help`
- [x] Top-level `az -h`
- [x] Module-level `--help`
- [x] Module-level `-h`
- [x] Command-level `--help`
- [x] Command-level `-h`
- [x] `IsCmdIdxRebuildTriggered` still set correctly
- [x] Verify telemetry can be found in `Kusto`

To query in Kusto:

 Commands (successful) sent from this branch:
```
RawEventsAzCli
| where Params == "--help"
| where ActionResult == "Success"
```

In Kusto, there are many records already with `Params` set to `--help`, however they are only for records where `ActionResult` != `Success`. It appears records can make it to Kusto with `Params` set to `--help` if someone has set `extension.use_dynamic_install=yes_prompt` and cancel out of a prompt to install an extension, initiated by a command appended with `--help`, i.e., `az monitor scheduled-query --help`. 

You can view these records with this query:
```
RawEventsAzCli
| where Params == "--help"
| where ActionResult != "Success"
```

The ResultSummary="show help" records appearing in Kusto are from legacy dev environments running editable installs that report as version 0.1.1b3+dev. These use the old event naming convention (azurecli/commands/vm) which isn't in the suppression list, while modern versions use azurecli/command (which is suppressed). The fix is working correctly for production users.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
