### PR TITLE
{Core} Bump azure-core to 1.39.0

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -45,7 +45,7 @@ CLASSIFIERS = [
 DEPENDENCIES = [
     'argcomplete~=3.5.2',
     'azure-cli-telemetry==1.1.0.*',
-    'azure-core~=1.38.0',
+    'azure-core~=1.39.0',
     'azure-mgmt-core>=1.2.0,<2',
     'cryptography',
     # On Linux, the distribution (Ubuntu, Debian, etc) and version are logged in telemetry

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -8,7 +8,7 @@ azure-cli-core==2.84.0
 azure-cli-telemetry==1.1.0
 azure-cli==2.84.0
 azure-common==1.1.22
-azure-core==1.38.0
+azure-core==1.39.0
 azure-cosmos==3.2.0
 azure-data-tables==12.4.0
 azure-datalake-store==1.0.1

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -8,7 +8,7 @@ azure-cli-core==2.84.0
 azure-cli-telemetry==1.1.0
 azure-cli==2.84.0
 azure-common==1.1.22
-azure-core==1.38.0
+azure-core==1.39.0
 azure-cosmos==3.2.0
 azure-data-tables==12.4.0
 azure-datalake-store==1.0.1

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -8,7 +8,7 @@ azure-cli-core==2.84.0
 azure-cli-telemetry==1.1.0
 azure-cli==2.84.0
 azure-common==1.1.22
-azure-core==1.38.0
+azure-core==1.39.0
 azure-cosmos==3.2.0
 azure-data-tables==12.4.0
 azure-datalake-store==1.0.1


### PR DESCRIPTION
### Related command
N/A - dependency update

### Description
Bump azure-core from 1.38.0 to 1.39.0.

This update picks up the rename of the AZURE_CLOUD environment variable to AZURE_SDK_CLOUD_CONF (https://github.com/Azure/azure-sdk-for-python/pull/45763). The old AZURE_CLOUD variable was too general that it conflicted with other software, causing ValueError: Cannot convert AzureCloud to Azure Cloud when its value is not understood by SDK. With this bump, azure-core stops reading AZURE_CLOUD and reads AZURE_SDK_CLOUD_CONF instead, resolving the conflict.

### Testing Guide
Ran azure-cli-core unit tests locally — no new failures introduced by this change.

### History Notes
[Core] Bump azure-core to 1.39.0 to resolve ValueError caused by AZURE_CLOUD environment variable conflict