### PR TITLE
[POSTGRESQL] `az postgres flexible-server long-term-retention`: Add breaking change announcement for command group removal

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/postgresql/_breaking_change.py
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/_breaking_change.py
@@ -19,8 +19,8 @@ register_command_group_deprecate(command_group='postgres flexible-server index-t
 
 # Long term retention  command argument changes
 register_command_group_deprecate(command_group='postgres flexible-server long-term-retention',
-                                 message='Long term retention feature is under development. Moving forward to '
-                                 'access support, please turn to Azure Portal.')
+                                 message='Long term retention command group will be removed. '
+                                 'For more information, open a support incident.')
 
 # Upgrade command argument changes
 register_other_breaking_change('postgres flexible-server upgrade',


### PR DESCRIPTION
**Related command**
`az postgres flexible-server long-term-retention`

**Description**<!--Mandatory-->
Will be removing this command group

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[POSTGRESQL] `az postgres flexible-server long-term-retention`: Add breaking change announcement for command group removal

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
