### PR TITLE
{EventHubs} `az eventhubs --help`: Args-guided AAZ command tree loading for eventhubs module

### DIFF
--- a/src/azure-cli-core/azure/cli/core/aaz/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/__init__.py
@@ -21,7 +21,8 @@ from ._arg_fmt import AAZStrArgFormat, AAZIntArgFormat, AAZFloatArgFormat, AAZBo
     AAZPaginationTokenArgFormat
 from ._base import has_value, AAZValuePatch, AAZUndefined
 from ._command import AAZCommand, AAZWaitCommand, AAZCommandGroup, \
-    register_callback, register_command, register_command_group, load_aaz_command_table, link_helper
+    register_callback, register_command, register_command_group, load_aaz_command_table, \
+    load_aaz_command_table_optimized, link_helper
 from ._field_type import AAZIntType, AAZFloatType, AAZStrType, AAZBoolType, AAZDictType, AAZFreeFormDictType, \
     AAZListType, AAZObjectType, AAZIdentityObjectType, AAZAnyType
 from ._operation import AAZHttpOperation, AAZJsonInstanceUpdateOperation, AAZGenericInstanceUpdateOperation, \

--- a/src/azure-cli-core/azure/cli/core/aaz/_command.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_command.py
@@ -387,6 +387,170 @@ def register_command(
 AAZ_PACKAGE_FULL_LOAD_ENV_NAME = 'AZURE_AAZ_FULL_LOAD'
 
 
+def load_aaz_command_table_optimized(loader, aaz_pkg_name, args):
+    """Args-guided AAZ command tree loader.
+
+    Instead of importing the entire AAZ package tree (all __init__.py files which eagerly
+    import all command classes), this function navigates only to the relevant subtree based
+    on CLI args. For example, ``az eventhubs namespace create --help`` only loads the
+    ``namespace`` sub-package and the ``_create`` module, skipping all other commands.
+
+    This requires that AAZ ``__init__.py`` files do NOT contain wildcard imports
+    (``from ._create import *`` etc.) -- they should be empty (just the license header).
+    """
+    profile_pkg = _get_profile_pkg(aaz_pkg_name, loader.cli_ctx.cloud)
+
+    command_table = {}
+    command_group_table = {}
+    if args is None or os.environ.get(AAZ_PACKAGE_FULL_LOAD_ENV_NAME, 'False').lower() == 'true':
+        effective_args = None  # fully load
+    else:
+        effective_args = list(args)
+    if profile_pkg is not None:
+        _load_aaz_by_pkg(loader, profile_pkg, effective_args,
+                         command_table, command_group_table)
+
+    for group_name, command_group in command_group_table.items():
+        loader.command_group_table[group_name] = command_group
+    for command_name, command in command_table.items():
+        loader.command_table[command_name] = command
+    return command_table, command_group_table
+
+
+def _try_import_module(relative_name, package):
+    """Try to import a module by relative name, return None on failure."""
+    try:
+        return importlib.import_module(relative_name, package)
+    except (ModuleNotFoundError, ImportError):
+        return None
+
+
+def _register_from_module(loader, mod, command_table, command_group_table):
+    """Scan a module's namespace for AAZCommand/AAZCommandGroup classes and register them."""
+    for value in mod.__dict__.values():
+        if not isinstance(value, type):
+            continue
+        if issubclass(value, AAZCommandGroup) and value.AZ_NAME:
+            command_group_table[value.AZ_NAME] = value(cli_ctx=loader.cli_ctx)
+        elif issubclass(value, AAZCommand) and value.AZ_NAME:
+            command_table[value.AZ_NAME] = value(loader=loader)
+
+
+def _get_pkg_children(pkg):
+    """List child entries of a package using pkgutil.
+
+    Returns two sets: (file_stems, subdir_names).
+    - file_stems: module-like stems, e.g. {'_create', '_list', '__cmd_group'}
+    - subdir_names: sub-package directory names, e.g. {'namespace', 'eventhub'}
+    """
+    import pkgutil
+    file_stems = set()
+    subdir_names = set()
+
+    pkg_path = getattr(pkg, '__path__', None)
+    if not pkg_path:
+        return file_stems, subdir_names
+
+    for _importer, name, ispkg in pkgutil.iter_modules(pkg_path):
+        if ispkg:
+            if not name.startswith('_'):
+                subdir_names.add(name)
+        else:
+            file_stems.add(name)
+
+    return file_stems, subdir_names
+
+
+def _load_aaz_by_pkg(loader, pkg, args, command_table, command_group_table):
+    """Recursively navigate the AAZ package tree guided by CLI args.
+
+    - args is None or empty  -> full recursive load of all commands under this package.
+    - args has items -> try to match first arg as a command module or sub-package,
+                        recurse with remaining args on match.
+    - args exhausted / no match -> load current level's commands and sub-group headers.
+    """
+    base_module = pkg.__name__
+    file_stems, subdir_names = _get_pkg_children(pkg)
+
+    if args is not None and args and not args[0].startswith('-'):
+        first_arg = args[0].lower().replace('-', '_')
+
+        # First arg matches a command module (e.g. "create" -> "_create")
+        if f"_{first_arg}" in file_stems:
+            mod = _try_import_module(f"._{first_arg}", base_module)
+            if mod:
+                _register_from_module(loader, mod, command_table, command_group_table)
+                return
+
+        # First arg matches a sub-package (command group)
+        if first_arg in subdir_names:
+            sub_module = f"{base_module}.{first_arg}"
+            mod = _try_import_module('.__cmd_group', sub_module)
+            if mod:
+                _register_from_module(loader, mod, command_table, command_group_table)
+            sub_pkg = _try_import_module(f'.{first_arg}', base_module)
+            if sub_pkg:
+                _load_aaz_by_pkg(loader, sub_pkg, args[1:], command_table, command_group_table)
+                return
+
+    # Load __cmd_group + all command modules at this level
+    mod = _try_import_module('.__cmd_group', base_module)
+    if mod:
+        _register_from_module(loader, mod, command_table, command_group_table)
+
+    for stem in file_stems:
+        if stem.startswith('_') and not stem.startswith('__'):
+            mod = _try_import_module(f'.{stem}', base_module)
+            if mod:
+                _register_from_module(loader, mod, command_table, command_group_table)
+
+    for subdir in subdir_names:
+        sub_module = f"{base_module}.{subdir}"
+        if not args:
+            # Full load -> recurse into every sub-package
+            sub_pkg = _try_import_module(f'.{subdir}', base_module)
+            if sub_pkg:
+                _load_aaz_by_pkg(loader, sub_pkg, None, command_table, command_group_table)
+        else:
+            # Args exhausted / not matched -> load sub-group header and the first
+            # command so the group is non-empty and the parser creates a subparser
+            # for it (required for help output).
+            # TODO: After optimized loading is applied to the whole CLI, revisit
+            # this and consider a lighter approach (e.g. parser-level fix) to
+            # avoid importing one command per trimmed sub-group.
+            mod = _try_import_module('.__cmd_group', sub_module)
+            if mod:
+                _register_from_module(loader, mod, command_table, command_group_table)
+            sub_pkg = _try_import_module(f'.{subdir}', base_module)
+            if sub_pkg:
+                _load_first_command(loader, sub_pkg, command_table)
+
+
+def _load_first_command(loader, pkg, command_table):
+    """Load the first available command module from a package.
+
+    This ensures the command group is non-empty so the parser creates a subparser
+    for it, which is required for it to appear in help output.
+    """
+    file_stems, subdir_names = _get_pkg_children(pkg)
+    base_module = pkg.__name__
+
+    # Try to load a command module at this level first
+    for stem in sorted(file_stems):
+        if stem.startswith('_') and not stem.startswith('__'):
+            mod = _try_import_module(f'.{stem}', base_module)
+            if mod:
+                _register_from_module(loader, mod, command_table, {})
+                return
+
+    # No command at this level, recurse into the first sub-package
+    for subdir in sorted(subdir_names):
+        sub_pkg = _try_import_module(f'.{subdir}', base_module)
+        if sub_pkg:
+            _load_first_command(loader, sub_pkg, command_table)
+            return
+
+
 def load_aaz_command_table(loader, aaz_pkg_name, args):
     """ This function is used in AzCommandsLoader.load_command_table.
     It will load commands in module's aaz package.

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/__init__.py
@@ -3,11 +3,16 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from azure.cli.core import AzCommandsLoader
+from azure.cli.core import AzCommandsLoader, get_logger
 
 # pylint: disable=unused-import
 
 from ._help import helps
+
+logger = get_logger(__name__)
+
+_OPTIMIZED_LOADING_CONFIG_SECTION = 'eventhubs'
+_OPTIMIZED_LOADING_CONFIG_KEY = 'optimized_loading'
 
 
 class EventhubCommandsLoader(AzCommandsLoader):
@@ -26,17 +31,35 @@ class EventhubCommandsLoader(AzCommandsLoader):
 
     def load_command_table(self, args):
         from azure.cli.command_modules.eventhubs.commands import load_command_table
-        from azure.cli.core.aaz import load_aaz_command_table
+        from azure.cli.core.aaz import load_aaz_command_table_optimized
+
+        use_optimized = self.cli_ctx.config.getboolean(
+            _OPTIMIZED_LOADING_CONFIG_SECTION, _OPTIMIZED_LOADING_CONFIG_KEY, fallback=True)
+
+        # When optimized loading is disabled, still use the optimized loader but
+        # pass args=None to force a full load (no trimming). The gutted __init__.py
+        # files are incompatible with the old load_aaz_command_table loader, so we
+        # cannot fall back to it.
+        effective_args = args if use_optimized else None
+
+        if use_optimized and args and args[0:1] == ['eventhubs']:
+            logger.warning(
+                "The eventhubs module is using optimized command loading for improved performance. "
+                "If you encounter any issues, you can disable this by running: "
+                "az config set %s.%s=false",
+                _OPTIMIZED_LOADING_CONFIG_SECTION, _OPTIMIZED_LOADING_CONFIG_KEY)
+
         try:
             from . import aaz
         except ImportError:
             aaz = None
         if aaz:
-            load_aaz_command_table(
+            load_aaz_command_table_optimized(
                 loader=self,
                 aaz_pkg_name=aaz.__name__,
-                args=args
+                args=effective_args
             )
+
         load_command_table(self, args)
         return self.command_table
 

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/__init__.py
@@ -7,5 +7,3 @@
 
 # pylint: skip-file
 # flake8: noqa
-
-from .__cmd_group import *

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/cluster/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/cluster/__init__.py
@@ -7,12 +7,3 @@
 
 # pylint: skip-file
 # flake8: noqa
-
-from .__cmd_group import *
-from ._available_region import *
-from ._create import *
-from ._delete import *
-from ._list import *
-from ._show import *
-from ._update import *
-from ._wait import *

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/cluster/namespace/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/cluster/namespace/__init__.py
@@ -7,6 +7,3 @@
 
 # pylint: skip-file
 # flake8: noqa
-
-from .__cmd_group import *
-from ._list import *

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/eventhub/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/eventhub/__init__.py
@@ -7,10 +7,3 @@
 
 # pylint: skip-file
 # flake8: noqa
-
-from .__cmd_group import *
-from ._create import *
-from ._delete import *
-from ._list import *
-from ._show import *
-from ._update import *

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/eventhub/authorization_rule/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/eventhub/authorization_rule/__init__.py
@@ -7,10 +7,3 @@
 
 # pylint: skip-file
 # flake8: noqa
-
-from .__cmd_group import *
-from ._create import *
-from ._delete import *
-from ._list import *
-from ._show import *
-from ._update import *

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/eventhub/authorization_rule/keys/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/eventhub/authorization_rule/keys/__init__.py
@@ -7,7 +7,3 @@
 
 # pylint: skip-file
 # flake8: noqa
-
-from .__cmd_group import *
-from ._list import *
-from ._renew import *

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/eventhub/consumer_group/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/eventhub/consumer_group/__init__.py
@@ -7,10 +7,3 @@
 
 # pylint: skip-file
 # flake8: noqa
-
-from .__cmd_group import *
-from ._create import *
-from ._delete import *
-from ._list import *
-from ._show import *
-from ._update import *

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/georecovery_alias/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/georecovery_alias/__init__.py
@@ -7,12 +7,3 @@
 
 # pylint: skip-file
 # flake8: noqa
-
-from .__cmd_group import *
-from ._break_pair import *
-from ._create import *
-from ._delete import *
-from ._exists import *
-from ._fail_over import *
-from ._list import *
-from ._show import *

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/georecovery_alias/authorization_rule/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/georecovery_alias/authorization_rule/__init__.py
@@ -7,7 +7,3 @@
 
 # pylint: skip-file
 # flake8: noqa
-
-from .__cmd_group import *
-from ._list import *
-from ._show import *

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/georecovery_alias/authorization_rule/keys/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/georecovery_alias/authorization_rule/keys/__init__.py
@@ -7,6 +7,3 @@
 
 # pylint: skip-file
 # flake8: noqa
-
-from .__cmd_group import *
-from ._list import *

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/namespace/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/namespace/__init__.py
@@ -7,13 +7,3 @@
 
 # pylint: skip-file
 # flake8: noqa
-
-from .__cmd_group import *
-from ._create import *
-from ._delete import *
-from ._exists import *
-from ._failover import *
-from ._list import *
-from ._show import *
-from ._update import *
-from ._wait import *

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/namespace/application_group/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/namespace/application_group/__init__.py
@@ -7,10 +7,3 @@
 
 # pylint: skip-file
 # flake8: noqa
-
-from .__cmd_group import *
-from ._create import *
-from ._delete import *
-from ._list import *
-from ._show import *
-from ._update import *

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/namespace/authorization_rule/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/namespace/authorization_rule/__init__.py
@@ -7,10 +7,3 @@
 
 # pylint: skip-file
 # flake8: noqa
-
-from .__cmd_group import *
-from ._create import *
-from ._delete import *
-from ._list import *
-from ._show import *
-from ._update import *

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/namespace/authorization_rule/keys/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/namespace/authorization_rule/keys/__init__.py
@@ -7,7 +7,3 @@
 
 # pylint: skip-file
 # flake8: noqa
-
-from .__cmd_group import *
-from ._list import *
-from ._renew import *

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/namespace/network_rule_set/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/namespace/network_rule_set/__init__.py
@@ -7,9 +7,3 @@
 
 # pylint: skip-file
 # flake8: noqa
-
-from .__cmd_group import *
-from ._create import *
-from ._list import *
-from ._show import *
-from ._update import *

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/namespace/nsp_configuration/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/namespace/nsp_configuration/__init__.py
@@ -7,7 +7,3 @@
 
 # pylint: skip-file
 # flake8: noqa
-
-from .__cmd_group import *
-from ._list import *
-from ._show import *

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/namespace/private_endpoint_connection/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/namespace/private_endpoint_connection/__init__.py
@@ -7,11 +7,3 @@
 
 # pylint: skip-file
 # flake8: noqa
-
-from .__cmd_group import *
-from ._create import *
-from ._delete import *
-from ._list import *
-from ._show import *
-from ._update import *
-from ._wait import *

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/namespace/private_link_resource/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/namespace/private_link_resource/__init__.py
@@ -7,6 +7,3 @@
 
 # pylint: skip-file
 # flake8: noqa
-
-from .__cmd_group import *
-from ._show import *

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/namespace/schema_registry/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/latest/eventhubs/namespace/schema_registry/__init__.py
@@ -7,10 +7,3 @@
 
 # pylint: skip-file
 # flake8: noqa
-
-from .__cmd_group import *
-from ._create import *
-from ._delete import *
-from ._list import *
-from ._show import *
-from ._update import *

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/profile_2019_03_01_hybrid/eventhubs/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/profile_2019_03_01_hybrid/eventhubs/__init__.py
@@ -7,5 +7,3 @@
 
 # pylint: skip-file
 # flake8: noqa
-
-from .__cmd_group import *

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/profile_2019_03_01_hybrid/eventhubs/eventhub/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/profile_2019_03_01_hybrid/eventhubs/eventhub/__init__.py
@@ -7,5 +7,3 @@
 
 # pylint: skip-file
 # flake8: noqa
-
-from .__cmd_group import *

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/profile_2019_03_01_hybrid/eventhubs/eventhub/authorization_rule/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/profile_2019_03_01_hybrid/eventhubs/eventhub/authorization_rule/__init__.py
@@ -7,10 +7,3 @@
 
 # pylint: skip-file
 # flake8: noqa
-
-from .__cmd_group import *
-from ._create import *
-from ._delete import *
-from ._list import *
-from ._show import *
-from ._update import *

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/profile_2019_03_01_hybrid/eventhubs/eventhub/authorization_rule/keys/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/profile_2019_03_01_hybrid/eventhubs/eventhub/authorization_rule/keys/__init__.py
@@ -7,7 +7,3 @@
 
 # pylint: skip-file
 # flake8: noqa
-
-from .__cmd_group import *
-from ._list import *
-from ._renew import *

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/profile_2019_03_01_hybrid/eventhubs/namespace/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/profile_2019_03_01_hybrid/eventhubs/namespace/__init__.py
@@ -7,5 +7,3 @@
 
 # pylint: skip-file
 # flake8: noqa
-
-from .__cmd_group import *

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/profile_2019_03_01_hybrid/eventhubs/namespace/authorization_rule/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/profile_2019_03_01_hybrid/eventhubs/namespace/authorization_rule/__init__.py
@@ -7,10 +7,3 @@
 
 # pylint: skip-file
 # flake8: noqa
-
-from .__cmd_group import *
-from ._create import *
-from ._delete import *
-from ._list import *
-from ._show import *
-from ._update import *

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/profile_2019_03_01_hybrid/eventhubs/namespace/authorization_rule/keys/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/aaz/profile_2019_03_01_hybrid/eventhubs/namespace/authorization_rule/keys/__init__.py
@@ -7,7 +7,3 @@
 
 # pylint: skip-file
 # flake8: noqa
-
-from .__cmd_group import *
-from ._list import *
-from ._renew import *

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/operations/app_group_custom_file.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/operations/app_group_custom_file.py
@@ -24,7 +24,7 @@ def create_app_group_policy_object(col):
 
 def cli_appgroup_create(cmd, resource_group_name, namespace_name, application_group_name, client_app_group_identifier,
                         throttling_policy_config=None, is_enabled=None):
-    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace.application_group import Create
+    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace.application_group._create import Create
     command_args_dict = {}
 
     command_args_dict.update({
@@ -40,8 +40,8 @@ def cli_appgroup_create(cmd, resource_group_name, namespace_name, application_gr
 
 
 def cli_add_appgroup_policy(cmd, resource_group_name, namespace_name, application_group_name, throttling_policy_config):
-    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace.application_group import Update
-    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace.application_group import Show
+    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace.application_group._update import Update
+    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace.application_group._show import Show
 
     application_group = Show(cli_ctx=cmd.cli_ctx)(command_args={
         "resource_group": resource_group_name,
@@ -65,8 +65,8 @@ def cli_add_appgroup_policy(cmd, resource_group_name, namespace_name, applicatio
 
 def cli_remove_appgroup_policy(cmd, resource_group_name, namespace_name, application_group_name, policy):
     from azure.cli.core.azclierror import ResourceNotFoundError
-    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace.application_group import Update
-    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace.application_group import Show
+    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace.application_group._update import Update
+    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace.application_group._show import Show
     application_group = Show(cli_ctx=cmd.cli_ctx)(command_args={
         "resource_group": resource_group_name,
         "namespace_name": namespace_name,

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/operations/event_hub_entity.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/operations/event_hub_entity.py
@@ -9,7 +9,7 @@
 from azure.cli.command_modules.eventhubs.constants import SYSTEM
 from azure.cli.command_modules.eventhubs.constants import SYSTEMUSER
 from azure.cli.command_modules.eventhubs.constants import USER
-from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.eventhub import Update as _EventHubEntityUpdate
+from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.eventhub._update import Update as _EventHubEntityUpdate
 
 
 def cli_eventhub_create(cmd, resource_group_name, namespace_name, event_hub_name,
@@ -19,7 +19,7 @@ def cli_eventhub_create(cmd, resource_group_name, namespace_name, event_hub_name
                         mi_user_assigned=None, mi_system_assigned=False,
                         timestamp_type=None, user_metadata=None, min_compaction_lag_in_mins=None):
 
-    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.eventhub import Create
+    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.eventhub._create import Create
     command_arg_dict = {}
     if cleanup_policy:
         command_arg_dict.update({

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/operations/namespace_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/operations/namespace_custom.py
@@ -44,7 +44,7 @@ def create_eventhub_namespace(cmd, resource_group_name, namespace_name, location
                               is_kafka_enabled=None, is_auto_inflate_enabled=None, alternate_name=None,
                               public_network_access=None, cluster_arm_id=None, max_replication_lag_duration_in_seconds=None,
                               geo_data_replication_config=None):
-    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace import Create
+    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace._create import Create
 
     user_assigned_identity = {}
     command_args_dict = {}
@@ -117,8 +117,8 @@ def create_eventhub_namespace(cmd, resource_group_name, namespace_name, location
 
 def cli_add_encryption(cmd, resource_group_name, namespace_name, encryption_config,
                        require_infrastructure_encryption=None):
-    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace import Update
-    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace import Show
+    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace._update import Update
+    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace._show import Show
 
     eventhubsnm = Show(cli_ctx=cmd.cli_ctx)(command_args={
         "resource_group": resource_group_name,
@@ -148,8 +148,8 @@ def cli_add_encryption(cmd, resource_group_name, namespace_name, encryption_conf
 
 
 def cli_remove_encryption(cmd, resource_group_name, namespace_name, encryption_config):
-    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace import Update
-    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace import Show
+    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace._update import Update
+    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace._show import Show
 
     eventhubsnm = Show(cli_ctx=cmd.cli_ctx)(command_args={
         "resource_group": resource_group_name,
@@ -176,8 +176,8 @@ def cli_remove_encryption(cmd, resource_group_name, namespace_name, encryption_c
 
 
 def cli_add_identity(cmd, resource_group_name, namespace_name, system_assigned=None, user_assigned=None):
-    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace import Update
-    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace import Show
+    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace._update import Update
+    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace._show import Show
 
     eventhubsnm = Show(cli_ctx=cmd.cli_ctx)(command_args={
         "resource_group": resource_group_name,
@@ -226,8 +226,8 @@ def cli_add_identity(cmd, resource_group_name, namespace_name, system_assigned=N
 
 
 def cli_remove_identity(cmd, resource_group_name, namespace_name, system_assigned=None, user_assigned=None):
-    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace import Update
-    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace import Show
+    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace._update import Update
+    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace._show import Show
 
     eventhubsnm = Show(cli_ctx=cmd.cli_ctx)(command_args={
         "resource_group": resource_group_name,
@@ -272,8 +272,8 @@ def cli_remove_identity(cmd, resource_group_name, namespace_name, system_assigne
 def approve_private_endpoint_connection(cmd, resource_group_name, namespace_name,
                                         private_endpoint_connection_name, description=None):
 
-    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace.private_endpoint_connection import Update
-    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace.private_endpoint_connection import Show
+    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace.private_endpoint_connection._update import Update
+    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace.private_endpoint_connection._show import Show
 
     private_endpoint_connection = Show(cli_ctx=cmd.cli_ctx)(command_args={
         "resource_group": resource_group_name,
@@ -299,7 +299,7 @@ def approve_private_endpoint_connection(cmd, resource_group_name, namespace_name
 
 def reject_private_endpoint_connection(cmd, resource_group_name, namespace_name, private_endpoint_connection_name,
                                        description=None):
-    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace.private_endpoint_connection import Update
+    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace.private_endpoint_connection._update import Update
     command_args_dict = {
         "resource_group": resource_group_name,
         "namespace_name": namespace_name,
@@ -312,7 +312,7 @@ def reject_private_endpoint_connection(cmd, resource_group_name, namespace_name,
 
 def delete_private_endpoint_connection(cmd, resource_group_name, namespace_name, private_endpoint_connection_name,
                                        description=None):
-    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace.private_endpoint_connection import Delete
+    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace.private_endpoint_connection._delete import Delete
     command_args_dict = {
         "resource_group": resource_group_name,
         "namespace_name": namespace_name,
@@ -324,7 +324,7 @@ def delete_private_endpoint_connection(cmd, resource_group_name, namespace_name,
 
 def set_georecovery_alias(cmd, resource_group_name, namespace_name, alias,
                           partner_namespace, alternate_name=None):
-    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.georecovery_alias import Create
+    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.georecovery_alias._create import Create
     command_arg_dict = {
         "resource_group": resource_group_name,
         "namespace_name": namespace_name,
@@ -336,8 +336,8 @@ def set_georecovery_alias(cmd, resource_group_name, namespace_name, alias,
 
 
 def cli_add_location(cmd, resource_group_name, namespace_name, geo_data_replication_config):
-    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace import Update
-    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace import Show
+    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace._update import Update
+    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace._show import Show
 
     eventhubsnm = Show(cli_ctx=cmd.cli_ctx)(command_args={
         "resource_group": resource_group_name,
@@ -361,8 +361,8 @@ def cli_add_location(cmd, resource_group_name, namespace_name, geo_data_replicat
 
 
 def cli_remove_location(cmd, resource_group_name, namespace_name, geo_data_replication_config):
-    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace import Update
-    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace import Show
+    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace._update import Update
+    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace._show import Show
 
     eventhubsnm = Show(cli_ctx=cmd.cli_ctx)(command_args={
         "resource_group": resource_group_name,

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/operations/network_rule_set.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/operations/network_rule_set.py
@@ -15,8 +15,8 @@ from azure.cli.core.azclierror import CLIError
 
 
 def add_network_rule_set_ip_rule(cmd, resource_group_name, namespace_name, ip_rule=None):
-    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace.network_rule_set import Update
-    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace.network_rule_set import Show
+    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace.network_rule_set._update import Update
+    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace.network_rule_set._show import Show
 
     eventhubs_ip_rule = Show(cli_ctx=cmd.cli_ctx)(command_args={
         "resource_group": resource_group_name,
@@ -47,8 +47,8 @@ def add_network_rule_set_ip_rule(cmd, resource_group_name, namespace_name, ip_ru
 
 
 def remove_network_rule_set_ip_rule(cmd, resource_group_name, namespace_name, ip_rule=None):
-    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace.network_rule_set import Update
-    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace.network_rule_set import Show
+    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace.network_rule_set._update import Update
+    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace.network_rule_set._show import Show
     eventhubs_ip_rule = Show(cli_ctx=cmd.cli_ctx)(command_args={
         "resource_group": resource_group_name,
         "namespace_name": namespace_name
@@ -74,8 +74,8 @@ def remove_network_rule_set_ip_rule(cmd, resource_group_name, namespace_name, ip
 
 
 def add_virtual_network_rule(cmd, resource_group_name, namespace_name, subnet=None):
-    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace.network_rule_set import Update
-    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace.network_rule_set import Show
+    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace.network_rule_set._update import Update
+    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace.network_rule_set._show import Show
     eventhubs_nw_rule = Show(cli_ctx=cmd.cli_ctx)(command_args={
         "resource_group": resource_group_name,
         "namespace_name": namespace_name
@@ -106,8 +106,8 @@ def add_virtual_network_rule(cmd, resource_group_name, namespace_name, subnet=No
 
 def remove_virtual_network_rule(cmd, resource_group_name, namespace_name, subnet=None):
 
-    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace.network_rule_set import Update
-    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace.network_rule_set import Show
+    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace.network_rule_set._update import Update
+    from azure.cli.command_modules.eventhubs.aaz.latest.eventhubs.namespace.network_rule_set._show import Show
     eventhubs_nw_rule = Show(cli_ctx=cmd.cli_ctx)(command_args={
         "resource_group": resource_group_name,
         "namespace_name": namespace_name


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az eventhubs --help`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Introduces an optimized AAZ command loader (`load_aaz_command_table_optimized`) that navigates the package tree guided by CLI args instead of importing all command modules eagerly. Applied to the `eventhubs` module as a pilot.

**What changed**

- **New loader in `_command.py`**: `load_aaz_command_table_optimized` uses `pkgutil.iter_modules()` to match CLI args against subpackages/command modules, loading only the targeted subtree. Helper functions `_load_aaz_by_pkg`, `_get_pkg_children`, `_load_first_command` support the navigation.
- **Gutted `__init__.py` files**: Removed wildcard imports (`from ._create import *`) from 26 eventhubs AAZ `__init__.py` files to prevent cascade imports.
- **Direct module imports**: Updated all operations files to import from specific modules (e.g., `._update import Update`) instead of package-level imports.
- **Config toggle**: `az config set eventhubs.optimized_loading=false` disables the optimization (falls back to full load). Warning shown only for eventhubs commands.
- **Tests**: 17 new unit tests covering both original and optimized loaders.

**Performance — Hyperfine (10 runs, 3 warmups)**

| Command | dev | optimized | Improvement |
|---------|-----|-----------|-------------|
| `az eventhubs --help` | 1,489 ms ± 86 | 1,217 ms ± 15 | **-272 ms (18%)** |
| `az eventhubs namespace --help` | 1,580 ms ± 99 | 1,276 ms ± 12 | **-304 ms (19%)** |
| `az eventhubs namespace create --help` | 1,702 ms ± 85 | 1,401 ms ± 43 | **-301 ms (18%)** |
| `az eventhubs eventhub --help` | 1,426 ms ± 53 | 1,229 ms ± 28 | **-197 ms (14%)** |

**Performance — VizTracer Breakdown (after warmup)**

**`az eventhubs --help`**

| Function | dev | optimized | Δ |
|----------|-----|-----------|---|
| AAZ loader (`load_aaz_command_table`) | 73.6 ms | 36.3 ms | **-37.3 ms (51%)** |
| `EventhubCommandsLoader.load_command_table` | 290.5 ms | 262.9 ms | **-27.6 ms (10%)** |

**`az eventhubs namespace create --help`**

| Function | dev | optimized | Δ |
|----------|-----|-----------|---|
| AAZ loader (`load_aaz_command_table`) | 320.6 ms | 16.4 ms | **-304.2 ms (95%)** |
| `EventhubCommandsLoader.load_command_table` | 695.0 ms | 233.4 ms | **-461.6 ms (66%)** |

**Risk & Rollback**

Users can disable the optimization without code changes:

```
az config set eventhubs.optimized_loading=false
```

The fallback uses the same optimized loader with `args=None` (full load), ensuring compatibility with the gutted `__init__.py` files.

A warning message is added.
<img width="1349" height="228" alt="image" src="https://github.com/user-attachments/assets/a4172a94-bfaf-424a-980a-14204b3f6ee6" />

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
