### PR TITLE
[App Service] Fix #30336, #29761: Improve `--scope` and `--linux-fx-version` help text and examples

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -1665,6 +1665,15 @@ examples:
   - name: set configuration through a JSON file called params.json
     text: >
         az webapp config set -g MyResourceGroup -n MyUniqueApp --generic-configurations "@.\\params.json"
+  - name: Set the linux runtime stack to Python 3.11 (format is RUNTIME|VERSION).
+    text: >
+        az webapp config set -g MyResourceGroup -n MyUniqueApp --linux-fx-version "PYTHON|3.11"
+  - name: Set the linux runtime stack to Node.js 18 LTS.
+    text: >
+        az webapp config set -g MyResourceGroup -n MyUniqueApp --linux-fx-version "NODE|18-lts"
+  - name: Set the linux runtime stack to .NET 8.0.
+    text: >
+        az webapp config set -g MyResourceGroup -n MyUniqueApp --linux-fx-version "DOTNETCORE|8.0"
 
 """
 
@@ -1910,6 +1919,9 @@ examples:
   - name: Create a web app with end-to-end encryption enabled and minimum TLS version 1.2
     text: >
         az webapp create -g MyResourceGroup -p MyPlan -n MyUniqueAppName --end-to-end-encryption-enabled true --min-tls-version 1.2
+  - name: Create a web app with a system-assigned managed identity and grant it access to a storage account.
+    text: >
+        az webapp create -g MyResourceGroup -p MyPlan -n MyUniqueAppName --assign-identity [system] --scope /subscriptions/{subscription}/resourceGroups/{resourceGroup}/providers/Microsoft.Storage/storageAccounts/{storageAccount} --role Contributor
 """
 
 helps['webapp create-remote-connection'] = """

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -581,7 +581,7 @@ subscription than the app service environment, please use the resource ID for --
             c.argument('power_shell_version', help='The version used to run your function app if using PowerShell, e.g., 7.2', options_list=['--powershell-version'])
             c.argument('python_version', help='The version used to run your web app if using Python, e.g., 2.7, 3.4')
             c.argument('net_framework_version', help="The version used to run your web app if using .NET Framework, e.g., 'v4.0' for .NET 4.6 and 'v3.0' for .NET 3.5")
-            c.argument('linux_fx_version', help="The runtime stack used for your linux-based webapp, e.g., \"RUBY|2.5.5\", \"NODE|12LTS\", \"PHP|7.2\", \"DOTNETCORE|2.1\". See https://aka.ms/linux-stacks for more info.")
+            c.argument('linux_fx_version', help="The runtime stack used for your linux-based webapp, in the format 'RUNTIME|VERSION'. Common examples: \"PYTHON|3.11\", \"NODE|18-lts\", \"DOTNETCORE|8.0\", \"JAVA|17-java17\", \"PHP|8.2\". Use `az webapp list-runtimes --os linux` to see all supported values. See https://aka.ms/linux-stacks for more info.")
             c.argument('windows_fx_version', help="A docker image name used for your windows container web app, e.g., microsoft/nanoserver:ltsc2016")
             if scope == 'functionapp':
                 c.ignore('windows_fx_version')


### PR DESCRIPTION
## Description

Fixes #30336 and #29761.

### Changes:
- **#30336**: Added `--scope` example to `az webapp create` help showing how to create a web app with a system-assigned managed identity and grant it access to a resource.
- **#29761**: Updated `--linux-fx-version` parameter help text with the `RUNTIME|VERSION` format and current runtime examples (PYTHON|3.11, NODE|18-lts, DOTNETCORE|8.0, JAVA|17-java17, PHP|8.2). Added `--linux-fx-version` examples to `az webapp config set` help.

### Testing:
- Compile-checked all modified files
- Pylint clean (10.00/10 on _help.py)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>