### PR TITLE
[App Service] `az webapp list-runtimes`: Pre-announce breaking changes

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_breaking_change.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_breaking_change.py
@@ -17,7 +17,7 @@ register_output_breaking_change(
           'Use -o table for a human-readable view, or -o json and parse the new structured format.')
 
 # az webapp list-runtimes --linux removal
-register_argument_deprecate('webapp list-runtimes', '--linux', redirect='--os linux')
+register_argument_deprecate('webapp list-runtimes', '--linux', redirect='--os-type')
 
 # az webapp list-runtimes --show-runtime-details removal
 register_argument_deprecate('webapp list-runtimes', '--show-runtime-details')


### PR DESCRIPTION
**Related command**
`az webapp list-runtimes`

**Description**

Pre-announce upcoming breaking changes for `az webapp list-runtimes` targeting the next breaking change window (Build 2026).

This PR adds `_breaking_change.py` to the appservice module to display warnings when users run `az webapp list-runtimes`:

1. **Output format change**: The output will change from a flat list of strings to a structured list of objects with keys: `os`, `runtime`, `version`, `config`, `support`, `end_of_life`.
2. **`--linux` removal**: Deprecated in favor of `--os linux`.
3. **`--show-runtime-details` removal**: Will be removed with no replacement (subsumed by new output format).

The actual breaking change implementation is in #32903 (draft, to be merged during the breaking change window).

**Testing Guide**

```bash
# After this PR, running the command should show deprecation warnings:
az webapp list-runtimes
# WARNING: The output will change from a flat list of strings to a structured list of objects...

az webapp list-runtimes --linux
# WARNING: Option '--linux' has been deprecated and will be removed in next breaking change release...

az webapp list-runtimes --show-runtime-details
# WARNING: Option '--show-runtime-details' has been deprecated and will be removed in next breaking change release...
```

**History Notes**

This PR is not customer-facing (pre-announcement warnings only).

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
