### PR TITLE
{Misc.} Fix dependsOn indentation in macos-standalone-release.yml

### DIFF
--- a/.azure-pipelines/macos-standalone-release.yml
+++ b/.azure-pipelines/macos-standalone-release.yml
@@ -177,9 +177,9 @@ jobs:
       MacosIntelImage: ${{ variables.macos_intel_pool }}
       PythonVersion: ${{ parameters.PythonVersion }}
       Debug: ${{ parameters.Debug }}
-    dependsOn:
-    - TestTempTapCask
-    - TestOfflineInstall
+      dependsOn:
+      - TestTempTapCask
+      - TestOfflineInstall
 
 # Jobs included:
 # - CreateGitHubRelease (conditional)


### PR DESCRIPTION
## Description

Fix incorrect YAML indentation of `dependsOn` in the macOS publish phase of `macos-standalone-release.yml`.

The `dependsOn` key and its list items were indented at the `template:` level instead of inside the `parameters:` block, causing an "Unexpected value 'dependsOn'" validation error.

## Testing Guide

YAML validation passes after the fix. No functional change — this is a pipeline syntax correction.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
