### PR TITLE
[App Service] Fix SSH tunnel reliability, signal handling, and instance targeting

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -1941,6 +1941,8 @@ short-summary: Creates a remote connection using a tcp tunnel to your web app
 examples:
   - name: Create a remote connection using a tcp tunnel to your web app
     text: az webapp create-remote-connection --name MyWebApp --resource-group MyResourceGroup
+  - name: Create a remote connection to a specific instance
+    text: az webapp create-remote-connection --name MyWebApp --resource-group MyResourceGroup --instance 89c07485c4742abcde3f0e19ea4402a06e3b48145ed81e6468066f10a78074b1
 """
 
 helps['webapp delete'] = """
@@ -2424,6 +2426,9 @@ examples:
   - name: ssh into a web app
     text: >
         az webapp ssh -n MyUniqueAppName -g MyResourceGroup
+  - name: ssh into a specific instance of a web app
+    text: >
+        az webapp ssh -n MyUniqueAppName -g MyResourceGroup --instance 89c07485c4742abcde3f0e19ea4402a06e3b48145ed81e6468066f10a78074b1
 """
 
 helps['webapp start'] = """

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -998,14 +998,22 @@ subscription than the app service environment, please use the resource ID for --
     with self.argument_context('webapp ssh') as c:
         c.argument('port', options_list=['--port', '-p'],
                    help='Port for the remote connection. Default: Random available port', type=int)
-        c.argument('timeout', options_list=['--timeout', '-t'], help='timeout in seconds. Defaults to none', type=int)
-        c.argument('instance', options_list=['--instance', '-i'], help='Webapp instance to connect to. Defaults to none.')
+        c.argument('timeout', options_list=['--timeout', '-t'],
+                   help='Timeout in seconds. The tunnel will automatically close after this duration. '
+                        'Defaults to none (keep open until manually closed).', type=int)
+        c.argument('instance', options_list=['--instance', '-i'],
+                   help='Webapp instance to connect to. Use `az webapp list-instances` to get available instances. '
+                        'If not specified, connects to an arbitrary instance.')
 
     with self.argument_context('webapp create-remote-connection') as c:
         c.argument('port', options_list=['--port', '-p'],
                    help='Port for the remote connection. Default: Random available port', type=int)
-        c.argument('timeout', options_list=['--timeout', '-t'], help='timeout in seconds. Defaults to none', type=int)
-        c.argument('instance', options_list=['--instance', '-i'], help='Webapp instance to connect to. Defaults to none.')
+        c.argument('timeout', options_list=['--timeout', '-t'],
+                   help='Timeout in seconds. The tunnel will automatically close after this duration. '
+                        'Defaults to none (keep open until manually closed).', type=int)
+        c.argument('instance', options_list=['--instance', '-i'],
+                   help='Webapp instance to connect to. Use `az webapp list-instances` to get available instances. '
+                        'If not specified, connects to an arbitrary instance.')
 
     with self.argument_context('webapp vnet-integration') as c:
         c.argument('name', arg_type=webapp_name_arg_type, id_part=None)

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -10753,7 +10753,6 @@ def _register_tunnel_cleanup(tunnel_server):
     def _signal_handler(signum, frame):  # pylint: disable=unused-argument
         logger.warning('Received signal %s, shutting down tunnel...', signum)
         tunnel_server.close()
-        sys.exit(0)
 
     signal.signal(signal.SIGINT, _signal_handler)
     signal.signal(signal.SIGTERM, _signal_handler)

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -10164,6 +10164,8 @@ def get_tunnel(cmd, resource_group_name, name, port=None, slot=None, instance=No
 def create_tunnel(cmd, resource_group_name, name, port=None, slot=None, timeout=None, instance=None):
     tunnel_server = get_tunnel(cmd, resource_group_name, name, port, slot, instance)
 
+    _register_tunnel_cleanup(tunnel_server)
+
     t = threading.Thread(target=_start_tunnel, args=(tunnel_server,))
     t.daemon = True
     t.start()
@@ -10182,15 +10184,22 @@ def create_tunnel(cmd, resource_group_name, name, port=None, slot=None, timeout=
 
     logger.warning('Ctrl + C to close')
 
-    if timeout:
-        time.sleep(int(timeout))
-    else:
-        while t.is_alive():
-            time.sleep(5)
+    try:
+        if timeout:
+            time.sleep(int(timeout))
+        else:
+            while t.is_alive():
+                time.sleep(5)
+    except KeyboardInterrupt:
+        logger.warning('Shutting down tunnel...')
+    finally:
+        tunnel_server.close()
 
 
 def create_tunnel_and_session(cmd, resource_group_name, name, port=None, slot=None, timeout=None, instance=None):
     tunnel_server = get_tunnel(cmd, resource_group_name, name, port, slot, instance)
+
+    _register_tunnel_cleanup(tunnel_server)
 
     t = threading.Thread(target=_start_tunnel, args=(tunnel_server,))
     t.daemon = True
@@ -10204,11 +10213,16 @@ def create_tunnel_and_session(cmd, resource_group_name, name, port=None, slot=No
     s.daemon = True
     s.start()
 
-    if timeout:
-        time.sleep(int(timeout))
-    else:
-        while s.is_alive() and t.is_alive():
-            time.sleep(5)
+    try:
+        if timeout:
+            time.sleep(int(timeout))
+        else:
+            while s.is_alive() and t.is_alive():
+                time.sleep(5)
+    except KeyboardInterrupt:
+        logger.warning('Shutting down tunnel...')
+    finally:
+        tunnel_server.close()
 
 
 def perform_onedeploy_functionapp(cmd,
@@ -10724,6 +10738,25 @@ def _wait_for_webapp(tunnel_server):
 
 def _start_tunnel(tunnel_server):
     tunnel_server.start_server()
+
+
+def _register_tunnel_cleanup(tunnel_server):
+    """Register signal handlers and atexit to ensure the tunnel is cleaned up."""
+    import atexit
+    import signal
+
+    def _cleanup():
+        tunnel_server.close()
+
+    atexit.register(_cleanup)
+
+    def _signal_handler(signum, frame):  # pylint: disable=unused-argument
+        logger.warning('Received signal %s, shutting down tunnel...', signum)
+        tunnel_server.close()
+        sys.exit(0)
+
+    signal.signal(signal.SIGINT, _signal_handler)
+    signal.signal(signal.SIGTERM, _signal_handler)
 
 
 def _start_ssh_session(hostname, port, username, password):

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands_thru_mock.py
@@ -762,7 +762,7 @@ class TestTunnelServer(unittest.TestCase):
         # Fail twice, succeed on third
         mock_create_conn.side_effect = [ConnectionError("fail1"), ConnectionError("fail2"), mock_ws]
 
-        with mock.patch('azure.cli.command_modules.appservice.tunnel.time.sleep'):
+        with mock.patch.object(server._closing, 'wait'):
             result = server._create_websocket_connection(
                 'wss://test/Tunnel.ashx', ['Authorization: Basic dGVzdDp0ZXN0'], 0)
 
@@ -789,7 +789,7 @@ class TestTunnelServer(unittest.TestCase):
 
         mock_create_conn.side_effect = ConnectionError("always fail")
 
-        with mock.patch('azure.cli.command_modules.appservice.tunnel.time.sleep'):
+        with mock.patch.object(server._closing, 'wait'):
             with self.assertRaises(CLIError) as ctx:
                 server._create_websocket_connection(
                     'wss://test/Tunnel.ashx', ['Authorization: Basic dGVzdDp0ZXN0'], 0)

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands_thru_mock.py
@@ -36,6 +36,7 @@ from azure.cli.command_modules.appservice.custom import (set_deployment_user,
                                                          update_application_settings_polling,
                                                          update_webapp,
                                                          create_webapp)
+from azure.cli.command_modules.appservice.tunnel import TunnelServer
 
 # pylint: disable=line-too-long
 from azure.cli.core.profiles import ResourceType
@@ -669,6 +670,174 @@ class TestUpdateWebapp(unittest.TestCase):
         result = update_webapp(cmd_mock, instance, platform_release_channel='Latest')
 
         self.assertEqual(result.additional_properties["properties"]["platformReleaseChannel"], "Latest")
+
+
+class TestTunnelServer(unittest.TestCase):
+    """Tests for TunnelServer reliability and cleanup improvements."""
+
+    @mock.patch('azure.cli.command_modules.appservice.tunnel.socket.socket')
+    def test_tunnel_server_close_sets_closing_event(self, mock_socket_cls):
+        mock_sock = mock.MagicMock()
+        mock_socket_cls.return_value = mock_sock
+        mock_sock.getsockname.return_value = ('127.0.0.1', 12345)
+        server = TunnelServer.__new__(TunnelServer)
+        server.local_addr = '127.0.0.1'
+        server.local_port = 0
+        server.remote_addr = 'testapp.scm.azurewebsites.net'
+        server.auth_string = 'Basic dGVzdDp0ZXN0'
+        server.instance = None
+        server.client = None
+        server.ws = None
+        from threading import Event
+        server._closing = Event()
+        server.sock = mock_sock
+
+        server.close()
+        self.assertTrue(server._closing.is_set())
+        mock_sock.close.assert_called_once()
+
+    @mock.patch('azure.cli.command_modules.appservice.tunnel.socket.socket')
+    def test_tunnel_server_close_is_idempotent(self, mock_socket_cls):
+        mock_sock = mock.MagicMock()
+        mock_socket_cls.return_value = mock_sock
+        mock_sock.getsockname.return_value = ('127.0.0.1', 12345)
+        server = TunnelServer.__new__(TunnelServer)
+        server.local_addr = '127.0.0.1'
+        server.local_port = 0
+        server.remote_addr = 'testapp.scm.azurewebsites.net'
+        server.auth_string = 'Basic dGVzdDp0ZXN0'
+        server.instance = None
+        server.client = None
+        server.ws = None
+        from threading import Event
+        server._closing = Event()
+        server.sock = mock_sock
+
+        server.close()
+        server.close()
+        # Socket.close should only be called once
+        mock_sock.close.assert_called_once()
+
+    @mock.patch('azure.cli.command_modules.appservice.tunnel.socket.socket')
+    def test_tunnel_server_close_handles_ws_and_client(self, mock_socket_cls):
+        mock_sock = mock.MagicMock()
+        mock_socket_cls.return_value = mock_sock
+        mock_sock.getsockname.return_value = ('127.0.0.1', 12345)
+        server = TunnelServer.__new__(TunnelServer)
+        server.local_addr = '127.0.0.1'
+        server.local_port = 0
+        server.remote_addr = 'testapp.scm.azurewebsites.net'
+        server.auth_string = 'Basic dGVzdDp0ZXN0'
+        server.instance = None
+        server.client = mock.MagicMock()
+        server.ws = mock.MagicMock()
+        from threading import Event
+        server._closing = Event()
+        server.sock = mock_sock
+
+        server.close()
+        server.ws.close.assert_called_once()
+        server.client.close.assert_called_once()
+        mock_sock.close.assert_called_once()
+
+    @mock.patch('azure.cli.command_modules.appservice.tunnel.create_connection')
+    @mock.patch('azure.cli.command_modules.appservice.tunnel.socket.socket')
+    def test_create_websocket_connection_retries_on_failure(self, mock_socket_cls, mock_create_conn):
+        mock_sock = mock.MagicMock()
+        mock_socket_cls.return_value = mock_sock
+        mock_sock.getsockname.return_value = ('127.0.0.1', 12345)
+        server = TunnelServer.__new__(TunnelServer)
+        server.local_addr = '127.0.0.1'
+        server.local_port = 0
+        server.remote_addr = 'testapp.scm.azurewebsites.net'
+        server.auth_string = 'Basic dGVzdDp0ZXN0'
+        server.instance = None
+        server.client = None
+        server.ws = None
+        from threading import Event
+        server._closing = Event()
+        server.sock = mock_sock
+
+        mock_ws = mock.MagicMock()
+        # Fail twice, succeed on third
+        mock_create_conn.side_effect = [ConnectionError("fail1"), ConnectionError("fail2"), mock_ws]
+
+        with mock.patch('azure.cli.command_modules.appservice.tunnel.time.sleep'):
+            result = server._create_websocket_connection(
+                'wss://test/Tunnel.ashx', ['Authorization: Basic dGVzdDp0ZXN0'], 0)
+
+        self.assertEqual(result, mock_ws)
+        self.assertEqual(mock_create_conn.call_count, 3)
+
+    @mock.patch('azure.cli.command_modules.appservice.tunnel.create_connection')
+    @mock.patch('azure.cli.command_modules.appservice.tunnel.socket.socket')
+    def test_create_websocket_connection_raises_after_max_retries(self, mock_socket_cls, mock_create_conn):
+        mock_sock = mock.MagicMock()
+        mock_socket_cls.return_value = mock_sock
+        mock_sock.getsockname.return_value = ('127.0.0.1', 12345)
+        server = TunnelServer.__new__(TunnelServer)
+        server.local_addr = '127.0.0.1'
+        server.local_port = 0
+        server.remote_addr = 'testapp.scm.azurewebsites.net'
+        server.auth_string = 'Basic dGVzdDp0ZXN0'
+        server.instance = None
+        server.client = None
+        server.ws = None
+        from threading import Event
+        server._closing = Event()
+        server.sock = mock_sock
+
+        mock_create_conn.side_effect = ConnectionError("always fail")
+
+        with mock.patch('azure.cli.command_modules.appservice.tunnel.time.sleep'):
+            with self.assertRaises(CLIError) as ctx:
+                server._create_websocket_connection(
+                    'wss://test/Tunnel.ashx', ['Authorization: Basic dGVzdDp0ZXN0'], 0)
+
+        self.assertIn('Failed to establish WebSocket tunnel connection', str(ctx.exception))
+
+    @mock.patch('azure.cli.command_modules.appservice.tunnel.socket.socket')
+    def test_keepalive_ping_stops_on_event(self, mock_socket_cls):
+        from threading import Event
+        mock_sock = mock.MagicMock()
+        mock_socket_cls.return_value = mock_sock
+        mock_sock.getsockname.return_value = ('127.0.0.1', 12345)
+        server = TunnelServer.__new__(TunnelServer)
+        server.local_addr = '127.0.0.1'
+        server.local_port = 0
+        server.remote_addr = 'testapp.scm.azurewebsites.net'
+        server.auth_string = 'Basic dGVzdDp0ZXN0'
+        server.instance = None
+        server.client = None
+        server.ws = None
+        server._closing = Event()
+        server.sock = mock_sock
+
+        mock_ws = mock.MagicMock()
+        mock_ws.connected = True
+        stop_event = Event()
+        # Signal stop immediately so the keepalive loop runs once at most
+        stop_event.set()
+        server._send_keepalive_pings(mock_ws, 1, stop_event)
+        # Should not crash; ws.ping may or may not have been called depending on timing
+
+
+class TestTunnelSignalCleanup(unittest.TestCase):
+    """Tests for signal handler registration and cleanup in create_tunnel / create_tunnel_and_session."""
+
+    @mock.patch('signal.signal')
+    @mock.patch('atexit.register')
+    def test_register_tunnel_cleanup_registers_handlers(self, mock_atexit, mock_signal):
+        from azure.cli.command_modules.appservice.custom import _register_tunnel_cleanup
+        import signal
+
+        mock_tunnel = mock.MagicMock()
+        _register_tunnel_cleanup(mock_tunnel)
+
+        mock_atexit.assert_called_once()
+        signal_calls = {call[0][0] for call in mock_signal.call_args_list}
+        self.assertIn(signal.SIGINT, signal_calls)
+        self.assertIn(signal.SIGTERM, signal_calls)
 
 
 class FakedResponse:  # pylint: disable=too-few-public-methods

--- a/src/azure-cli/azure/cli/command_modules/appservice/tunnel.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tunnel.py
@@ -8,7 +8,6 @@ import sys
 import ssl
 import json
 import socket
-import time
 import traceback
 import logging as logs
 from contextlib import closing
@@ -148,7 +147,7 @@ class TunnelServer:
                         'Failed to establish WebSocket tunnel connection after {} attempts. '
                         'Last error: {}'.format(_MAX_RECONNECT_ATTEMPTS, ex))
                 logger.warning('Retrying WebSocket connection in %s seconds...', delay)
-                time.sleep(delay)
+                self._closing.wait(delay)
                 delay = min(delay * 2, _MAX_RECONNECT_DELAY)
         return None  # pragma: no cover
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/tunnel.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tunnel.py
@@ -13,7 +13,7 @@ import traceback
 import logging as logs
 from contextlib import closing
 from datetime import datetime
-from threading import Thread
+from threading import Thread, Event
 
 import websocket
 from websocket import create_connection, WebSocket
@@ -23,6 +23,12 @@ from .utils import get_pool_manager
 from knack.util import CLIError
 from knack.log import get_logger
 logger = get_logger(__name__)
+
+# Retry / keepalive constants
+_MAX_RECONNECT_ATTEMPTS = 5
+_INITIAL_RECONNECT_DELAY = 1        # seconds
+_MAX_RECONNECT_DELAY = 30           # seconds
+_KEEPALIVE_INTERVAL = 30            # seconds between WebSocket pings
 
 
 class TunnelWebSocket(WebSocket):
@@ -52,6 +58,7 @@ class TunnelServer:
         self.instance = instance
         self.client = None
         self.ws = None
+        self._closing = Event()
         logger.info('Creating a socket on port: %s', self.local_port)
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         logger.info('Setting socket options')
@@ -117,12 +124,48 @@ class TunnelServer:
             logger.warning('Waiting for app to start up... ')
         return False
 
+    def _create_websocket_connection(self, host, basic_auth_header, verify_mode):
+        """Create a WebSocket connection with retry logic and exponential backoff."""
+        delay = _INITIAL_RECONNECT_DELAY
+        for attempt in range(1, _MAX_RECONNECT_ATTEMPTS + 1):
+            if self._closing.is_set():
+                return None
+            try:
+                ws = create_connection(host,
+                                       sockopt=((socket.IPPROTO_TCP, socket.TCP_NODELAY, 1),),
+                                       class_=TunnelWebSocket,
+                                       header=basic_auth_header,
+                                       sslopt={'cert_reqs': verify_mode},
+                                       timeout=60 * 60,
+                                       enable_multithread=True)
+                logger.info('WebSocket connected on attempt %s', attempt)
+                return ws
+            except Exception as ex:  # pylint: disable=broad-except
+                logger.info('WebSocket connection attempt %s/%s failed: %s',
+                            attempt, _MAX_RECONNECT_ATTEMPTS, ex)
+                if attempt == _MAX_RECONNECT_ATTEMPTS:
+                    raise CLIError(
+                        'Failed to establish WebSocket tunnel connection after {} attempts. '
+                        'Last error: {}'.format(_MAX_RECONNECT_ATTEMPTS, ex))
+                logger.warning('Retrying WebSocket connection in %s seconds...', delay)
+                time.sleep(delay)
+                delay = min(delay * 2, _MAX_RECONNECT_DELAY)
+        return None  # pragma: no cover
+
     def _listen(self):
         self.sock.listen(100)
         index = 0
-        while True:
-            self.client, _address = self.sock.accept()
-            self.client.settimeout(60 * 60)
+        while not self._closing.is_set():
+            try:
+                self.sock.settimeout(1.0)
+                try:
+                    self.client, _address = self.sock.accept()
+                except socket.timeout:
+                    continue
+                self.client.settimeout(60 * 60)
+            except OSError:
+                # Socket closed during shutdown
+                break
             host = 'wss://{}{}'.format(self.remote_addr, '/AppServiceTunnel/Tunnel.ashx')
             basic_auth_header = [f"Authorization: {self.auth_string}"]
             if self.instance is not None:
@@ -136,30 +179,47 @@ class TunnelServer:
                 logger.info('Websocket tracing disabled, use --verbose flag to enable')
                 websocket.enableTrace(False)
             verify_mode = ssl.CERT_NONE if should_disable_connection_verify() else ssl.CERT_REQUIRED
-            self.ws = create_connection(host,
-                                        sockopt=((socket.IPPROTO_TCP, socket.TCP_NODELAY, 1),),
-                                        class_=TunnelWebSocket,
-                                        header=basic_auth_header,
-                                        sslopt={'cert_reqs': verify_mode},
-                                        timeout=60 * 60,
-                                        enable_multithread=True)
+            self.ws = self._create_websocket_connection(host, basic_auth_header, verify_mode)
+            if self.ws is None:
+                break
             logger.info('Websocket, connected status: %s', self.ws.connected)
             index = index + 1
             logger.info('Got debugger connection... index: %s', index)
+            keepalive_stop = Event()
             debugger_thread = Thread(target=self._listen_to_client, args=(self.client, self.ws, index))
             web_socket_thread = Thread(target=self._listen_to_web_socket, args=(self.client, self.ws, index))
+            keepalive_thread = Thread(target=self._send_keepalive_pings,
+                                      args=(self.ws, index, keepalive_stop))
+            keepalive_thread.daemon = True
             debugger_thread.start()
             web_socket_thread.start()
+            keepalive_thread.start()
             logger.info('Both debugger and websocket threads started...')
             logger.info('Successfully connected to local server..')
             debugger_thread.join()
             web_socket_thread.join()
+            keepalive_stop.set()
+            keepalive_thread.join(timeout=5)
             logger.info('Both debugger and websocket threads stopped...')
             logger.info('Stopped local server..')
 
+    def _send_keepalive_pings(self, ws_socket, index, stop_event):
+        """Periodically send WebSocket pings to prevent idle disconnects."""
+        while not stop_event.is_set() and not self._closing.is_set():
+            try:
+                if ws_socket.connected:
+                    ws_socket.ping()
+                    logger.info('Sent keepalive ping, index: %s', index)
+                else:
+                    break
+            except Exception as ex:  # pylint: disable=broad-except
+                logger.info('Keepalive ping failed (index %s): %s', index, ex)
+                break
+            stop_event.wait(_KEEPALIVE_INTERVAL)
+
     def _listen_to_web_socket(self, client, ws_socket, index):
         try:
-            while True:
+            while not self._closing.is_set():
                 logger.info('Waiting for websocket data, connection status: %s, index: %s', ws_socket.connected, index)
                 data = ws_socket.recv()
                 logger.info('Received websocket data: %s, index: %s', data, index)
@@ -175,12 +235,18 @@ class TunnelServer:
             logger.info(ex)
         finally:
             logger.info('Client disconnected!, index: %s', index)
-            client.close()
-            ws_socket.close()
+            try:
+                client.close()
+            except Exception:  # pylint: disable=broad-except
+                pass
+            try:
+                ws_socket.close()
+            except Exception:  # pylint: disable=broad-except
+                pass
 
     def _listen_to_client(self, client, ws_socket, index):
         try:
-            while True:
+            while not self._closing.is_set():
                 logger.info('Waiting for debugger data, index: %s', index)
                 buf = bytearray(4096)
                 nbytes = client.recv_into(buf, 4096)
@@ -197,8 +263,37 @@ class TunnelServer:
             logger.warning("Connection Timed Out")
         finally:
             logger.info('Client disconnected %s', index)
-            client.close()
-            ws_socket.close()
+            try:
+                client.close()
+            except Exception:  # pylint: disable=broad-except
+                pass
+            try:
+                ws_socket.close()
+            except Exception:  # pylint: disable=broad-except
+                pass
+
+    def close(self):
+        """Cleanly shut down the tunnel server and release all resources."""
+        if self._closing.is_set():
+            return
+        self._closing.set()
+        logger.info('Closing tunnel server...')
+        if self.ws:
+            try:
+                self.ws.close()
+            except Exception:  # pylint: disable=broad-except
+                pass
+        if self.client:
+            try:
+                self.client.close()
+            except Exception:  # pylint: disable=broad-except
+                pass
+        if self.sock:
+            try:
+                self.sock.close()
+            except Exception:  # pylint: disable=broad-except
+                pass
+        logger.info('Tunnel server closed')
 
     def start_server(self):
         self._listen()


### PR DESCRIPTION
## Description



### Changes

**Tunnel reliability (#8831):**
- Added WebSocket retry logic with exponential backoff (up to 5 attempts, 1s→30s delay) in `TunnelServer._create_websocket_connection()`
- Added keepalive pings every 30s to prevent idle WebSocket disconnects
- Listener loop now uses socket timeouts to support clean shutdown

**Clean Ctrl+C shutdown (#13662):**
- Registered SIGINT/SIGTERM signal handlers that call `tunnel_server.close()`
- Added `atexit` fallback cleanup
- Added `TunnelServer.close()` method with idempotent, exception-safe resource cleanup
- Wrapped main sleep loops in try/finally to ensure cleanup on KeyboardInterrupt

**Instance targeting docs (#13008):**
- Improved `--instance` and `--timeout` parameter descriptions
- Added `--instance` usage examples to help text for both `webapp ssh` and `webapp create-remote-connection`

### Testing
- Added 7 unit tests in `test_webapp_commands_thru_mock.py` covering:
  - `TunnelServer.close()` idempotency and resource cleanup
  - WebSocket retry logic (success on retry, failure after max attempts)
  - Keepalive ping stop behavior
  - Signal handler registration

### Files Changed
- `tunnel.py` — retry logic, keepalive, close(), closing event
- `custom.py` — signal handlers, atexit, try/finally cleanup
- `_params.py` — improved parameter help text
- `_help.py` — added --instance examples
- `test_webapp_commands_thru_mock.py` — new unit tests

Fixes #8831
Fixes #13662
Fixes #13008