### PR TITLE
{Packaging} Bump `msal-extensions`, `portalocker`, `pywin32` for supporting Python 3.14

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -54,7 +54,7 @@ DEPENDENCIES = [
     'jmespath',
     'knack~=0.11.0',
     'microsoft-security-utilities-secret-masker~=1.0.0b4',
-    'msal-extensions==1.2.0',
+    'msal-extensions==1.3.1',
     'msal[broker]==1.35.1; sys_platform == "win32"',
     'msal==1.35.1; sys_platform != "win32"',
     'packaging>=20.9',

--- a/src/azure-cli-telemetry/setup.py
+++ b/src/azure-cli-telemetry/setup.py
@@ -41,7 +41,7 @@ setup(
     classifiers=CLASSIFIERS,
     install_requires=[
         'applicationinsights>=0.11.1,<0.12',
-        'portalocker>=1.6,<3',
+        'portalocker>=1.6,<4',
     ],
     packages=[
         'azure.cli.telemetry',

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -108,7 +108,7 @@ javaproperties==0.5.1
 jmespath==0.9.5
 jsondiff==2.0.0
 knack==0.11.0
-msal-extensions==1.2.0
+msal-extensions==1.3.1
 msal==1.35.1
 msrest==0.7.1
 oauthlib==3.2.2
@@ -116,7 +116,7 @@ packaging==25.0
 paramiko==3.5.0
 pbr==7.0.3
 pkginfo==1.8.2
-portalocker==2.3.2
+portalocker==3.2.0
 psutil==6.1.0
 pycomposefile==0.0.34
 PyGithub==1.55

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -109,7 +109,7 @@ javaproperties==0.5.1
 jmespath==0.9.5
 jsondiff==2.0.0
 knack==0.11.0
-msal-extensions==1.2.0
+msal-extensions==1.3.1
 msal==1.35.1
 msrest==0.7.1
 oauthlib==3.2.2
@@ -117,7 +117,7 @@ packaging==25.0
 paramiko==3.5.0
 pbr==7.0.3
 pkginfo==1.8.2
-portalocker==2.3.2
+portalocker==3.2.0
 psutil==6.1.0
 pycomposefile==0.0.34
 PyGithub==1.55

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -108,7 +108,7 @@ javaproperties==0.5.1
 jmespath==0.9.5
 jsondiff==2.0.0
 knack==0.11.0
-msal-extensions==1.2.0
+msal-extensions==1.3.1
 msal[broker]==1.35.1
 msrest==0.7.1
 oauthlib==3.2.2
@@ -116,7 +116,7 @@ packaging==25.0
 paramiko==3.5.0
 pbr==7.0.3
 pkginfo==1.8.2
-portalocker==2.3.2
+portalocker==3.2.0
 psutil==6.1.0
 pycomposefile==0.0.34
 PyGithub==1.55
@@ -126,7 +126,7 @@ PyNaCl==1.6.2
 pyOpenSSL==25.3.0
 PySocks==1.7.1
 python-dateutil==2.8.0
-pywin32==310
+pywin32==311
 requests-oauthlib==1.2.0
 requests==2.32.4
 scp==0.13.2


### PR DESCRIPTION
**Description**<!--Mandatory-->
Bump dependencies for supporting Python 3.14.

This makes `azdev setup -c` succeed.
