### PR TITLE
[App Service] Fix #30021: `az webapp deployment source config`: Detect SP auth and provide guidance

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -117,6 +117,17 @@ logger = get_logger(__name__)
 # Please maintain compatibility in both interfaces and functionalities"
 
 
+def _is_service_principal_auth(cli_ctx):
+    """Check if current authentication is via Service Principal."""
+    from azure.cli.core._profile import Profile
+    from azure.cli.core.commands.client_factory import get_subscription_id
+    profile = Profile(cli_ctx=cli_ctx)
+    subscription_id = get_subscription_id(cli_ctx)
+    account = profile.get_subscription(subscription=subscription_id)
+    # Service principals have user.type == 'servicePrincipal'
+    return account.get('user', {}).get('type') == 'servicePrincipal'
+
+
 def create_webapp(cmd, resource_group_name, name, plan, runtime=None, startup_file=None,  # pylint: disable=too-many-statements,too-many-branches
                   deployment_container_image_name=None, deployment_source_url=None, deployment_source_branch='master',
                   deployment_local_git=None, sitecontainers_app=None,
@@ -3996,6 +4007,13 @@ def config_source_control(cmd, resource_group_name, name, repo_url, repository_t
                           manual_integration=None, git_token=None, slot=None, github_action=None):
     client = web_client_factory(cmd.cli_ctx)
     location = _get_location_from_webapp(client, resource_group_name, name)
+
+    # Check for Service Principal + GitHub Actions incompatibility
+    if github_action and _is_service_principal_auth(cmd.cli_ctx):
+        raise ValidationError(
+            "GitHub Actions deployment cannot be configured with Service Principal authentication. "
+            "Use 'az webapp deployment github-actions add' instead, which supports Service Principal workflows."
+        )
 
     from azure.mgmt.web.models import SiteSourceControl, SourceControl
     if git_token:

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands_thru_mock.py
@@ -33,7 +33,8 @@ from azure.cli.command_modules.appservice.custom import (set_deployment_user,
                                                          add_github_actions,
                                                          update_app_settings,
                                                          update_application_settings_polling,
-                                                         update_webapp)
+                                                         update_webapp,
+                                                         config_source_control)
 
 # pylint: disable=line-too-long
 from azure.cli.core.profiles import ResourceType
@@ -637,6 +638,114 @@ class TestUpdateWebapp(unittest.TestCase):
         result = update_webapp(cmd_mock, instance, platform_release_channel='Latest')
 
         self.assertEqual(result.additional_properties["properties"]["platformReleaseChannel"], "Latest")
+
+
+class TestServicePrincipalDeploymentSource(unittest.TestCase):
+    """Tests for Service Principal authentication detection in deployment source config"""
+
+    @mock.patch('azure.cli.command_modules.appservice.custom._is_service_principal_auth')
+    @mock.patch('azure.cli.command_modules.appservice.custom._get_location_from_webapp')
+    @mock.patch('azure.cli.command_modules.appservice.custom.web_client_factory')
+    def test_config_source_control_with_sp_and_github_action_raises_error(
+        self, web_client_factory_mock, get_location_mock, is_sp_auth_mock
+    ):
+        """Test that SP auth + --github-action raises ValidationError"""
+        from azure.cli.core.azclierror import ValidationError
+        
+        # Setup mocks
+        is_sp_auth_mock.return_value = True
+        get_location_mock.return_value = 'eastus'
+        
+        cmd = _get_test_cmd()
+        
+        # Execute and assert
+        with self.assertRaises(ValidationError) as context:
+            config_source_control(
+                cmd,
+                resource_group_name='test-rg',
+                name='test-app',
+                repo_url='https://github.com/test/repo',
+                github_action=True
+            )
+        
+        self.assertIn('Service Principal authentication', str(context.exception))
+        self.assertIn('az webapp deployment github-actions add', str(context.exception))
+
+    @mock.patch('azure.cli.command_modules.appservice.custom._is_service_principal_auth')
+    @mock.patch('azure.cli.command_modules.appservice.custom._generic_site_operation')
+    @mock.patch('azure.cli.command_modules.appservice.custom._get_location_from_webapp')
+    @mock.patch('azure.cli.command_modules.appservice.custom.web_client_factory')
+    def test_config_source_control_with_user_and_github_action_succeeds(
+        self, web_client_factory_mock, get_location_mock, generic_site_op_mock, is_sp_auth_mock
+    ):
+        """Test that user auth + --github-action passes through (no error raised)"""
+        
+        # Setup mocks
+        is_sp_auth_mock.return_value = False  # User authentication
+        get_location_mock.return_value = 'eastus'
+        
+        # Mock the site operation to return a mock response
+        mock_poller = mock.Mock()
+        mock_poller.done.return_value = True
+        mock_response = mock.Mock()
+        mock_response.git_hub_action_configuration = None
+        mock_poller.result.return_value = mock_response
+        generic_site_op_mock.return_value = mock_poller
+        
+        cmd = _get_test_cmd()
+        
+        # Execute - should not raise an error
+        config_source_control(
+            cmd,
+            resource_group_name='test-rg',
+            name='test-app',
+            repo_url='https://github.com/test/repo',
+            github_action=True
+        )
+
+        # Assert _generic_site_operation was called with correct SiteSourceControl
+        generic_site_op_mock.assert_called_once()
+        call_args = generic_site_op_mock.call_args
+        source_control_arg = call_args[0][5]
+        self.assertTrue(source_control_arg.is_git_hub_action)
+
+    @mock.patch('azure.cli.command_modules.appservice.custom._is_service_principal_auth')
+    @mock.patch('azure.cli.command_modules.appservice.custom._generic_site_operation')
+    @mock.patch('azure.cli.command_modules.appservice.custom._get_location_from_webapp')
+    @mock.patch('azure.cli.command_modules.appservice.custom.web_client_factory')
+    def test_config_source_control_with_sp_without_github_action_succeeds(
+        self, web_client_factory_mock, get_location_mock, generic_site_op_mock, is_sp_auth_mock
+    ):
+        """Test that SP auth without --github-action passes through (no error raised)"""
+        
+        # Setup mocks
+        is_sp_auth_mock.return_value = True  # Service Principal authentication
+        get_location_mock.return_value = 'eastus'
+        
+        # Mock the site operation to return a mock response
+        mock_poller = mock.Mock()
+        mock_poller.done.return_value = True
+        mock_response = mock.Mock()
+        mock_response.git_hub_action_configuration = None
+        mock_poller.result.return_value = mock_response
+        generic_site_op_mock.return_value = mock_poller
+        
+        cmd = _get_test_cmd()
+        
+        # Execute - should not raise an error when github_action is None/False
+        config_source_control(
+            cmd,
+            resource_group_name='test-rg',
+            name='test-app',
+            repo_url='https://github.com/test/repo',
+            github_action=None  # Not using GitHub Actions
+        )
+
+        # Assert _generic_site_operation was called with correct SiteSourceControl
+        generic_site_op_mock.assert_called_once()
+        call_args = generic_site_op_mock.call_args
+        source_control_arg = call_args[0][5]
+        self.assertFalse(source_control_arg.is_git_hub_action)
 
 
 class FakedResponse:  # pylint: disable=too-few-public-methods


### PR DESCRIPTION
## Description

This PR fixes issue #30021 where `az webapp deployment source config --github-action` fails with a cryptic "Cannot find User" error when called with Service Principal authentication.

## Root Cause
The Azure App Service backend API requires a publishing user when `isGitHubAction=true` is set in the deployment source config request. Service Principals do not have publishing users, causing a 404 error from the backend.

## Solution
Added client-side validation in the `config_source_control` function to detect when:
1. The current authentication context is a Service Principal
2. The `--github-action` flag is set to true

When both conditions are met, the CLI now raises a clear `ValidationError` directing users to use `az webapp deployment github-actions add` instead, which properly supports Service Principal authentication.

## Changes
- Added `_is_service_principal_auth` helper function to detect SP authentication
- Added validation logic in `config_source_control` function
- Added comprehensive unit tests covering:
  - SP + --github-action raises error
  - User + --github-action works normally
  - SP without --github-action works normally

## Testing
All tests pass:
```
pytest src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands_thru_mock.py::TestServicePrincipalDeploymentSource -v
# 3 passed
```

Style checks pass:
```
azdev style appservice
# Pylint: PASSED
# Flake8: PASSED
```

## Breaking Change
This is **not** a breaking change. The current behavior is already broken for Service Principals. This change adds validation to prevent a confusing backend error and provides clear guidance to users.

## Related Issue
Fixes #30021

---

### History Notes

**App Service**
* Fix #30021: Detect Service Principal authentication in `az webapp deployment source config` and provide clear error when `--github-action` is used, directing users to `az webapp deployment github-actions add`