### PR TITLE
{Telemetry} Defer applicationinsights import in telemetry save() to avoid loading it in the main CLI process

### DIFF
--- a/src/azure-cli-telemetry/azure/cli/telemetry/__init__.py
+++ b/src/azure-cli-telemetry/azure/cli/telemetry/__init__.py
@@ -46,7 +46,6 @@ def _start(config_dir, cache_dir):
 
 
 def save(config_dir, payload):
-    from azure.cli.telemetry.components.telemetry_client import CliTelemetryClient
     from azure.cli.telemetry.components.telemetry_logging import get_logger
 
     logger = get_logger('main')
@@ -59,14 +58,21 @@ def save(config_dir, payload):
 
         logger.info('Begin splitting cli events and extra events, total events: %s', len(events))
         cli_events = {}
-        client = CliTelemetryClient()
+        extra_events = {}
         for key, event in events.items():
             if key == DEFAULT_INSTRUMENTATION_KEY:
                 cli_events[key] = event
             else:
-                extra_event = {key: event}
-                client.add(json.dumps(extra_event), flush=True)
-        client.flush(force=True)
+                extra_events[key] = event
+
+        if extra_events:
+            # Defer applicationinsights import to only when extra events exist
+            from azure.cli.telemetry.components.telemetry_client import CliTelemetryClient
+            client = CliTelemetryClient()
+            for key, event in extra_events.items():
+                client.add(json.dumps({key: event}), flush=True)
+            client.flush(force=True)
+
         cli_payload = json.dumps(cli_events) if cli_events else None
         logger.info('Finish splitting cli events and extra events, cli events: %s', len(cli_events))
     except Exception as ex:  # pylint: disable=broad-except


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

*Problem*
The `save()` function in `azure/cli/telemetry/__init__.py` unconditionally imports `CliTelemetryClient`, which triggers top-level `from applicationinsights import ...` in `telemetry_client.py`. This loads 146 modules — even though the client is only needed for "extra events" with non-default instrumentation keys, which no extension currently uses.

*Fix*
Defer the `CliTelemetryClient` import behind an `if extra_events:` guard. Events are first split by instrumentation key; only if non-default key events exist does the code import applicationinsights and create a client. The common path (all events use `DEFAULT_INSTRUMENTATION_KEY`) now skips the import entirely.

*Time Save (on DevBox)*
Before:
The `save` method takes 111ms in conclude telemetry.
<img width="1311" height="332" alt="image" src="https://github.com/user-attachments/assets/42f574b3-2a35-4d3a-afda-cf71e9e96549" />
<img width="906" height="75" alt="image" src="https://github.com/user-attachments/assets/a2c4a009-9e5e-45a3-9e42-fe200cc0f2e2" />

After:
The `save` method takes 22ms in concluding telemetry.
<img width="1237" height="504" alt="image" src="https://github.com/user-attachments/assets/dda6f7b6-52be-4e77-9a20-70b571654c51" />
The `extension --help` command saves about 90 ms.
<img width="898" height="80" alt="image" src="https://github.com/user-attachments/assets/2cc1e21e-dbe8-44c1-984f-3ec2a9097485" />

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
