### PR TITLE
{Branch Management} Fix merge-base: Merge release 2.84.0 back to dev

### DIFF
--- a/scripts/ci/credscan/CredScanSuppressions.json
+++ b/scripts/ci/credscan/CredScanSuppressions.json
@@ -683,6 +683,18 @@
         "src\\azure-cli\\azure\\cli\\command_modules\\network\\tests\\latest\\test_network_commands.py"
       ],
       "_justification": "[Network] False positive"
+    },
+    {
+      "placeholder": "asdfghjkl",
+      "_justification": "[ARO] Dummy client_secret value in test_validators.py unit tests"
+    },
+    {
+      "placeholder": "secret_123",
+      "_justification": "[ARO] Dummy client_secret value in test_validators.py unit tests"
+    },
+    {
+      "placeholder": "client_id_456",
+      "_justification": "[ARO] Dummy client_id value in test_validators.py unit tests"
     }
   ]
 }


### PR DESCRIPTION
## Fix merge-base between `release` and `dev`

PR #32896 (`{Branch Management} Merge release 2.84.0 back to dev`) was squash-merged on 2026-03-04 instead of being merge-committed. This broke the merge-base between `release` and `dev`.

### What happened

The hotfix PR #32847 (`{Misc.} Fix up credscan false positive`) was merged to `release` (commit `6043dca9c2`). Then PR #32896 was created to merge `release` back to `dev`, but it was squash-merged — producing a single-parent commit that copied the file content without linking `release` history into `dev`.

### Current state (broken)

| Metric | Expected | Actual |
|--------|----------|--------|
| Merge-base (dev, release) | `6043dca9c2` (release HEAD) | `d01027d241` (stuck) |
| `release` is ancestor of `dev`? | YES | **NO** |

### What this PR does

This PR exists to satisfy the `azure-production-ruleset` PR requirement. It will be merged **locally** using `git merge --no-ff` and pushed, creating a 2-parent merge commit that links `release` history into `dev` and advances the merge-base.

### How to merge

🛑 **Do NOT use the GitHub UI merge button or GitHub CLI `gh pr merge`.**

Follow the documented hotfix process:
1. ✅ Create this PR (done)
2. ✅ Approve this PR in GitHub UI
3. Merge locally: `git checkout dev && git pull origin dev && git merge origin/release --no-ff -m "Merge release 2.84.0 back to dev"`
4. Push: `git push origin dev`
5. This PR will automatically be marked as Merged

### File changes

Only 1 file changed: `scripts/ci/credscan/CredScanSuppressions.json` (12 additions) — the credscan false positive fix from PR #32847.

### Tested

This exact process was validated end-to-end on test branches (`naga_test_dev_2` / `naga_test_release_2`) with a PR-required ruleset and no bypass privileges. See PR #32923 for the successful test.