### PR TITLE
{Misc.} Escape percent sign to comply with Python 3.14's `argparse`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_params.py
@@ -513,7 +513,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
     for scope in ['acr token create', 'acr token credential generate']:
         with self.argument_context(scope) as c:
             c.argument('expiration', validator=validate_expiration_time,
-                       help='UTC time for which the credentials will be valid. In the format of %Y-%m-%dT%H:%M:%SZ, e.g. 2025-12-31T12:59:59Z')
+                       help='UTC time for which the credentials will be valid. In the format of %%Y-%%m-%%dT%%H:%%M:%%SZ, e.g. 2025-12-31T12:59:59Z')
 
     with self.argument_context('acr token credential delete') as c:
         c.argument('password1', options_list=['--password1'], help='Flag indicating if first password should be deleted', action='store_true', required=False)

--- a/src/azure-cli/azure/cli/command_modules/appconfig/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/_params.py
@@ -314,14 +314,14 @@ def load_arguments(self, _):
                    help="Export key-values as App Configuration references. For more information, see https://learn.microsoft.com/en-us/azure/app-service/app-service-configuration-references")
 
     with self.argument_context('appconfig kv set') as c:
-        c.argument('key', validator=validate_key, help="Key to be set. Key cannot be a '.' or '..', or contain the '%' character.")
+        c.argument('key', validator=validate_key, help="Key to be set. Key cannot be a '.' or '..', or contain the '%%' character.")
         c.argument('label', help="If no label specified, set the key with null label by default")
         c.argument('tags', arg_type=tags_type)
         c.argument('content_type', help='Content type of the key-value to be set.')
         c.argument('value', help='Value of the key-value to be set.')
 
     with self.argument_context('appconfig kv set-keyvault') as c:
-        c.argument('key', validator=validate_key, help="Key to be set. Key cannot be a '.' or '..', or contain the '%' character.")
+        c.argument('key', validator=validate_key, help="Key to be set. Key cannot be a '.' or '..', or contain the '%%' character.")
         c.argument('label', help="If no label specified, set the key with null label by default")
         c.argument('tags', arg_type=tags_type)
         c.argument('secret_identifier', validator=validate_secret_identifier, help="ID of the Key Vault object. Can be found using 'az keyvault {collection} show' command, where collection is key, secret or certificate. To set reference to the latest version of your secret, remove version information from secret identifier.")
@@ -364,7 +364,7 @@ def load_arguments(self, _):
 
     with self.argument_context('appconfig feature') as c:
         c.argument('name', arg_type=data_plane_name_arg_type)
-        c.argument('key', validator=validate_feature_key, help='Key of the feature flag. Key must start with the ".appconfig.featureflag/" prefix. Key cannot contain the "%" character. If both key and feature arguments are provided, only key will be used. Default key is the reserved prefix ".appconfig.featureflag/" + feature name.')
+        c.argument('key', validator=validate_feature_key, help='Key of the feature flag. Key must start with the ".appconfig.featureflag/" prefix. Key cannot contain the "%%" character. If both key and feature arguments are provided, only key will be used. Default key is the reserved prefix ".appconfig.featureflag/" + feature name.')
 
     with self.argument_context('appconfig feature show') as c:
         c.argument('feature', help='Name of the feature flag to be retrieved. If the feature flag key is different from the default key, provide the `--key` argument instead.')
@@ -372,10 +372,10 @@ def load_arguments(self, _):
         c.argument('fields', arg_type=feature_fields_arg_type)
 
     with self.argument_context('appconfig feature set') as c:
-        c.argument('feature', validator=validate_feature, help="Name of the feature flag to be set. Feature name cannot contain the '%' or ':' characters.")
+        c.argument('feature', validator=validate_feature, help="Name of the feature flag to be set. Feature name cannot contain the '%%' or ':' characters.")
         c.argument('label', help="If no label specified, set the feature flag with null label by default")
         c.argument('description', help='Description of the feature flag to be set.')
-        c.argument('key', validator=validate_feature_key, help='Key of the feature flag. Key must start with the ".appconfig.featureflag/" prefix. Key cannot contain the "%" character. Default key is the reserved prefix ".appconfig.featureflag/" + feature name.')
+        c.argument('key', validator=validate_feature_key, help='Key of the feature flag. Key must start with the ".appconfig.featureflag/" prefix. Key cannot contain the "%%" character. Default key is the reserved prefix ".appconfig.featureflag/" + feature name.')
         c.argument('requirement_type', arg_type=get_enum_type([FeatureFlagConstants.REQUIREMENT_TYPE_ALL, FeatureFlagConstants.REQUIREMENT_TYPE_ANY]),
                    help='Requirement type determines if filters should use "Any" or "All" logic when evaluating the state of a feature.')
         c.argument('telemetry_enabled', arg_type=get_three_state_flag(), help='Enable or disable telemetry for the feature flag.')
@@ -384,7 +384,7 @@ def load_arguments(self, _):
     with self.argument_context('appconfig feature delete') as c:
         c.argument('feature', help='Name of the feature to be deleted. If the feature flag key is different from the default key, provide the `--key` argument instead. Support star sign as filters, for instance * means all features and abc* means features with abc as prefix. Comma separated features are not supported. Please provide escaped string if your feature name contains comma.')
         c.argument('label', help="If no label specified, delete the feature flag with null label by default. Support star sign as filters, for instance * means all labels and abc* means labels with abc as prefix.")
-        c.argument('key', validator=validate_feature_key, help='Key of the feature flag. Key must start with the ".appconfig.featureflag/" prefix. Key cannot contain the "%" character. If both key and feature arguments are provided, only key will be used. Support star sign as filters, for instance ".appconfig.featureflag/*" means all features and ".appconfig.featureflag/abc*" means features with abc as prefix. Comma separated features are not supported. Please provide escaped string if your feature name contains comma.')
+        c.argument('key', validator=validate_feature_key, help='Key of the feature flag. Key must start with the ".appconfig.featureflag/" prefix. Key cannot contain the "%%" character. If both key and feature arguments are provided, only key will be used. Support star sign as filters, for instance ".appconfig.featureflag/*" means all features and ".appconfig.featureflag/abc*" means features with abc as prefix. Comma separated features are not supported. Please provide escaped string if your feature name contains comma.')
         c.argument('tags', arg_type=tags_arg_type, help="If no tags are specified, delete all feature flags with any tags. Support space-separated tags: key[=value] [key[=value] ...].")
 
     with self.argument_context('appconfig feature list') as c:
@@ -392,7 +392,7 @@ def load_arguments(self, _):
         c.argument('label', help="If no label specified, list all labels. Support star sign as filters, for instance * means all labels and abc* means labels with abc as prefix. Use '\\0' for null label.")
         c.argument('fields', arg_type=feature_fields_arg_type)
         c.argument('all_', help="List all feature flags.")
-        c.argument('key', validator=validate_feature_key, help='Key of the feature flag. Key must start with the ".appconfig.featureflag/" prefix. Key cannot contain the "%" character. If both key and feature arguments are provided, only key will be used. Support star sign as filters, for instance ".appconfig.featureflag/*" means all features and ".appconfig.featureflag/abc*" means features with abc as prefix. Comma separated features are not supported. Please provide escaped string if your feature name contains comma.')
+        c.argument('key', validator=validate_feature_key, help='Key of the feature flag. Key must start with the ".appconfig.featureflag/" prefix. Key cannot contain the "%%" character. If both key and feature arguments are provided, only key will be used. Support star sign as filters, for instance ".appconfig.featureflag/*" means all features and ".appconfig.featureflag/abc*" means features with abc as prefix. Comma separated features are not supported. Please provide escaped string if your feature name contains comma.')
         c.argument('tags', arg_type=tags_arg_type, help="If no tags are specified, list all feature flags with any tags. Support space-separated tags: key[=value] [key[=value] ...].")
 
     with self.argument_context('appconfig feature lock') as c:

--- a/src/azure-cli/azure/cli/command_modules/containerapp/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/containerapp/_params.py
@@ -317,7 +317,7 @@ def load_arguments(self, _):
     with self.argument_context('containerapp env dapr-component') as c:
         c.argument('dapr_component_name', help="The Dapr component name.")
         c.argument('environment_name', options_list=['--name', '-n'], help="The environment name.")
-        c.argument('yaml', type=file_type, help='Path to a .yaml file with the configuration of a Dapr component. All other parameters will be ignored. For an example, see https://learn.microsoft.com/en-us/azure/container-apps/dapr-overview?tabs=bicep1%2Cyaml#component-schema')
+        c.argument('yaml', type=file_type, help='Path to a .yaml file with the configuration of a Dapr component. All other parameters will be ignored. For an example, see https://learn.microsoft.com/en-us/azure/container-apps/dapr-overview?tabs=bicep1%%2Cyaml#component-schema')
 
     with self.argument_context('containerapp revision set-mode') as c:
         c.argument('mode', arg_type=get_enum_type(['single', 'multiple']), help="The active revisions mode for the container app.")

--- a/src/azure-cli/azure/cli/command_modules/monitor/aaz/latest/monitor/autoscale/_show_predictive_metric.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/aaz/latest/monitor/autoscale/_show_predictive_metric.py
@@ -62,7 +62,7 @@ class ShowPredictiveMetric(AAZCommand):
         )
         _args_schema.metric_name = AAZStrArg(
             options=["--metric-name"],
-            help="The names of the metrics (comma separated) to retrieve. Special case: If a metricname itself has a comma in it then use %2 to indicate it. Eg: 'Metric,Name1' should be **'Metric%2Name1'**",
+            help="The names of the metrics (comma separated) to retrieve. Special case: If a metricname itself has a comma in it then use %%2 to indicate it. Eg: 'Metric,Name1' should be **'Metric%%2Name1'**",
             required=True,
         )
         _args_schema.metric_namespace = AAZStrArg(

--- a/src/azure-cli/azure/cli/command_modules/monitor/aaz/latest/monitor/metrics/_list.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/aaz/latest/monitor/metrics/_list.py
@@ -49,7 +49,7 @@ class List(AAZCommand):
         )
         _args_schema.filter = AAZStrArg(
             options=["--filter"],
-            help="The **$filter** is used to reduce the set of metric data returned. Example: Metric contains metadata A, B and C. - Return all time series of C where A = a1 and B = b1 or b2 **$filter=A eq 'a1' and B eq 'b1' or B eq 'b2' and C eq '*'** - Invalid variant: **$filter=A eq 'a1' and B eq 'b1' and C eq '*' or B = 'b2'** This is invalid because the logical or operator cannot separate two different metadata names. - Return all time series where A = a1, B = b1 and C = c1: **$filter=A eq 'a1' and B eq 'b1' and C eq 'c1'** - Return all time series where A = a1 **$filter=A eq 'a1' and B eq '*' and C eq '*'**. Special case: When dimension name or dimension value uses round brackets. Eg: When dimension name is **dim (test) 1** Instead of using $filter= \"dim (test) 1 eq '*' \" use **$filter= \"dim %2528test%2529 1 eq '*' \"** When dimension name is **dim (test) 3** and dimension value is **dim3 (test) val** Instead of using $filter= \"dim (test) 3 eq 'dim3 (test) val' \" use **$filter= \"dim %2528test%2529 3 eq 'dim3 %2528test%2529 val' \"**",
+            help="The **$filter** is used to reduce the set of metric data returned. Example: Metric contains metadata A, B and C. - Return all time series of C where A = a1 and B = b1 or b2 **$filter=A eq 'a1' and B eq 'b1' or B eq 'b2' and C eq '*'** - Invalid variant: **$filter=A eq 'a1' and B eq 'b1' and C eq '*' or B = 'b2'** This is invalid because the logical or operator cannot separate two different metadata names. - Return all time series where A = a1, B = b1 and C = c1: **$filter=A eq 'a1' and B eq 'b1' and C eq 'c1'** - Return all time series where A = a1 **$filter=A eq 'a1' and B eq '*' and C eq '*'**. Special case: When dimension name or dimension value uses round brackets. Eg: When dimension name is **dim (test) 1** Instead of using $filter= \"dim (test) 1 eq '*' \" use **$filter= \"dim %%2528test%%2529 1 eq '*' \"** When dimension name is **dim (test) 3** and dimension value is **dim3 (test) val** Instead of using $filter= \"dim (test) 3 eq 'dim3 (test) val' \" use **$filter= \"dim %%2528test%%2529 3 eq 'dim3 %%2528test%%2529 val' \"**",
         )
         _args_schema.interval = AAZDurationArg(
             options=["--interval"],
@@ -57,7 +57,7 @@ class List(AAZCommand):
         )
         _args_schema.metricnames = AAZStrArg(
             options=["--metricnames"],
-            help="The names of the metrics (comma separated) to retrieve. Special case: If a metricname itself has a comma in it then use %2 to indicate it. Eg: 'Metric,Name1' should be **'Metric%2Name1'**",
+            help="The names of the metrics (comma separated) to retrieve. Special case: If a metricname itself has a comma in it then use %%2 to indicate it. Eg: 'Metric,Name1' should be **'Metric%%2Name1'**",
         )
         _args_schema.metricnamespace = AAZStrArg(
             options=["--metricnamespace"],

--- a/src/azure-cli/azure/cli/command_modules/netappfiles/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/netappfiles/custom.py
@@ -630,7 +630,7 @@ class VolumeGroupCreate(_VolumeGroupCreate):
         args_schema.add_snapshot_capacity = AAZIntArg(
             options=["--add-snapshot-capacity"],
             arg_group="Volumes",
-            help="Additional memory to store snapshots, must be specified as % of RAM (range 0-200). This is used to auto compute storage size.  Default: 50.",
+            help="Additional memory to store snapshots, must be specified as %% of RAM (range 0-200). This is used to auto compute storage size.  Default: 50.",
             required=False,
             default=50
         )

--- a/src/azure-cli/azure/cli/command_modules/role/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_params.py
@@ -185,7 +185,7 @@ def load_arguments(self, _):
 
     with self.argument_context('ad sp create-for-rbac') as c:
         c.argument('display_name', options_list=['--display-name', '--name', '-n'],
-                   help='Display name of the service principal. If not present, default to azure-cli-%Y-%m-%d-%H-%M-%S '
+                   help='Display name of the service principal. If not present, default to azure-cli-%%Y-%%m-%%d-%%H-%%M-%%S '
                         'where the suffix is the time of creation.')
         c.argument('create_password', arg_type=get_three_state_flag(), arg_group='Credential',
                    help='Create a password credential (secret) on the the application. This is the default behavior. '
@@ -359,7 +359,7 @@ def load_arguments(self, _):
         c.argument('include_groups', action='store_true',
                    help='Include extra assignments to the groups of which the user is a member (transitively).')
 
-    time_help = 'The {} of the query in the format of %Y-%m-%dT%H:%M:%SZ, e.g. 2000-12-31T12:59:59Z. Defaults to {}'
+    time_help = 'The {} of the query in the format of %%Y-%%m-%%dT%%H:%%M:%%SZ, e.g. 2000-12-31T12:59:59Z. Defaults to {}'
     with self.argument_context('role assignment list-changelogs') as c:
         c.argument('start_time', help=time_help.format('start time', '1 Hour prior to the current time'))
         c.argument('end_time', help=time_help.format('end time', 'the current time'))

--- a/src/azure-cli/azure/cli/command_modules/vm/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_params.py
@@ -435,7 +435,7 @@ def load_arguments(self, _):
         c.argument('disk_mbps_read_write', options_list=['--data-disk-mbps'], type=int, help='Specify the bandwidth in MB per second for the managed disk when storage account type is UltraSSD_LRS.')
         c.argument('availability_set', help='Name or ID of an existing availability set to add the VM to. None by default.')
         c.argument('vmss', help='Name or ID of an existing virtual machine scale set that the virtual machine should be assigned to. None by default.')
-        c.argument('nsg', help='The name to use when creating a new Network Security Group (default) or referencing an existing one. Can also reference an existing NSG by ID or specify "" for none (\'""\' in Azure CLI using PowerShell or --% operator).', arg_group='Network')
+        c.argument('nsg', help='The name to use when creating a new Network Security Group (default) or referencing an existing one. Can also reference an existing NSG by ID or specify "" for none (\'""\' in Azure CLI using PowerShell or --%% operator).', arg_group='Network')
         c.argument('nsg_rule', help='NSG rule to create when creating a new NSG. Defaults to open ports for allowing RDP on Windows and allowing SSH on Linux. NONE represents no NSG rule', arg_group='Network', arg_type=get_enum_type(['RDP', 'SSH', 'NONE']))
         c.argument('application_security_groups', resource_type=ResourceType.MGMT_NETWORK, min_api='2017-09-01', nargs='+', options_list=['--asgs'], help='Space-separated list of existing application security groups to associate with the VM.', arg_group='Network', validator=validate_asg_names_or_ids)
         c.argument('boot_diagnostics_storage',
@@ -904,11 +904,11 @@ def load_arguments(self, _):
             c.argument('terminate_notification_time', min_api='2019-03-01',
                        help='Length of time (in minutes, between 5 and 15) a notification to be sent to the VM on the instance metadata server till the VM gets deleted')
             c.argument('max_batch_instance_percent', type=int, min_api='2020-12-01',
-                       help='The maximum percent of total virtual machine instances that will be upgraded simultaneously by the rolling upgrade in one batch. Default: 20%')
+                       help='The maximum percent of total virtual machine instances that will be upgraded simultaneously by the rolling upgrade in one batch. Default: 20%%')
             c.argument('max_unhealthy_instance_percent', type=int, min_api='2020-12-01',
-                       help='The maximum percentage of the total virtual machine instances in the scale set that can be simultaneously unhealthy. Default: 20%')
+                       help='The maximum percentage of the total virtual machine instances in the scale set that can be simultaneously unhealthy. Default: 20%%')
             c.argument('max_unhealthy_upgraded_instance_percent', type=int, min_api='2020-12-01',
-                       help='The maximum percentage of upgraded virtual machine instances that can be found to be in an unhealthy state. Default: 20%')
+                       help='The maximum percentage of upgraded virtual machine instances that can be found to be in an unhealthy state. Default: 20%%')
             c.argument('pause_time_between_batches', min_api='2020-12-01',
                        help='The wait time between completing the update for all virtual machines in one batch and starting the next batch. Default: 0 seconds')
             c.argument('enable_cross_zone_upgrade', arg_type=get_three_state_flag(), min_api='2020-12-01',

--- a/src/azure-cli/azure/cli/command_modules/vm/aaz/latest/vmss/_create.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/aaz/latest/vmss/_create.py
@@ -572,7 +572,7 @@ class Create(AAZCommand):
         )
         rolling_upgrade_policy.max_batch_instance_percent = AAZIntArg(
             options=["max-batch-instance-percent"],
-            help="The maximum percent of total virtual machine instances that will be upgraded simultaneously by the rolling upgrade in one batch. As this is a maximum, unhealthy instances in previous or future batches can cause the percentage of instances in a batch to decrease to ensure higher reliability. The default value for this parameter is 20%.",
+            help="The maximum percent of total virtual machine instances that will be upgraded simultaneously by the rolling upgrade in one batch. As this is a maximum, unhealthy instances in previous or future batches can cause the percentage of instances in a batch to decrease to ensure higher reliability. The default value for this parameter is 20%%.",
             fmt=AAZIntArgFormat(
                 maximum=100,
                 minimum=5,
@@ -584,7 +584,7 @@ class Create(AAZCommand):
         )
         rolling_upgrade_policy.max_unhealthy_instance_percent = AAZIntArg(
             options=["max-unhealthy-instance-percent"],
-            help="The maximum percentage of the total virtual machine instances in the scale set that can be simultaneously unhealthy, either as a result of being upgraded, or by being found in an unhealthy state by the virtual machine health checks before the rolling upgrade aborts. This constraint will be checked prior to starting any batch. The default value for this parameter is 20%.",
+            help="The maximum percentage of the total virtual machine instances in the scale set that can be simultaneously unhealthy, either as a result of being upgraded, or by being found in an unhealthy state by the virtual machine health checks before the rolling upgrade aborts. This constraint will be checked prior to starting any batch. The default value for this parameter is 20%%.",
             fmt=AAZIntArgFormat(
                 maximum=100,
                 minimum=5,
@@ -592,7 +592,7 @@ class Create(AAZCommand):
         )
         rolling_upgrade_policy.max_unhealthy_upgraded_instance_percent = AAZIntArg(
             options=["max-unhealthy-upgraded-instance-percent"],
-            help="The maximum percentage of upgraded virtual machine instances that can be found to be in an unhealthy state. This check will happen after each batch is upgraded. If this percentage is ever exceeded, the rolling update aborts. The default value for this parameter is 20%.",
+            help="The maximum percentage of upgraded virtual machine instances that can be found to be in an unhealthy state. This check will happen after each batch is upgraded. If this percentage is ever exceeded, the rolling update aborts. The default value for this parameter is 20%%.",
             fmt=AAZIntArgFormat(
                 maximum=100,
             ),

--- a/src/azure-cli/azure/cli/command_modules/vm/aaz/latest/vmss/_patch.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/aaz/latest/vmss/_patch.py
@@ -394,7 +394,7 @@ class Patch(AAZCommand):
         )
         rolling_upgrade_policy.max_batch_instance_percent = AAZIntArg(
             options=["max-batch-instance-percent"],
-            help="The maximum percent of total virtual machine instances that will be upgraded simultaneously by the rolling upgrade in one batch. As this is a maximum, unhealthy instances in previous or future batches can cause the percentage of instances in a batch to decrease to ensure higher reliability. The default value for this parameter is 20%.",
+            help="The maximum percent of total virtual machine instances that will be upgraded simultaneously by the rolling upgrade in one batch. As this is a maximum, unhealthy instances in previous or future batches can cause the percentage of instances in a batch to decrease to ensure higher reliability. The default value for this parameter is 20%%.",
             fmt=AAZIntArgFormat(
                 maximum=100,
                 minimum=5,
@@ -406,7 +406,7 @@ class Patch(AAZCommand):
         )
         rolling_upgrade_policy.max_unhealthy_instance_percent = AAZIntArg(
             options=["max-unhealthy-instance-percent"],
-            help="The maximum percentage of the total virtual machine instances in the scale set that can be simultaneously unhealthy, either as a result of being upgraded, or by being found in an unhealthy state by the virtual machine health checks before the rolling upgrade aborts. This constraint will be checked prior to starting any batch. The default value for this parameter is 20%.",
+            help="The maximum percentage of the total virtual machine instances in the scale set that can be simultaneously unhealthy, either as a result of being upgraded, or by being found in an unhealthy state by the virtual machine health checks before the rolling upgrade aborts. This constraint will be checked prior to starting any batch. The default value for this parameter is 20%%.",
             fmt=AAZIntArgFormat(
                 maximum=100,
                 minimum=5,
@@ -414,7 +414,7 @@ class Patch(AAZCommand):
         )
         rolling_upgrade_policy.max_unhealthy_upgraded_instance_percent = AAZIntArg(
             options=["max-unhealthy-upgraded-instance-percent"],
-            help="The maximum percentage of upgraded virtual machine instances that can be found to be in an unhealthy state. This check will happen after each batch is upgraded. If this percentage is ever exceeded, the rolling update aborts. The default value for this parameter is 20%.",
+            help="The maximum percentage of upgraded virtual machine instances that can be found to be in an unhealthy state. This check will happen after each batch is upgraded. If this percentage is ever exceeded, the rolling update aborts. The default value for this parameter is 20%%.",
             fmt=AAZIntArgFormat(
                 maximum=100,
                 minimum=0,

--- a/src/azure-cli/azure/cli/command_modules/vm/aaz/latest/vmss/_update.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/aaz/latest/vmss/_update.py
@@ -656,7 +656,7 @@ class Update(AAZCommand):
         )
         rolling_upgrade_policy.max_batch_instance_percent = AAZIntArg(
             options=["max-batch-instance-percent"],
-            help="The maximum percent of total virtual machine instances that will be upgraded simultaneously by the rolling upgrade in one batch. As this is a maximum, unhealthy instances in previous or future batches can cause the percentage of instances in a batch to decrease to ensure higher reliability. The default value for this parameter is 20%.",
+            help="The maximum percent of total virtual machine instances that will be upgraded simultaneously by the rolling upgrade in one batch. As this is a maximum, unhealthy instances in previous or future batches can cause the percentage of instances in a batch to decrease to ensure higher reliability. The default value for this parameter is 20%%.",
             nullable=True,
             fmt=AAZIntArgFormat(
                 maximum=100,
@@ -670,7 +670,7 @@ class Update(AAZCommand):
         )
         rolling_upgrade_policy.max_unhealthy_instance_percent = AAZIntArg(
             options=["max-unhealthy-instance-percent"],
-            help="The maximum percentage of the total virtual machine instances in the scale set that can be simultaneously unhealthy, either as a result of being upgraded, or by being found in an unhealthy state by the virtual machine health checks before the rolling upgrade aborts. This constraint will be checked prior to starting any batch. The default value for this parameter is 20%.",
+            help="The maximum percentage of the total virtual machine instances in the scale set that can be simultaneously unhealthy, either as a result of being upgraded, or by being found in an unhealthy state by the virtual machine health checks before the rolling upgrade aborts. This constraint will be checked prior to starting any batch. The default value for this parameter is 20%%.",
             nullable=True,
             fmt=AAZIntArgFormat(
                 maximum=100,
@@ -679,7 +679,7 @@ class Update(AAZCommand):
         )
         rolling_upgrade_policy.max_unhealthy_upgraded_instance_percent = AAZIntArg(
             options=["max-unhealthy-upgraded-instance-percent"],
-            help="The maximum percentage of upgraded virtual machine instances that can be found to be in an unhealthy state. This check will happen after each batch is upgraded. If this percentage is ever exceeded, the rolling update aborts. The default value for this parameter is 20%.",
+            help="The maximum percentage of upgraded virtual machine instances that can be found to be in an unhealthy state. This check will happen after each batch is upgraded. If this percentage is ever exceeded, the rolling update aborts. The default value for this parameter is 20%%.",
             nullable=True,
             fmt=AAZIntArgFormat(
                 maximum=100,


### PR DESCRIPTION
**Related command**
`az ad sp create-for-rbac`
`az vmss update`

**Description**<!--Mandatory-->
Fix https://github.com/Azure/azure-cli/issues/32832
Fix https://github.com/Azure/azure-cli/issues/32356

Python 3.14's `argparse` now validates help strings via `%`-formatting ([python/cpython#124899](https://github.com/python/cpython/pull/124899)), raising `ValueError: badly formed help string` when a help string contains an unescaped `%`. Per the [argparse docs](https://docs.python.org/3/library/argparse.html#help), literal `%` must be escaped as `%%`.

This PR escapes all unescaped `%` characters in argparse help strings across command modules.

### Changes

| Module | Occurrences | Pattern |
|--------|------------|---------|
| `role` | 2 | `%Y-%m-%d` date format specifiers |
| `vm` | 4 | `Default: 20%`, `--% operator` |
| `vm/aaz` (vmss _create, _update, _patch) | 9 | `is 20%.` |
| `acr` | 1 | `%Y-%m-%dT%H:%M:%SZ` date format |
| `appconfig` | 7 | `the '%' character` |
| `containerapp` | 1 | `%2C` URL-encoded comma in URL |
| `netappfiles` | 1 | `% of RAM` |
| `monitor` (metrics, autoscale) | 3 | `%2528`, `%2` URL-encoded values |

**Testing Guide**

These are help string-only changes with no behavioral impact. The fix can be verified by running any of the previously failing commands on Python 3.14:

```
az ad sp create-for-rbac --help
az vmss update --help
```

**Additional information**

🤖 This PR is assisted by VS Code GitHub Copilot, with Claude Opus 4.6 Medium model, and human-verified.

Prompt:

> Fix https://github.com/Azure/azure-cli/issues/32832 and https://github.com/Azure/azure-cli/issues/32356 and all related errors caused by %. The root cause analysis is in those issues.