### PR TITLE
[ARM] `az bicep decompile-params`: Add `--force` option to overwrite existing file

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_help.py
@@ -2410,6 +2410,8 @@ examples:
     text: az bicep decompile-params --file {json_template_file}
   - name: Attempts to decompile a parameters .json file to .bicepparam using the bicep file given.
     text: az bicep decompile-params --file {json_template_file} --bicep-file {bicep_file}
+  - name: Attempts to decompile a parameters .json file to .bicepparam and overwrite existing output.
+    text: az bicep decompile-params --file {json_template_file} --force
   - name: Attempts to decompile a parameters .json file to .bicepparam and print all output to stdout.
     text: az bicep decompile-params --file {json_template_file} --stdout
   - name: Attempts to decompile a parameters .json file to .bicepparam and print all output to stdout and save the result to the specified directory.

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -4198,7 +4198,7 @@ def decompile_bicep_file(cmd, file, force=None):
     run_bicep_command(cmd.cli_ctx, args)
 
 
-def decompileparams_bicep_file(cmd, file, bicep_file=None, outdir=None, outfile=None, stdout=None):
+def decompileparams_bicep_file(cmd, file, bicep_file=None, outdir=None, outfile=None, stdout=None, force=None):
     ensure_bicep_installation(cmd.cli_ctx)
 
     minimum_supported_version = "0.18.4"
@@ -4212,6 +4212,8 @@ def decompileparams_bicep_file(cmd, file, bicep_file=None, outdir=None, outfile=
             args += ["--outfile", outfile]
         if stdout:
             args += ["--stdout"]
+        if force:
+            args += ["--force"]
 
         output = run_bicep_command(cmd.cli_ctx, args)
 


### PR DESCRIPTION
**Related command**

`bicep decompile-params`

**Description**

Enable `--force` passthrough for `az bicep decompile-params` to allow overwriting existing output.

Add CLI help example showing `--force` usage.

**Testing Guide**

`python -m pytest src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_custom.py -k test_bicep_decompile_params_defaults`

**History Notes**

[ARM] `az bicep decompile-params`: Add new parameter `--force` to overwrite existing files (#32739)

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
