### PR TITLE
[ACR] `az acr network-rule add`: Add example of adding a rule to allow access for a specific virtual network

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_help.py
@@ -364,6 +364,9 @@ examples:
   - name: Add a rule to allow access for a specific IP address-range.
     text: >
         az acr network-rule add -n myregistry --ip-address 23.45.1.0/24
+  - name: Add a rule to allow access for a specific virtual network.
+    text: >
+        az acr network-rule add -n myregistry --subnet $subnetId
 """
 
 helps['acr network-rule list'] = """


### PR DESCRIPTION
**Related command**
az acr network-rule add 

**Description**<!--Mandatory-->
I do not see any mention that there is a parameter --subnet for command az acr network-rule add 

**Testing Guide**
az acr network-rule add -n myacr --subnet <subnet_id>
