### PR TITLE
[Test 3] Merge release back to dev (prove squash-only blocks merge commits)

### DIFF
--- a/naga_test3_hotfix.txt
+++ b/naga_test3_hotfix.txt
@@ -1,0 +1,1 @@
+hotfix for test 3 - simulating a release hotfix


### PR DESCRIPTION
Test PR to prove that the Copilot review ruleset (squash-only allowed_merge_methods) blocks merge commit pushes.

**Test setup on naga_test_dev_3:**
- naga-test-production-ruleset-3 (ID: 13601685) — replica of azure-production-ruleset
- naga-test-copilot-review-3 (ID: 13601696) — replica of Copilot review (squash-only)

**Expected outcome:** After approval, local merge + push should be rejected with 'Merge commits are not allowed'.