### PR TITLE
{Core} Bump MSAL to 1.35.1

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -55,8 +55,8 @@ DEPENDENCIES = [
     'knack~=0.11.0',
     'microsoft-security-utilities-secret-masker~=1.0.0b4',
     'msal-extensions==1.2.0',
-    'msal[broker]==1.35.0b1; sys_platform == "win32"',
-    'msal==1.35.0b1; sys_platform != "win32"',
+    'msal[broker]==1.35.1; sys_platform == "win32"',
+    'msal==1.35.1; sys_platform != "win32"',
     'packaging>=20.9',
     'pkginfo>=1.5.0.1',
     # psutil can't install on cygwin: https://github.com/Azure/azure-cli/issues/9399

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -109,7 +109,7 @@ jmespath==0.9.5
 jsondiff==2.0.0
 knack==0.11.0
 msal-extensions==1.2.0
-msal==1.35.0b1
+msal==1.35.1
 msrest==0.7.1
 oauthlib==3.2.2
 packaging==25.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -110,7 +110,7 @@ jmespath==0.9.5
 jsondiff==2.0.0
 knack==0.11.0
 msal-extensions==1.2.0
-msal==1.35.0b1
+msal==1.35.1
 msrest==0.7.1
 oauthlib==3.2.2
 packaging==25.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -109,7 +109,7 @@ jmespath==0.9.5
 jsondiff==2.0.0
 knack==0.11.0
 msal-extensions==1.2.0
-msal[broker]==1.35.0b1
+msal[broker]==1.35.1
 msrest==0.7.1
 oauthlib==3.2.2
 packaging==25.0


### PR DESCRIPTION
Updates Azure CLI’s MSAL (Python) dependency to pick up the upstream fix that prevents auth discovery from performing unnecessary network-dependent lookups in known clouds. This resolves az login hangs/failures seen in Bleu cloud