### PR TITLE
{Core} `aaz`: Remove `requests` in main thread

### DIFF
--- a/src/azure-cli-core/azure/cli/core/aaz/_poller.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_poller.py
@@ -12,9 +12,6 @@ from azure.core.polling import NoPolling
 from azure.core.polling.base_polling import LROBasePolling
 from azure.core.tracing.common import with_current_context
 from azure.core.tracing.decorator import distributed_trace
-# import requests in main thread to resolve import deadlock between threads in python
-# reference https://github.com/psf/requests/issues/2925 and https://github.com/Azure/azure-cli/issues/26272
-import requests  # pylint: disable=unused-import
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
in core aaz, the use of `requests` can cause performance degradation for modules such as `network` and `storage`—that is, any modules with potential import chains.

the following is an experiment conducted for `az network -h`:
_before:_
<img width="2856" height="1232" alt="image" src="https://github.com/user-attachments/assets/f9b57fd6-aaba-40e7-b173-366528c2caab" />
```bash
Time (mean ± σ):      2.906 s ±  0.030 s    [User: 0.979 s, System: 1.324 s]
Range (min … max):    2.869 s …  2.961 s    10 runs
```

_after:_
<img width="2850" height="1229" alt="image" src="https://github.com/user-attachments/assets/c3d1ef27-2d18-4a12-921e-bd76691493d2" />
```bash
Time (mean ± σ):      2.361 s ±  0.061 s    [User: 0.893 s, System: 0.939 s]
Range (min … max):    2.296 s …  2.485 s    10 runs
```

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
