### PR TITLE
[AKS] Fix #32957: `az aks get-credentials`: Surface user-friendly error instead of unexpected traceback

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -1970,16 +1970,16 @@ def load_kubernetes_configuration(filename):
             return yaml.safe_load(stream)
     except OSError as ex:
         if getattr(ex, 'errno', 0) == errno.ENOENT:
-            raise CLIError('{} does not exist'.format(filename))
-        if getattr(ex, 'errno', 0) == errno.EACCES:
+            raise CLIError('{} does not exist'.format(filename)) from ex
+        if getattr(ex, 'errno', 0) in (errno.EACCES, errno.EPERM):
             raise FileOperationError(
                 'Permission denied when trying to read {}. '
                 'Please ensure you have read access to this file, or specify a different file path '
                 'using the --file/-f argument.'.format(filename)
-            )
+            ) from ex
         raise
     except (yaml.parser.ParserError, UnicodeDecodeError) as ex:
-        raise CLIError('Error parsing {} ({})'.format(filename, str(ex)))
+        raise CLIError('Error parsing {} ({})'.format(filename, str(ex))) from ex
 
 
 def merge_kubernetes_configurations(existing_file, addition_file, replace, context_name=None):
@@ -2028,12 +2028,14 @@ def merge_kubernetes_configurations(existing_file, addition_file, replace, conte
     try:
         with open(existing_file, 'w+') as stream:
             yaml.safe_dump(existing, stream, default_flow_style=False)
-    except PermissionError as ex:
-        raise FileOperationError(
-            'Permission denied when trying to write to {}. '
-            'Please ensure you have write access to this file, or specify a different file path '
-            'using the --file/-f argument.'.format(existing_file)
-        ) from ex
+    except OSError as ex:
+        if getattr(ex, 'errno', 0) in (errno.EACCES, errno.EPERM, errno.EROFS):
+            raise FileOperationError(
+                'Permission denied when trying to write to {}. '
+                'Please ensure you have write access to this file, or specify a different file path '
+                'using the --file/-f argument.'.format(existing_file)
+            ) from ex
+        raise
 
     current_context = addition.get('current-context', 'UNKNOWN')
     msg = 'Merged "{}" as current context in {}'.format(


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Surface user-friendly error instead of unexpected traceback when encountering permission issues when load or save kubeconfig. Fix #32957.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
