### PR TITLE
{Core} reduce DevExtension discovery max_depth from 3 to 2

### DIFF
--- a/src/azure-cli-core/azure/cli/core/extension/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/extension/__init__.py
@@ -268,7 +268,7 @@ class DevExtension(Extension):
                 for item in os.listdir(path):
                     _collect(os.path.join(path, item), depth + 1, max_depth)
         for source in DEV_EXTENSION_SOURCES:
-            _collect(source)
+            _collect(source, max_depth=2)
         # https://docs.python.org/3/library/os.html#os.listdir, listdir is in arbitrary order.
         # Sort the extensions by name to support overwrite extension feature: https://github.com/Azure/azure-cli/issues/25782.
         exts.sort(key=lambda ext: ext.name)


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
The `_collect()` helper in `DevExtension.get_all()` recursively walks directories to find `*.egg-info` markers. A max_depth of 3 is excessive since standard dev extension layouts place .egg-info at depth 1 (`pip install -e`) or depth 2 (`azure-cli-extensions repo: src/<ext_name>/*.egg-info`).

Reducing to max_depth=2 eliminates an entire level of recursive `os.path.isdir()`, `glob()`, and `os.listdir()` calls, saving ~30-50 ms on Windows when `DEV_EXTENSION_SOURCES` is configured.

Before:
<img width="929" height="326" alt="image" src="https://github.com/user-attachments/assets/943552f2-7be5-42d1-a79a-5e72f759a7ab" />

After:
<img width="754" height="285" alt="image" src="https://github.com/user-attachments/assets/76a87a34-e265-4ece-8a6e-450a64f50be0" />

**Testing Guide**
<!--Example commands with explanations.-->
```
(venv) PS C:\Users\qinkaiwu\Repo\azure-cli> hyperfine --warmup 2 --runs 10 -n "dev (baseline, max_depth=3)" --prepare "git checkout dev" "az extension --help" -n "fix (max_depth=2)" --prepare "git checkout perf/reduce-dev-extension-max-depth" "az extension --help" --export-markdown benchmark_labeled.md
Benchmark 1: dev (baseline, max_depth=3)                                                                                                                                                                                                                                                                                                                    
  Time (mean ± σ):      1.316 s ±  0.102 s    [User: 0.429 s, System: 0.507 s]                                                                                                                                                                                                                                                                              
  Range (min … max):    1.214 s …  1.504 s    10 runs

Benchmark 2: fix (max_depth=2)
  Time (mean ± σ):      1.233 s ±  0.065 s    [User: 0.426 s, System: 0.443 s]                                                                                                                                                                                                                                                                              
  Range (min … max):    1.132 s …  1.326 s    10 runs

Summary
  fix (max_depth=2) ran
    1.07 ± 0.10 times faster than dev (baseline, max_depth=3)
```

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
