### PR TITLE
[POSTGRESQL] Fix #33090: `az postgres flexible-server server-logs list`: Fix command crash with an AttributeError when listing log files

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/postgresql/commands/server_logs_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/commands/server_logs_commands.py
@@ -37,7 +37,7 @@ def _sanitize_log_file(log_obj):
         elif isinstance(obj, list):
             for item in obj:
                 remove_created_time(item)
-    
+
     remove_created_time(result)
     return result
 

--- a/src/azure-cli/azure/cli/command_modules/postgresql/commands/server_logs_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/commands/server_logs_commands.py
@@ -28,17 +28,21 @@ def _sanitize_log_file(log_obj):
     else:
         result = vars(log_obj).copy()
 
-    # Recursively remove created_time variants from all levels
-    def remove_created_time(obj):
-        if isinstance(obj, dict):
-            obj.pop('createdTime', None)
-            for value in obj.values():
-                remove_created_time(value)
-        elif isinstance(obj, list):
-            for item in obj:
-                remove_created_time(item)
+    # Flatten properties from nested structure and reshape to legacy format
+    if 'properties' in result and isinstance(result['properties'], dict):
+        properties = result.pop('properties')
+        # Extract type from properties and rename to typePropertiesType
+        if 'createdTime' in properties:
+            del properties['createdTime']  # Remove created_time as it's not in the original SDK model
+        if 'type' in properties:
+            result['typePropertiesType'] = properties.pop('type')
+        # Merge remaining properties into root level
+        result.update(properties)
 
-    remove_created_time(result)
+    # Add systemData if not present (for backward compatibility)
+    if 'systemData' not in result:
+        result['systemData'] = None
+
     return result
 
 

--- a/src/azure-cli/azure/cli/command_modules/postgresql/commands/server_logs_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/commands/server_logs_commands.py
@@ -19,6 +19,31 @@ from ..utils.validators import validate_citus_cluster, validate_resource_group
 logger = get_logger(__name__)
 
 
+def _sanitize_log_file(log_obj):
+    """Convert log object to dict and remove created_time for SDK compatibility."""
+    if hasattr(log_obj, 'as_dict'):
+        result = log_obj.as_dict()
+    elif isinstance(log_obj, dict):
+        result = dict(log_obj)
+    else:
+        result = vars(log_obj).copy()
+    
+    # Recursively remove created_time variants from all levels
+    def remove_created_time(obj):
+        if isinstance(obj, dict):
+            obj.pop('created_time', None)
+            obj.pop('createdTime', None)
+            obj.pop('created-time', None)
+            for value in obj.values():
+                remove_created_time(value)
+        elif isinstance(obj, list):
+            for item in obj:
+                remove_created_time(item)
+    
+    remove_created_time(result)
+    return result
+
+
 def flexible_server_download_log_files(client, resource_group_name, server_name, file_name):
     validate_resource_group(resource_group_name)
 
@@ -50,8 +75,7 @@ def flexible_server_list_log_files_with_filter(client, resource_group_name, serv
         if max_file_size is not None and f.size_in_kb > max_file_size:
             continue
 
-        del f.created_time
-        files.append(f)
+        files.append(_sanitize_log_file(f))
 
     return files
 
@@ -75,8 +99,7 @@ def flexible_server_log_list(client, resource_group_name, server_name, filename_
         if max_file_size is not None and f.size_in_kb > max_file_size:
             continue
 
-        del f.created_time
-        files.append(f)
+        files.append(_sanitize_log_file(f))
 
     return files
 

--- a/src/azure-cli/azure/cli/command_modules/postgresql/commands/server_logs_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/commands/server_logs_commands.py
@@ -27,13 +27,11 @@ def _sanitize_log_file(log_obj):
         result = dict(log_obj)
     else:
         result = vars(log_obj).copy()
-    
+
     # Recursively remove created_time variants from all levels
     def remove_created_time(obj):
         if isinstance(obj, dict):
-            obj.pop('created_time', None)
             obj.pop('createdTime', None)
-            obj.pop('created-time', None)
             for value in obj.values():
                 remove_created_time(value)
         elif isinstance(obj, list):

--- a/src/azure-cli/azure/cli/command_modules/postgresql/commands/server_logs_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/commands/server_logs_commands.py
@@ -20,13 +20,8 @@ logger = get_logger(__name__)
 
 
 def _sanitize_log_file(log_obj):
-    """Convert log object to dict and remove created_time for SDK compatibility."""
-    if hasattr(log_obj, 'as_dict'):
-        result = log_obj.as_dict()
-    elif isinstance(log_obj, dict):
-        result = dict(log_obj)
-    else:
-        result = vars(log_obj).copy()
+    # Convert log object to dict
+    result = log_obj.as_dict()
 
     # Flatten properties from nested structure and reshape to legacy format
     if 'properties' in result and isinstance(result['properties'], dict):

--- a/src/azure-cli/azure/cli/command_modules/postgresql/commands/server_logs_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/commands/server_logs_commands.py
@@ -28,7 +28,7 @@ def _sanitize_log_file(log_obj):
         properties = result.pop('properties')
         # Extract type from properties and rename to typePropertiesType
         if 'createdTime' in properties:
-            del properties['createdTime']  # Remove created_time as it's not in the original SDK model
+            del properties['createdTime']  # Remove createdTime as it's not in the original SDK model
         if 'type' in properties:
             result['typePropertiesType'] = properties.pop('type')
         # Merge remaining properties into root level

--- a/src/azure-cli/azure/cli/command_modules/postgresql/tests/latest/recordings/test_postgres_flexible_server_logs_mgmt.yaml
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/tests/latest/recordings/test_postgres_flexible_server_logs_mgmt.yaml
@@ -13,7 +13,7 @@ interactions:
       ParameterSetName:
       - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
       User-Agent:
-      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: HEAD
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2024-11-01
   response:
@@ -25,7 +25,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 30 Mar 2026 14:12:12 GMT
+      - Tue, 31 Mar 2026 21:47:36 GMT
       expires:
       - '-1'
       pragma:
@@ -39,7 +39,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 32835CC0E3EF452C9E0FD42965627EB2 Ref B: DUB241062309031 Ref C: 2026-03-30T14:12:13Z'
+      - 'Ref A: 15B1D982B8C444FEBAE9B398390AAE33 Ref B: AMS231022012053 Ref C: 2026-03-31T21:47:37Z'
     status:
       code: 204
       message: No Content
@@ -57,12 +57,12 @@ interactions:
       ParameterSetName:
       - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
       User-Agent:
-      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2024-11-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"canadacentral","tags":{"product":"azurecli","cause":"automation","test":"test_postgres_flexible_server_logs_mgmt","date":"2026-03-30T14:12:09Z","module":"postgresql"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"canadacentral","tags":{"product":"azurecli","cause":"automation","test":"test_postgres_flexible_server_logs_mgmt","date":"2026-03-31T21:47:33Z","module":"postgresql"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -71,7 +71,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 30 Mar 2026 14:12:13 GMT
+      - Tue, 31 Mar 2026 21:47:36 GMT
       expires:
       - '-1'
       pragma:
@@ -85,7 +85,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 90E4C0917D3D444FB712E52D46E71041 Ref B: AMS231032608017 Ref C: 2026-03-30T14:12:13Z'
+      - 'Ref A: D8B01322C4094C1C9A4DC5228FCD7A18 Ref B: AMS231032608031 Ref C: 2026-03-31T21:47:37Z'
     status:
       code: 200
       message: OK
@@ -107,7 +107,7 @@ interactions:
       ParameterSetName:
       - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
       User-Agent:
-      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/checkNameAvailability?api-version=2026-01-01-preview
   response:
@@ -121,7 +121,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 30 Mar 2026 14:12:14 GMT
+      - Tue, 31 Mar 2026 21:47:37 GMT
       expires:
       - '-1'
       pragma:
@@ -133,13 +133,13 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/377ff9f1-ed38-412d-886b-930c38a60bf6
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/9e0ef41a-721e-4c56-9caf-896f6a3472a4
       x-ms-ratelimit-remaining-subscription-global-writes:
       - '11999'
       x-ms-ratelimit-remaining-subscription-writes:
       - '799'
       x-msedge-ref:
-      - 'Ref A: 7B112200D63943F5A3CF48B1DB8A9014 Ref B: DUB601080510042 Ref C: 2026-03-30T14:12:14Z'
+      - 'Ref A: 9AC1F481AED945F292EC960358E0C94C Ref B: AMS231020614037 Ref C: 2026-03-31T21:47:37Z'
     status:
       code: 200
       message: OK
@@ -157,21 +157,23 @@ interactions:
       ParameterSetName:
       - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
       User-Agent:
-      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/capabilities?api-version=2026-01-01-preview
   response:
     body:
-      string: '{"value":[{"name":"FlexibleServerCapabilities","supportedServerEditions":[{"supportedServerSkus":[{"supportedFeatures":[],"name":"Standard_B1ms","vCores":1,"supportedIops":640,"supportedMemoryPerVcoreMb":2048,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_B2s","vCores":2,"supportedIops":1280,"supportedMemoryPerVcoreMb":2048,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_B2ms","vCores":2,"supportedIops":1920,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_B4ms","vCores":4,"supportedIops":2880,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_B8ms","vCores":8,"supportedIops":4320,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_B12ms","vCores":12,"supportedIops":4320,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_B16ms","vCores":16,"supportedIops":4320,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_B20ms","vCores":20,"supportedIops":4320,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]}],"name":"Burstable","defaultSkuName":"Standard_B2s","supportedStorageEditions":[{"name":"ManagedDisk","defaultStorageSizeMb":32768,"supportedStorageMb":[{"supportedIops":120,"storageSizeMb":32768,"defaultIopsTier":"P4","supportedIopsTiers":[{"name":"P4","iops":120},{"name":"P6","iops":240},{"name":"P10","iops":500},{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":240,"storageSizeMb":65536,"defaultIopsTier":"P6","supportedIopsTiers":[{"name":"P6","iops":240},{"name":"P10","iops":500},{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":500,"storageSizeMb":131072,"defaultIopsTier":"P10","supportedIopsTiers":[{"name":"P10","iops":500},{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":1100,"storageSizeMb":262144,"defaultIopsTier":"P15","supportedIopsTiers":[{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":2300,"storageSizeMb":524288,"defaultIopsTier":"P20","supportedIopsTiers":[{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":5000,"storageSizeMb":1048576,"defaultIopsTier":"P30","supportedIopsTiers":[{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":7500,"storageSizeMb":2097152,"defaultIopsTier":"P40","supportedIopsTiers":[{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":7500,"storageSizeMb":4193280,"defaultIopsTier":"P50","supportedIopsTiers":[{"name":"P50","iops":7500}]},{"supportedIops":7500,"storageSizeMb":4194304,"defaultIopsTier":"P50","supportedIopsTiers":[{"name":"P50","iops":7500}]},{"supportedIops":16000,"storageSizeMb":8388608,"defaultIopsTier":"P60","supportedIopsTiers":[{"name":"P60","iops":16000},{"name":"P70","iops":18000},{"name":"P80","iops":20000}]},{"supportedIops":18000,"storageSizeMb":16777216,"defaultIopsTier":"P70","supportedIopsTiers":[{"name":"P70","iops":18000},{"name":"P80","iops":20000}]},{"supportedIops":20000,"storageSizeMb":33553408,"defaultIopsTier":"P80","supportedIopsTiers":[{"name":"P80","iops":20000}]}]},{"name":"ManagedDiskV2","defaultStorageSizeMb":32768,"supportedStorageMb":[{"supportedIops":3000,"supportedMaximumIops":80000,"storageSizeMb":32768,"maximumStorageSizeMb":67108864,"supportedThroughput":125,"supportedMaximumThroughput":1200,"defaultIopsTier":"None","supportedIopsTiers":[{"name":"None","iops":0}]}]}]},{"supportedServerSkus":[{"supportedFeatures":[],"name":"Standard_D2s_v3","vCores":2,"supportedIops":3200,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D4s_v3","vCores":4,"supportedIops":6400,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D8s_v3","vCores":8,"supportedIops":12800,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D16s_v3","vCores":16,"supportedIops":25600,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D32s_v3","vCores":32,"supportedIops":51200,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D48s_v3","vCores":48,"supportedIops":76800,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D64s_v3","vCores":64,"supportedIops":80000,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D2ds_v4","vCores":2,"supportedIops":3200,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D4ds_v4","vCores":4,"supportedIops":6400,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D8ds_v4","vCores":8,"supportedIops":12800,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D16ds_v4","vCores":16,"supportedIops":25600,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D32ds_v4","vCores":32,"supportedIops":51200,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D48ds_v4","vCores":48,"supportedIops":76800,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D64ds_v4","vCores":64,"supportedIops":80000,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D2ads_v5","vCores":2,"supportedIops":3200,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D4ads_v5","vCores":4,"supportedIops":6400,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D8ads_v5","vCores":8,"supportedIops":12800,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D16ads_v5","vCores":16,"supportedIops":25600,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D32ads_v5","vCores":32,"supportedIops":51200,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D48ads_v5","vCores":48,"supportedIops":76800,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D64ads_v5","vCores":64,"supportedIops":80000,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D96ads_v5","vCores":96,"supportedIops":80000,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D2ds_v5","vCores":2,"supportedIops":3750,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D4ds_v5","vCores":4,"supportedIops":6400,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D8ds_v5","vCores":8,"supportedIops":12800,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D16ds_v5","vCores":16,"supportedIops":25600,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D32ds_v5","vCores":32,"supportedIops":51200,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D48ds_v5","vCores":48,"supportedIops":76800,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D64ds_v5","vCores":64,"supportedIops":80000,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D96ds_v5","vCores":96,"supportedIops":80000,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]}],"name":"GeneralPurpose","defaultSkuName":"Standard_D4ads_v5","supportedStorageEditions":[{"name":"ManagedDisk","defaultStorageSizeMb":65536,"supportedStorageMb":[{"supportedIops":120,"storageSizeMb":32768,"defaultIopsTier":"P4","supportedIopsTiers":[{"name":"P4","iops":120},{"name":"P6","iops":240},{"name":"P10","iops":500},{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":240,"storageSizeMb":65536,"defaultIopsTier":"P6","supportedIopsTiers":[{"name":"P6","iops":240},{"name":"P10","iops":500},{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":500,"storageSizeMb":131072,"defaultIopsTier":"P10","supportedIopsTiers":[{"name":"P10","iops":500},{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":1100,"storageSizeMb":262144,"defaultIopsTier":"P15","supportedIopsTiers":[{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":2300,"storageSizeMb":524288,"defaultIopsTier":"P20","supportedIopsTiers":[{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":5000,"storageSizeMb":1048576,"defaultIopsTier":"P30","supportedIopsTiers":[{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":7500,"storageSizeMb":2097152,"defaultIopsTier":"P40","supportedIopsTiers":[{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":7500,"storageSizeMb":4193280,"defaultIopsTier":"P50","supportedIopsTiers":[{"name":"P50","iops":7500}]},{"supportedIops":7500,"storageSizeMb":4194304,"defaultIopsTier":"P50","supportedIopsTiers":[{"name":"P50","iops":7500}]},{"supportedIops":16000,"storageSizeMb":8388608,"defaultIopsTier":"P60","supportedIopsTiers":[{"name":"P60","iops":16000},{"name":"P70","iops":18000},{"name":"P80","iops":20000}]},{"supportedIops":18000,"storageSizeMb":16777216,"defaultIopsTier":"P70","supportedIopsTiers":[{"name":"P70","iops":18000},{"name":"P80","iops":20000}]},{"supportedIops":20000,"storageSizeMb":33553408,"defaultIopsTier":"P80","supportedIopsTiers":[{"name":"P80","iops":20000}]}]},{"name":"ManagedDiskV2","defaultStorageSizeMb":65536,"supportedStorageMb":[{"supportedIops":3000,"supportedMaximumIops":80000,"storageSizeMb":32768,"maximumStorageSizeMb":67108864,"supportedThroughput":125,"supportedMaximumThroughput":1200,"defaultIopsTier":"None","supportedIopsTiers":[{"name":"None","iops":0}]}]},{"name":"UltraDisk","defaultStorageSizeMb":65536,"supportedStorageMb":[{"supportedIops":4800,"supportedMaximumIops":400000,"storageSizeMb":32768,"maximumStorageSizeMb":67108864,"supportedThroughput":1200,"supportedMaximumThroughput":10000,"defaultIopsTier":"None","supportedIopsTiers":[{"name":"None","iops":0}]}]}]},{"supportedServerSkus":[{"supportedFeatures":[],"name":"Standard_E2s_v3","vCores":2,"supportedIops":3200,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E4s_v3","vCores":4,"supportedIops":6400,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E8s_v3","vCores":8,"supportedIops":12800,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E16s_v3","vCores":16,"supportedIops":25600,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E32s_v3","vCores":32,"supportedIops":32000,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E48s_v3","vCores":48,"supportedIops":51200,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E64s_v3","vCores":64,"supportedIops":76800,"supportedMemoryPerVcoreMb":6912,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E2ds_v4","vCores":2,"supportedIops":3200,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E4ds_v4","vCores":4,"supportedIops":6400,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E8ds_v4","vCores":8,"supportedIops":12800,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E16ds_v4","vCores":16,"supportedIops":25600,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E20ds_v4","vCores":20,"supportedIops":32000,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E32ds_v4","vCores":32,"supportedIops":51200,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E48ds_v4","vCores":48,"supportedIops":76800,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E64ds_v4","vCores":64,"supportedIops":80000,"supportedMemoryPerVcoreMb":6912,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E2ads_v5","vCores":2,"supportedIops":3750,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E4ads_v5","vCores":4,"supportedIops":6400,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E8ads_v5","vCores":8,"supportedIops":12800,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E16ads_v5","vCores":16,"supportedIops":25600,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E20ads_v5","vCores":20,"supportedIops":32000,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E32ads_v5","vCores":32,"supportedIops":51200,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E48ads_v5","vCores":48,"supportedIops":76800,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E64ads_v5","vCores":64,"supportedIops":80000,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E96ads_v5","vCores":96,"supportedIops":80000,"supportedMemoryPerVcoreMb":7168,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E2ds_v5","vCores":2,"supportedIops":3750,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E4ds_v5","vCores":4,"supportedIops":6400,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E8ds_v5","vCores":8,"supportedIops":12800,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E16ds_v5","vCores":16,"supportedIops":25600,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E20ds_v5","vCores":20,"supportedIops":32000,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E32ds_v5","vCores":32,"supportedIops":51200,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E48ds_v5","vCores":48,"supportedIops":76800,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E64ds_v5","vCores":64,"supportedIops":80000,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E96ds_v5","vCores":96,"supportedIops":80000,"supportedMemoryPerVcoreMb":7168,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E96bds_v5","vCores":96,"supportedIops":160000,"supportedMemoryPerVcoreMb":7168,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]}],"name":"MemoryOptimized","defaultSkuName":"Standard_E4ads_v5","supportedStorageEditions":[{"name":"ManagedDisk","defaultStorageSizeMb":131072,"supportedStorageMb":[{"supportedIops":120,"storageSizeMb":32768,"defaultIopsTier":"P4","supportedIopsTiers":[{"name":"P4","iops":120},{"name":"P6","iops":240},{"name":"P10","iops":500},{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":240,"storageSizeMb":65536,"defaultIopsTier":"P6","supportedIopsTiers":[{"name":"P6","iops":240},{"name":"P10","iops":500},{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":500,"storageSizeMb":131072,"defaultIopsTier":"P10","supportedIopsTiers":[{"name":"P10","iops":500},{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":1100,"storageSizeMb":262144,"defaultIopsTier":"P15","supportedIopsTiers":[{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":2300,"storageSizeMb":524288,"defaultIopsTier":"P20","supportedIopsTiers":[{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":5000,"storageSizeMb":1048576,"defaultIopsTier":"P30","supportedIopsTiers":[{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":7500,"storageSizeMb":2097152,"defaultIopsTier":"P40","supportedIopsTiers":[{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":7500,"storageSizeMb":4193280,"defaultIopsTier":"P50","supportedIopsTiers":[{"name":"P50","iops":7500}]},{"supportedIops":7500,"storageSizeMb":4194304,"defaultIopsTier":"P50","supportedIopsTiers":[{"name":"P50","iops":7500}]},{"supportedIops":16000,"storageSizeMb":8388608,"defaultIopsTier":"P60","supportedIopsTiers":[{"name":"P60","iops":16000},{"name":"P70","iops":18000},{"name":"P80","iops":20000}]},{"supportedIops":18000,"storageSizeMb":16777216,"defaultIopsTier":"P70","supportedIopsTiers":[{"name":"P70","iops":18000},{"name":"P80","iops":20000}]},{"supportedIops":20000,"storageSizeMb":33553408,"defaultIopsTier":"P80","supportedIopsTiers":[{"name":"P80","iops":20000}]}]},{"name":"ManagedDiskV2","defaultStorageSizeMb":131072,"supportedStorageMb":[{"supportedIops":3000,"supportedMaximumIops":80000,"storageSizeMb":32768,"maximumStorageSizeMb":67108864,"supportedThroughput":125,"supportedMaximumThroughput":1200,"defaultIopsTier":"None","supportedIopsTiers":[{"name":"None","iops":0}]}]},{"name":"UltraDisk","defaultStorageSizeMb":131072,"supportedStorageMb":[{"supportedIops":4800,"supportedMaximumIops":400000,"storageSizeMb":32768,"maximumStorageSizeMb":67108864,"supportedThroughput":1200,"supportedMaximumThroughput":10000,"defaultIopsTier":"None","supportedIopsTiers":[{"name":"None","iops":0}]}]}]}],"supportedServerVersions":[{"supportedFeatures":[],"name":"11","supportedVersionsToUpgrade":["12","13","14","15","16","17","18"]},{"supportedFeatures":[],"name":"12","supportedVersionsToUpgrade":["13","14","15","16","17","18"]},{"supportedFeatures":[],"name":"13","supportedVersionsToUpgrade":["14","15","16","17","18"]},{"supportedFeatures":[],"name":"14","supportedVersionsToUpgrade":["15","16","17","18"]},{"supportedFeatures":[],"name":"15","supportedVersionsToUpgrade":["16","17","18"]},{"supportedFeatures":[],"name":"16","supportedVersionsToUpgrade":["17","18"]},{"supportedFeatures":[],"name":"17","supportedVersionsToUpgrade":["18"]},{"supportedFeatures":[],"name":"18","supportedVersionsToUpgrade":[]}],"supportedFastProvisioningEditions":[],"supportedFeatures":[{"name":"FastProvisioning","status":"Disabled"},{"name":"ZoneRedundantHa","status":"Enabled"},{"name":"GeoBackup","status":"Enabled"},{"name":"ZoneRedundantHaAndGeoBackup","status":"Enabled"},{"name":"StorageAutoGrowth","status":"Enabled"},{"name":"OnlineResize","status":"Enabled"},{"name":"OfferRestricted","status":"Disabled"},{"name":"IndexTuning","status":"Enabled"},{"name":"Clusters","status":"Enabled"},{"name":"AdaptiveAutoVacuumAutoApply","status":"Disabled"},{"name":"ConfigTuning","status":"Disabled"}],"fastProvisioningSupported":"Disabled","geoBackupSupported":"Enabled","zoneRedundantHaSupported":"Enabled","zoneRedundantHaAndGeoBackupSupported":"Enabled","storageAutoGrowthSupported":"Enabled","onlineResizeSupported":"Enabled","indexTuningSupported":"Enabled"}]}'
+      string: '{"value":[{"name":"FlexibleServerCapabilities","supportedServerEditions":[{"supportedServerSkus":[{"supportedFeatures":[],"name":"Standard_B1ms","vCores":1,"supportedIops":640,"supportedMemoryPerVcoreMb":2048,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_B2s","vCores":2,"supportedIops":1280,"supportedMemoryPerVcoreMb":2048,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_B2ms","vCores":2,"supportedIops":1920,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_B4ms","vCores":4,"supportedIops":2880,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_B8ms","vCores":8,"supportedIops":4320,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_B12ms","vCores":12,"supportedIops":4320,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_B16ms","vCores":16,"supportedIops":4320,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_B20ms","vCores":20,"supportedIops":4320,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]}],"name":"Burstable","defaultSkuName":"Standard_B2s","supportedStorageEditions":[{"name":"ManagedDisk","defaultStorageSizeMb":32768,"supportedStorageMb":[{"supportedIops":120,"storageSizeMb":32768,"defaultIopsTier":"P4","supportedIopsTiers":[{"name":"P4","iops":120},{"name":"P6","iops":240},{"name":"P10","iops":500},{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":240,"storageSizeMb":65536,"defaultIopsTier":"P6","supportedIopsTiers":[{"name":"P6","iops":240},{"name":"P10","iops":500},{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":500,"storageSizeMb":131072,"defaultIopsTier":"P10","supportedIopsTiers":[{"name":"P10","iops":500},{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":1100,"storageSizeMb":262144,"defaultIopsTier":"P15","supportedIopsTiers":[{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":2300,"storageSizeMb":524288,"defaultIopsTier":"P20","supportedIopsTiers":[{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":5000,"storageSizeMb":1048576,"defaultIopsTier":"P30","supportedIopsTiers":[{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":7500,"storageSizeMb":2097152,"defaultIopsTier":"P40","supportedIopsTiers":[{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":7500,"storageSizeMb":4193280,"defaultIopsTier":"P50","supportedIopsTiers":[{"name":"P50","iops":7500}]},{"supportedIops":7500,"storageSizeMb":4194304,"defaultIopsTier":"P50","supportedIopsTiers":[{"name":"P50","iops":7500}]},{"supportedIops":16000,"storageSizeMb":8388608,"defaultIopsTier":"P60","supportedIopsTiers":[{"name":"P60","iops":16000},{"name":"P70","iops":18000},{"name":"P80","iops":20000}]},{"supportedIops":18000,"storageSizeMb":16777216,"defaultIopsTier":"P70","supportedIopsTiers":[{"name":"P70","iops":18000},{"name":"P80","iops":20000}]},{"supportedIops":20000,"storageSizeMb":33553408,"defaultIopsTier":"P80","supportedIopsTiers":[{"name":"P80","iops":20000}]}]},{"name":"ManagedDiskV2","defaultStorageSizeMb":32768,"supportedStorageMb":[{"supportedIops":3000,"supportedMaximumIops":80000,"storageSizeMb":32768,"maximumStorageSizeMb":67108864,"supportedThroughput":125,"supportedMaximumThroughput":1200,"defaultIopsTier":"None","supportedIopsTiers":[{"name":"None","iops":0}]}]}]},{"supportedServerSkus":[{"supportedFeatures":[],"name":"Standard_D2s_v3","vCores":2,"supportedIops":3200,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D4s_v3","vCores":4,"supportedIops":6400,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D8s_v3","vCores":8,"supportedIops":12800,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D16s_v3","vCores":16,"supportedIops":25600,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D32s_v3","vCores":32,"supportedIops":51200,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D48s_v3","vCores":48,"supportedIops":76800,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D64s_v3","vCores":64,"supportedIops":80000,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D2ds_v4","vCores":2,"supportedIops":3200,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D4ds_v4","vCores":4,"supportedIops":6400,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D8ds_v4","vCores":8,"supportedIops":12800,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D16ds_v4","vCores":16,"supportedIops":25600,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D32ds_v4","vCores":32,"supportedIops":51200,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D48ds_v4","vCores":48,"supportedIops":76800,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D64ds_v4","vCores":64,"supportedIops":80000,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D2ads_v5","vCores":2,"supportedIops":3200,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D4ads_v5","vCores":4,"supportedIops":6400,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D8ads_v5","vCores":8,"supportedIops":12800,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D16ads_v5","vCores":16,"supportedIops":25600,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D32ads_v5","vCores":32,"supportedIops":51200,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D48ads_v5","vCores":48,"supportedIops":76800,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D64ads_v5","vCores":64,"supportedIops":80000,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D96ads_v5","vCores":96,"supportedIops":80000,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D2ds_v5","vCores":2,"supportedIops":3750,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D4ds_v5","vCores":4,"supportedIops":6400,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D8ds_v5","vCores":8,"supportedIops":12800,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D16ds_v5","vCores":16,"supportedIops":25600,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D32ds_v5","vCores":32,"supportedIops":51200,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D48ds_v5","vCores":48,"supportedIops":76800,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D64ds_v5","vCores":64,"supportedIops":80000,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D96ds_v5","vCores":96,"supportedIops":80000,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]}],"name":"GeneralPurpose","defaultSkuName":"Standard_D4ads_v5","supportedStorageEditions":[{"name":"ManagedDisk","defaultStorageSizeMb":65536,"supportedStorageMb":[{"supportedIops":120,"storageSizeMb":32768,"defaultIopsTier":"P4","supportedIopsTiers":[{"name":"P4","iops":120},{"name":"P6","iops":240},{"name":"P10","iops":500},{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":240,"storageSizeMb":65536,"defaultIopsTier":"P6","supportedIopsTiers":[{"name":"P6","iops":240},{"name":"P10","iops":500},{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":500,"storageSizeMb":131072,"defaultIopsTier":"P10","supportedIopsTiers":[{"name":"P10","iops":500},{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":1100,"storageSizeMb":262144,"defaultIopsTier":"P15","supportedIopsTiers":[{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":2300,"storageSizeMb":524288,"defaultIopsTier":"P20","supportedIopsTiers":[{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":5000,"storageSizeMb":1048576,"defaultIopsTier":"P30","supportedIopsTiers":[{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":7500,"storageSizeMb":2097152,"defaultIopsTier":"P40","supportedIopsTiers":[{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":7500,"storageSizeMb":4193280,"defaultIopsTier":"P50","supportedIopsTiers":[{"name":"P50","iops":7500}]},{"supportedIops":7500,"storageSizeMb":4194304,"defaultIopsTier":"P50","supportedIopsTiers":[{"name":"P50","iops":7500}]},{"supportedIops":16000,"storageSizeMb":8388608,"defaultIopsTier":"P60","supportedIopsTiers":[{"name":"P60","iops":16000},{"name":"P70","iops":18000},{"name":"P80","iops":20000}]},{"supportedIops":18000,"storageSizeMb":16777216,"defaultIopsTier":"P70","supportedIopsTiers":[{"name":"P70","iops":18000},{"name":"P80","iops":20000}]},{"supportedIops":20000,"storageSizeMb":33553408,"defaultIopsTier":"P80","supportedIopsTiers":[{"name":"P80","iops":20000}]}]},{"name":"ManagedDiskV2","defaultStorageSizeMb":65536,"supportedStorageMb":[{"supportedIops":3000,"supportedMaximumIops":80000,"storageSizeMb":32768,"maximumStorageSizeMb":67108864,"supportedThroughput":125,"supportedMaximumThroughput":1200,"defaultIopsTier":"None","supportedIopsTiers":[{"name":"None","iops":0}]}]},{"name":"UltraDisk","defaultStorageSizeMb":65536,"supportedStorageMb":[],"reason":"Specified
+        Storage Edition not supported in this region."}]},{"supportedServerSkus":[{"supportedFeatures":[],"name":"Standard_E2s_v3","vCores":2,"supportedIops":3200,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E4s_v3","vCores":4,"supportedIops":6400,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E8s_v3","vCores":8,"supportedIops":12800,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E16s_v3","vCores":16,"supportedIops":25600,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E32s_v3","vCores":32,"supportedIops":32000,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E48s_v3","vCores":48,"supportedIops":51200,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E64s_v3","vCores":64,"supportedIops":76800,"supportedMemoryPerVcoreMb":6912,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E2ds_v4","vCores":2,"supportedIops":3200,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E4ds_v4","vCores":4,"supportedIops":6400,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E8ds_v4","vCores":8,"supportedIops":12800,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E16ds_v4","vCores":16,"supportedIops":25600,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E20ds_v4","vCores":20,"supportedIops":32000,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E32ds_v4","vCores":32,"supportedIops":51200,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E48ds_v4","vCores":48,"supportedIops":76800,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E64ds_v4","vCores":64,"supportedIops":80000,"supportedMemoryPerVcoreMb":6912,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E2ads_v5","vCores":2,"supportedIops":3750,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E4ads_v5","vCores":4,"supportedIops":6400,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E8ads_v5","vCores":8,"supportedIops":12800,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E16ads_v5","vCores":16,"supportedIops":25600,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E20ads_v5","vCores":20,"supportedIops":32000,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E32ads_v5","vCores":32,"supportedIops":51200,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E48ads_v5","vCores":48,"supportedIops":76800,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E64ads_v5","vCores":64,"supportedIops":80000,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E96ads_v5","vCores":96,"supportedIops":80000,"supportedMemoryPerVcoreMb":7168,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E2ds_v5","vCores":2,"supportedIops":3750,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E4ds_v5","vCores":4,"supportedIops":6400,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E8ds_v5","vCores":8,"supportedIops":12800,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E16ds_v5","vCores":16,"supportedIops":25600,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E20ds_v5","vCores":20,"supportedIops":32000,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E32ds_v5","vCores":32,"supportedIops":51200,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E48ds_v5","vCores":48,"supportedIops":76800,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E64ds_v5","vCores":64,"supportedIops":80000,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E96ds_v5","vCores":96,"supportedIops":80000,"supportedMemoryPerVcoreMb":7168,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E96bds_v5","vCores":96,"supportedIops":160000,"supportedMemoryPerVcoreMb":7168,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]}],"name":"MemoryOptimized","defaultSkuName":"Standard_E4ads_v5","supportedStorageEditions":[{"name":"ManagedDisk","defaultStorageSizeMb":131072,"supportedStorageMb":[{"supportedIops":120,"storageSizeMb":32768,"defaultIopsTier":"P4","supportedIopsTiers":[{"name":"P4","iops":120},{"name":"P6","iops":240},{"name":"P10","iops":500},{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":240,"storageSizeMb":65536,"defaultIopsTier":"P6","supportedIopsTiers":[{"name":"P6","iops":240},{"name":"P10","iops":500},{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":500,"storageSizeMb":131072,"defaultIopsTier":"P10","supportedIopsTiers":[{"name":"P10","iops":500},{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":1100,"storageSizeMb":262144,"defaultIopsTier":"P15","supportedIopsTiers":[{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":2300,"storageSizeMb":524288,"defaultIopsTier":"P20","supportedIopsTiers":[{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":5000,"storageSizeMb":1048576,"defaultIopsTier":"P30","supportedIopsTiers":[{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":7500,"storageSizeMb":2097152,"defaultIopsTier":"P40","supportedIopsTiers":[{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":7500,"storageSizeMb":4193280,"defaultIopsTier":"P50","supportedIopsTiers":[{"name":"P50","iops":7500}]},{"supportedIops":7500,"storageSizeMb":4194304,"defaultIopsTier":"P50","supportedIopsTiers":[{"name":"P50","iops":7500}]},{"supportedIops":16000,"storageSizeMb":8388608,"defaultIopsTier":"P60","supportedIopsTiers":[{"name":"P60","iops":16000},{"name":"P70","iops":18000},{"name":"P80","iops":20000}]},{"supportedIops":18000,"storageSizeMb":16777216,"defaultIopsTier":"P70","supportedIopsTiers":[{"name":"P70","iops":18000},{"name":"P80","iops":20000}]},{"supportedIops":20000,"storageSizeMb":33553408,"defaultIopsTier":"P80","supportedIopsTiers":[{"name":"P80","iops":20000}]}]},{"name":"ManagedDiskV2","defaultStorageSizeMb":131072,"supportedStorageMb":[{"supportedIops":3000,"supportedMaximumIops":80000,"storageSizeMb":32768,"maximumStorageSizeMb":67108864,"supportedThroughput":125,"supportedMaximumThroughput":1200,"defaultIopsTier":"None","supportedIopsTiers":[{"name":"None","iops":0}]}]},{"name":"UltraDisk","defaultStorageSizeMb":131072,"supportedStorageMb":[],"reason":"Specified
+        Storage Edition not supported in this region."}]}],"supportedServerVersions":[{"supportedFeatures":[],"name":"11","supportedVersionsToUpgrade":["12","13","14","15","16","17","18"]},{"supportedFeatures":[],"name":"12","supportedVersionsToUpgrade":["13","14","15","16","17","18"]},{"supportedFeatures":[],"name":"13","supportedVersionsToUpgrade":["14","15","16","17","18"]},{"supportedFeatures":[],"name":"14","supportedVersionsToUpgrade":["15","16","17","18"]},{"supportedFeatures":[],"name":"15","supportedVersionsToUpgrade":["16","17","18"]},{"supportedFeatures":[],"name":"16","supportedVersionsToUpgrade":["17","18"]},{"supportedFeatures":[],"name":"17","supportedVersionsToUpgrade":["18"]},{"supportedFeatures":[],"name":"18","supportedVersionsToUpgrade":[]}],"supportedFastProvisioningEditions":[],"supportedFeatures":[{"name":"FastProvisioning","status":"Disabled"},{"name":"ZoneRedundantHa","status":"Enabled"},{"name":"GeoBackup","status":"Enabled"},{"name":"ZoneRedundantHaAndGeoBackup","status":"Enabled"},{"name":"StorageAutoGrowth","status":"Enabled"},{"name":"OnlineResize","status":"Enabled"},{"name":"OfferRestricted","status":"Disabled"},{"name":"IndexTuning","status":"Enabled"},{"name":"Clusters","status":"Enabled"},{"name":"AdaptiveAutoVacuumAutoApply","status":"Disabled"},{"name":"ConfigTuning","status":"Disabled"}],"fastProvisioningSupported":"Disabled","geoBackupSupported":"Enabled","zoneRedundantHaSupported":"Enabled","zoneRedundantHaAndGeoBackupSupported":"Enabled","storageAutoGrowthSupported":"Enabled","onlineResizeSupported":"Enabled","indexTuningSupported":"Enabled"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '24690'
+      - '24342'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 30 Mar 2026 14:12:16 GMT
+      - Tue, 31 Mar 2026 21:47:40 GMT
       expires:
       - '-1'
       pragma:
@@ -183,22 +185,22 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/87160815-89c2-45ee-96fd-2f1de347c3d5
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/b740467f-9cb3-44d5-bf81-16a9ca6c4dc8
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: CC66B4FF5E504D5D83FF6A194E23CE22 Ref B: AMS231020512033 Ref C: 2026-03-30T14:12:15Z'
+      - 'Ref A: AC708787A83A4576A583A4B07F6436EB Ref B: AMS231020615025 Ref C: 2026-03-31T21:47:38Z'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"location": "canadacentral", "sku": {"name": "Standard_D4ads_v5", "tier":
-      "GeneralPurpose"}, "properties": {"administratorLogin": "unlinedparrot3", "backup":
-      {"backupRetentionDays": 7, "geoRedundantBackup": "Disabled"}, "version": "17",
-      "highAvailability": {"mode": "Disabled"}, "network": {"publicNetworkAccess":
-      "Disabled"}, "storage": {"storageSizeGB": 128, "autoGrow": "Disabled"}, "createMode":
-      "Create", "administratorLoginPassword": "K1lfnFRaaDetyuuMaG2k0w", "authConfig":
-      {"activeDirectoryAuth": "Disabled", "passwordAuth": "Enabled"}}}'
+    body: '{"location": "canadacentral", "sku": {"name": "Standard_D2ds_v5", "tier":
+      "GeneralPurpose"}, "properties": {"authConfig": {"activeDirectoryAuth": "Disabled",
+      "passwordAuth": "Enabled"}, "administratorLogin": "amusedeggs1", "administratorLoginPassword":
+      "OwqeUbQ5Tu_Ta_VSj5L6Fw", "network": {"publicNetworkAccess": "Disabled"}, "highAvailability":
+      {"mode": "Disabled"}, "createMode": "Create", "storage": {"storageSizeGB": 128,
+      "autoGrow": "Disabled"}, "backup": {"backupRetentionDays": 7, "geoRedundantBackup":
+      "Disabled"}, "version": "17"}}'
     headers:
       Accept:
       - '*/*'
@@ -209,33 +211,33 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '545'
+      - '541'
       Content-Type:
       - application/json
       ParameterSetName:
       - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
       User-Agent:
-      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002?api-version=2026-01-01-preview
   response:
     body:
-      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2026-03-30T14:12:18.98Z"}'
+      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2026-03-31T21:47:41.577Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/a9b6af9f-8c5f-411b-9087-11a46647c67f?api-version=2026-01-01-preview&t=639104767394137249&c=MIIHlTCCBn2gAwIBAgIRAMrMZgep9-LTubYuD5c1bMgwDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgRVVTMiBDQSAwMTAeFw0yNjAyMjQxMzAxMjBaFw0yNjA4MTkxOTAxMjBaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtc9VqEvVV-f6_yUuDcAswQOf3pY-Y8bo2vLNVJr1CPCcGcMSxZtU9_kSwuHc77o3SYmOurgLtp6WdXT4o-p6NrDTkTl4KV4uY6pssTu-K6TasXs4zEWA4TN1ivwt0dt28Rl9RL-iTYepHyDjf7TsPethzhl3Yea9Bye2ACwkc4mI1PM1dSuDybmebI78BA3xYA6_LqSlF1-Pjk5qFuqHwPEIuiZCm7r8dtCGdMAyv075r86onD9M06bLHeKFbD0PsqtV9xwcaIM1wl6LdKNpYkkmcleFSWjil1F44HliNV85aG4ULUFhSxymugnZDV1k4dLp2b-NFd0ErNAMc8l2DQIDAQABo4IEkjCCBI4wgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQUAs4IkRNNSi2LOcksFd0_oJ9LnTwwHwYDVR0jBBgwFoAU_Ow-26p8H4IeBbihBvlD5wKzCrkwggGyBgNVHR8EggGpMIIBpTBpoGegZYZjaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzg5L2N1cnJlbnQuY3JsMGugaaBnhmVodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NybHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS84OS9jdXJyZW50LmNybDBaoFigVoZUaHR0cDovL2NybC5taWNyb3NvZnQuY29tL2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzg5L2N1cnJlbnQuY3JsMG-gbaBrhmlodHRwOi8vY2NtZWVhc3R1czJwa2kuZWFzdHVzMi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVlYXN0dXMyaWNhMDEvODkvY3VycmVudC5jcmwwggG3BggrBgEFBQcBAQSCAakwggGlMGwGCCsGAQUFBzAChmBodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwbgYIKwYBBQUHMAKGYmh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY2FjZXJ0cy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxL2NlcnQuY2VyMF0GCCsGAQUFBzAChlFodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwZgYIKwYBBQUHMAKGWmh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMTANBgkqhkiG9w0BAQsFAAOCAQEAEKc49KJHc6By0YpRr-FLth5Lupbcfj855fKMIxBRydPRMy2ML_NCOORdCclSMJOOS8fT_jyVfAgWbuOJjQqmoinjcf_Dn5apduFtwmTSWlJ00RLrD0f2x3veqrW9aqy0unjq5PVrwEgPAUXX4ng_iKGUKLjXcJHqB54M8_ZZwND8cZGmd0QuZ1lOsLua3ztb331S21nKgR84tkH51d2vGzWTRlnPbWwuXOJyAiVoPBJ5wQ9oxLFDAUtreJJDinMpHVPA6UOCg4x0k07b02_tycryA5zghFvFX-Vaw7F5Vm0bwz7vrYdS1dl478O8qtnRvMAvaIFNwkeB6HV29ubjUg&s=GYmyM_7hodJoMDy6Vcg3IV4vIMlpM4GMMT7TaH19mj9IyZQtPBvqv4HY4IGXP7KoiezGJ-e1ZnWF8kjBubhZyh4lSqnwxBaStpL8QIcaA92TY9ePxVJgZkF7IH6ZyYPE56ve0-u_6WJ16nG_SRPqFC5xJJdq40iX4Mc_J-AuhHuKyjV3SQgjiwwCqTbOBswn_kS60zzKdN82oEyJrKKePtiRawrpnl7XRvr2b9tkKRsJ0hxyHInHbVOqiLI8iQ8qBChxmTjmmpzzu5G2SrG30wfK2udgWz1ViMxaBtBGHflOj1lEIdwaEGDKTAQ32fqzLJhlekhmvCrxgyTTdT3YAw&h=Rd-91wJdq06ezIal_utYXgyD8ZbyZwDVBwmwnen9giM
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/4d32f3dd-88e0-4c75-8151-af8a124659c9?api-version=2026-01-01-preview&t=639105904616933354&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=rPZQDWr1PVETImg15rqV73rQG7elimeZdaMmrAxUdcZM56UT46mSKCuKyTXzWVzN_Az5bSoPJBYYz3Vh53t4lCYu1j25ZC2vScLHSHBnYRvq2ZR63-_OuNke85PqwnBp9ghHMg-tVwY66cmnNOGIdd61hrzrCdoBGyI8iJiv6jDTUqzJf2Yj9BUUF88Dsq5Oq31r2NlkihuE3PQv08zSgWi9bDwxtmt5_0IYfgzsYBxo27NoaGhDNvMiL32aALCzfo17U9iSG-ENmzh1ws_Gl_FP74BZHZlmFgKmcH3ol-uzKPpuB2raEn-pXm2SDtuqpgvin4_sL_pEHxnFKjeScA&h=R4NrL547ygVfoyktfS1t_fYPRAw26FawnJDYvsi5Zzk
       cache-control:
       - no-cache
       content-length:
-      - '87'
+      - '88'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 30 Mar 2026 14:12:18 GMT
+      - Tue, 31 Mar 2026 21:47:41 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/operationResults/a9b6af9f-8c5f-411b-9087-11a46647c67f?api-version=2026-01-01-preview&t=639104767394294820&c=MIIHlTCCBn2gAwIBAgIRAMrMZgep9-LTubYuD5c1bMgwDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgRVVTMiBDQSAwMTAeFw0yNjAyMjQxMzAxMjBaFw0yNjA4MTkxOTAxMjBaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtc9VqEvVV-f6_yUuDcAswQOf3pY-Y8bo2vLNVJr1CPCcGcMSxZtU9_kSwuHc77o3SYmOurgLtp6WdXT4o-p6NrDTkTl4KV4uY6pssTu-K6TasXs4zEWA4TN1ivwt0dt28Rl9RL-iTYepHyDjf7TsPethzhl3Yea9Bye2ACwkc4mI1PM1dSuDybmebI78BA3xYA6_LqSlF1-Pjk5qFuqHwPEIuiZCm7r8dtCGdMAyv075r86onD9M06bLHeKFbD0PsqtV9xwcaIM1wl6LdKNpYkkmcleFSWjil1F44HliNV85aG4ULUFhSxymugnZDV1k4dLp2b-NFd0ErNAMc8l2DQIDAQABo4IEkjCCBI4wgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQUAs4IkRNNSi2LOcksFd0_oJ9LnTwwHwYDVR0jBBgwFoAU_Ow-26p8H4IeBbihBvlD5wKzCrkwggGyBgNVHR8EggGpMIIBpTBpoGegZYZjaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzg5L2N1cnJlbnQuY3JsMGugaaBnhmVodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NybHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS84OS9jdXJyZW50LmNybDBaoFigVoZUaHR0cDovL2NybC5taWNyb3NvZnQuY29tL2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzg5L2N1cnJlbnQuY3JsMG-gbaBrhmlodHRwOi8vY2NtZWVhc3R1czJwa2kuZWFzdHVzMi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVlYXN0dXMyaWNhMDEvODkvY3VycmVudC5jcmwwggG3BggrBgEFBQcBAQSCAakwggGlMGwGCCsGAQUFBzAChmBodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwbgYIKwYBBQUHMAKGYmh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY2FjZXJ0cy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxL2NlcnQuY2VyMF0GCCsGAQUFBzAChlFodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwZgYIKwYBBQUHMAKGWmh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMTANBgkqhkiG9w0BAQsFAAOCAQEAEKc49KJHc6By0YpRr-FLth5Lupbcfj855fKMIxBRydPRMy2ML_NCOORdCclSMJOOS8fT_jyVfAgWbuOJjQqmoinjcf_Dn5apduFtwmTSWlJ00RLrD0f2x3veqrW9aqy0unjq5PVrwEgPAUXX4ng_iKGUKLjXcJHqB54M8_ZZwND8cZGmd0QuZ1lOsLua3ztb331S21nKgR84tkH51d2vGzWTRlnPbWwuXOJyAiVoPBJ5wQ9oxLFDAUtreJJDinMpHVPA6UOCg4x0k07b02_tycryA5zghFvFX-Vaw7F5Vm0bwz7vrYdS1dl478O8qtnRvMAvaIFNwkeB6HV29ubjUg&s=g_2js2iWZ_dXjl-KSrh2aZiSmly3WzNHaVnU3NoYy7X_g9iVLGGizAMvlgpEmGKqmIorRmaB2KZRttE4OmovUu1ksGIT-9dr5gFv9lTO31xjgR2egluOLPCQS8FiQUevBoNvq5CIuq49mEe1WAewIg_48FMivF1Vih0vpfWHZ5abe2dlO46V_9pS0Kh1XyW5Gy9ATvXaoTzdlusGLAP0aSiEUfHyvQWauQCk1af9SWVt6eryXzF1bM6je-smxUy8HC1Cl-c2T_qHZDwiFuhcx3iL8KtywJKwvH3MQ5JbvRPQbBHv0P1Rd51wSTWUinxmzcwAQhHdbv9R5ULANXUQjQ&h=afjGkG0eD9YN9cYRpMC-SQQLkUqzeWTgRP6cDD-NLLc
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/operationResults/4d32f3dd-88e0-4c75-8151-af8a124659c9?api-version=2026-01-01-preview&t=639105904617089594&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=EeCZGezrPiNicD8tYXJmi36TnKVeJKthzX8a-Q4ykk7w9VStGI0qm-mI5zzxaNHhIqRp3RfS7NPgHQvP2S69UoA-lZJ72YDfHd3TjdeqESLFKFyIZS1KPlFSaFAsVj0waEdXn-K7GpkPJ6h1Kfu-5izg7nNQ1QCPrGH_vJxZ8zLp4FVNy-NRLzsAY6oKmXeBaTBSNsVEjaivFwXpg_LTQlPxBPSL9pbGED3m0kRDmEohlOQoBQoODRk-9PPrdWzApUtR_k0Fnx2pK3t9LgZr7XG2DK6eh2nuLKINQxEM81DO7zWXF3Udxx9qdyc8m5o1cw2ga30px9UW2EfGxiWgIQ&h=oC9LdH2U6uYuHU7jOmgZeQYAlsGt1hjD2FztSkkHTz8
       pragma:
       - no-cache
       strict-transport-security:
@@ -245,13 +247,13 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/ukwest/2433fc5f-af44-4a61-842b-12614ee5f779
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/8c248779-7720-449b-9e1d-674ff084a80c
       x-ms-ratelimit-remaining-subscription-global-writes:
       - '11999'
       x-ms-ratelimit-remaining-subscription-writes:
       - '799'
       x-msedge-ref:
-      - 'Ref A: F9B778328E604C68ADF2B7ADD9444126 Ref B: DUB601080513042 Ref C: 2026-03-30T14:12:17Z'
+      - 'Ref A: 69BEF648B0AD4989BD15426837AF99AD Ref B: AMS231020614021 Ref C: 2026-03-31T21:47:41Z'
     status:
       code: 202
       message: Accepted
@@ -269,12 +271,252 @@ interactions:
       ParameterSetName:
       - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
       User-Agent:
-      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/a9b6af9f-8c5f-411b-9087-11a46647c67f?api-version=2026-01-01-preview&t=639104767394137249&c=MIIHlTCCBn2gAwIBAgIRAMrMZgep9-LTubYuD5c1bMgwDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgRVVTMiBDQSAwMTAeFw0yNjAyMjQxMzAxMjBaFw0yNjA4MTkxOTAxMjBaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtc9VqEvVV-f6_yUuDcAswQOf3pY-Y8bo2vLNVJr1CPCcGcMSxZtU9_kSwuHc77o3SYmOurgLtp6WdXT4o-p6NrDTkTl4KV4uY6pssTu-K6TasXs4zEWA4TN1ivwt0dt28Rl9RL-iTYepHyDjf7TsPethzhl3Yea9Bye2ACwkc4mI1PM1dSuDybmebI78BA3xYA6_LqSlF1-Pjk5qFuqHwPEIuiZCm7r8dtCGdMAyv075r86onD9M06bLHeKFbD0PsqtV9xwcaIM1wl6LdKNpYkkmcleFSWjil1F44HliNV85aG4ULUFhSxymugnZDV1k4dLp2b-NFd0ErNAMc8l2DQIDAQABo4IEkjCCBI4wgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQUAs4IkRNNSi2LOcksFd0_oJ9LnTwwHwYDVR0jBBgwFoAU_Ow-26p8H4IeBbihBvlD5wKzCrkwggGyBgNVHR8EggGpMIIBpTBpoGegZYZjaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzg5L2N1cnJlbnQuY3JsMGugaaBnhmVodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NybHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS84OS9jdXJyZW50LmNybDBaoFigVoZUaHR0cDovL2NybC5taWNyb3NvZnQuY29tL2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzg5L2N1cnJlbnQuY3JsMG-gbaBrhmlodHRwOi8vY2NtZWVhc3R1czJwa2kuZWFzdHVzMi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVlYXN0dXMyaWNhMDEvODkvY3VycmVudC5jcmwwggG3BggrBgEFBQcBAQSCAakwggGlMGwGCCsGAQUFBzAChmBodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwbgYIKwYBBQUHMAKGYmh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY2FjZXJ0cy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxL2NlcnQuY2VyMF0GCCsGAQUFBzAChlFodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwZgYIKwYBBQUHMAKGWmh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMTANBgkqhkiG9w0BAQsFAAOCAQEAEKc49KJHc6By0YpRr-FLth5Lupbcfj855fKMIxBRydPRMy2ML_NCOORdCclSMJOOS8fT_jyVfAgWbuOJjQqmoinjcf_Dn5apduFtwmTSWlJ00RLrD0f2x3veqrW9aqy0unjq5PVrwEgPAUXX4ng_iKGUKLjXcJHqB54M8_ZZwND8cZGmd0QuZ1lOsLua3ztb331S21nKgR84tkH51d2vGzWTRlnPbWwuXOJyAiVoPBJ5wQ9oxLFDAUtreJJDinMpHVPA6UOCg4x0k07b02_tycryA5zghFvFX-Vaw7F5Vm0bwz7vrYdS1dl478O8qtnRvMAvaIFNwkeB6HV29ubjUg&s=GYmyM_7hodJoMDy6Vcg3IV4vIMlpM4GMMT7TaH19mj9IyZQtPBvqv4HY4IGXP7KoiezGJ-e1ZnWF8kjBubhZyh4lSqnwxBaStpL8QIcaA92TY9ePxVJgZkF7IH6ZyYPE56ve0-u_6WJ16nG_SRPqFC5xJJdq40iX4Mc_J-AuhHuKyjV3SQgjiwwCqTbOBswn_kS60zzKdN82oEyJrKKePtiRawrpnl7XRvr2b9tkKRsJ0hxyHInHbVOqiLI8iQ8qBChxmTjmmpzzu5G2SrG30wfK2udgWz1ViMxaBtBGHflOj1lEIdwaEGDKTAQ32fqzLJhlekhmvCrxgyTTdT3YAw&h=Rd-91wJdq06ezIal_utYXgyD8ZbyZwDVBwmwnen9giM
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/4d32f3dd-88e0-4c75-8151-af8a124659c9?api-version=2026-01-01-preview&t=639105904616933354&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=rPZQDWr1PVETImg15rqV73rQG7elimeZdaMmrAxUdcZM56UT46mSKCuKyTXzWVzN_Az5bSoPJBYYz3Vh53t4lCYu1j25ZC2vScLHSHBnYRvq2ZR63-_OuNke85PqwnBp9ghHMg-tVwY66cmnNOGIdd61hrzrCdoBGyI8iJiv6jDTUqzJf2Yj9BUUF88Dsq5Oq31r2NlkihuE3PQv08zSgWi9bDwxtmt5_0IYfgzsYBxo27NoaGhDNvMiL32aALCzfo17U9iSG-ENmzh1ws_Gl_FP74BZHZlmFgKmcH3ol-uzKPpuB2raEn-pXm2SDtuqpgvin4_sL_pEHxnFKjeScA&h=R4NrL547ygVfoyktfS1t_fYPRAw26FawnJDYvsi5Zzk
   response:
     body:
-      string: '{"name":"a9b6af9f-8c5f-411b-9087-11a46647c67f","status":"InProgress","startTime":"2026-03-30T14:12:18.98Z"}'
+      string: '{"name":"4d32f3dd-88e0-4c75-8151-af8a124659c9","status":"InProgress","startTime":"2026-03-31T21:47:41.577Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Mar 2026 21:47:41 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/7ae36553-448c-4712-9818-966c18a3878a
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 0C056EFD534A4315A89D30A5B6C5DD5B Ref B: AMS231020512009 Ref C: 2026-03-31T21:47:42Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - postgres flexible-server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
+      User-Agent:
+      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/4d32f3dd-88e0-4c75-8151-af8a124659c9?api-version=2026-01-01-preview&t=639105904616933354&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=rPZQDWr1PVETImg15rqV73rQG7elimeZdaMmrAxUdcZM56UT46mSKCuKyTXzWVzN_Az5bSoPJBYYz3Vh53t4lCYu1j25ZC2vScLHSHBnYRvq2ZR63-_OuNke85PqwnBp9ghHMg-tVwY66cmnNOGIdd61hrzrCdoBGyI8iJiv6jDTUqzJf2Yj9BUUF88Dsq5Oq31r2NlkihuE3PQv08zSgWi9bDwxtmt5_0IYfgzsYBxo27NoaGhDNvMiL32aALCzfo17U9iSG-ENmzh1ws_Gl_FP74BZHZlmFgKmcH3ol-uzKPpuB2raEn-pXm2SDtuqpgvin4_sL_pEHxnFKjeScA&h=R4NrL547ygVfoyktfS1t_fYPRAw26FawnJDYvsi5Zzk
+  response:
+    body:
+      string: '{"name":"4d32f3dd-88e0-4c75-8151-af8a124659c9","status":"InProgress","startTime":"2026-03-31T21:47:41.577Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Mar 2026 21:48:42 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/f38d1504-96ae-4cb3-95a1-6d735dc30885
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: B680C6B804374C90ACBE996D3C645128 Ref B: AMS231022012027 Ref C: 2026-03-31T21:48:42Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - postgres flexible-server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
+      User-Agent:
+      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/4d32f3dd-88e0-4c75-8151-af8a124659c9?api-version=2026-01-01-preview&t=639105904616933354&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=rPZQDWr1PVETImg15rqV73rQG7elimeZdaMmrAxUdcZM56UT46mSKCuKyTXzWVzN_Az5bSoPJBYYz3Vh53t4lCYu1j25ZC2vScLHSHBnYRvq2ZR63-_OuNke85PqwnBp9ghHMg-tVwY66cmnNOGIdd61hrzrCdoBGyI8iJiv6jDTUqzJf2Yj9BUUF88Dsq5Oq31r2NlkihuE3PQv08zSgWi9bDwxtmt5_0IYfgzsYBxo27NoaGhDNvMiL32aALCzfo17U9iSG-ENmzh1ws_Gl_FP74BZHZlmFgKmcH3ol-uzKPpuB2raEn-pXm2SDtuqpgvin4_sL_pEHxnFKjeScA&h=R4NrL547ygVfoyktfS1t_fYPRAw26FawnJDYvsi5Zzk
+  response:
+    body:
+      string: '{"name":"4d32f3dd-88e0-4c75-8151-af8a124659c9","status":"InProgress","startTime":"2026-03-31T21:47:41.577Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Mar 2026 21:49:42 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/ddf334e2-3e54-46c8-8afd-5282c99d7ff5
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: EDD3D4BE3BE34CB7BD218AAB334F386F Ref B: AMS231032608049 Ref C: 2026-03-31T21:49:43Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - postgres flexible-server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
+      User-Agent:
+      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/4d32f3dd-88e0-4c75-8151-af8a124659c9?api-version=2026-01-01-preview&t=639105904616933354&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=rPZQDWr1PVETImg15rqV73rQG7elimeZdaMmrAxUdcZM56UT46mSKCuKyTXzWVzN_Az5bSoPJBYYz3Vh53t4lCYu1j25ZC2vScLHSHBnYRvq2ZR63-_OuNke85PqwnBp9ghHMg-tVwY66cmnNOGIdd61hrzrCdoBGyI8iJiv6jDTUqzJf2Yj9BUUF88Dsq5Oq31r2NlkihuE3PQv08zSgWi9bDwxtmt5_0IYfgzsYBxo27NoaGhDNvMiL32aALCzfo17U9iSG-ENmzh1ws_Gl_FP74BZHZlmFgKmcH3ol-uzKPpuB2raEn-pXm2SDtuqpgvin4_sL_pEHxnFKjeScA&h=R4NrL547ygVfoyktfS1t_fYPRAw26FawnJDYvsi5Zzk
+  response:
+    body:
+      string: '{"name":"4d32f3dd-88e0-4c75-8151-af8a124659c9","status":"InProgress","startTime":"2026-03-31T21:47:41.577Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Mar 2026 21:50:43 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/ukwest/10fd1178-7a79-4cc8-aac1-4a9f62627f9b
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 9344C576A289437E8D4CDD01E98590C1 Ref B: AMS231022012009 Ref C: 2026-03-31T21:50:43Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - postgres flexible-server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
+      User-Agent:
+      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/4d32f3dd-88e0-4c75-8151-af8a124659c9?api-version=2026-01-01-preview&t=639105904616933354&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=rPZQDWr1PVETImg15rqV73rQG7elimeZdaMmrAxUdcZM56UT46mSKCuKyTXzWVzN_Az5bSoPJBYYz3Vh53t4lCYu1j25ZC2vScLHSHBnYRvq2ZR63-_OuNke85PqwnBp9ghHMg-tVwY66cmnNOGIdd61hrzrCdoBGyI8iJiv6jDTUqzJf2Yj9BUUF88Dsq5Oq31r2NlkihuE3PQv08zSgWi9bDwxtmt5_0IYfgzsYBxo27NoaGhDNvMiL32aALCzfo17U9iSG-ENmzh1ws_Gl_FP74BZHZlmFgKmcH3ol-uzKPpuB2raEn-pXm2SDtuqpgvin4_sL_pEHxnFKjeScA&h=R4NrL547ygVfoyktfS1t_fYPRAw26FawnJDYvsi5Zzk
+  response:
+    body:
+      string: '{"name":"4d32f3dd-88e0-4c75-8151-af8a124659c9","status":"InProgress","startTime":"2026-03-31T21:47:41.577Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Mar 2026 21:51:44 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/d8b730ed-be3d-4dc2-af9f-92b1b3292f71
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: B8DE07CFC9B840CDA6CC00337C82E0AC Ref B: AMS231032608037 Ref C: 2026-03-31T21:51:44Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - postgres flexible-server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
+      User-Agent:
+      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/4d32f3dd-88e0-4c75-8151-af8a124659c9?api-version=2026-01-01-preview&t=639105904616933354&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=rPZQDWr1PVETImg15rqV73rQG7elimeZdaMmrAxUdcZM56UT46mSKCuKyTXzWVzN_Az5bSoPJBYYz3Vh53t4lCYu1j25ZC2vScLHSHBnYRvq2ZR63-_OuNke85PqwnBp9ghHMg-tVwY66cmnNOGIdd61hrzrCdoBGyI8iJiv6jDTUqzJf2Yj9BUUF88Dsq5Oq31r2NlkihuE3PQv08zSgWi9bDwxtmt5_0IYfgzsYBxo27NoaGhDNvMiL32aALCzfo17U9iSG-ENmzh1ws_Gl_FP74BZHZlmFgKmcH3ol-uzKPpuB2raEn-pXm2SDtuqpgvin4_sL_pEHxnFKjeScA&h=R4NrL547ygVfoyktfS1t_fYPRAw26FawnJDYvsi5Zzk
+  response:
+    body:
+      string: '{"name":"4d32f3dd-88e0-4c75-8151-af8a124659c9","status":"Succeeded","startTime":"2026-03-31T21:47:41.577Z"}'
     headers:
       cache-control:
       - no-cache
@@ -283,7 +525,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 30 Mar 2026 14:12:19 GMT
+      - Tue, 31 Mar 2026 21:52:45 GMT
       expires:
       - '-1'
       pragma:
@@ -295,11 +537,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/811bdabb-3cbb-488c-bbd7-37bfa9576ed4
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/09abd17a-0b29-4a1f-9c16-b9fd64ac820f
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 834973342E134441A33B6BD9D88AC7ED Ref B: DUB601080510042 Ref C: 2026-03-30T14:12:19Z'
+      - 'Ref A: 4BEDA02EE3CD46C5AC47CF8D0804E599 Ref B: AMS231020614021 Ref C: 2026-03-31T21:52:45Z'
     status:
       code: 200
       message: OK
@@ -317,262 +559,22 @@ interactions:
       ParameterSetName:
       - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
       User-Agent:
-      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/a9b6af9f-8c5f-411b-9087-11a46647c67f?api-version=2026-01-01-preview&t=639104767394137249&c=MIIHlTCCBn2gAwIBAgIRAMrMZgep9-LTubYuD5c1bMgwDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgRVVTMiBDQSAwMTAeFw0yNjAyMjQxMzAxMjBaFw0yNjA4MTkxOTAxMjBaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtc9VqEvVV-f6_yUuDcAswQOf3pY-Y8bo2vLNVJr1CPCcGcMSxZtU9_kSwuHc77o3SYmOurgLtp6WdXT4o-p6NrDTkTl4KV4uY6pssTu-K6TasXs4zEWA4TN1ivwt0dt28Rl9RL-iTYepHyDjf7TsPethzhl3Yea9Bye2ACwkc4mI1PM1dSuDybmebI78BA3xYA6_LqSlF1-Pjk5qFuqHwPEIuiZCm7r8dtCGdMAyv075r86onD9M06bLHeKFbD0PsqtV9xwcaIM1wl6LdKNpYkkmcleFSWjil1F44HliNV85aG4ULUFhSxymugnZDV1k4dLp2b-NFd0ErNAMc8l2DQIDAQABo4IEkjCCBI4wgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQUAs4IkRNNSi2LOcksFd0_oJ9LnTwwHwYDVR0jBBgwFoAU_Ow-26p8H4IeBbihBvlD5wKzCrkwggGyBgNVHR8EggGpMIIBpTBpoGegZYZjaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzg5L2N1cnJlbnQuY3JsMGugaaBnhmVodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NybHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS84OS9jdXJyZW50LmNybDBaoFigVoZUaHR0cDovL2NybC5taWNyb3NvZnQuY29tL2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzg5L2N1cnJlbnQuY3JsMG-gbaBrhmlodHRwOi8vY2NtZWVhc3R1czJwa2kuZWFzdHVzMi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVlYXN0dXMyaWNhMDEvODkvY3VycmVudC5jcmwwggG3BggrBgEFBQcBAQSCAakwggGlMGwGCCsGAQUFBzAChmBodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwbgYIKwYBBQUHMAKGYmh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY2FjZXJ0cy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxL2NlcnQuY2VyMF0GCCsGAQUFBzAChlFodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwZgYIKwYBBQUHMAKGWmh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMTANBgkqhkiG9w0BAQsFAAOCAQEAEKc49KJHc6By0YpRr-FLth5Lupbcfj855fKMIxBRydPRMy2ML_NCOORdCclSMJOOS8fT_jyVfAgWbuOJjQqmoinjcf_Dn5apduFtwmTSWlJ00RLrD0f2x3veqrW9aqy0unjq5PVrwEgPAUXX4ng_iKGUKLjXcJHqB54M8_ZZwND8cZGmd0QuZ1lOsLua3ztb331S21nKgR84tkH51d2vGzWTRlnPbWwuXOJyAiVoPBJ5wQ9oxLFDAUtreJJDinMpHVPA6UOCg4x0k07b02_tycryA5zghFvFX-Vaw7F5Vm0bwz7vrYdS1dl478O8qtnRvMAvaIFNwkeB6HV29ubjUg&s=GYmyM_7hodJoMDy6Vcg3IV4vIMlpM4GMMT7TaH19mj9IyZQtPBvqv4HY4IGXP7KoiezGJ-e1ZnWF8kjBubhZyh4lSqnwxBaStpL8QIcaA92TY9ePxVJgZkF7IH6ZyYPE56ve0-u_6WJ16nG_SRPqFC5xJJdq40iX4Mc_J-AuhHuKyjV3SQgjiwwCqTbOBswn_kS60zzKdN82oEyJrKKePtiRawrpnl7XRvr2b9tkKRsJ0hxyHInHbVOqiLI8iQ8qBChxmTjmmpzzu5G2SrG30wfK2udgWz1ViMxaBtBGHflOj1lEIdwaEGDKTAQ32fqzLJhlekhmvCrxgyTTdT3YAw&h=Rd-91wJdq06ezIal_utYXgyD8ZbyZwDVBwmwnen9giM
-  response:
-    body:
-      string: '{"name":"a9b6af9f-8c5f-411b-9087-11a46647c67f","status":"InProgress","startTime":"2026-03-30T14:12:18.98Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '107'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 30 Mar 2026 14:13:19 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-cache:
-      - CONFIG_NOCACHE
-      x-content-type-options:
-      - nosniff
-      x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/e09bdc15-288d-4567-8044-6235641a6b95
-      x-ms-ratelimit-remaining-subscription-global-reads:
-      - '16499'
-      x-msedge-ref:
-      - 'Ref A: 5A8E71C309AF44688246EDB51E556738 Ref B: DUB241062309023 Ref C: 2026-03-30T14:13:20Z'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - postgres flexible-server create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
-      User-Agent:
-      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/a9b6af9f-8c5f-411b-9087-11a46647c67f?api-version=2026-01-01-preview&t=639104767394137249&c=MIIHlTCCBn2gAwIBAgIRAMrMZgep9-LTubYuD5c1bMgwDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgRVVTMiBDQSAwMTAeFw0yNjAyMjQxMzAxMjBaFw0yNjA4MTkxOTAxMjBaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtc9VqEvVV-f6_yUuDcAswQOf3pY-Y8bo2vLNVJr1CPCcGcMSxZtU9_kSwuHc77o3SYmOurgLtp6WdXT4o-p6NrDTkTl4KV4uY6pssTu-K6TasXs4zEWA4TN1ivwt0dt28Rl9RL-iTYepHyDjf7TsPethzhl3Yea9Bye2ACwkc4mI1PM1dSuDybmebI78BA3xYA6_LqSlF1-Pjk5qFuqHwPEIuiZCm7r8dtCGdMAyv075r86onD9M06bLHeKFbD0PsqtV9xwcaIM1wl6LdKNpYkkmcleFSWjil1F44HliNV85aG4ULUFhSxymugnZDV1k4dLp2b-NFd0ErNAMc8l2DQIDAQABo4IEkjCCBI4wgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQUAs4IkRNNSi2LOcksFd0_oJ9LnTwwHwYDVR0jBBgwFoAU_Ow-26p8H4IeBbihBvlD5wKzCrkwggGyBgNVHR8EggGpMIIBpTBpoGegZYZjaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzg5L2N1cnJlbnQuY3JsMGugaaBnhmVodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NybHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS84OS9jdXJyZW50LmNybDBaoFigVoZUaHR0cDovL2NybC5taWNyb3NvZnQuY29tL2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzg5L2N1cnJlbnQuY3JsMG-gbaBrhmlodHRwOi8vY2NtZWVhc3R1czJwa2kuZWFzdHVzMi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVlYXN0dXMyaWNhMDEvODkvY3VycmVudC5jcmwwggG3BggrBgEFBQcBAQSCAakwggGlMGwGCCsGAQUFBzAChmBodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwbgYIKwYBBQUHMAKGYmh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY2FjZXJ0cy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxL2NlcnQuY2VyMF0GCCsGAQUFBzAChlFodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwZgYIKwYBBQUHMAKGWmh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMTANBgkqhkiG9w0BAQsFAAOCAQEAEKc49KJHc6By0YpRr-FLth5Lupbcfj855fKMIxBRydPRMy2ML_NCOORdCclSMJOOS8fT_jyVfAgWbuOJjQqmoinjcf_Dn5apduFtwmTSWlJ00RLrD0f2x3veqrW9aqy0unjq5PVrwEgPAUXX4ng_iKGUKLjXcJHqB54M8_ZZwND8cZGmd0QuZ1lOsLua3ztb331S21nKgR84tkH51d2vGzWTRlnPbWwuXOJyAiVoPBJ5wQ9oxLFDAUtreJJDinMpHVPA6UOCg4x0k07b02_tycryA5zghFvFX-Vaw7F5Vm0bwz7vrYdS1dl478O8qtnRvMAvaIFNwkeB6HV29ubjUg&s=GYmyM_7hodJoMDy6Vcg3IV4vIMlpM4GMMT7TaH19mj9IyZQtPBvqv4HY4IGXP7KoiezGJ-e1ZnWF8kjBubhZyh4lSqnwxBaStpL8QIcaA92TY9ePxVJgZkF7IH6ZyYPE56ve0-u_6WJ16nG_SRPqFC5xJJdq40iX4Mc_J-AuhHuKyjV3SQgjiwwCqTbOBswn_kS60zzKdN82oEyJrKKePtiRawrpnl7XRvr2b9tkKRsJ0hxyHInHbVOqiLI8iQ8qBChxmTjmmpzzu5G2SrG30wfK2udgWz1ViMxaBtBGHflOj1lEIdwaEGDKTAQ32fqzLJhlekhmvCrxgyTTdT3YAw&h=Rd-91wJdq06ezIal_utYXgyD8ZbyZwDVBwmwnen9giM
-  response:
-    body:
-      string: '{"name":"a9b6af9f-8c5f-411b-9087-11a46647c67f","status":"InProgress","startTime":"2026-03-30T14:12:18.98Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '107'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 30 Mar 2026 14:14:20 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-cache:
-      - CONFIG_NOCACHE
-      x-content-type-options:
-      - nosniff
-      x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/129672e6-ff19-4345-963a-fb9db47650d2
-      x-ms-ratelimit-remaining-subscription-global-reads:
-      - '16499'
-      x-msedge-ref:
-      - 'Ref A: DC7821B8AAC64586927D51F70BD76753 Ref B: DUB601080513052 Ref C: 2026-03-30T14:14:20Z'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - postgres flexible-server create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
-      User-Agent:
-      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/a9b6af9f-8c5f-411b-9087-11a46647c67f?api-version=2026-01-01-preview&t=639104767394137249&c=MIIHlTCCBn2gAwIBAgIRAMrMZgep9-LTubYuD5c1bMgwDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgRVVTMiBDQSAwMTAeFw0yNjAyMjQxMzAxMjBaFw0yNjA4MTkxOTAxMjBaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtc9VqEvVV-f6_yUuDcAswQOf3pY-Y8bo2vLNVJr1CPCcGcMSxZtU9_kSwuHc77o3SYmOurgLtp6WdXT4o-p6NrDTkTl4KV4uY6pssTu-K6TasXs4zEWA4TN1ivwt0dt28Rl9RL-iTYepHyDjf7TsPethzhl3Yea9Bye2ACwkc4mI1PM1dSuDybmebI78BA3xYA6_LqSlF1-Pjk5qFuqHwPEIuiZCm7r8dtCGdMAyv075r86onD9M06bLHeKFbD0PsqtV9xwcaIM1wl6LdKNpYkkmcleFSWjil1F44HliNV85aG4ULUFhSxymugnZDV1k4dLp2b-NFd0ErNAMc8l2DQIDAQABo4IEkjCCBI4wgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQUAs4IkRNNSi2LOcksFd0_oJ9LnTwwHwYDVR0jBBgwFoAU_Ow-26p8H4IeBbihBvlD5wKzCrkwggGyBgNVHR8EggGpMIIBpTBpoGegZYZjaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzg5L2N1cnJlbnQuY3JsMGugaaBnhmVodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NybHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS84OS9jdXJyZW50LmNybDBaoFigVoZUaHR0cDovL2NybC5taWNyb3NvZnQuY29tL2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzg5L2N1cnJlbnQuY3JsMG-gbaBrhmlodHRwOi8vY2NtZWVhc3R1czJwa2kuZWFzdHVzMi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVlYXN0dXMyaWNhMDEvODkvY3VycmVudC5jcmwwggG3BggrBgEFBQcBAQSCAakwggGlMGwGCCsGAQUFBzAChmBodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwbgYIKwYBBQUHMAKGYmh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY2FjZXJ0cy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxL2NlcnQuY2VyMF0GCCsGAQUFBzAChlFodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwZgYIKwYBBQUHMAKGWmh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMTANBgkqhkiG9w0BAQsFAAOCAQEAEKc49KJHc6By0YpRr-FLth5Lupbcfj855fKMIxBRydPRMy2ML_NCOORdCclSMJOOS8fT_jyVfAgWbuOJjQqmoinjcf_Dn5apduFtwmTSWlJ00RLrD0f2x3veqrW9aqy0unjq5PVrwEgPAUXX4ng_iKGUKLjXcJHqB54M8_ZZwND8cZGmd0QuZ1lOsLua3ztb331S21nKgR84tkH51d2vGzWTRlnPbWwuXOJyAiVoPBJ5wQ9oxLFDAUtreJJDinMpHVPA6UOCg4x0k07b02_tycryA5zghFvFX-Vaw7F5Vm0bwz7vrYdS1dl478O8qtnRvMAvaIFNwkeB6HV29ubjUg&s=GYmyM_7hodJoMDy6Vcg3IV4vIMlpM4GMMT7TaH19mj9IyZQtPBvqv4HY4IGXP7KoiezGJ-e1ZnWF8kjBubhZyh4lSqnwxBaStpL8QIcaA92TY9ePxVJgZkF7IH6ZyYPE56ve0-u_6WJ16nG_SRPqFC5xJJdq40iX4Mc_J-AuhHuKyjV3SQgjiwwCqTbOBswn_kS60zzKdN82oEyJrKKePtiRawrpnl7XRvr2b9tkKRsJ0hxyHInHbVOqiLI8iQ8qBChxmTjmmpzzu5G2SrG30wfK2udgWz1ViMxaBtBGHflOj1lEIdwaEGDKTAQ32fqzLJhlekhmvCrxgyTTdT3YAw&h=Rd-91wJdq06ezIal_utYXgyD8ZbyZwDVBwmwnen9giM
-  response:
-    body:
-      string: '{"name":"a9b6af9f-8c5f-411b-9087-11a46647c67f","status":"InProgress","startTime":"2026-03-30T14:12:18.98Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '107'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 30 Mar 2026 14:15:21 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-cache:
-      - CONFIG_NOCACHE
-      x-content-type-options:
-      - nosniff
-      x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/ukwest/1043ad15-a47d-4b04-b3ca-eafc009a527f
-      x-ms-ratelimit-remaining-subscription-global-reads:
-      - '16499'
-      x-msedge-ref:
-      - 'Ref A: FD4F07D9F5B34EF9B27E1FB4024EE2DB Ref B: DUB601080511029 Ref C: 2026-03-30T14:15:21Z'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - postgres flexible-server create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
-      User-Agent:
-      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/a9b6af9f-8c5f-411b-9087-11a46647c67f?api-version=2026-01-01-preview&t=639104767394137249&c=MIIHlTCCBn2gAwIBAgIRAMrMZgep9-LTubYuD5c1bMgwDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgRVVTMiBDQSAwMTAeFw0yNjAyMjQxMzAxMjBaFw0yNjA4MTkxOTAxMjBaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtc9VqEvVV-f6_yUuDcAswQOf3pY-Y8bo2vLNVJr1CPCcGcMSxZtU9_kSwuHc77o3SYmOurgLtp6WdXT4o-p6NrDTkTl4KV4uY6pssTu-K6TasXs4zEWA4TN1ivwt0dt28Rl9RL-iTYepHyDjf7TsPethzhl3Yea9Bye2ACwkc4mI1PM1dSuDybmebI78BA3xYA6_LqSlF1-Pjk5qFuqHwPEIuiZCm7r8dtCGdMAyv075r86onD9M06bLHeKFbD0PsqtV9xwcaIM1wl6LdKNpYkkmcleFSWjil1F44HliNV85aG4ULUFhSxymugnZDV1k4dLp2b-NFd0ErNAMc8l2DQIDAQABo4IEkjCCBI4wgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQUAs4IkRNNSi2LOcksFd0_oJ9LnTwwHwYDVR0jBBgwFoAU_Ow-26p8H4IeBbihBvlD5wKzCrkwggGyBgNVHR8EggGpMIIBpTBpoGegZYZjaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzg5L2N1cnJlbnQuY3JsMGugaaBnhmVodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NybHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS84OS9jdXJyZW50LmNybDBaoFigVoZUaHR0cDovL2NybC5taWNyb3NvZnQuY29tL2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzg5L2N1cnJlbnQuY3JsMG-gbaBrhmlodHRwOi8vY2NtZWVhc3R1czJwa2kuZWFzdHVzMi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVlYXN0dXMyaWNhMDEvODkvY3VycmVudC5jcmwwggG3BggrBgEFBQcBAQSCAakwggGlMGwGCCsGAQUFBzAChmBodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwbgYIKwYBBQUHMAKGYmh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY2FjZXJ0cy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxL2NlcnQuY2VyMF0GCCsGAQUFBzAChlFodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwZgYIKwYBBQUHMAKGWmh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMTANBgkqhkiG9w0BAQsFAAOCAQEAEKc49KJHc6By0YpRr-FLth5Lupbcfj855fKMIxBRydPRMy2ML_NCOORdCclSMJOOS8fT_jyVfAgWbuOJjQqmoinjcf_Dn5apduFtwmTSWlJ00RLrD0f2x3veqrW9aqy0unjq5PVrwEgPAUXX4ng_iKGUKLjXcJHqB54M8_ZZwND8cZGmd0QuZ1lOsLua3ztb331S21nKgR84tkH51d2vGzWTRlnPbWwuXOJyAiVoPBJ5wQ9oxLFDAUtreJJDinMpHVPA6UOCg4x0k07b02_tycryA5zghFvFX-Vaw7F5Vm0bwz7vrYdS1dl478O8qtnRvMAvaIFNwkeB6HV29ubjUg&s=GYmyM_7hodJoMDy6Vcg3IV4vIMlpM4GMMT7TaH19mj9IyZQtPBvqv4HY4IGXP7KoiezGJ-e1ZnWF8kjBubhZyh4lSqnwxBaStpL8QIcaA92TY9ePxVJgZkF7IH6ZyYPE56ve0-u_6WJ16nG_SRPqFC5xJJdq40iX4Mc_J-AuhHuKyjV3SQgjiwwCqTbOBswn_kS60zzKdN82oEyJrKKePtiRawrpnl7XRvr2b9tkKRsJ0hxyHInHbVOqiLI8iQ8qBChxmTjmmpzzu5G2SrG30wfK2udgWz1ViMxaBtBGHflOj1lEIdwaEGDKTAQ32fqzLJhlekhmvCrxgyTTdT3YAw&h=Rd-91wJdq06ezIal_utYXgyD8ZbyZwDVBwmwnen9giM
-  response:
-    body:
-      string: '{"name":"a9b6af9f-8c5f-411b-9087-11a46647c67f","status":"InProgress","startTime":"2026-03-30T14:12:18.98Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '107'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 30 Mar 2026 14:16:21 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-cache:
-      - CONFIG_NOCACHE
-      x-content-type-options:
-      - nosniff
-      x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/ac18b833-d921-4005-8648-b95b9d7580c1
-      x-ms-ratelimit-remaining-subscription-global-reads:
-      - '16499'
-      x-msedge-ref:
-      - 'Ref A: 79CE9AFD7AD7478F837E8117E4115351 Ref B: AMS231022012045 Ref C: 2026-03-30T14:16:22Z'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - postgres flexible-server create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
-      User-Agent:
-      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/a9b6af9f-8c5f-411b-9087-11a46647c67f?api-version=2026-01-01-preview&t=639104767394137249&c=MIIHlTCCBn2gAwIBAgIRAMrMZgep9-LTubYuD5c1bMgwDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgRVVTMiBDQSAwMTAeFw0yNjAyMjQxMzAxMjBaFw0yNjA4MTkxOTAxMjBaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtc9VqEvVV-f6_yUuDcAswQOf3pY-Y8bo2vLNVJr1CPCcGcMSxZtU9_kSwuHc77o3SYmOurgLtp6WdXT4o-p6NrDTkTl4KV4uY6pssTu-K6TasXs4zEWA4TN1ivwt0dt28Rl9RL-iTYepHyDjf7TsPethzhl3Yea9Bye2ACwkc4mI1PM1dSuDybmebI78BA3xYA6_LqSlF1-Pjk5qFuqHwPEIuiZCm7r8dtCGdMAyv075r86onD9M06bLHeKFbD0PsqtV9xwcaIM1wl6LdKNpYkkmcleFSWjil1F44HliNV85aG4ULUFhSxymugnZDV1k4dLp2b-NFd0ErNAMc8l2DQIDAQABo4IEkjCCBI4wgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQUAs4IkRNNSi2LOcksFd0_oJ9LnTwwHwYDVR0jBBgwFoAU_Ow-26p8H4IeBbihBvlD5wKzCrkwggGyBgNVHR8EggGpMIIBpTBpoGegZYZjaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzg5L2N1cnJlbnQuY3JsMGugaaBnhmVodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NybHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS84OS9jdXJyZW50LmNybDBaoFigVoZUaHR0cDovL2NybC5taWNyb3NvZnQuY29tL2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzg5L2N1cnJlbnQuY3JsMG-gbaBrhmlodHRwOi8vY2NtZWVhc3R1czJwa2kuZWFzdHVzMi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVlYXN0dXMyaWNhMDEvODkvY3VycmVudC5jcmwwggG3BggrBgEFBQcBAQSCAakwggGlMGwGCCsGAQUFBzAChmBodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwbgYIKwYBBQUHMAKGYmh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY2FjZXJ0cy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxL2NlcnQuY2VyMF0GCCsGAQUFBzAChlFodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwZgYIKwYBBQUHMAKGWmh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMTANBgkqhkiG9w0BAQsFAAOCAQEAEKc49KJHc6By0YpRr-FLth5Lupbcfj855fKMIxBRydPRMy2ML_NCOORdCclSMJOOS8fT_jyVfAgWbuOJjQqmoinjcf_Dn5apduFtwmTSWlJ00RLrD0f2x3veqrW9aqy0unjq5PVrwEgPAUXX4ng_iKGUKLjXcJHqB54M8_ZZwND8cZGmd0QuZ1lOsLua3ztb331S21nKgR84tkH51d2vGzWTRlnPbWwuXOJyAiVoPBJ5wQ9oxLFDAUtreJJDinMpHVPA6UOCg4x0k07b02_tycryA5zghFvFX-Vaw7F5Vm0bwz7vrYdS1dl478O8qtnRvMAvaIFNwkeB6HV29ubjUg&s=GYmyM_7hodJoMDy6Vcg3IV4vIMlpM4GMMT7TaH19mj9IyZQtPBvqv4HY4IGXP7KoiezGJ-e1ZnWF8kjBubhZyh4lSqnwxBaStpL8QIcaA92TY9ePxVJgZkF7IH6ZyYPE56ve0-u_6WJ16nG_SRPqFC5xJJdq40iX4Mc_J-AuhHuKyjV3SQgjiwwCqTbOBswn_kS60zzKdN82oEyJrKKePtiRawrpnl7XRvr2b9tkKRsJ0hxyHInHbVOqiLI8iQ8qBChxmTjmmpzzu5G2SrG30wfK2udgWz1ViMxaBtBGHflOj1lEIdwaEGDKTAQ32fqzLJhlekhmvCrxgyTTdT3YAw&h=Rd-91wJdq06ezIal_utYXgyD8ZbyZwDVBwmwnen9giM
-  response:
-    body:
-      string: '{"name":"a9b6af9f-8c5f-411b-9087-11a46647c67f","status":"Succeeded","startTime":"2026-03-30T14:12:18.98Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '106'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 30 Mar 2026 14:17:22 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-cache:
-      - CONFIG_NOCACHE
-      x-content-type-options:
-      - nosniff
-      x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/07e2baa9-249c-4118-837b-5120679d07c6
-      x-ms-ratelimit-remaining-subscription-global-reads:
-      - '16499'
-      x-msedge-ref:
-      - 'Ref A: B3E383A695FC43F1BD38E0C6C91DE814 Ref B: AMS231020615025 Ref C: 2026-03-30T14:17:23Z'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - postgres flexible-server create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
-      User-Agent:
-      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002?api-version=2026-01-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D4ads_v5","tier":"GeneralPurpose"},"systemData":{"createdAt":"2026-03-30T14:12:31.5499334Z"},"properties":{"dataEncryption":{"type":"SystemManaged"},"replica":{"role":"Primary","capacity":6},"storage":{"type":"","iops":500,"tier":"P10","storageSizeGB":128,"autoGrow":"Disabled"},"network":{"publicNetworkAccess":"Disabled"},"privateEndpointConnections":[],"authConfig":{"activeDirectoryAuth":"Disabled","passwordAuth":"Enabled"},"fullyQualifiedDomainName":"azuredbclitest-000002.postgres.database.azure.com","version":"17","minorVersion":"9","administratorLogin":"unlinedparrot3","state":"Ready","availabilityZone":"2","backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"},"maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Primary","replicaCapacity":6},"location":"Canada
+      string: '{"sku":{"name":"Standard_D2ds_v5","tier":"GeneralPurpose"},"systemData":{"createdAt":"2026-03-31T21:47:53.2079992Z"},"properties":{"dataEncryption":{"type":"SystemManaged"},"replica":{"role":"Primary","capacity":5},"storage":{"type":"","iops":500,"tier":"P10","storageSizeGB":128,"autoGrow":"Disabled"},"network":{"publicNetworkAccess":"Disabled"},"privateEndpointConnections":[],"authConfig":{"activeDirectoryAuth":"Disabled","passwordAuth":"Enabled"},"fullyQualifiedDomainName":"azuredbclitest-000002.postgres.database.azure.com","version":"17","minorVersion":"9","administratorLogin":"amusedeggs1","state":"Ready","availabilityZone":"1","backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"},"maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Primary","replicaCapacity":5},"location":"Canada
         Central","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforPostgreSQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1187'
+      - '1183'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 30 Mar 2026 14:17:23 GMT
+      - Tue, 31 Mar 2026 21:52:46 GMT
       expires:
       - '-1'
       pragma:
@@ -586,7 +588,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 633EE550A63C4756B829CF3DF9F72002 Ref B: DUB241062309031 Ref C: 2026-03-30T14:17:23Z'
+      - 'Ref A: F1555A8FFAAD4788803ACCF97A9B7649 Ref B: AMS231020512037 Ref C: 2026-03-31T21:52:45Z'
     status:
       code: 200
       message: OK
@@ -604,7 +606,7 @@ interactions:
       ParameterSetName:
       - -g --server-name --name --value
       User-Agent:
-      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/configurations/logfiles.download_enable?api-version=2026-01-01-preview
   response:
@@ -619,7 +621,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 30 Mar 2026 14:17:24 GMT
+      - Tue, 31 Mar 2026 21:52:46 GMT
       expires:
       - '-1'
       pragma:
@@ -631,11 +633,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/c5774dad-4296-417a-a66e-da201260f30a
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/4856977e-0849-4898-a378-451fee6470a8
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 2BEB3F3E69894248A5C6C1318F386B4B Ref B: AMS231020512033 Ref C: 2026-03-30T14:17:24Z'
+      - 'Ref A: 22CBF0CDC07C41B5ACDA2A487DE037E5 Ref B: AMS231020512045 Ref C: 2026-03-31T21:52:46Z'
     status:
       code: 200
       message: OK
@@ -657,27 +659,27 @@ interactions:
       ParameterSetName:
       - -g --server-name --name --value
       User-Agent:
-      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/configurations/logfiles.download_enable?api-version=2026-01-01-preview
   response:
     body:
-      string: '{"operation":"UpdateOrcasServerParameterManagementOperation","startTime":"2026-03-30T14:17:25.1Z"}'
+      string: '{"operation":"UpdateOrcasServerParameterManagementOperation","startTime":"2026-03-31T21:52:47.503Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/e31d58b6-16bb-45a7-88ce-978f1878e88b?api-version=2026-01-01-preview&t=639104770451583147&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=PcTcBRqI22FSk2PXa8CXIU3vBBNIQ7hWUpHhv1kmdJT9-UsV8KLwtUAYkxxIc2_G1w_juXsjoWk9DbWMn5r94VKaxiRdKjtDfSw2CFc4zVCjKTPmmSMIqH9ExtNtHRuNA9squKPxe3b1-ZraoL3j2GU6Bg60qtYIXlfUoQkB4fmnRch-E4w2PBGXYoZTETxH4eu6nm4zyq0LpuiHajH68NZrGP5uyNBi55DaHDYOKUvGZKuKh0g9CzxTHvRyN3ffa8Tyye3fOF5Q3stolYnnhglcflAI_5EcYxIUI-sP8vxu_08PbK2rEP3aJzkraNjarEYtb2wGbmqOEeFd1faZHw&h=fq2lEMCPJCXyZwGeWxNvBny1zKWWZRUz8cCqTv89LZ8
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/1abb990b-8bce-4f6c-8f1e-f67d90fd8b4e?api-version=2026-01-01-preview&t=639105907675269972&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=NVjP2dcc5NIlOHSDHoBYbmhzhpXvZSLeGUsIBzvM8YFzpR8S9Hsp9sAGbHn95nHo4NK8i0zeDpo-Oe-UmFMxaBB2QfkUT84Tf4xzHI2WCtxWgCWMEQNNDS2-X2rh453uAd3_soH6LFQcgkmkCHVdILg1FQZSdFAWKiW6sHDMtby6dFpHvkQSRZxLDIR64Rjg-PGb6PA-JYKWvOLA8UOGhc5ukCtruc_KdmnsjYx-GxwBuDRyuDpcC8P3GUghvqRNvHoPGrvbTOLiRKfbrZf-0-AWjX92nOcpDaeP3MoIUXnk8q_0i_hob14yy9eUU11JQhY1Z_5wo-t3X0kbZWzMog&h=Y9190tAue9Q0p8UB0dmLqw1Nx79P0xr2-5bqvIzjvNU
       cache-control:
       - no-cache
       content-length:
-      - '98'
+      - '100'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 30 Mar 2026 14:17:24 GMT
+      - Tue, 31 Mar 2026 21:52:47 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/operationResults/e31d58b6-16bb-45a7-88ce-978f1878e88b?api-version=2026-01-01-preview&t=639104770451583147&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=UOo-4sxZDA9FRndpi-KoiSPXr3G1rp4lG-vGQDfLa_t4D0i_UsuvEQ2HoQiTNRb3dgd3bIjnnaxPzGwWBs8u2Xt6tjY2L4iEJdyW5D8pkQJnddSqVanRnFDQxme4yt2mdCQj5bqBhroBEIWYlrALOd3ofsn4xPlWbQrlq941hOgZUQIdMTNXPhaI0IKdxUnLoe5zgvddz66ZIaN2HbndMiUGK1TAHiJgfxG_MaAFRGZnrBDaaYxsJ4jESr-4JVFy5i49tzUSKDoqS9R0yo0OwaxHE_h9zZ42H8V6-hR5gj--Hcy5KzTaG7ONz17KT5gDHdWIUzgcxD9OPcCQ5segxg&h=Q2KxoYd7UPlYCaYn8uIZENS_Sdrb6_FutmQKMHjnzo0
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/operationResults/1abb990b-8bce-4f6c-8f1e-f67d90fd8b4e?api-version=2026-01-01-preview&t=639105907675427168&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=xXXLqQ8Omo_NGTwKp3sYuNdS7fS1u-_p7vAykj_jwRpgfEeoDjkfh-sVCP1iCi77XwldI2yISrCXmuwg-dowQtmC7qbfB3qorZOGKuZxuBruQT65zEdK4wdXrlyKATJSvg0E5I7EAUoktDehMhNu1wCkuuXZW3ikspQiXDP6lglyi-m9loy6TQoNiTPkJSXOJQxmajgF98E5_PagnqFi1nQA5RK576-tVPqu4xtGOqxgULdmt0kxT8LnE6g5VCXboY9pEWGtlS6ULnkrZuIn734SLpJtyJUqx6618tklCVF3Z6bwKsmcUz_Cq_HK59IylGgRGGYSVxBbW_j-2C8teQ&h=y4pB56t0gcJsVg9i8EADEkGOiLNslZos1WHv5F1R1h8
       pragma:
       - no-cache
       strict-transport-security:
@@ -687,13 +689,13 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/956f6009-b377-4ff9-bfeb-a27decbc3ead
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/f18af6ef-5841-4f3d-b6d6-595daa62cad4
       x-ms-ratelimit-remaining-subscription-global-writes:
       - '11999'
       x-ms-ratelimit-remaining-subscription-writes:
       - '799'
       x-msedge-ref:
-      - 'Ref A: CF5E45F4638340A78CE87F18F9527269 Ref B: AMS231032608031 Ref C: 2026-03-30T14:17:24Z'
+      - 'Ref A: ECD1F28A99434BDE90099773EF513723 Ref B: AMS231022012017 Ref C: 2026-03-31T21:52:47Z'
     status:
       code: 202
       message: Accepted
@@ -711,21 +713,21 @@ interactions:
       ParameterSetName:
       - -g --server-name --name --value
       User-Agent:
-      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/e31d58b6-16bb-45a7-88ce-978f1878e88b?api-version=2026-01-01-preview&t=639104770451583147&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=PcTcBRqI22FSk2PXa8CXIU3vBBNIQ7hWUpHhv1kmdJT9-UsV8KLwtUAYkxxIc2_G1w_juXsjoWk9DbWMn5r94VKaxiRdKjtDfSw2CFc4zVCjKTPmmSMIqH9ExtNtHRuNA9squKPxe3b1-ZraoL3j2GU6Bg60qtYIXlfUoQkB4fmnRch-E4w2PBGXYoZTETxH4eu6nm4zyq0LpuiHajH68NZrGP5uyNBi55DaHDYOKUvGZKuKh0g9CzxTHvRyN3ffa8Tyye3fOF5Q3stolYnnhglcflAI_5EcYxIUI-sP8vxu_08PbK2rEP3aJzkraNjarEYtb2wGbmqOEeFd1faZHw&h=fq2lEMCPJCXyZwGeWxNvBny1zKWWZRUz8cCqTv89LZ8
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/1abb990b-8bce-4f6c-8f1e-f67d90fd8b4e?api-version=2026-01-01-preview&t=639105907675269972&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=NVjP2dcc5NIlOHSDHoBYbmhzhpXvZSLeGUsIBzvM8YFzpR8S9Hsp9sAGbHn95nHo4NK8i0zeDpo-Oe-UmFMxaBB2QfkUT84Tf4xzHI2WCtxWgCWMEQNNDS2-X2rh453uAd3_soH6LFQcgkmkCHVdILg1FQZSdFAWKiW6sHDMtby6dFpHvkQSRZxLDIR64Rjg-PGb6PA-JYKWvOLA8UOGhc5ukCtruc_KdmnsjYx-GxwBuDRyuDpcC8P3GUghvqRNvHoPGrvbTOLiRKfbrZf-0-AWjX92nOcpDaeP3MoIUXnk8q_0i_hob14yy9eUU11JQhY1Z_5wo-t3X0kbZWzMog&h=Y9190tAue9Q0p8UB0dmLqw1Nx79P0xr2-5bqvIzjvNU
   response:
     body:
-      string: '{"name":"e31d58b6-16bb-45a7-88ce-978f1878e88b","status":"InProgress","startTime":"2026-03-30T14:17:25.1Z"}'
+      string: '{"name":"1abb990b-8bce-4f6c-8f1e-f67d90fd8b4e","status":"InProgress","startTime":"2026-03-31T21:52:47.503Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '106'
+      - '108'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 30 Mar 2026 14:17:25 GMT
+      - Tue, 31 Mar 2026 21:52:47 GMT
       expires:
       - '-1'
       pragma:
@@ -737,11 +739,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/ukwest/60a9ae8b-5dae-461a-b210-fee74e2493ec
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/ukwest/8b41b0ef-4c8e-408e-9436-aef843d2c9b9
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 7D737CF9E29D41D78F738E0DE1583199 Ref B: AMS231032607009 Ref C: 2026-03-30T14:17:25Z'
+      - 'Ref A: 923BB228F92747889C91D41E95A6D5DF Ref B: AMS231020615007 Ref C: 2026-03-31T21:52:47Z'
     status:
       code: 200
       message: OK
@@ -759,21 +761,21 @@ interactions:
       ParameterSetName:
       - -g --server-name --name --value
       User-Agent:
-      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/e31d58b6-16bb-45a7-88ce-978f1878e88b?api-version=2026-01-01-preview&t=639104770451583147&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=PcTcBRqI22FSk2PXa8CXIU3vBBNIQ7hWUpHhv1kmdJT9-UsV8KLwtUAYkxxIc2_G1w_juXsjoWk9DbWMn5r94VKaxiRdKjtDfSw2CFc4zVCjKTPmmSMIqH9ExtNtHRuNA9squKPxe3b1-ZraoL3j2GU6Bg60qtYIXlfUoQkB4fmnRch-E4w2PBGXYoZTETxH4eu6nm4zyq0LpuiHajH68NZrGP5uyNBi55DaHDYOKUvGZKuKh0g9CzxTHvRyN3ffa8Tyye3fOF5Q3stolYnnhglcflAI_5EcYxIUI-sP8vxu_08PbK2rEP3aJzkraNjarEYtb2wGbmqOEeFd1faZHw&h=fq2lEMCPJCXyZwGeWxNvBny1zKWWZRUz8cCqTv89LZ8
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/1abb990b-8bce-4f6c-8f1e-f67d90fd8b4e?api-version=2026-01-01-preview&t=639105907675269972&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=NVjP2dcc5NIlOHSDHoBYbmhzhpXvZSLeGUsIBzvM8YFzpR8S9Hsp9sAGbHn95nHo4NK8i0zeDpo-Oe-UmFMxaBB2QfkUT84Tf4xzHI2WCtxWgCWMEQNNDS2-X2rh453uAd3_soH6LFQcgkmkCHVdILg1FQZSdFAWKiW6sHDMtby6dFpHvkQSRZxLDIR64Rjg-PGb6PA-JYKWvOLA8UOGhc5ukCtruc_KdmnsjYx-GxwBuDRyuDpcC8P3GUghvqRNvHoPGrvbTOLiRKfbrZf-0-AWjX92nOcpDaeP3MoIUXnk8q_0i_hob14yy9eUU11JQhY1Z_5wo-t3X0kbZWzMog&h=Y9190tAue9Q0p8UB0dmLqw1Nx79P0xr2-5bqvIzjvNU
   response:
     body:
-      string: '{"name":"e31d58b6-16bb-45a7-88ce-978f1878e88b","status":"Succeeded","startTime":"2026-03-30T14:17:25.1Z"}'
+      string: '{"name":"1abb990b-8bce-4f6c-8f1e-f67d90fd8b4e","status":"Succeeded","startTime":"2026-03-31T21:52:47.503Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '105'
+      - '107'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 30 Mar 2026 14:17:35 GMT
+      - Tue, 31 Mar 2026 21:52:58 GMT
       expires:
       - '-1'
       pragma:
@@ -785,11 +787,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/4a6512f1-2fd1-4abb-98a9-243634b36603
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/e14843da-b23d-413a-86c1-6a997bafced8
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 853CF8B374A244278E19E7B7FD6A42E4 Ref B: AMS231022012023 Ref C: 2026-03-30T14:17:36Z'
+      - 'Ref A: 07595B5BDC98420E91C9947A4577AE10 Ref B: AMS231022012039 Ref C: 2026-03-31T21:52:58Z'
     status:
       code: 200
       message: OK
@@ -807,7 +809,7 @@ interactions:
       ParameterSetName:
       - -g --server-name --name --value
       User-Agent:
-      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/configurations/logfiles.download_enable?api-version=2026-01-01-preview
   response:
@@ -822,7 +824,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 30 Mar 2026 14:17:37 GMT
+      - Tue, 31 Mar 2026 21:52:58 GMT
       expires:
       - '-1'
       pragma:
@@ -834,11 +836,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/ukwest/9faaf9a4-327c-49ef-9085-ea8bf593294b
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/3d18cd81-b1f1-4ada-a90d-7da39bf470aa
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: B0954060381A4638B7559EAF629827ED Ref B: AMS231022012053 Ref C: 2026-03-30T14:17:36Z'
+      - 'Ref A: A88AD7E9C37B46F6ADC815B6067456C4 Ref B: AMS231032607021 Ref C: 2026-03-31T21:52:59Z'
     status:
       code: 200
       message: OK
@@ -856,7 +858,7 @@ interactions:
       ParameterSetName:
       - -g --server-name --name --value
       User-Agent:
-      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/configurations/logfiles.retention_days?api-version=2026-01-01-preview
   response:
@@ -871,7 +873,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 30 Mar 2026 14:17:37 GMT
+      - Tue, 31 Mar 2026 21:52:59 GMT
       expires:
       - '-1'
       pragma:
@@ -883,11 +885,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/80834962-0a1c-4da4-b9f9-e114c10a5e71
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/ce40026e-60c7-4632-806a-2918de330505
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: B4B624F4AB374C709D75CCA7E0B6EFF6 Ref B: DUB601080513036 Ref C: 2026-03-30T14:17:37Z'
+      - 'Ref A: 6E18668F29E04A9DB47DABB92E782F93 Ref B: AMS231032607007 Ref C: 2026-03-31T21:52:59Z'
     status:
       code: 200
       message: OK
@@ -909,27 +911,27 @@ interactions:
       ParameterSetName:
       - -g --server-name --name --value
       User-Agent:
-      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/configurations/logfiles.retention_days?api-version=2026-01-01-preview
   response:
     body:
-      string: '{"operation":"UpdateOrcasServerParameterManagementOperation","startTime":"2026-03-30T14:17:38.813Z"}'
+      string: '{"operation":"UpdateOrcasServerParameterManagementOperation","startTime":"2026-03-31T21:53:00.52Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/01b8a738-bb8f-4598-bad3-6ccf23e110ba?api-version=2026-01-01-preview&t=639104770588437955&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=fE8CuxnP9NbZdLcTtPTjAOjsU3TVnM811Ss28BfGzVCQXHMVliRGUgUp9Wwwx_OVoZZ9IXMToVP-ycjH2e-P_K0l6JBXjTjNZCbjLw7dUElB2nLDFspc0O-Hm1Sga8K74sV1XsRB-5YURZ7nD_kc55bdKd-m9gZ68bHwqkwpsg7VoCxd5xudKHI8SnkmS_zrhR8nCeKaKCe4hLN3goqICsvaUw7okl4JaojNCj-RXIdjyYT3-tiAhRpqmI1k4jcM9r8DqBl76SIGmSjcaylU5R1Zt2O8V5a-C9Ojx7ipYmmpCTY5xDerE1wHLMx0oSVquN5ODxgSp9mgGMs5d67Fiw&h=A0ja3b_WJ4WaP6-M20aDszVVAfnx61vm1doAoNK0_gU
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/6cd7953a-2df2-4280-9b9e-6f140d1f6b23?api-version=2026-01-01-preview&t=639105907805494394&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=woZFtLv0Bv3XYvNUQ9LUAQypcPAuktn9KSXTySQQF3OfokJ8Z_GoDHjdwKfAsfV6HbxnXzF2ZDjxRUkxN__rbJz1RnMMzHpizN17WwNomPnpX3EzDPOOOEWD0LlbkMHgWg2ll3AbG9TR39KEbxwSqI0z46MDuCqG6Z_fZUUc7fhc_9BA0b0EEyU2NqXDMZYJa4TkQPOTDMm0I4yZEZd0HFEBQqVLqYe3iAy9u3e2Wa-so1HHLq-My-XdZ8FoRkr2UltltL4NZXImIicy5dtZdHt2NIw_AyIG8ijkz-maKBxrefC41L7epTXs8R7GTmj4TGE8wS7vjfvbfDZXHZbZ8w&h=vflfzRbzpxci8lPoYmgtr-vDstWF1D0V51cFWQEEJvw
       cache-control:
       - no-cache
       content-length:
-      - '100'
+      - '99'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 30 Mar 2026 14:17:38 GMT
+      - Tue, 31 Mar 2026 21:53:00 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/operationResults/01b8a738-bb8f-4598-bad3-6ccf23e110ba?api-version=2026-01-01-preview&t=639104770588594200&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=oS3CNKL8Dd1iNmJ1yffgCXnhIsHjf5RA6GD3uQFt8xhDYMiLiZfv301fHn4iqXmVocvHoRkIXBw9E6Sf-YID1j4sDNXr1oWhaP5qliIXMysvO9egpKas0R-Hd0Bbjxmc0WPS-s6C9UVKnBNn0VBldP6wNy2NmZFU37IVsnOGLnGjgQ77iZQGKlM7VaL5SFPLo7AHq0QYLpXSSu2F8kQ_aFze9fcf4J2ZA0sZ29ZUSgZbQhBpmKP3gzRNJ-lXeD-2DIfgaJekClkPzJBuO9GPsWy5fvWiT3EdCMaoDvdY3k20ROq3lwBIeVHk7uU5sRKSqvU8X7G2d50na25kOCjekg&h=B-vtp0_7MI4UdMRs6UUygjto-kwltGn-jvCpxnQZ8xQ
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/operationResults/6cd7953a-2df2-4280-9b9e-6f140d1f6b23?api-version=2026-01-01-preview&t=639105907805650665&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=Yt2h4gu1RSnwRoUat-Nw7SB-R5H6zr_xoqKuCPThqh-iwkh9FDs50VCEWj9m2EXtxXTC7yJNm0yIoXVSnfYrlplEZPa4B0qoz5egeklPu45KSB5qbGuIzLbY3_MuZQ1qNgZYlYp2CB6d8BLN2Kj7U7lacnSWRSWEp1IF0_ygzD0n8exL18msFspPZlwaX447Ot9LRGgHVCfOI87zXAfMbbJLzFVdJKp5gGXCNVeaNJyUvO1IHlGDb_P0vcYd4K5TGC4vR-mcIQf67Qe5iUtwSwd0K3NIsP70-E_EVqAxF4JegDH-_zXhrWgpfH7tTXzyEZGG7EjfvY1QNvFryBxaXg&h=D3_YQKTl3rz3b4-WF7gPvJOxyYOIFuCoDFiXLRf9HUY
       pragma:
       - no-cache
       strict-transport-security:
@@ -939,13 +941,13 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/3a1e2ece-849f-4688-97a6-086f3a0f41b6
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/7f92bc52-e076-445b-89c1-e60475fbe8c7
       x-ms-ratelimit-remaining-subscription-global-writes:
       - '11999'
       x-ms-ratelimit-remaining-subscription-writes:
       - '799'
       x-msedge-ref:
-      - 'Ref A: 48D45DC5C2734F97940717ED85CE6BEA Ref B: DUB601080513023 Ref C: 2026-03-30T14:17:38Z'
+      - 'Ref A: BC69EAF167FE41CA982559B75FCA4FFF Ref B: AMS231032607025 Ref C: 2026-03-31T21:53:00Z'
     status:
       code: 202
       message: Accepted
@@ -963,60 +965,12 @@ interactions:
       ParameterSetName:
       - -g --server-name --name --value
       User-Agent:
-      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/01b8a738-bb8f-4598-bad3-6ccf23e110ba?api-version=2026-01-01-preview&t=639104770588437955&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=fE8CuxnP9NbZdLcTtPTjAOjsU3TVnM811Ss28BfGzVCQXHMVliRGUgUp9Wwwx_OVoZZ9IXMToVP-ycjH2e-P_K0l6JBXjTjNZCbjLw7dUElB2nLDFspc0O-Hm1Sga8K74sV1XsRB-5YURZ7nD_kc55bdKd-m9gZ68bHwqkwpsg7VoCxd5xudKHI8SnkmS_zrhR8nCeKaKCe4hLN3goqICsvaUw7okl4JaojNCj-RXIdjyYT3-tiAhRpqmI1k4jcM9r8DqBl76SIGmSjcaylU5R1Zt2O8V5a-C9Ojx7ipYmmpCTY5xDerE1wHLMx0oSVquN5ODxgSp9mgGMs5d67Fiw&h=A0ja3b_WJ4WaP6-M20aDszVVAfnx61vm1doAoNK0_gU
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/6cd7953a-2df2-4280-9b9e-6f140d1f6b23?api-version=2026-01-01-preview&t=639105907805494394&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=woZFtLv0Bv3XYvNUQ9LUAQypcPAuktn9KSXTySQQF3OfokJ8Z_GoDHjdwKfAsfV6HbxnXzF2ZDjxRUkxN__rbJz1RnMMzHpizN17WwNomPnpX3EzDPOOOEWD0LlbkMHgWg2ll3AbG9TR39KEbxwSqI0z46MDuCqG6Z_fZUUc7fhc_9BA0b0EEyU2NqXDMZYJa4TkQPOTDMm0I4yZEZd0HFEBQqVLqYe3iAy9u3e2Wa-so1HHLq-My-XdZ8FoRkr2UltltL4NZXImIicy5dtZdHt2NIw_AyIG8ijkz-maKBxrefC41L7epTXs8R7GTmj4TGE8wS7vjfvbfDZXHZbZ8w&h=vflfzRbzpxci8lPoYmgtr-vDstWF1D0V51cFWQEEJvw
   response:
     body:
-      string: '{"name":"01b8a738-bb8f-4598-bad3-6ccf23e110ba","status":"InProgress","startTime":"2026-03-30T14:17:38.813Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '108'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 30 Mar 2026 14:17:38 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-cache:
-      - CONFIG_NOCACHE
-      x-content-type-options:
-      - nosniff
-      x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/c309e041-8391-4e8b-b624-df88b8b81fd9
-      x-ms-ratelimit-remaining-subscription-global-reads:
-      - '16499'
-      x-msedge-ref:
-      - 'Ref A: D01F197332674C7C8E8FF769CEC604CF Ref B: DUB241062309054 Ref C: 2026-03-30T14:17:39Z'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - postgres flexible-server parameter set
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --server-name --name --value
-      User-Agent:
-      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/01b8a738-bb8f-4598-bad3-6ccf23e110ba?api-version=2026-01-01-preview&t=639104770588437955&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=fE8CuxnP9NbZdLcTtPTjAOjsU3TVnM811Ss28BfGzVCQXHMVliRGUgUp9Wwwx_OVoZZ9IXMToVP-ycjH2e-P_K0l6JBXjTjNZCbjLw7dUElB2nLDFspc0O-Hm1Sga8K74sV1XsRB-5YURZ7nD_kc55bdKd-m9gZ68bHwqkwpsg7VoCxd5xudKHI8SnkmS_zrhR8nCeKaKCe4hLN3goqICsvaUw7okl4JaojNCj-RXIdjyYT3-tiAhRpqmI1k4jcM9r8DqBl76SIGmSjcaylU5R1Zt2O8V5a-C9Ojx7ipYmmpCTY5xDerE1wHLMx0oSVquN5ODxgSp9mgGMs5d67Fiw&h=A0ja3b_WJ4WaP6-M20aDszVVAfnx61vm1doAoNK0_gU
-  response:
-    body:
-      string: '{"name":"01b8a738-bb8f-4598-bad3-6ccf23e110ba","status":"Succeeded","startTime":"2026-03-30T14:17:38.813Z"}'
+      string: '{"name":"6cd7953a-2df2-4280-9b9e-6f140d1f6b23","status":"InProgress","startTime":"2026-03-31T21:53:00.52Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1025,7 +979,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 30 Mar 2026 14:17:49 GMT
+      - Tue, 31 Mar 2026 21:53:00 GMT
       expires:
       - '-1'
       pragma:
@@ -1037,11 +991,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/ba040e7b-93da-4397-a656-938a14c6ad82
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/ukwest/527cd67e-cd4d-4d5c-bf7b-edaa370c4edc
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: FB0BDA779CA148C6A6C57E4278F2FC15 Ref B: AMS231022012021 Ref C: 2026-03-30T14:17:49Z'
+      - 'Ref A: 2C55C2FDF19541B4B846E88CCE827386 Ref B: AMS231020614053 Ref C: 2026-03-31T21:53:00Z'
     status:
       code: 200
       message: OK
@@ -1059,7 +1013,55 @@ interactions:
       ParameterSetName:
       - -g --server-name --name --value
       User-Agent:
-      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/6cd7953a-2df2-4280-9b9e-6f140d1f6b23?api-version=2026-01-01-preview&t=639105907805494394&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=woZFtLv0Bv3XYvNUQ9LUAQypcPAuktn9KSXTySQQF3OfokJ8Z_GoDHjdwKfAsfV6HbxnXzF2ZDjxRUkxN__rbJz1RnMMzHpizN17WwNomPnpX3EzDPOOOEWD0LlbkMHgWg2ll3AbG9TR39KEbxwSqI0z46MDuCqG6Z_fZUUc7fhc_9BA0b0EEyU2NqXDMZYJa4TkQPOTDMm0I4yZEZd0HFEBQqVLqYe3iAy9u3e2Wa-so1HHLq-My-XdZ8FoRkr2UltltL4NZXImIicy5dtZdHt2NIw_AyIG8ijkz-maKBxrefC41L7epTXs8R7GTmj4TGE8wS7vjfvbfDZXHZbZ8w&h=vflfzRbzpxci8lPoYmgtr-vDstWF1D0V51cFWQEEJvw
+  response:
+    body:
+      string: '{"name":"6cd7953a-2df2-4280-9b9e-6f140d1f6b23","status":"Succeeded","startTime":"2026-03-31T21:53:00.52Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '106'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Mar 2026 21:53:11 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/ukwest/c7dce134-97ac-4c24-abb0-46866c88132e
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 1BC6FA9DD5AB449FB6216979656BB270 Ref B: AMS231020512049 Ref C: 2026-03-31T21:53:11Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - postgres flexible-server parameter set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --server-name --name --value
+      User-Agent:
+      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/configurations/logfiles.retention_days?api-version=2026-01-01-preview
   response:
@@ -1074,7 +1076,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 30 Mar 2026 14:17:49 GMT
+      - Tue, 31 Mar 2026 21:53:11 GMT
       expires:
       - '-1'
       pragma:
@@ -1086,4075 +1088,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/80a28ff4-94a2-4ae7-896b-043ae00e9458
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/bcb300b5-0263-454d-8d1f-15dcf19ffb53
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 74870E269CD7400EB0701EA76661D74C Ref B: AMS231032607029 Ref C: 2026-03-30T14:17:50Z'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - postgres flexible-server server-logs list
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --server-name
-      User-Agent:
-      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/logFiles?api-version=2026-01-01-preview
-  response:
-    body:
-      string: '{"value":[{"properties":{"sizeInKb":168,"createdTime":"2026-03-30T14:36:36+00:00","lastModifiedTime":"2026-03-30T14:46:39+00:00","type":"ServerLogs","url":"https://e3091069db5dsa.blob.core.windows.net/d04ef2a694bb414da5336f0e5c112469bak/serverlogs/postgresql_2026_03_30_14_00_00.log?sv=2025-05-05&se=2026-03-30T14%3A52%3A51Z&sr=b&sp=rdl&sig=fF1DNdIUKx9v%2BeoHw4v762ysLRwXaPQfpp0C%2FzkDeg8%3D"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/logFiles","name":"postgresql_2026_03_30_14_00_00.log","type":"Microsoft.DBforPostgreSQL/flexibleServers/logFiles"}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '674'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 30 Mar 2026 14:47:50 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-cache:
-      - CONFIG_NOCACHE
-      x-content-type-options:
-      - nosniff
-      x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/49fd8b11-fcae-4c19-b45e-288f75881c55
-      x-ms-ratelimit-remaining-subscription-global-reads:
-      - '16499'
-      x-msedge-ref:
-      - 'Ref A: 70CE7374CC7A4F23B74E88E4AA97B6FC Ref B: AMS231020615023 Ref C: 2026-03-30T14:47:51Z'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - postgres flexible-server server-logs download
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --server-name --name
-      User-Agent:
-      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/logFiles?api-version=2026-01-01-preview
-  response:
-    body:
-      string: '{"value":[{"properties":{"sizeInKb":168,"createdTime":"2026-03-30T14:36:36+00:00","lastModifiedTime":"2026-03-30T14:46:39+00:00","type":"ServerLogs","url":"https://e3091069db5dsa.blob.core.windows.net/d04ef2a694bb414da5336f0e5c112469bak/serverlogs/postgresql_2026_03_30_14_00_00.log?sv=2025-05-05&se=2026-03-30T14%3A52%3A51Z&sr=b&sp=rdl&sig=fF1DNdIUKx9v%2BeoHw4v762ysLRwXaPQfpp0C%2FzkDeg8%3D"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/logFiles","name":"postgresql_2026_03_30_14_00_00.log","type":"Microsoft.DBforPostgreSQL/flexibleServers/logFiles"}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '674'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 30 Mar 2026 14:47:51 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-cache:
-      - CONFIG_NOCACHE
-      x-content-type-options:
-      - nosniff
-      x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/532b8d8a-c4a5-4c29-9caa-7983ca29b888
-      x-ms-ratelimit-remaining-subscription-global-reads:
-      - '16499'
-      x-msedge-ref:
-      - 'Ref A: 5FDD57AF55294DE2851F334743C87306 Ref B: DUB601080511029 Ref C: 2026-03-30T14:47:51Z'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Connection:
-      - close
-      Host:
-      - e3091069db5dsa.blob.core.windows.net
-      User-Agent:
-      - Python-urllib/3.13
-    method: GET
-    uri: https://e3091069db5dsa.blob.core.windows.net/d04ef2a694bb414da5336f0e5c112469bak/serverlogs/postgresql_2026_03_30_14_00_00.log?sv=2025-05-05&se=2026-03-30T14%3A52%3A51Z&sr=b&sp=rdl&sig=fF1DNdIUKx9v%2BeoHw4v762ysLRwXaPQfpp0C%2FzkDeg8%3D
-  response:
-    body:
-      string: '2026-03-30 14:26:35 UTC-69ca881b.590-LOG:  connection received: host=127.0.0.1
-        port=37508
-
-        2026-03-30 14:26:35 UTC-69ca881b.590-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:26:35 UTC-69ca881b.590-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:26:35 UTC-69ca881b.590-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:26:42 UTC-69ca880e.57f-LOG:  disconnection: session time: 0:00:20.024
-        user=azuresu database=azure_sys host=127.0.0.1 port=45082
-
-        2026-03-30 14:26:45 UTC-69ca8811.581-LOG:  disconnection: session time: 0:00:20.027
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=52854
-
-        2026-03-30 14:26:47 UTC-69ca8827.593-LOG:  connection received: host=127.0.0.1
-        port=51638
-
-        2026-03-30 14:26:47 UTC-69ca8827.593-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:26:47 UTC-69ca8827.593-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:26:47 UTC-69ca8827.593-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:26:47 UTC-69ca8813.58c-LOG:  disconnection: session time: 0:00:20.023
-        user=azuresu database=postgres host=127.0.0.1 port=52878
-
-        2026-03-30 14:26:47 UTC-69ca8827.594-LOG:  connection received: host=127.0.0.1
-        port=51650
-
-        2026-03-30 14:26:47 UTC-69ca8827.594-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:26:47 UTC-69ca8827.594-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:26:47 UTC-69ca8827.594-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:26:49 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
-        0/4000548, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
-
-        2026-03-30 14:26:50 UTC-69ca882a.59f-LOG:  connection received: host=127.0.0.1
-        port=51660
-
-        2026-03-30 14:26:50 UTC-69ca882a.59f-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:26:50 UTC-69ca882a.59f-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:26:50 UTC-69ca882a.59f-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:26:50 UTC-69ca882a.59f-LOG:  disconnection: session time: 0:00:00.047
-        user=azuresu database=postgres host=127.0.0.1 port=51660
-
-        2026-03-30 14:26:53 UTC-69ca882d.5a1-LOG:  connection received: host=127.0.0.1
-        port=51674
-
-        2026-03-30 14:26:53 UTC-69ca882d.5a1-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:26:53 UTC-69ca882d.5a1-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:26:53 UTC-69ca882d.5a1-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:26:55 UTC-69ca881b.590-LOG:  disconnection: session time: 0:00:20.031
-        user=azuresu database=azure_sys host=127.0.0.1 port=37508
-
-        2026-03-30 14:27:07 UTC-69ca883b.5a5-LOG:  connection received: host=127.0.0.1
-        port=43408
-
-        2026-03-30 14:27:07 UTC-69ca8827.593-LOG:  disconnection: session time: 0:00:20.023
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=51638
-
-        2026-03-30 14:27:07 UTC-69ca883b.5a5-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:27:07 UTC-69ca883b.5a5-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:27:07 UTC-69ca883b.5a5-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:27:07 UTC-69ca8827.594-LOG:  disconnection: session time: 0:00:20.024
-        user=azuresu database=postgres host=127.0.0.1 port=51650
-
-        2026-03-30 14:27:09 UTC-69ca883d.5a7-LOG:  connection received: host=127.0.0.1
-        port=43412
-
-        2026-03-30 14:27:09 UTC-69ca883d.5a7-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:27:09 UTC-69ca883d.5a7-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:27:09 UTC-69ca883d.5a7-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:27:13 UTC-69ca882d.5a1-LOG:  disconnection: session time: 0:00:20.023
-        user=azuresu database=azure_sys host=127.0.0.1 port=51674
-
-        2026-03-30 14:27:15 UTC-69ca8843.5b3-LOG:  connection received: host=127.0.0.1
-        port=57650
-
-        2026-03-30 14:27:15 UTC-69ca8843.5b3-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:27:15 UTC-69ca8843.5b3-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:27:15 UTC-69ca8843.5b3-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:27:15 UTC-69ca8843.5b3-LOG:  disconnection: session time: 0:00:00.046
-        user=azuresu database=postgres host=127.0.0.1 port=57650
-
-        2026-03-30 14:27:24 UTC-69ca884c.5b6-LOG:  connection received: host=127.0.0.1
-        port=57660
-
-        2026-03-30 14:27:24 UTC-69ca884c.5b6-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:27:24 UTC-69ca884c.5b6-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:27:24 UTC-69ca884c.5b6-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:27:27 UTC-69ca883b.5a5-LOG:  disconnection: session time: 0:00:20.751
-        user=azuresu database=postgres host=127.0.0.1 port=43408
-
-        2026-03-30 14:27:27 UTC-69ca884f.5b7-LOG:  connection received: host=127.0.0.1
-        port=33676
-
-        2026-03-30 14:27:27 UTC-69ca884f.5b7-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:27:27 UTC-69ca884f.5b7-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:27:27 UTC-69ca884f.5b7-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:27:29 UTC-69ca883d.5a7-LOG:  disconnection: session time: 0:00:20.026
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=43412
-
-        2026-03-30 14:27:31 UTC-69ca8853.5b9-LOG:  connection received: host=127.0.0.1
-        port=33688
-
-        2026-03-30 14:27:31 UTC-69ca8853.5b9-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:27:31 UTC-69ca8853.5b9-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:27:31 UTC-69ca8853.5b9-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:27:40 UTC-69ca885c.5c6-LOG:  connection received: host=127.0.0.1
-        port=39226
-
-        2026-03-30 14:27:40 UTC-69ca885c.5c6-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:27:40 UTC-69ca885c.5c6-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:27:40 UTC-69ca885c.5c6-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:27:40 UTC-69ca885c.5c6-LOG:  disconnection: session time: 0:00:00.048
-        user=azuresu database=postgres host=127.0.0.1 port=39226
-
-        2026-03-30 14:27:44 UTC-69ca884c.5b6-LOG:  disconnection: session time: 0:00:20.033
-        user=azuresu database=azure_sys host=127.0.0.1 port=57660
-
-        2026-03-30 14:27:47 UTC-69ca884f.5b7-LOG:  disconnection: session time: 0:00:20.024
-        user=azuresu database=postgres host=127.0.0.1 port=33676
-
-        2026-03-30 14:27:48 UTC-69ca8864.5c9-LOG:  connection received: host=127.0.0.1
-        port=36184
-
-        2026-03-30 14:27:48 UTC-69ca8864.5c9-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:27:48 UTC-69ca8864.5c9-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:27:48 UTC-69ca8864.5c9-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:27:49 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
-        0/4000BE8, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
-
-        2026-03-30 14:27:51 UTC-69ca8853.5b9-LOG:  disconnection: session time: 0:00:20.024
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=33688
-
-        2026-03-30 14:27:53 UTC-69ca8869.5cb-LOG:  connection received: host=127.0.0.1
-        port=36192
-
-        2026-03-30 14:27:53 UTC-69ca8869.5cb-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:27:53 UTC-69ca8869.5cb-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:27:53 UTC-69ca8869.5cb-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:27:55 UTC-69ca886b.5cd-LOG:  connection received: host=127.0.0.1
-        port=53856
-
-        2026-03-30 14:27:55 UTC-69ca886b.5cd-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:27:55 UTC-69ca886b.5cd-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:27:55 UTC-69ca886b.5cd-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:28:05 UTC-69ca8875.5d9-LOG:  connection received: host=127.0.0.1
-        port=42734
-
-        2026-03-30 14:28:05 UTC-69ca8875.5d9-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:28:05 UTC-69ca8875.5d9-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:28:05 UTC-69ca8875.5d9-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:28:05 UTC-69ca8875.5d9-LOG:  disconnection: session time: 0:00:00.047
-        user=azuresu database=postgres host=127.0.0.1 port=42734
-
-        2026-03-30 14:28:08 UTC-69ca8864.5c9-LOG:  disconnection: session time: 0:00:20.026
-        user=azuresu database=postgres host=127.0.0.1 port=36184
-
-        2026-03-30 14:28:08 UTC-69ca8878.5db-LOG:  connection received: host=127.0.0.1
-        port=42746
-
-        2026-03-30 14:28:08 UTC-69ca8878.5db-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:28:08 UTC-69ca8878.5db-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:28:08 UTC-69ca8878.5db-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:28:13 UTC-69ca8869.5cb-LOG:  disconnection: session time: 0:00:20.022
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=36192
-
-        2026-03-30 14:28:15 UTC-69ca887f.5de-LOG:  connection received: host=127.0.0.1
-        port=44900
-
-        2026-03-30 14:28:15 UTC-69ca886b.5cd-LOG:  disconnection: session time: 0:00:20.026
-        user=azuresu database=azure_sys host=127.0.0.1 port=53856
-
-        2026-03-30 14:28:15 UTC-69ca887f.5de-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:28:15 UTC-69ca887f.5de-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:28:15 UTC-69ca887f.5de-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:28:26 UTC-69ca888a.5e1-LOG:  connection received: host=127.0.0.1
-        port=52892
-
-        2026-03-30 14:28:26 UTC-69ca888a.5e1-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:28:26 UTC-69ca888a.5e1-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:28:26 UTC-69ca888a.5e1-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:28:28 UTC-69ca8878.5db-LOG:  disconnection: session time: 0:00:20.023
-        user=azuresu database=postgres host=127.0.0.1 port=42746
-
-        2026-03-30 14:28:28 UTC-69ca888c.5e3-LOG:  connection received: host=127.0.0.1
-        port=52894
-
-        2026-03-30 14:28:28 UTC-69ca888c.5e3-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:28:28 UTC-69ca888c.5e3-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:28:28 UTC-69ca888c.5e3-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:28:30 UTC-69ca888e.5ed-LOG:  connection received: host=127.0.0.1
-        port=52906
-
-        2026-03-30 14:28:30 UTC-69ca888e.5ed-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:28:30 UTC-69ca888e.5ed-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:28:30 UTC-69ca888e.5ed-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:28:30 UTC-69ca888e.5ed-LOG:  disconnection: session time: 0:00:00.046
-        user=azuresu database=postgres host=127.0.0.1 port=52906
-
-        2026-03-30 14:28:35 UTC-69ca887f.5de-LOG:  disconnection: session time: 0:00:20.028
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=44900
-
-        2026-03-30 14:28:37 UTC-69ca8895.5f0-LOG:  connection received: host=127.0.0.1
-        port=59294
-
-        2026-03-30 14:28:37 UTC-69ca8895.5f0-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:28:37 UTC-69ca8895.5f0-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:28:37 UTC-69ca8895.5f0-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:28:46 UTC-69ca888a.5e1-LOG:  disconnection: session time: 0:00:20.026
-        user=azuresu database=azure_sys host=127.0.0.1 port=52892
-
-        2026-03-30 14:28:48 UTC-69ca888c.5e3-LOG:  disconnection: session time: 0:00:20.022
-        user=azuresu database=postgres host=127.0.0.1 port=52894
-
-        2026-03-30 14:28:48 UTC-69ca88a0.5f4-LOG:  connection received: host=127.0.0.1
-        port=60218
-
-        2026-03-30 14:28:48 UTC-69ca88a0.5f4-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:28:48 UTC-69ca88a0.5f4-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:28:48 UTC-69ca88a0.5f4-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:28:49 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
-        0/4001288, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
-
-        2026-03-30 14:28:55 UTC-69ca88a7.600-LOG:  connection received: host=127.0.0.1
-        port=34854
-
-        2026-03-30 14:28:55 UTC-69ca88a7.600-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:28:55 UTC-69ca88a7.600-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:28:55 UTC-69ca88a7.600-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:28:55 UTC-69ca88a7.600-LOG:  disconnection: session time: 0:00:00.046
-        user=azuresu database=postgres host=127.0.0.1 port=34854
-
-        2026-03-30 14:28:57 UTC-69ca88a9.601-LOG:  connection received: host=127.0.0.1
-        port=34864
-
-        2026-03-30 14:28:57 UTC-69ca8895.5f0-LOG:  disconnection: session time: 0:00:20.027
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=59294
-
-        2026-03-30 14:28:57 UTC-69ca88a9.601-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:28:57 UTC-69ca88a9.601-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:28:57 UTC-69ca88a9.601-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:28:59 UTC-69ca88ab.603-LOG:  connection received: host=127.0.0.1
-        port=34876
-
-        2026-03-30 14:28:59 UTC-69ca88ab.603-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:28:59 UTC-69ca88ab.603-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:28:59 UTC-69ca88ab.603-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:29:08 UTC-69ca88a0.5f4-LOG:  disconnection: session time: 0:00:20.022
-        user=azuresu database=postgres host=127.0.0.1 port=60218
-
-        2026-03-30 14:29:08 UTC-69ca88b4.606-LOG:  connection received: host=127.0.0.1
-        port=44922
-
-        2026-03-30 14:29:08 UTC-69ca88b4.606-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:29:08 UTC-69ca88b4.606-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:29:08 UTC-69ca88b4.606-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:29:17 UTC-69ca88a9.601-LOG:  disconnection: session time: 0:00:20.026
-        user=azuresu database=azure_sys host=127.0.0.1 port=34864
-
-        2026-03-30 14:29:19 UTC-69ca88ab.603-LOG:  disconnection: session time: 0:00:20.024
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=34876
-
-        2026-03-30 14:29:21 UTC-69ca88c1.613-LOG:  connection received: host=127.0.0.1
-        port=39840
-
-        2026-03-30 14:29:21 UTC-69ca88c1.614-LOG:  connection received: host=127.0.0.1
-        port=39842
-
-        2026-03-30 14:29:21 UTC-69ca88c1.614-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:29:21 UTC-69ca88c1.614-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:29:21 UTC-69ca88c1.614-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:29:21 UTC-69ca88c1.613-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:29:21 UTC-69ca88c1.613-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:29:21 UTC-69ca88c1.613-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:29:21 UTC-69ca88c1.613-LOG:  disconnection: session time: 0:00:00.051
-        user=azuresu database=postgres host=127.0.0.1 port=39840
-
-        2026-03-30 14:29:28 UTC-69ca88c8.616-LOG:  connection received: host=127.0.0.1
-        port=49968
-
-        2026-03-30 14:29:28 UTC-69ca88c8.616-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:29:28 UTC-69ca88c8.616-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:29:28 UTC-69ca88c8.616-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:29:28 UTC-69ca88b4.606-LOG:  disconnection: session time: 0:00:20.026
-        user=azuresu database=postgres host=127.0.0.1 port=44922
-
-        2026-03-30 14:29:28 UTC-69ca88c8.618-LOG:  connection received: host=127.0.0.1
-        port=49980
-
-        2026-03-30 14:29:28 UTC-69ca88c8.618-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:29:28 UTC-69ca88c8.618-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:29:28 UTC-69ca88c8.618-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:29:41 UTC-69ca88c1.614-LOG:  disconnection: session time: 0:00:20.027
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=39842
-
-        2026-03-30 14:29:43 UTC-69ca88d7.61c-LOG:  connection received: host=127.0.0.1
-        port=35190
-
-        2026-03-30 14:29:43 UTC-69ca88d7.61c-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:29:43 UTC-69ca88d7.61c-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:29:43 UTC-69ca88d7.61c-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:29:46 UTC-69ca88da.627-LOG:  connection received: host=127.0.0.1
-        port=44182
-
-        2026-03-30 14:29:46 UTC-69ca88da.627-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:29:46 UTC-69ca88da.627-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:29:46 UTC-69ca88da.627-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:29:46 UTC-69ca88da.627-LOG:  disconnection: session time: 0:00:00.047
-        user=azuresu database=postgres host=127.0.0.1 port=44182
-
-        2026-03-30 14:29:48 UTC-69ca88c8.616-LOG:  disconnection: session time: 0:00:20.025
-        user=azuresu database=azure_sys host=127.0.0.1 port=49968
-
-        2026-03-30 14:29:48 UTC-69ca88c8.618-LOG:  disconnection: session time: 0:00:20.025
-        user=azuresu database=postgres host=127.0.0.1 port=49980
-
-        2026-03-30 14:29:48 UTC-69ca88dc.629-LOG:  connection received: host=127.0.0.1
-        port=44190
-
-        2026-03-30 14:29:48 UTC-69ca88dc.629-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:29:48 UTC-69ca88dc.629-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:29:48 UTC-69ca88dc.629-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:29:49 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
-        0/4001928, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
-
-        2026-03-30 14:29:59 UTC-69ca88e7.62d-LOG:  connection received: host=127.0.0.1
-        port=49612
-
-        2026-03-30 14:29:59 UTC-69ca88e7.62d-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:29:59 UTC-69ca88e7.62d-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:29:59 UTC-69ca88e7.62d-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:30:03 UTC-69ca88d7.61c-LOG:  disconnection: session time: 0:00:20.025
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=35190
-
-        2026-03-30 14:30:03 UTC-69ca85d0.2f7-LOG:  checkpoint starting: time
-
-        2026-03-30 14:30:05 UTC-69ca88ed.62f-LOG:  connection received: host=127.0.0.1
-        port=35500
-
-        2026-03-30 14:30:05 UTC-69ca88ed.62f-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:30:05 UTC-69ca88ed.62f-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:30:05 UTC-69ca88ed.62f-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:30:06 UTC-69ca85d0.2f7-LOG:  checkpoint complete: wrote 31 buffers
-        (0.0%); 0 WAL file(s) added, 0 removed, 0 recycled; write=3.015 s, sync=0.005
-        s, total=3.032 s; sync files=22, longest=0.004 s, average=0.001 s; distance=32774
-        kB, estimate=32774 kB; lsn=0/4002100, redo lsn=0/4001A98
-
-        2026-03-30 14:30:08 UTC-69ca88dc.629-LOG:  disconnection: session time: 0:00:20.029
-        user=azuresu database=postgres host=127.0.0.1 port=44190
-
-        2026-03-30 14:30:08 UTC-69ca88f0.631-LOG:  connection received: host=127.0.0.1
-        port=35510
-
-        2026-03-30 14:30:08 UTC-69ca88f0.631-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:30:08 UTC-69ca88f0.631-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:30:08 UTC-69ca88f0.631-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:30:11 UTC-69ca88f3.63b-LOG:  connection received: host=127.0.0.1
-        port=35518
-
-        2026-03-30 14:30:11 UTC-69ca88f3.63b-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:30:11 UTC-69ca88f3.63b-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:30:11 UTC-69ca88f3.63b-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:30:11 UTC-69ca88f3.63b-LOG:  disconnection: session time: 0:00:00.047
-        user=azuresu database=postgres host=127.0.0.1 port=35518
-
-        2026-03-30 14:30:19 UTC-69ca88e7.62d-LOG:  disconnection: session time: 0:00:20.023
-        user=azuresu database=azure_sys host=127.0.0.1 port=49612
-
-        2026-03-30 14:30:25 UTC-69ca88ed.62f-LOG:  disconnection: session time: 0:00:20.024
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=35500
-
-        2026-03-30 14:30:27 UTC-69ca8903.640-LOG:  connection received: host=127.0.0.1
-        port=44080
-
-        2026-03-30 14:30:27 UTC-69ca8903.640-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:30:27 UTC-69ca8903.640-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:30:27 UTC-69ca8903.640-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:30:28 UTC-69ca88f0.631-LOG:  disconnection: session time: 0:00:20.024
-        user=azuresu database=postgres host=127.0.0.1 port=35510
-
-        2026-03-30 14:30:28 UTC-69ca8904.642-LOG:  connection received: host=127.0.0.1
-        port=44092
-
-        2026-03-30 14:30:28 UTC-69ca8904.642-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:30:28 UTC-69ca8904.642-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:30:28 UTC-69ca8904.642-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:30:30 UTC-69ca8906.643-LOG:  connection received: host=127.0.0.1
-        port=44096
-
-        2026-03-30 14:30:30 UTC-69ca8906.643-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:30:30 UTC-69ca8906.643-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:30:30 UTC-69ca8906.643-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:30:36 UTC-69ca890c.64f-LOG:  connection received: host=127.0.0.1
-        port=43804
-
-        2026-03-30 14:30:36 UTC-69ca890c.64f-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:30:36 UTC-69ca890c.64f-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:30:36 UTC-69ca890c.64f-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:30:36 UTC-69ca890c.64f-LOG:  disconnection: session time: 0:00:00.046
-        user=azuresu database=postgres host=127.0.0.1 port=43804
-
-        2026-03-30 14:30:47 UTC-69ca8903.640-LOG:  disconnection: session time: 0:00:20.036
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=44080
-
-        2026-03-30 14:30:48 UTC-69ca8904.642-LOG:  disconnection: session time: 0:00:20.023
-        user=azuresu database=postgres host=127.0.0.1 port=44092
-
-        2026-03-30 14:30:49 UTC-69ca8919.653-LOG:  connection received: host=127.0.0.1
-        port=38378
-
-        2026-03-30 14:30:49 UTC-69ca8919.654-LOG:  connection received: host=127.0.0.1
-        port=38392
-
-        2026-03-30 14:30:49 UTC-69ca8919.653-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:30:49 UTC-69ca8919.653-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:30:49 UTC-69ca8919.653-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:30:49 UTC-69ca8919.654-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:30:49 UTC-69ca8919.654-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:30:49 UTC-69ca8919.654-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:30:49 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
-        0/4002670, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
-
-        2026-03-30 14:30:50 UTC-69ca8906.643-LOG:  disconnection: session time: 0:00:20.030
-        user=azuresu database=azure_sys host=127.0.0.1 port=44096
-
-        2026-03-30 14:31:01 UTC-69ca8925.658-LOG:  connection received: host=127.0.0.1
-        port=34600
-
-        2026-03-30 14:31:01 UTC-69ca8925.658-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:31:01 UTC-69ca8925.658-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:31:01 UTC-69ca8925.658-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:31:01 UTC-69ca8925.662-LOG:  connection received: host=127.0.0.1
-        port=34616
-
-        2026-03-30 14:31:01 UTC-69ca8925.662-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:31:01 UTC-69ca8925.662-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:31:01 UTC-69ca8925.662-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:31:01 UTC-69ca8925.662-LOG:  disconnection: session time: 0:00:00.047
-        user=azuresu database=postgres host=127.0.0.1 port=34616
-
-        2026-03-30 14:31:09 UTC-69ca8919.653-LOG:  disconnection: session time: 0:00:20.041
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=38378
-
-        2026-03-30 14:31:09 UTC-69ca8919.654-LOG:  disconnection: session time: 0:00:20.038
-        user=azuresu database=postgres host=127.0.0.1 port=38392
-
-        2026-03-30 14:31:09 UTC-69ca892d.67e-LOG:  connection received: host=127.0.0.1
-        port=56154
-
-        2026-03-30 14:31:09 UTC-69ca892d.67e-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:31:09 UTC-69ca892d.67e-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:31:09 UTC-69ca892d.67e-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:31:11 UTC-69ca892f.681-LOG:  connection received: host=127.0.0.1
-        port=56156
-
-        2026-03-30 14:31:11 UTC-69ca892f.681-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:31:11 UTC-69ca892f.681-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:31:11 UTC-69ca892f.681-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:31:21 UTC-69ca8925.658-LOG:  disconnection: session time: 0:00:20.026
-        user=azuresu database=azure_sys host=127.0.0.1 port=34600
-
-        2026-03-30 14:31:26 UTC-69ca893e.691-LOG:  connection received: host=127.0.0.1
-        port=51438
-
-        2026-03-30 14:31:26 UTC-69ca893e.691-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:31:26 UTC-69ca893e.691-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:31:26 UTC-69ca893e.691-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:31:26 UTC-69ca893e.691-LOG:  disconnection: session time: 0:00:00.046
-        user=azuresu database=postgres host=127.0.0.1 port=51438
-
-        2026-03-30 14:31:29 UTC-69ca892d.67e-LOG:  disconnection: session time: 0:00:20.026
-        user=azuresu database=postgres host=127.0.0.1 port=56154
-
-        2026-03-30 14:31:29 UTC-69ca8941.693-LOG:  connection received: host=127.0.0.1
-        port=51452
-
-        2026-03-30 14:31:29 UTC-69ca8941.693-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:31:29 UTC-69ca8941.693-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:31:29 UTC-69ca8941.693-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:31:31 UTC-69ca892f.681-LOG:  disconnection: session time: 0:00:20.022
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=56156
-
-        2026-03-30 14:31:32 UTC-69ca8944.694-LOG:  connection received: host=127.0.0.1
-        port=51456
-
-        2026-03-30 14:31:32 UTC-69ca8944.694-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:31:32 UTC-69ca8944.694-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:31:32 UTC-69ca8944.694-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:31:33 UTC-69ca8945.695-LOG:  connection received: host=127.0.0.1
-        port=51468
-
-        2026-03-30 14:31:33 UTC-69ca8945.695-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:31:33 UTC-69ca8945.695-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:31:33 UTC-69ca8945.695-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:31:35 UTC-69ca8947.698-LOG:  connection received: host=127.0.0.1
-        port=36632
-
-        2026-03-30 14:31:35 UTC-69ca8947.698-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:31:35 UTC-69ca8947.698-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:31:35 UTC-69ca8947.698-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:31:49 UTC-69ca8941.693-LOG:  disconnection: session time: 0:00:20.023
-        user=azuresu database=postgres host=127.0.0.1 port=51452
-
-        2026-03-30 14:31:49 UTC-69ca8955.69c-LOG:  connection received: host=127.0.0.1
-        port=56600
-
-        2026-03-30 14:31:49 UTC-69ca8955.69c-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:31:49 UTC-69ca8955.69c-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:31:49 UTC-69ca8955.69c-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:31:49 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
-        0/5006F70, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
-
-        2026-03-30 14:31:51 UTC-69ca8957.6a6-LOG:  connection received: host=127.0.0.1
-        port=56608
-
-        2026-03-30 14:31:51 UTC-69ca8957.6a6-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:31:51 UTC-69ca8957.6a6-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:31:51 UTC-69ca8957.6a6-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:31:51 UTC-69ca8957.6a6-LOG:  disconnection: session time: 0:00:00.047
-        user=azuresu database=postgres host=127.0.0.1 port=56608
-
-        2026-03-30 14:31:52 UTC-69ca8944.694-LOG:  disconnection: session time: 0:00:20.025
-        user=azuresu database=azure_sys host=127.0.0.1 port=51456
-
-        2026-03-30 14:31:53 UTC-69ca8945.695-LOG:  disconnection: session time: 0:00:20.025
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=51468
-
-        2026-03-30 14:31:55 UTC-69ca895b.6a9-LOG:  connection received: host=127.0.0.1
-        port=36514
-
-        2026-03-30 14:31:55 UTC-69ca8947.698-LOG:  disconnection: session time: 0:00:20.024
-        user=azuresu database=azure_sys host=127.0.0.1 port=36632
-
-        2026-03-30 14:31:55 UTC-69ca895b.6a9-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:31:55 UTC-69ca895b.6a9-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:31:55 UTC-69ca895b.6a9-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:31:59 UTC-69ca85db.373-LOG:  pg_qs: qs bgworker: worker woke
-        up and performed operations, with query data store as on
-
-        2026-03-30 14:31:59 UTC-69ca85db.373-LOG:  pg_qs: qs bgworker: instanceType=primary,
-        default_transaction_read_only=false
-
-        2026-03-30 14:31:59 UTC-69ca85db.373-LOG:  pg_qs: pg_qs_staging_data: Shall
-        collect the minimum of pg_qs.max_captured_queries (500) and pg_qs.max_queries
-        (1000).","context": "SQL statement \"SELECT *\n        FROM query_store.staging_data_1_4(showtext)\"\nPL/pgSQL
-        function query_store.staging_data(boolean) line 15 at RETURN QUERY\nSQL statement
-        \"WITH staging_data AS(\n\t\t\tSELECT * FROM query_store.staging_data(true)\n\t\t),\n\t\tdummyData
-        AS(\n\t\t\tINSERT INTO query_store.query_texts (query_text_id, query_sql_text,
-        query_type)\n\t\t\t\tSELECT query_id, CAST(query AS varchar(10000)) AS query,
-        query_type\n\t\t\t\tFROM staging_data\n\t\t\t\tON CONFLICT DO NOTHING\n\t\t\t\tRETURNING
-        query_text_id\n\t\t),\n\t\tdummyData2 AS(\n\t\t\tUPDATE query_store.query_texts
-        AS qt\n\t\t\t\tSET query_type = sd.query_type\n\t\t\t\tFROM staging_data AS
-        sd\n\t\t\t\tWHERE qt.query_text_id = sd.query_id\n\t\t\t\tRETURNING qt.query_text_id\n\t\t),
-        aux_interval_variables AS(\n            INSERT INTO query_store.runtime_stats_intervals
-        (start_time, end_time, comment) VALUES (current_timestamp - $1::INTERVAL,
-        current_timestamp, null) RETURNING runtime_stats_interval_id\n        ), aux_runtime_stats_variables
-        AS(\n            INSERT INTO query_store.runtime_stats_entries (user_id, db_id,
-        query_id, search_path, plan_id, runtime_stats_interval_id, query_parameters,
-        parameters_capture_status, search_path_capture_status)\n                SELECT
-        user_id, db_id, query_id, search_path, plan_id, aux_interval_variables.runtime_stats_interval_id,
-        query_parameters, parameters_capture_status, search_path_capture_status\n                FROM
-        aux_interval_variables, staging_data\n                RETURNING runtime_stats_entry_id,
-        user_id, db_id, query_id\n        ),\n\t\taux_runtime_stats_ws_entries AS(\n            INSERT
-        INTO query_store.runtime_stats_ws_entries (user_id, db_id, query_id, event_type,
-        event, runtime_stats_interval_id)\n                SELECT user_id, db_id,
-        query_id, event_type, event, aux_interval_variables.runtime_stats_interval_id\n                FROM
-        aux_interval_variables, query_store.staging_ws_data()\n                RETURNING
-        runtime_stats_ws_entry_id, user_id, db_id, query_id, event_type, event\n        ),\n\t\taux_runtime_stats_ws_values
-        AS\n\t\t(\n\t\t\tINSERT INTO query_store.runtime_stats_ws_values (runtime_stats_ws_entry_id,
-        calls)\n\t\t\t\tSELECT\n                aux_runtime_stats_ws_entries.runtime_stats_ws_entry_id,
-        calls\n\t\t\t\tFROM aux_runtime_stats_ws_entries JOIN query_store.staging_ws_data()
-        AS t1\n\t\t\t\tON\n\t\t\t\t\taux_runtime_stats_ws_entries.query_id = t1.query_id
-        AND\n\t\t\t\t\taux_runtime_stats_ws_entries.user_id = t1.user_id AND\n\t\t\t\t\taux_runtime_stats_ws_entries.db_id
-        = t1.db_id AND\n\t\t\t\t\taux_runtime_stats_ws_entries.event = t1.event AND\n\t\t\t\t\taux_runtime_stats_ws_entries.event_type
-        = t1.event_type\n\t\t),\n        plans AS\n\t\t(\n            INSERT INTO
-        query_store.query_plans (plan_id, db_id, query_id, plan_text)\n                SELECT
-        plan_id, db_id, query_id, CAST(plan_text AS varchar(10000)) AS plan_text\n                FROM
-        staging_data\n                WHERE plan_text IS NOT NULL AND query_id IS
-        NOT NULL AND plan_id IS NOT NULL\n                ON CONFLICT(plan_id, db_id,
-        query_id) DO NOTHING\n                returning plan_id, plan_text, query_id\n        )\n        INSERT
-        INTO query_store.runtime_stats (\n            runtime_stats_entry_id,\n            calls,\n            total_time,\n            min_time,\n            max_time,\n            mean_time,\n            stddev_time,\n            rows,\n            shared_blks_hit,\n            shared_blks_read,\n            shared_blks_dirtied,\n            shared_blks_written,\n            local_blks_hit,\n            local_blks_read,\n            local_blks_dirtied,\n            local_blks_written,\n            temp_blks_read,\n            temp_blks_written,\n            blk_read_time,\n            blk_write_time\n        )\n        SELECT\n            runtime_stats_entry_id,\n            calls,\n            total_time,\n            min_time,\n            max_time,\n            mean_time,\n            stddev_time,\n            rows,\n            shared_blks_hit,\n            shared_blks_read,\n            shared_blks_dirtied,\n            shared_blks_written,\n            local_blks_hit,\n            local_blks_read,\n            local_blks_dirtied,\n            local_blks_written,\n            temp_blks_read,\n            temp_blks_written,\n            blk_read_time,\n            blk_write_time\n        FROM\n            aux_runtime_stats_variables
-        JOIN staging_data AS t1 ON aux_runtime_stats_variables.user_id = t1.user_id
-        AND aux_runtime_stats_variables.db_id = t1.db_id AND aux_runtime_stats_variables.query_id
-        = t1.query_id\n\t\t\tLEFT OUTER JOIN plans p\n            ON aux_runtime_stats_variables.query_id
-        = p.query_id\"\nPL/pgSQL function query_store.collect_data(text,text) line
-        9 at SQL statement\nSQL statement \"SELECT query_store.collect_data(''15 minutes'',
-        ''7 days'')\"
-
-        2026-03-30 14:31:59 UTC-69ca85db.373-LOG:  pg_qs: pg_qs_staging_data: number
-        of hash entries (114) is within the limit (500), returning all","context":
-        "SQL statement \"SELECT *\n        FROM query_store.staging_data_1_4(showtext)\"\nPL/pgSQL
-        function query_store.staging_data(boolean) line 15 at RETURN QUERY\nSQL statement
-        \"WITH staging_data AS(\n\t\t\tSELECT * FROM query_store.staging_data(true)\n\t\t),\n\t\tdummyData
-        AS(\n\t\t\tINSERT INTO query_store.query_texts (query_text_id, query_sql_text,
-        query_type)\n\t\t\t\tSELECT query_id, CAST(query AS varchar(10000)) AS query,
-        query_type\n\t\t\t\tFROM staging_data\n\t\t\t\tON CONFLICT DO NOTHING\n\t\t\t\tRETURNING
-        query_text_id\n\t\t),\n\t\tdummyData2 AS(\n\t\t\tUPDATE query_store.query_texts
-        AS qt\n\t\t\t\tSET query_type = sd.query_type\n\t\t\t\tFROM staging_data AS
-        sd\n\t\t\t\tWHERE qt.query_text_id = sd.query_id\n\t\t\t\tRETURNING qt.query_text_id\n\t\t),
-        aux_interval_variables AS(\n            INSERT INTO query_store.runtime_stats_intervals
-        (start_time, end_time, comment) VALUES (current_timestamp - $1::INTERVAL,
-        current_timestamp, null) RETURNING runtime_stats_interval_id\n        ), aux_runtime_stats_variables
-        AS(\n            INSERT INTO query_store.runtime_stats_entries (user_id, db_id,
-        query_id, search_path, plan_id, runtime_stats_interval_id, query_parameters,
-        parameters_capture_status, search_path_capture_status)\n                SELECT
-        user_id, db_id, query_id, search_path, plan_id, aux_interval_variables.runtime_stats_interval_id,
-        query_parameters, parameters_capture_status, search_path_capture_status\n                FROM
-        aux_interval_variables, staging_data\n                RETURNING runtime_stats_entry_id,
-        user_id, db_id, query_id\n        ),\n\t\taux_runtime_stats_ws_entries AS(\n            INSERT
-        INTO query_store.runtime_stats_ws_entries (user_id, db_id, query_id, event_type,
-        event, runtime_stats_interval_id)\n                SELECT user_id, db_id,
-        query_id, event_type, event, aux_interval_variables.runtime_stats_interval_id\n                FROM
-        aux_interval_variables, query_store.staging_ws_data()\n                RETURNING
-        runtime_stats_ws_entry_id, user_id, db_id, query_id, event_type, event\n        ),\n\t\taux_runtime_stats_ws_values
-        AS\n\t\t(\n\t\t\tINSERT INTO query_store.runtime_stats_ws_values (runtime_stats_ws_entry_id,
-        calls)\n\t\t\t\tSELECT\n                aux_runtime_stats_ws_entries.runtime_stats_ws_entry_id,
-        calls\n\t\t\t\tFROM aux_runtime_stats_ws_entries JOIN query_store.staging_ws_data()
-        AS t1\n\t\t\t\tON\n\t\t\t\t\taux_runtime_stats_ws_entries.query_id = t1.query_id
-        AND\n\t\t\t\t\taux_runtime_stats_ws_entries.user_id = t1.user_id AND\n\t\t\t\t\taux_runtime_stats_ws_entries.db_id
-        = t1.db_id AND\n\t\t\t\t\taux_runtime_stats_ws_entries.event = t1.event AND\n\t\t\t\t\taux_runtime_stats_ws_entries.event_type
-        = t1.event_type\n\t\t),\n        plans AS\n\t\t(\n            INSERT INTO
-        query_store.query_plans (plan_id, db_id, query_id, plan_text)\n                SELECT
-        plan_id, db_id, query_id, CAST(plan_text AS varchar(10000)) AS plan_text\n                FROM
-        staging_data\n                WHERE plan_text IS NOT NULL AND query_id IS
-        NOT NULL AND plan_id IS NOT NULL\n                ON CONFLICT(plan_id, db_id,
-        query_id) DO NOTHING\n                returning plan_id, plan_text, query_id\n        )\n        INSERT
-        INTO query_store.runtime_stats (\n            runtime_stats_entry_id,\n            calls,\n            total_time,\n            min_time,\n            max_time,\n            mean_time,\n            stddev_time,\n            rows,\n            shared_blks_hit,\n            shared_blks_read,\n            shared_blks_dirtied,\n            shared_blks_written,\n            local_blks_hit,\n            local_blks_read,\n            local_blks_dirtied,\n            local_blks_written,\n            temp_blks_read,\n            temp_blks_written,\n            blk_read_time,\n            blk_write_time\n        )\n        SELECT\n            runtime_stats_entry_id,\n            calls,\n            total_time,\n            min_time,\n            max_time,\n            mean_time,\n            stddev_time,\n            rows,\n            shared_blks_hit,\n            shared_blks_read,\n            shared_blks_dirtied,\n            shared_blks_written,\n            local_blks_hit,\n            local_blks_read,\n            local_blks_dirtied,\n            local_blks_written,\n            temp_blks_read,\n            temp_blks_written,\n            blk_read_time,\n            blk_write_time\n        FROM\n            aux_runtime_stats_variables
-        JOIN staging_data AS t1 ON aux_runtime_stats_variables.user_id = t1.user_id
-        AND aux_runtime_stats_variables.db_id = t1.db_id AND aux_runtime_stats_variables.query_id
-        = t1.query_id\n\t\t\tLEFT OUTER JOIN plans p\n            ON aux_runtime_stats_variables.query_id
-        = p.query_id\"\nPL/pgSQL function query_store.collect_data(text,text) line
-        9 at SQL statement\nSQL statement \"SELECT query_store.collect_data(''15 minutes'',
-        ''7 days'')\"
-
-        2026-03-30 14:31:59 UTC-69ca85db.373-LOG:  pg_qs: pg_qs_staging_data: emitted
-        114 entries.","context": "SQL statement \"SELECT *\n        FROM query_store.staging_data_1_4(showtext)\"\nPL/pgSQL
-        function query_store.staging_data(boolean) line 15 at RETURN QUERY\nSQL statement
-        \"WITH staging_data AS(\n\t\t\tSELECT * FROM query_store.staging_data(true)\n\t\t),\n\t\tdummyData
-        AS(\n\t\t\tINSERT INTO query_store.query_texts (query_text_id, query_sql_text,
-        query_type)\n\t\t\t\tSELECT query_id, CAST(query AS varchar(10000)) AS query,
-        query_type\n\t\t\t\tFROM staging_data\n\t\t\t\tON CONFLICT DO NOTHING\n\t\t\t\tRETURNING
-        query_text_id\n\t\t),\n\t\tdummyData2 AS(\n\t\t\tUPDATE query_store.query_texts
-        AS qt\n\t\t\t\tSET query_type = sd.query_type\n\t\t\t\tFROM staging_data AS
-        sd\n\t\t\t\tWHERE qt.query_text_id = sd.query_id\n\t\t\t\tRETURNING qt.query_text_id\n\t\t),
-        aux_interval_variables AS(\n            INSERT INTO query_store.runtime_stats_intervals
-        (start_time, end_time, comment) VALUES (current_timestamp - $1::INTERVAL,
-        current_timestamp, null) RETURNING runtime_stats_interval_id\n        ), aux_runtime_stats_variables
-        AS(\n            INSERT INTO query_store.runtime_stats_entries (user_id, db_id,
-        query_id, search_path, plan_id, runtime_stats_interval_id, query_parameters,
-        parameters_capture_status, search_path_capture_status)\n                SELECT
-        user_id, db_id, query_id, search_path, plan_id, aux_interval_variables.runtime_stats_interval_id,
-        query_parameters, parameters_capture_status, search_path_capture_status\n                FROM
-        aux_interval_variables, staging_data\n                RETURNING runtime_stats_entry_id,
-        user_id, db_id, query_id\n        ),\n\t\taux_runtime_stats_ws_entries AS(\n            INSERT
-        INTO query_store.runtime_stats_ws_entries (user_id, db_id, query_id, event_type,
-        event, runtime_stats_interval_id)\n                SELECT user_id, db_id,
-        query_id, event_type, event, aux_interval_variables.runtime_stats_interval_id\n                FROM
-        aux_interval_variables, query_store.staging_ws_data()\n                RETURNING
-        runtime_stats_ws_entry_id, user_id, db_id, query_id, event_type, event\n        ),\n\t\taux_runtime_stats_ws_values
-        AS\n\t\t(\n\t\t\tINSERT INTO query_store.runtime_stats_ws_values (runtime_stats_ws_entry_id,
-        calls)\n\t\t\t\tSELECT\n                aux_runtime_stats_ws_entries.runtime_stats_ws_entry_id,
-        calls\n\t\t\t\tFROM aux_runtime_stats_ws_entries JOIN query_store.staging_ws_data()
-        AS t1\n\t\t\t\tON\n\t\t\t\t\taux_runtime_stats_ws_entries.query_id = t1.query_id
-        AND\n\t\t\t\t\taux_runtime_stats_ws_entries.user_id = t1.user_id AND\n\t\t\t\t\taux_runtime_stats_ws_entries.db_id
-        = t1.db_id AND\n\t\t\t\t\taux_runtime_stats_ws_entries.event = t1.event AND\n\t\t\t\t\taux_runtime_stats_ws_entries.event_type
-        = t1.event_type\n\t\t),\n        plans AS\n\t\t(\n            INSERT INTO
-        query_store.query_plans (plan_id, db_id, query_id, plan_text)\n                SELECT
-        plan_id, db_id, query_id, CAST(plan_text AS varchar(10000)) AS plan_text\n                FROM
-        staging_data\n                WHERE plan_text IS NOT NULL AND query_id IS
-        NOT NULL AND plan_id IS NOT NULL\n                ON CONFLICT(plan_id, db_id,
-        query_id) DO NOTHING\n                returning plan_id, plan_text, query_id\n        )\n        INSERT
-        INTO query_store.runtime_stats (\n            runtime_stats_entry_id,\n            calls,\n            total_time,\n            min_time,\n            max_time,\n            mean_time,\n            stddev_time,\n            rows,\n            shared_blks_hit,\n            shared_blks_read,\n            shared_blks_dirtied,\n            shared_blks_written,\n            local_blks_hit,\n            local_blks_read,\n            local_blks_dirtied,\n            local_blks_written,\n            temp_blks_read,\n            temp_blks_written,\n            blk_read_time,\n            blk_write_time\n        )\n        SELECT\n            runtime_stats_entry_id,\n            calls,\n            total_time,\n            min_time,\n            max_time,\n            mean_time,\n            stddev_time,\n            rows,\n            shared_blks_hit,\n            shared_blks_read,\n            shared_blks_dirtied,\n            shared_blks_written,\n            local_blks_hit,\n            local_blks_read,\n            local_blks_dirtied,\n            local_blks_written,\n            temp_blks_read,\n            temp_blks_written,\n            blk_read_time,\n            blk_write_time\n        FROM\n            aux_runtime_stats_variables
-        JOIN staging_data AS t1 ON aux_runtime_stats_variables.user_id = t1.user_id
-        AND aux_runtime_stats_variables.db_id = t1.db_id AND aux_runtime_stats_variables.query_id
-        = t1.query_id\n\t\t\tLEFT OUTER JOIN plans p\n            ON aux_runtime_stats_variables.query_id
-        = p.query_id\"\nPL/pgSQL function query_store.collect_data(text,text) line
-        9 at SQL statement\nSQL statement \"SELECT query_store.collect_data(''15 minutes'',
-        ''7 days'')\"
-
-        2026-03-30 14:31:59 UTC-69ca85db.373-LOG:  pgms_wait_sampling: num_entries
-        in table before calling collect_data: 22.","context": "SQL statement \"WITH
-        staging_data AS(\n\t\t\tSELECT * FROM query_store.staging_data(true)\n\t\t),\n\t\tdummyData
-        AS(\n\t\t\tINSERT INTO query_store.query_texts (query_text_id, query_sql_text,
-        query_type)\n\t\t\t\tSELECT query_id, CAST(query AS varchar(10000)) AS query,
-        query_type\n\t\t\t\tFROM staging_data\n\t\t\t\tON CONFLICT DO NOTHING\n\t\t\t\tRETURNING
-        query_text_id\n\t\t),\n\t\tdummyData2 AS(\n\t\t\tUPDATE query_store.query_texts
-        AS qt\n\t\t\t\tSET query_type = sd.query_type\n\t\t\t\tFROM staging_data AS
-        sd\n\t\t\t\tWHERE qt.query_text_id = sd.query_id\n\t\t\t\tRETURNING qt.query_text_id\n\t\t),
-        aux_interval_variables AS(\n            INSERT INTO query_store.runtime_stats_intervals
-        (start_time, end_time, comment) VALUES (current_timestamp - $1::INTERVAL,
-        current_timestamp, null) RETURNING runtime_stats_interval_id\n        ), aux_runtime_stats_variables
-        AS(\n            INSERT INTO query_store.runtime_stats_entries (user_id, db_id,
-        query_id, search_path, plan_id, runtime_stats_interval_id, query_parameters,
-        parameters_capture_status, search_path_capture_status)\n                SELECT
-        user_id, db_id, query_id, search_path, plan_id, aux_interval_variables.runtime_stats_interval_id,
-        query_parameters, parameters_capture_status, search_path_capture_status\n                FROM
-        aux_interval_variables, staging_data\n                RETURNING runtime_stats_entry_id,
-        user_id, db_id, query_id\n        ),\n\t\taux_runtime_stats_ws_entries AS(\n            INSERT
-        INTO query_store.runtime_stats_ws_entries (user_id, db_id, query_id, event_type,
-        event, runtime_stats_interval_id)\n                SELECT user_id, db_id,
-        query_id, event_type, event, aux_interval_variables.runtime_stats_interval_id\n                FROM
-        aux_interval_variables, query_store.staging_ws_data()\n                RETURNING
-        runtime_stats_ws_entry_id, user_id, db_id, query_id, event_type, event\n        ),\n\t\taux_runtime_stats_ws_values
-        AS\n\t\t(\n\t\t\tINSERT INTO query_store.runtime_stats_ws_values (runtime_stats_ws_entry_id,
-        calls)\n\t\t\t\tSELECT\n                aux_runtime_stats_ws_entries.runtime_stats_ws_entry_id,
-        calls\n\t\t\t\tFROM aux_runtime_stats_ws_entries JOIN query_store.staging_ws_data()
-        AS t1\n\t\t\t\tON\n\t\t\t\t\taux_runtime_stats_ws_entries.query_id = t1.query_id
-        AND\n\t\t\t\t\taux_runtime_stats_ws_entries.user_id = t1.user_id AND\n\t\t\t\t\taux_runtime_stats_ws_entries.db_id
-        = t1.db_id AND\n\t\t\t\t\taux_runtime_stats_ws_entries.event = t1.event AND\n\t\t\t\t\taux_runtime_stats_ws_entries.event_type
-        = t1.event_type\n\t\t),\n        plans AS\n\t\t(\n            INSERT INTO
-        query_store.query_plans (plan_id, db_id, query_id, plan_text)\n                SELECT
-        plan_id, db_id, query_id, CAST(plan_text AS varchar(10000)) AS plan_text\n                FROM
-        staging_data\n                WHERE plan_text IS NOT NULL AND query_id IS
-        NOT NULL AND plan_id IS NOT NULL\n                ON CONFLICT(plan_id, db_id,
-        query_id) DO NOTHING\n                returning plan_id, plan_text, query_id\n        )\n        INSERT
-        INTO query_store.runtime_stats (\n            runtime_stats_entry_id,\n            calls,\n            total_time,\n            min_time,\n            max_time,\n            mean_time,\n            stddev_time,\n            rows,\n            shared_blks_hit,\n            shared_blks_read,\n            shared_blks_dirtied,\n            shared_blks_written,\n            local_blks_hit,\n            local_blks_read,\n            local_blks_dirtied,\n            local_blks_written,\n            temp_blks_read,\n            temp_blks_written,\n            blk_read_time,\n            blk_write_time\n        )\n        SELECT\n            runtime_stats_entry_id,\n            calls,\n            total_time,\n            min_time,\n            max_time,\n            mean_time,\n            stddev_time,\n            rows,\n            shared_blks_hit,\n            shared_blks_read,\n            shared_blks_dirtied,\n            shared_blks_written,\n            local_blks_hit,\n            local_blks_read,\n            local_blks_dirtied,\n            local_blks_written,\n            temp_blks_read,\n            temp_blks_written,\n            blk_read_time,\n            blk_write_time\n        FROM\n            aux_runtime_stats_variables
-        JOIN staging_data AS t1 ON aux_runtime_stats_variables.user_id = t1.user_id
-        AND aux_runtime_stats_variables.db_id = t1.db_id AND aux_runtime_stats_variables.query_id
-        = t1.query_id\n\t\t\tLEFT OUTER JOIN plans p\n            ON aux_runtime_stats_variables.query_id
-        = p.query_id\"\nPL/pgSQL function query_store.collect_data(text,text) line
-        9 at SQL statement\nSQL statement \"SELECT query_store.collect_data(''15 minutes'',
-        ''7 days'')\"
-
-        2026-03-30 14:31:59 UTC-69ca85db.373-LOG:  pgms_wait_sampling: num_entries
-        in table before calling collect_data: 22.","context": "SQL statement \"WITH
-        staging_data AS(\n\t\t\tSELECT * FROM query_store.staging_data(true)\n\t\t),\n\t\tdummyData
-        AS(\n\t\t\tINSERT INTO query_store.query_texts (query_text_id, query_sql_text,
-        query_type)\n\t\t\t\tSELECT query_id, CAST(query AS varchar(10000)) AS query,
-        query_type\n\t\t\t\tFROM staging_data\n\t\t\t\tON CONFLICT DO NOTHING\n\t\t\t\tRETURNING
-        query_text_id\n\t\t),\n\t\tdummyData2 AS(\n\t\t\tUPDATE query_store.query_texts
-        AS qt\n\t\t\t\tSET query_type = sd.query_type\n\t\t\t\tFROM staging_data AS
-        sd\n\t\t\t\tWHERE qt.query_text_id = sd.query_id\n\t\t\t\tRETURNING qt.query_text_id\n\t\t),
-        aux_interval_variables AS(\n            INSERT INTO query_store.runtime_stats_intervals
-        (start_time, end_time, comment) VALUES (current_timestamp - $1::INTERVAL,
-        current_timestamp, null) RETURNING runtime_stats_interval_id\n        ), aux_runtime_stats_variables
-        AS(\n            INSERT INTO query_store.runtime_stats_entries (user_id, db_id,
-        query_id, search_path, plan_id, runtime_stats_interval_id, query_parameters,
-        parameters_capture_status, search_path_capture_status)\n                SELECT
-        user_id, db_id, query_id, search_path, plan_id, aux_interval_variables.runtime_stats_interval_id,
-        query_parameters, parameters_capture_status, search_path_capture_status\n                FROM
-        aux_interval_variables, staging_data\n                RETURNING runtime_stats_entry_id,
-        user_id, db_id, query_id\n        ),\n\t\taux_runtime_stats_ws_entries AS(\n            INSERT
-        INTO query_store.runtime_stats_ws_entries (user_id, db_id, query_id, event_type,
-        event, runtime_stats_interval_id)\n                SELECT user_id, db_id,
-        query_id, event_type, event, aux_interval_variables.runtime_stats_interval_id\n                FROM
-        aux_interval_variables, query_store.staging_ws_data()\n                RETURNING
-        runtime_stats_ws_entry_id, user_id, db_id, query_id, event_type, event\n        ),\n\t\taux_runtime_stats_ws_values
-        AS\n\t\t(\n\t\t\tINSERT INTO query_store.runtime_stats_ws_values (runtime_stats_ws_entry_id,
-        calls)\n\t\t\t\tSELECT\n                aux_runtime_stats_ws_entries.runtime_stats_ws_entry_id,
-        calls\n\t\t\t\tFROM aux_runtime_stats_ws_entries JOIN query_store.staging_ws_data()
-        AS t1\n\t\t\t\tON\n\t\t\t\t\taux_runtime_stats_ws_entries.query_id = t1.query_id
-        AND\n\t\t\t\t\taux_runtime_stats_ws_entries.user_id = t1.user_id AND\n\t\t\t\t\taux_runtime_stats_ws_entries.db_id
-        = t1.db_id AND\n\t\t\t\t\taux_runtime_stats_ws_entries.event = t1.event AND\n\t\t\t\t\taux_runtime_stats_ws_entries.event_type
-        = t1.event_type\n\t\t),\n        plans AS\n\t\t(\n            INSERT INTO
-        query_store.query_plans (plan_id, db_id, query_id, plan_text)\n                SELECT
-        plan_id, db_id, query_id, CAST(plan_text AS varchar(10000)) AS plan_text\n                FROM
-        staging_data\n                WHERE plan_text IS NOT NULL AND query_id IS
-        NOT NULL AND plan_id IS NOT NULL\n                ON CONFLICT(plan_id, db_id,
-        query_id) DO NOTHING\n                returning plan_id, plan_text, query_id\n        )\n        INSERT
-        INTO query_store.runtime_stats (\n            runtime_stats_entry_id,\n            calls,\n            total_time,\n            min_time,\n            max_time,\n            mean_time,\n            stddev_time,\n            rows,\n            shared_blks_hit,\n            shared_blks_read,\n            shared_blks_dirtied,\n            shared_blks_written,\n            local_blks_hit,\n            local_blks_read,\n            local_blks_dirtied,\n            local_blks_written,\n            temp_blks_read,\n            temp_blks_written,\n            blk_read_time,\n            blk_write_time\n        )\n        SELECT\n            runtime_stats_entry_id,\n            calls,\n            total_time,\n            min_time,\n            max_time,\n            mean_time,\n            stddev_time,\n            rows,\n            shared_blks_hit,\n            shared_blks_read,\n            shared_blks_dirtied,\n            shared_blks_written,\n            local_blks_hit,\n            local_blks_read,\n            local_blks_dirtied,\n            local_blks_written,\n            temp_blks_read,\n            temp_blks_written,\n            blk_read_time,\n            blk_write_time\n        FROM\n            aux_runtime_stats_variables
-        JOIN staging_data AS t1 ON aux_runtime_stats_variables.user_id = t1.user_id
-        AND aux_runtime_stats_variables.db_id = t1.db_id AND aux_runtime_stats_variables.query_id
-        = t1.query_id\n\t\t\tLEFT OUTER JOIN plans p\n            ON aux_runtime_stats_variables.query_id
-        = p.query_id\"\nPL/pgSQL function query_store.collect_data(text,text) line
-        9 at SQL statement\nSQL statement \"SELECT query_store.collect_data(''15 minutes'',
-        ''7 days'')\"
-
-        2026-03-30 14:31:59 UTC-69ca85db.373-LOG:  pg_qs: number of rows inserted
-        into runtime_stats: 114","context": "PL/pgSQL function query_store.collect_data(text,text)
-        line 110 at RAISE\nSQL statement \"SELECT query_store.collect_data(''15 minutes'',
-        ''7 days'')\"
-
-        2026-03-30 14:31:59 UTC-69ca85db.373-LOG:  pgms_wait_sampling: entry_reset
-        called","context": "SQL statement \"SELECT query_store.staging_ws_data_reset()\"\nPL/pgSQL
-        function query_store.collect_data(text,text) line 129 at PERFORM\nSQL statement
-        \"SELECT query_store.collect_data(''15 minutes'', ''7 days'')\"
-
-        2026-03-30 14:31:59 UTC-69ca85db.373-LOG:  pgms_wait_sampling: entry_reset
-        called","context": "SQL statement \"SELECT query_store.staging_ws_data_reset()\"
-
-        2026-03-30 14:31:59 UTC-69ca85db.373-LOG:  pg_qs: qs bgworker: worker finished
-        successfully in 13.288836 ms, with query store as on, is_writable_instance
-        as on and having_schema as true
-
-        2026-03-30 14:31:59 UTC-69ca85db.373-LOG:  pg_qs: qs bgworker: entry limit:
-        1000, tracked entries: 114, collected entries: 114, hash overflows: 0, entry
-        creation failures: 0, lock partitions: 32, spinlock buckets: on
-
-        2026-03-30 14:32:03 UTC-69ca8963.6ab-LOG:  connection received: host=127.0.0.1
-        port=36526
-
-        2026-03-30 14:32:03 UTC-69ca8963.6ab-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:32:03 UTC-69ca8963.6ab-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:32:03 UTC-69ca8963.6ab-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:32:09 UTC-69ca8955.69c-LOG:  disconnection: session time: 0:00:20.023
-        user=azuresu database=postgres host=127.0.0.1 port=56600
-
-        2026-03-30 14:32:09 UTC-69ca8969.6ae-LOG:  connection received: host=127.0.0.1
-        port=34570
-
-        2026-03-30 14:32:09 UTC-69ca8969.6ae-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:32:09 UTC-69ca8969.6ae-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:32:09 UTC-69ca8969.6ae-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:32:15 UTC-69ca895b.6a9-LOG:  disconnection: session time: 0:00:20.023
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=36514
-
-        2026-03-30 14:32:16 UTC-69ca8970.6ba-LOG:  connection received: host=127.0.0.1
-        port=60280
-
-        2026-03-30 14:32:16 UTC-69ca8970.6ba-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:32:16 UTC-69ca8970.6ba-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:32:16 UTC-69ca8970.6ba-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:32:16 UTC-69ca8970.6ba-LOG:  disconnection: session time: 0:00:00.047
-        user=azuresu database=postgres host=127.0.0.1 port=60280
-
-        2026-03-30 14:32:17 UTC-69ca8971.6bb-LOG:  connection received: host=127.0.0.1
-        port=60296
-
-        2026-03-30 14:32:17 UTC-69ca8971.6bb-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:32:17 UTC-69ca8971.6bb-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:32:17 UTC-69ca8971.6bb-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:32:23 UTC-69ca8963.6ab-LOG:  disconnection: session time: 0:00:20.036
-        user=azuresu database=azure_sys host=127.0.0.1 port=36526
-
-        2026-03-30 14:32:29 UTC-69ca8969.6ae-LOG:  disconnection: session time: 0:00:20.129
-        user=azuresu database=postgres host=127.0.0.1 port=34570
-
-        2026-03-30 14:32:34 UTC-69ca8982.6c1-LOG:  connection received: host=127.0.0.1
-        port=41882
-
-        2026-03-30 14:32:34 UTC-69ca8982.6c1-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:32:34 UTC-69ca8982.6c1-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:32:34 UTC-69ca8982.6c1-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:32:37 UTC-69ca8985.6c2-LOG:  connection received: host=127.0.0.1
-        port=45760
-
-        2026-03-30 14:32:37 UTC-69ca8971.6bb-LOG:  disconnection: session time: 0:00:20.028
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=60296
-
-        2026-03-30 14:32:37 UTC-69ca8985.6c2-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:32:37 UTC-69ca8985.6c2-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:32:37 UTC-69ca8985.6c2-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:32:39 UTC-69ca8987.6c4-LOG:  connection received: host=127.0.0.1
-        port=45768
-
-        2026-03-30 14:32:39 UTC-69ca8987.6c4-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:32:39 UTC-69ca8987.6c4-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:32:39 UTC-69ca8987.6c4-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:32:41 UTC-69ca8989.6ce-LOG:  connection received: host=127.0.0.1
-        port=45772
-
-        2026-03-30 14:32:42 UTC-69ca8989.6ce-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:32:42 UTC-69ca8989.6ce-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:32:42 UTC-69ca8989.6ce-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:32:42 UTC-69ca8989.6ce-LOG:  disconnection: session time: 0:00:00.046
-        user=azuresu database=postgres host=127.0.0.1 port=45772
-
-        2026-03-30 14:32:49 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
-        0/502F078, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
-
-        2026-03-30 14:32:54 UTC-69ca8982.6c1-LOG:  disconnection: session time: 0:00:20.032
-        user=azuresu database=azure_sys host=127.0.0.1 port=41882
-
-        2026-03-30 14:32:57 UTC-69ca8985.6c2-LOG:  disconnection: session time: 0:00:20.026
-        user=azuresu database=postgres host=127.0.0.1 port=45760
-
-        2026-03-30 14:32:59 UTC-69ca8987.6c4-LOG:  disconnection: session time: 0:00:20.022
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=45768
-
-        2026-03-30 14:32:59 UTC-69ca899b.6d4-LOG:  connection received: host=127.0.0.1
-        port=42326
-
-        2026-03-30 14:32:59 UTC-69ca899b.6d4-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:32:59 UTC-69ca899b.6d4-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:32:59 UTC-69ca899b.6d4-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:33:01 UTC-69ca899d.6d5-LOG:  connection received: host=127.0.0.1
-        port=42342
-
-        2026-03-30 14:33:01 UTC-69ca899d.6d5-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:33:01 UTC-69ca899d.6d5-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:33:01 UTC-69ca899d.6d5-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:33:05 UTC-69ca89a1.6d7-LOG:  connection received: host=127.0.0.1
-        port=43248
-
-        2026-03-30 14:33:05 UTC-69ca89a1.6d7-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:33:05 UTC-69ca89a1.6d7-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:33:05 UTC-69ca89a1.6d7-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:33:07 UTC-69ca89a3.6e1-LOG:  connection received: host=127.0.0.1
-        port=43260
-
-        2026-03-30 14:33:07 UTC-69ca89a3.6e1-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:33:07 UTC-69ca89a3.6e1-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:33:07 UTC-69ca89a3.6e1-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:33:07 UTC-69ca89a3.6e1-LOG:  disconnection: session time: 0:00:00.048
-        user=azuresu database=postgres host=127.0.0.1 port=43260
-
-        2026-03-30 14:33:19 UTC-69ca899b.6d4-LOG:  disconnection: session time: 0:00:20.037
-        user=azuresu database=postgres host=127.0.0.1 port=42326
-
-        2026-03-30 14:33:19 UTC-69ca89af.6e6-LOG:  connection received: host=127.0.0.1
-        port=60822
-
-        2026-03-30 14:33:20 UTC-69ca89af.6e6-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:33:20 UTC-69ca89af.6e6-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:33:20 UTC-69ca89af.6e6-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:33:21 UTC-69ca899d.6d5-LOG:  disconnection: session time: 0:00:20.023
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=42342
-
-        2026-03-30 14:33:23 UTC-69ca89b3.6e7-LOG:  connection received: host=127.0.0.1
-        port=60826
-
-        2026-03-30 14:33:23 UTC-69ca89b3.6e7-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:33:23 UTC-69ca89b3.6e7-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:33:23 UTC-69ca89b3.6e7-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:33:25 UTC-69ca89a1.6d7-LOG:  disconnection: session time: 0:00:20.029
-        user=azuresu database=azure_sys host=127.0.0.1 port=43248
-
-        2026-03-30 14:33:32 UTC-69ca89bc.6f3-LOG:  connection received: host=127.0.0.1
-        port=35246
-
-        2026-03-30 14:33:32 UTC-69ca89bc.6f3-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:33:32 UTC-69ca89bc.6f3-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:33:32 UTC-69ca89bc.6f3-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:33:32 UTC-69ca89bc.6f3-LOG:  disconnection: session time: 0:00:00.046
-        user=azuresu database=postgres host=127.0.0.1 port=35246
-
-        2026-03-30 14:33:36 UTC-69ca89c0.6f6-LOG:  connection received: host=127.0.0.1
-        port=48462
-
-        2026-03-30 14:33:36 UTC-69ca89c0.6f6-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:33:36 UTC-69ca89c0.6f6-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:33:36 UTC-69ca89c0.6f6-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:33:40 UTC-69ca89af.6e6-LOG:  disconnection: session time: 0:00:20.022
-        user=azuresu database=postgres host=127.0.0.1 port=60822
-
-        2026-03-30 14:33:40 UTC-69ca89c4.6f8-LOG:  connection received: host=127.0.0.1
-        port=48464
-
-        2026-03-30 14:33:40 UTC-69ca89c4.6f8-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:33:40 UTC-69ca89c4.6f8-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:33:40 UTC-69ca89c4.6f8-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:33:43 UTC-69ca89b3.6e7-LOG:  disconnection: session time: 0:00:20.030
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=60826
-
-        2026-03-30 14:33:45 UTC-69ca89c9.6fa-LOG:  connection received: host=127.0.0.1
-        port=58190
-
-        2026-03-30 14:33:45 UTC-69ca89c9.6fa-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:33:45 UTC-69ca89c9.6fa-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:33:45 UTC-69ca89c9.6fa-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:33:49 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
-        0/502F718, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
-
-        2026-03-30 14:33:56 UTC-69ca89c0.6f6-LOG:  disconnection: session time: 0:00:20.025
-        user=azuresu database=azure_sys host=127.0.0.1 port=48462
-
-        2026-03-30 14:33:57 UTC-69ca89d5.707-LOG:  connection received: host=127.0.0.1
-        port=55038
-
-        2026-03-30 14:33:57 UTC-69ca89d5.707-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:33:57 UTC-69ca89d5.707-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:33:57 UTC-69ca89d5.707-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:33:57 UTC-69ca89d5.707-LOG:  disconnection: session time: 0:00:00.046
-        user=azuresu database=postgres host=127.0.0.1 port=55038
-
-        2026-03-30 14:34:00 UTC-69ca89c4.6f8-LOG:  disconnection: session time: 0:00:20.027
-        user=azuresu database=postgres host=127.0.0.1 port=48464
-
-        2026-03-30 14:34:00 UTC-69ca89d8.709-LOG:  connection received: host=127.0.0.1
-        port=55052
-
-        2026-03-30 14:34:00 UTC-69ca89d8.709-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:34:00 UTC-69ca89d8.709-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:34:00 UTC-69ca89d8.709-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:34:05 UTC-69ca89c9.6fa-LOG:  disconnection: session time: 0:00:20.030
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=58190
-
-        2026-03-30 14:34:07 UTC-69ca89df.70b-LOG:  connection received: host=127.0.0.1
-        port=35722
-
-        2026-03-30 14:34:07 UTC-69ca89df.70c-LOG:  connection received: host=127.0.0.1
-        port=35728
-
-        2026-03-30 14:34:07 UTC-69ca89df.70b-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:34:07 UTC-69ca89df.70b-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:34:07 UTC-69ca89df.70b-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:34:07 UTC-69ca89df.70c-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:34:07 UTC-69ca89df.70c-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:34:07 UTC-69ca89df.70c-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:34:08 UTC-69ca89e0.70d-LOG:  connection received: host=127.0.0.1
-        port=35732
-
-        2026-03-30 14:34:08 UTC-69ca89e0.70d-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:34:08 UTC-69ca89e0.70d-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:34:08 UTC-69ca89e0.70d-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:34:20 UTC-69ca89e0.70d-LOG:  disconnection: session time: 0:00:12.052
-        user=azuresu database=postgres host=127.0.0.1 port=35732
-
-        2026-03-30 14:34:20 UTC-69ca89d8.709-LOG:  disconnection: session time: 0:00:20.024
-        user=azuresu database=postgres host=127.0.0.1 port=55052
-
-        2026-03-30 14:34:20 UTC-69ca89ec.712-LOG:  connection received: host=127.0.0.1
-        port=35656
-
-        2026-03-30 14:34:20 UTC-69ca89ec.712-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:34:20 UTC-69ca89ec.712-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:34:20 UTC-69ca89ec.712-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:34:22 UTC-69ca89ee.71c-LOG:  connection received: host=127.0.0.1
-        port=35660
-
-        2026-03-30 14:34:22 UTC-69ca89ee.71c-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:34:22 UTC-69ca89ee.71c-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:34:22 UTC-69ca89ee.71c-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:34:22 UTC-69ca89ee.71c-LOG:  disconnection: session time: 0:00:00.046
-        user=azuresu database=postgres host=127.0.0.1 port=35660
-
-        2026-03-30 14:34:27 UTC-69ca89df.70b-LOG:  disconnection: session time: 0:00:20.027
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=35722
-
-        2026-03-30 14:34:27 UTC-69ca89df.70c-LOG:  disconnection: session time: 0:00:20.030
-        user=azuresu database=azure_sys host=127.0.0.1 port=35728
-
-        2026-03-30 14:34:29 UTC-69ca89f5.71f-LOG:  connection received: host=127.0.0.1
-        port=39428
-
-        2026-03-30 14:34:29 UTC-69ca89f5.71f-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:34:29 UTC-69ca89f5.71f-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:34:29 UTC-69ca89f5.71f-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:34:38 UTC-69ca89fe.722-LOG:  connection received: host=127.0.0.1
-        port=39476
-
-        2026-03-30 14:34:38 UTC-69ca89fe.722-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:34:38 UTC-69ca89fe.722-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:34:38 UTC-69ca89fe.722-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:34:40 UTC-69ca89ec.712-LOG:  disconnection: session time: 0:00:20.027
-        user=azuresu database=postgres host=127.0.0.1 port=35656
-
-        2026-03-30 14:34:40 UTC-69ca8a00.724-LOG:  connection received: host=127.0.0.1
-        port=39486
-
-        2026-03-30 14:34:40 UTC-69ca8a00.724-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:34:40 UTC-69ca8a00.724-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:34:40 UTC-69ca8a00.724-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:34:47 UTC-69ca8a07.72f-LOG:  connection received: host=127.0.0.1
-        port=42134
-
-        2026-03-30 14:34:47 UTC-69ca8a07.72f-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:34:47 UTC-69ca8a07.72f-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:34:47 UTC-69ca8a07.72f-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:34:47 UTC-69ca8a07.72f-LOG:  disconnection: session time: 0:00:00.046
-        user=azuresu database=postgres host=127.0.0.1 port=42134
-
-        2026-03-30 14:34:49 UTC-69ca89f5.71f-LOG:  disconnection: session time: 0:00:20.025
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=39428
-
-        2026-03-30 14:34:49 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
-        0/502FDB8, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
-
-        2026-03-30 14:34:51 UTC-69ca8a0b.731-LOG:  connection received: host=127.0.0.1
-        port=42136
-
-        2026-03-30 14:34:51 UTC-69ca8a0b.731-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:34:51 UTC-69ca8a0b.731-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:34:51 UTC-69ca8a0b.731-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:34:58 UTC-69ca89fe.722-LOG:  disconnection: session time: 0:00:20.023
-        user=azuresu database=azure_sys host=127.0.0.1 port=39476
-
-        2026-03-30 14:35:00 UTC-69ca8a00.724-LOG:  disconnection: session time: 0:00:20.024
-        user=azuresu database=postgres host=127.0.0.1 port=39486
-
-        2026-03-30 14:35:00 UTC-69ca8a14.735-LOG:  connection received: host=127.0.0.1
-        port=45000
-
-        2026-03-30 14:35:00 UTC-69ca8a14.735-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:35:00 UTC-69ca8a14.735-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:35:00 UTC-69ca8a14.735-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:35:09 UTC-69ca8a1d.738-LOG:  connection received: host=127.0.0.1
-        port=36916
-
-        2026-03-30 14:35:09 UTC-69ca8a1d.738-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:35:09 UTC-69ca8a1d.738-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:35:09 UTC-69ca8a1d.738-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:35:11 UTC-69ca8a0b.731-LOG:  disconnection: session time: 0:00:20.027
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=42136
-
-        2026-03-30 14:35:12 UTC-69ca8a20.742-LOG:  connection received: host=127.0.0.1
-        port=36930
-
-        2026-03-30 14:35:12 UTC-69ca8a20.742-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:35:12 UTC-69ca8a20.742-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:35:12 UTC-69ca8a20.742-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:35:12 UTC-69ca8a20.742-LOG:  disconnection: session time: 0:00:00.047
-        user=azuresu database=postgres host=127.0.0.1 port=36930
-
-        2026-03-30 14:35:13 UTC-69ca8a21.743-LOG:  connection received: host=127.0.0.1
-        port=36946
-
-        2026-03-30 14:35:13 UTC-69ca8a21.743-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:35:13 UTC-69ca8a21.743-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:35:13 UTC-69ca8a21.743-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:35:20 UTC-69ca8a14.735-LOG:  disconnection: session time: 0:00:20.022
-        user=azuresu database=postgres host=127.0.0.1 port=45000
-
-        2026-03-30 14:35:20 UTC-69ca8a28.747-LOG:  connection received: host=127.0.0.1
-        port=50564
-
-        2026-03-30 14:35:20 UTC-69ca8a28.747-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:35:20 UTC-69ca8a28.747-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:35:20 UTC-69ca8a28.747-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:35:29 UTC-69ca8a1d.738-LOG:  disconnection: session time: 0:00:20.025
-        user=azuresu database=azure_sys host=127.0.0.1 port=36916
-
-        2026-03-30 14:35:33 UTC-69ca8a21.743-LOG:  disconnection: session time: 0:00:20.024
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=36946
-
-        2026-03-30 14:35:35 UTC-69ca8a37.74c-LOG:  connection received: host=127.0.0.1
-        port=38640
-
-        2026-03-30 14:35:35 UTC-69ca8a37.74c-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:35:35 UTC-69ca8a37.74c-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:35:35 UTC-69ca8a37.74c-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:35:37 UTC-69ca8a39.756-LOG:  connection received: host=127.0.0.1
-        port=38642
-
-        2026-03-30 14:35:37 UTC-69ca8a39.756-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:35:37 UTC-69ca8a39.756-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:35:37 UTC-69ca8a39.756-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:35:37 UTC-69ca8a39.756-LOG:  disconnection: session time: 0:00:00.046
-        user=azuresu database=postgres host=127.0.0.1 port=38642
-
-        2026-03-30 14:35:40 UTC-69ca8a3c.758-LOG:  connection received: host=127.0.0.1
-        port=38650
-
-        2026-03-30 14:35:40 UTC-69ca8a3c.758-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:35:40 UTC-69ca8a3c.758-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:35:40 UTC-69ca8a3c.758-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:35:40 UTC-69ca8a28.747-LOG:  disconnection: session time: 0:00:20.023
-        user=azuresu database=postgres host=127.0.0.1 port=50564
-
-        2026-03-30 14:35:40 UTC-69ca8a3c.759-LOG:  connection received: host=127.0.0.1
-        port=38664
-
-        2026-03-30 14:35:40 UTC-69ca8a3c.759-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:35:40 UTC-69ca8a3c.759-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:35:40 UTC-69ca8a3c.759-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:35:49 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
-        0/5030470, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
-
-        2026-03-30 14:35:55 UTC-69ca8a37.74c-LOG:  disconnection: session time: 0:00:20.026
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=38640
-
-        2026-03-30 14:35:57 UTC-69ca8a4d.75e-LOG:  connection received: host=127.0.0.1
-        port=37128
-
-        2026-03-30 14:35:57 UTC-69ca8a4d.75e-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:35:57 UTC-69ca8a4d.75e-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:35:57 UTC-69ca8a4d.75e-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:36:00 UTC-69ca8a3c.758-LOG:  disconnection: session time: 0:00:20.026
-        user=azuresu database=azure_sys host=127.0.0.1 port=38650
-
-        2026-03-30 14:36:00 UTC-69ca8a3c.759-LOG:  disconnection: session time: 0:00:20.026
-        user=azuresu database=postgres host=127.0.0.1 port=38664
-
-        2026-03-30 14:36:00 UTC-69ca8a50.760-LOG:  connection received: host=127.0.0.1
-        port=37138
-
-        2026-03-30 14:36:00 UTC-69ca8a50.760-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:36:00 UTC-69ca8a50.760-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:36:00 UTC-69ca8a50.760-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:36:02 UTC-69ca8a52.76a-LOG:  connection received: host=127.0.0.1
-        port=37146
-
-        2026-03-30 14:36:02 UTC-69ca8a52.76a-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:36:02 UTC-69ca8a52.76a-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:36:02 UTC-69ca8a52.76a-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:36:02 UTC-69ca8a52.76a-LOG:  disconnection: session time: 0:00:00.046
-        user=azuresu database=postgres host=127.0.0.1 port=37146
-
-        2026-03-30 14:36:11 UTC-69ca8a5b.788-LOG:  connection received: host=127.0.0.1
-        port=35126
-
-        2026-03-30 14:36:11 UTC-69ca8a5b.788-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:36:11 UTC-69ca8a5b.788-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:36:11 UTC-69ca8a5b.788-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:36:17 UTC-69ca8a4d.75e-LOG:  disconnection: session time: 0:00:20.033
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=37128
-
-        2026-03-30 14:36:19 UTC-69ca8a63.78f-LOG:  connection received: host=127.0.0.1
-        port=52336
-
-        2026-03-30 14:36:19 UTC-69ca8a63.78f-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:36:19 UTC-69ca8a63.78f-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:36:19 UTC-69ca8a63.78f-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:36:20 UTC-69ca8a50.760-LOG:  disconnection: session time: 0:00:20.021
-        user=azuresu database=postgres host=127.0.0.1 port=37138
-
-        2026-03-30 14:36:21 UTC-69ca8a65.790-LOG:  connection received: host=127.0.0.1
-        port=52352
-
-        2026-03-30 14:36:21 UTC-69ca8a65.790-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:36:21 UTC-69ca8a65.790-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:36:21 UTC-69ca8a65.790-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:36:28 UTC-69ca8a6c.79b-LOG:  connection received: host=127.0.0.1
-        port=38176
-
-        2026-03-30 14:36:28 UTC-69ca8a6c.79b-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:36:28 UTC-69ca8a6c.79b-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:36:28 UTC-69ca8a6c.79b-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:36:28 UTC-69ca8a6c.79b-LOG:  disconnection: session time: 0:00:00.047
-        user=azuresu database=postgres host=127.0.0.1 port=38176
-
-        2026-03-30 14:36:31 UTC-69ca8a5b.788-LOG:  disconnection: session time: 0:00:20.025
-        user=azuresu database=azure_sys host=127.0.0.1 port=35126
-
-        2026-03-30 14:36:35 UTC-69ca8a73.79f-LOG:  connection received: host=127.0.0.1
-        port=36346
-
-        2026-03-30 14:36:35 UTC-69ca8a73.79f-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:36:35 UTC-69ca8a73.79f-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:36:35 UTC-69ca8a73.79f-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:36:39 UTC-69ca8a77.7a1-LOG:  connection received: host=127.0.0.1
-        port=36356
-
-        2026-03-30 14:36:39 UTC-69ca8a63.78f-LOG:  disconnection: session time: 0:00:20.026
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=52336
-
-        2026-03-30 14:36:39 UTC-69ca8a77.7a1-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:36:39 UTC-69ca8a77.7a1-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:36:39 UTC-69ca8a77.7a1-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:36:41 UTC-69ca8a65.790-LOG:  disconnection: session time: 0:00:20.028
-        user=azuresu database=postgres host=127.0.0.1 port=52352
-
-        2026-03-30 14:36:41 UTC-69ca8a79.7a2-LOG:  connection received: host=127.0.0.1
-        port=36362
-
-        2026-03-30 14:36:41 UTC-69ca8a79.7a2-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:36:41 UTC-69ca8a79.7a2-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:36:41 UTC-69ca8a79.7a2-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:36:42 UTC-69ca8a7a.7a3-LOG:  connection received: host=127.0.0.1
-        port=36376
-
-        2026-03-30 14:36:42 UTC-69ca8a7a.7a3-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:36:42 UTC-69ca8a7a.7a3-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:36:42 UTC-69ca8a7a.7a3-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:36:50 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
-        0/6000600, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
-
-        2026-03-30 14:36:53 UTC-69ca8a85.7af-LOG:  connection received: host=127.0.0.1
-        port=44106
-
-        2026-03-30 14:36:53 UTC-69ca8a85.7af-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:36:53 UTC-69ca8a85.7af-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:36:53 UTC-69ca8a85.7af-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:36:53 UTC-69ca8a85.7af-LOG:  disconnection: session time: 0:00:00.050
-        user=azuresu database=postgres host=127.0.0.1 port=44106
-
-        2026-03-30 14:36:55 UTC-69ca8a73.79f-LOG:  disconnection: session time: 0:00:20.028
-        user=azuresu database=azure_sys host=127.0.0.1 port=36346
-
-        2026-03-30 14:37:01 UTC-69ca8a77.7a1-LOG:  disconnection: session time: 0:00:21.904
-        user=azuresu database=postgres host=127.0.0.1 port=36356
-
-        2026-03-30 14:37:01 UTC-69ca8a79.7a2-LOG:  disconnection: session time: 0:00:20.024
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=36362
-
-        2026-03-30 14:37:01 UTC-69ca8a8d.7b3-LOG:  connection received: host=127.0.0.1
-        port=49392
-
-        2026-03-30 14:37:01 UTC-69ca8a8d.7b3-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:37:01 UTC-69ca8a8d.7b3-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:37:01 UTC-69ca8a8d.7b3-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:37:02 UTC-69ca8a7a.7a3-LOG:  disconnection: session time: 0:00:20.024
-        user=azuresu database=azure_sys host=127.0.0.1 port=36376
-
-        2026-03-30 14:37:03 UTC-69ca8a8f.7b4-LOG:  connection received: host=127.0.0.1
-        port=49404
-
-        2026-03-30 14:37:03 UTC-69ca8a8f.7b4-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:37:03 UTC-69ca8a8f.7b4-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:37:03 UTC-69ca8a8f.7b4-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:37:13 UTC-69ca8a99.7b7-LOG:  connection received: host=127.0.0.1
-        port=39602
-
-        2026-03-30 14:37:13 UTC-69ca8a99.7b7-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:37:13 UTC-69ca8a99.7b7-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:37:13 UTC-69ca8a99.7b7-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:37:18 UTC-69ca8a9e.7c4-LOG:  connection received: host=127.0.0.1
-        port=39248
-
-        2026-03-30 14:37:18 UTC-69ca8a9e.7c4-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:37:18 UTC-69ca8a9e.7c4-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:37:18 UTC-69ca8a9e.7c4-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:37:18 UTC-69ca8a9e.7c4-LOG:  disconnection: session time: 0:00:00.046
-        user=azuresu database=postgres host=127.0.0.1 port=39248
-
-        2026-03-30 14:37:21 UTC-69ca8a8d.7b3-LOG:  disconnection: session time: 0:00:20.035
-        user=azuresu database=postgres host=127.0.0.1 port=49392
-
-        2026-03-30 14:37:21 UTC-69ca8aa1.7c5-LOG:  connection received: host=127.0.0.1
-        port=39252
-
-        2026-03-30 14:37:21 UTC-69ca8aa1.7c5-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:37:21 UTC-69ca8aa1.7c5-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:37:21 UTC-69ca8aa1.7c5-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:37:23 UTC-69ca8a8f.7b4-LOG:  disconnection: session time: 0:00:20.024
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=49404
-
-        2026-03-30 14:37:25 UTC-69ca8aa5.7c7-LOG:  connection received: host=127.0.0.1
-        port=44814
-
-        2026-03-30 14:37:25 UTC-69ca8aa5.7c7-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:37:25 UTC-69ca8aa5.7c7-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:37:25 UTC-69ca8aa5.7c7-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:37:33 UTC-69ca8a99.7b7-LOG:  disconnection: session time: 0:00:20.130
-        user=azuresu database=azure_sys host=127.0.0.1 port=39602
-
-        2026-03-30 14:37:39 UTC-69ca8ab3.7cc-LOG:  connection received: host=127.0.0.1
-        port=46614
-
-        2026-03-30 14:37:39 UTC-69ca8ab3.7cc-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:37:39 UTC-69ca8ab3.7cc-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:37:39 UTC-69ca8ab3.7cc-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:37:41 UTC-69ca8aa1.7c5-LOG:  disconnection: session time: 0:00:20.023
-        user=azuresu database=postgres host=127.0.0.1 port=39252
-
-        2026-03-30 14:37:43 UTC-69ca8ab7.7d7-LOG:  connection received: host=127.0.0.1
-        port=46626
-
-        2026-03-30 14:37:43 UTC-69ca8ab7.7d7-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:37:43 UTC-69ca8ab7.7d7-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:37:43 UTC-69ca8ab7.7d7-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:37:43 UTC-69ca8ab7.7d7-LOG:  disconnection: session time: 0:00:00.046
-        user=azuresu database=postgres host=127.0.0.1 port=46626
-
-        2026-03-30 14:37:44 UTC-69ca8ab8.7d8-LOG:  connection received: host=127.0.0.1
-        port=46634
-
-        2026-03-30 14:37:44 UTC-69ca8ab8.7d8-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:37:44 UTC-69ca8ab8.7d8-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:37:44 UTC-69ca8ab8.7d8-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:37:45 UTC-69ca8aa5.7c7-LOG:  disconnection: session time: 0:00:20.025
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=44814
-
-        2026-03-30 14:37:47 UTC-69ca8abb.7d9-LOG:  connection received: host=127.0.0.1
-        port=54946
-
-        2026-03-30 14:37:47 UTC-69ca8abb.7d9-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:37:47 UTC-69ca8abb.7d9-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:37:47 UTC-69ca8abb.7d9-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:37:50 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
-        0/6000CA0, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
-
-        2026-03-30 14:38:01 UTC-69ca8ab3.7cc-LOG:  disconnection: session time: 0:00:22.238
-        user=azuresu database=postgres host=127.0.0.1 port=46614
-
-        2026-03-30 14:38:01 UTC-69ca8ac9.7de-LOG:  connection received: host=127.0.0.1
-        port=34026
-
-        2026-03-30 14:38:01 UTC-69ca8ac9.7de-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:38:01 UTC-69ca8ac9.7de-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:38:01 UTC-69ca8ac9.7de-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:38:04 UTC-69ca8ab8.7d8-LOG:  disconnection: session time: 0:00:20.026
-        user=azuresu database=azure_sys host=127.0.0.1 port=46634
-
-        2026-03-30 14:38:07 UTC-69ca8abb.7d9-LOG:  disconnection: session time: 0:00:20.025
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=54946
-
-        2026-03-30 14:38:08 UTC-69ca8ad0.7ea-LOG:  connection received: host=127.0.0.1
-        port=36640
-
-        2026-03-30 14:38:08 UTC-69ca8ad0.7ea-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:38:08 UTC-69ca8ad0.7ea-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:38:08 UTC-69ca8ad0.7ea-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:38:08 UTC-69ca8ad0.7ea-LOG:  disconnection: session time: 0:00:00.047
-        user=azuresu database=postgres host=127.0.0.1 port=36640
-
-        2026-03-30 14:38:09 UTC-69ca8ad1.7eb-LOG:  connection received: host=127.0.0.1
-        port=36652
-
-        2026-03-30 14:38:09 UTC-69ca8ad1.7eb-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:38:09 UTC-69ca8ad1.7eb-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:38:09 UTC-69ca8ad1.7eb-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:38:15 UTC-69ca8ad7.7ee-LOG:  connection received: host=127.0.0.1
-        port=53394
-
-        2026-03-30 14:38:15 UTC-69ca8ad7.7ee-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:38:15 UTC-69ca8ad7.7ee-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:38:15 UTC-69ca8ad7.7ee-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:38:21 UTC-69ca8ac9.7de-LOG:  disconnection: session time: 0:00:20.033
-        user=azuresu database=postgres host=127.0.0.1 port=34026
-
-        2026-03-30 14:38:21 UTC-69ca8add.7f0-LOG:  connection received: host=127.0.0.1
-        port=53398
-
-        2026-03-30 14:38:21 UTC-69ca8add.7f0-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:38:21 UTC-69ca8add.7f0-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:38:21 UTC-69ca8add.7f0-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:38:29 UTC-69ca8ad1.7eb-LOG:  disconnection: session time: 0:00:20.025
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=36652
-
-        2026-03-30 14:38:31 UTC-69ca8ae7.7f3-LOG:  connection received: host=127.0.0.1
-        port=34180
-
-        2026-03-30 14:38:31 UTC-69ca8ae7.7f3-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:38:31 UTC-69ca8ae7.7f3-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:38:31 UTC-69ca8ae7.7f3-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:38:33 UTC-69ca8ae9.7fe-LOG:  connection received: host=127.0.0.1
-        port=34190
-
-        2026-03-30 14:38:33 UTC-69ca8ae9.7fe-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:38:33 UTC-69ca8ae9.7fe-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:38:33 UTC-69ca8ae9.7fe-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:38:33 UTC-69ca8ae9.7fe-LOG:  disconnection: session time: 0:00:00.046
-        user=azuresu database=postgres host=127.0.0.1 port=34190
-
-        2026-03-30 14:38:35 UTC-69ca8ad7.7ee-LOG:  disconnection: session time: 0:00:20.022
-        user=azuresu database=azure_sys host=127.0.0.1 port=53394
-
-        2026-03-30 14:38:41 UTC-69ca8add.7f0-LOG:  disconnection: session time: 0:00:20.027
-        user=azuresu database=postgres host=127.0.0.1 port=53398
-
-        2026-03-30 14:38:42 UTC-69ca8af2.801-LOG:  connection received: host=127.0.0.1
-        port=59018
-
-        2026-03-30 14:38:42 UTC-69ca8af2.801-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:38:42 UTC-69ca8af2.801-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:38:42 UTC-69ca8af2.801-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:38:46 UTC-69ca8af6.803-LOG:  connection received: host=127.0.0.1
-        port=51010
-
-        2026-03-30 14:38:46 UTC-69ca8af6.803-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:38:46 UTC-69ca8af6.803-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:38:46 UTC-69ca8af6.803-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:38:50 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
-        0/6002960, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
-
-        2026-03-30 14:38:51 UTC-69ca8ae7.7f3-LOG:  disconnection: session time: 0:00:20.023
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=34180
-
-        2026-03-30 14:38:53 UTC-69ca8afd.805-LOG:  connection received: host=127.0.0.1
-        port=51024
-
-        2026-03-30 14:38:53 UTC-69ca8afd.805-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:38:53 UTC-69ca8afd.805-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:38:53 UTC-69ca8afd.805-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:38:58 UTC-69ca8b02.812-LOG:  connection received: host=127.0.0.1
-        port=47968
-
-        2026-03-30 14:38:58 UTC-69ca8b02.812-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:38:58 UTC-69ca8b02.812-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:38:58 UTC-69ca8b02.812-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:38:58 UTC-69ca8b02.812-LOG:  disconnection: session time: 0:00:00.047
-        user=azuresu database=postgres host=127.0.0.1 port=47968
-
-        2026-03-30 14:39:02 UTC-69ca8af2.801-LOG:  disconnection: session time: 0:00:20.025
-        user=azuresu database=postgres host=127.0.0.1 port=59018
-
-        2026-03-30 14:39:03 UTC-69ca8b07.813-LOG:  connection received: host=127.0.0.1
-        port=47980
-
-        2026-03-30 14:39:03 UTC-69ca8b07.813-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:39:03 UTC-69ca8b07.813-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:39:03 UTC-69ca8b07.813-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:39:06 UTC-69ca8af6.803-LOG:  disconnection: session time: 0:00:20.024
-        user=azuresu database=azure_sys host=127.0.0.1 port=51010
-
-        2026-03-30 14:39:13 UTC-69ca8afd.805-LOG:  disconnection: session time: 0:00:20.031
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=51024
-
-        2026-03-30 14:39:15 UTC-69ca8b13.818-LOG:  connection received: host=127.0.0.1
-        port=53640
-
-        2026-03-30 14:39:15 UTC-69ca8b13.818-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:39:15 UTC-69ca8b13.818-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:39:15 UTC-69ca8b13.818-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:39:17 UTC-69ca8b15.819-LOG:  connection received: host=127.0.0.1
-        port=53650
-
-        2026-03-30 14:39:17 UTC-69ca8b15.819-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:39:17 UTC-69ca8b15.819-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:39:17 UTC-69ca8b15.819-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:39:23 UTC-69ca8b07.813-LOG:  disconnection: session time: 0:00:20.027
-        user=azuresu database=postgres host=127.0.0.1 port=47980
-
-        2026-03-30 14:39:23 UTC-69ca8b1b.825-LOG:  connection received: host=127.0.0.1
-        port=53652
-
-        2026-03-30 14:39:23 UTC-69ca8b1b.825-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:39:23 UTC-69ca8b1b.825-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:39:23 UTC-69ca8b1b.825-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:39:23 UTC-69ca8b1b.825-LOG:  disconnection: session time: 0:00:00.046
-        user=azuresu database=postgres host=127.0.0.1 port=53652
-
-        2026-03-30 14:39:24 UTC-69ca8b1c.826-LOG:  connection received: host=127.0.0.1
-        port=53662
-
-        2026-03-30 14:39:24 UTC-69ca8b1c.826-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:39:24 UTC-69ca8b1c.826-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:39:24 UTC-69ca8b1c.826-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:39:35 UTC-69ca8b13.818-LOG:  disconnection: session time: 0:00:20.023
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=53640
-
-        2026-03-30 14:39:37 UTC-69ca8b29.82a-LOG:  connection received: host=127.0.0.1
-        port=46658
-
-        2026-03-30 14:39:37 UTC-69ca8b15.819-LOG:  disconnection: session time: 0:00:20.023
-        user=azuresu database=azure_sys host=127.0.0.1 port=53650
-
-        2026-03-30 14:39:37 UTC-69ca8b29.82a-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:39:37 UTC-69ca8b29.82a-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:39:37 UTC-69ca8b29.82a-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:39:44 UTC-69ca8b1c.826-LOG:  disconnection: session time: 0:00:20.025
-        user=azuresu database=postgres host=127.0.0.1 port=53662
-
-        2026-03-30 14:39:45 UTC-69ca8b31.82d-LOG:  connection received: host=127.0.0.1
-        port=36918
-
-        2026-03-30 14:39:45 UTC-69ca8b31.82d-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:39:45 UTC-69ca8b31.82d-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:39:45 UTC-69ca8b31.82d-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:39:48 UTC-69ca8b34.82e-LOG:  connection received: host=127.0.0.1
-        port=36932
-
-        2026-03-30 14:39:48 UTC-69ca8b34.82e-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:39:48 UTC-69ca8b34.82e-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:39:48 UTC-69ca8b34.82e-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:39:48 UTC-69ca8b34.839-LOG:  connection received: host=127.0.0.1
-        port=36936
-
-        2026-03-30 14:39:48 UTC-69ca8b34.839-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:39:48 UTC-69ca8b34.839-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:39:48 UTC-69ca8b34.839-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:39:48 UTC-69ca8b34.839-LOG:  disconnection: session time: 0:00:00.047
-        user=azuresu database=postgres host=127.0.0.1 port=36936
-
-        2026-03-30 14:39:50 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
-        0/6003000, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
-
-        2026-03-30 14:39:57 UTC-69ca8b29.82a-LOG:  disconnection: session time: 0:00:20.025
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=46658
-
-        2026-03-30 14:39:59 UTC-69ca8b3f.83d-LOG:  connection received: host=127.0.0.1
-        port=52944
-
-        2026-03-30 14:39:59 UTC-69ca8b3f.83d-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:39:59 UTC-69ca8b3f.83d-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:39:59 UTC-69ca8b3f.83d-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:40:03 UTC-69ca85d0.2f7-LOG:  checkpoint starting: time
-
-        2026-03-30 14:40:05 UTC-69ca8b31.82d-LOG:  disconnection: session time: 0:00:20.022
-        user=azuresu database=postgres host=127.0.0.1 port=36918
-
-        2026-03-30 14:40:06 UTC-69ca8b46.846-LOG:  connection received: host=127.0.0.1
-        port=58694
-
-        2026-03-30 14:40:06 UTC-69ca8b46.846-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:40:06 UTC-69ca8b46.846-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:40:06 UTC-69ca8b46.846-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:40:08 UTC-69ca8b34.82e-LOG:  disconnection: session time: 0:00:20.027
-        user=azuresu database=azure_sys host=127.0.0.1 port=36932
-
-        2026-03-30 14:40:12 UTC-69ca85d0.2f7-LOG:  checkpoint complete: wrote 88 buffers
-        (0.0%); 0 WAL file(s) added, 0 removed, 0 recycled; write=8.747 s, sync=0.003
-        s, total=8.779 s; sync files=49, longest=0.003 s, average=0.001 s; distance=32773
-        kB, estimate=32774 kB; lsn=0/60034C8, redo lsn=0/60031A8
-
-        2026-03-30 14:40:14 UTC-69ca8b4e.852-LOG:  connection received: host=127.0.0.1
-        port=58696
-
-        2026-03-30 14:40:14 UTC-69ca8b4e.852-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:40:14 UTC-69ca8b4e.852-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:40:14 UTC-69ca8b4e.852-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:40:14 UTC-69ca8b4e.852-LOG:  disconnection: session time: 0:00:00.047
-        user=azuresu database=postgres host=127.0.0.1 port=58696
-
-        2026-03-30 14:40:19 UTC-69ca8b53.855-LOG:  connection received: host=127.0.0.1
-        port=42404
-
-        2026-03-30 14:40:19 UTC-69ca8b3f.83d-LOG:  disconnection: session time: 0:00:20.022
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=52944
-
-        2026-03-30 14:40:19 UTC-69ca8b53.855-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:40:19 UTC-69ca8b53.855-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:40:19 UTC-69ca8b53.855-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:40:21 UTC-69ca8b55.856-LOG:  connection received: host=127.0.0.1
-        port=42418
-
-        2026-03-30 14:40:21 UTC-69ca8b55.856-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:40:21 UTC-69ca8b55.856-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:40:21 UTC-69ca8b55.856-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:40:26 UTC-69ca8b46.846-LOG:  disconnection: session time: 0:00:20.029
-        user=azuresu database=postgres host=127.0.0.1 port=58694
-
-        2026-03-30 14:40:28 UTC-69ca8b5c.858-LOG:  connection received: host=127.0.0.1
-        port=32916
-
-        2026-03-30 14:40:28 UTC-69ca8b5c.858-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:40:28 UTC-69ca8b5c.858-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:40:28 UTC-69ca8b5c.858-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:40:39 UTC-69ca8b67.866-LOG:  connection received: host=127.0.0.1
-        port=52136
-
-        2026-03-30 14:40:39 UTC-69ca8b67.866-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:40:39 UTC-69ca8b67.866-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:40:39 UTC-69ca8b67.866-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:40:39 UTC-69ca8b67.866-LOG:  disconnection: session time: 0:00:00.046
-        user=azuresu database=postgres host=127.0.0.1 port=52136
-
-        2026-03-30 14:40:39 UTC-69ca8b53.855-LOG:  disconnection: session time: 0:00:20.026
-        user=azuresu database=azure_sys host=127.0.0.1 port=42404
-
-        2026-03-30 14:40:41 UTC-69ca8b55.856-LOG:  disconnection: session time: 0:00:20.025
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=42418
-
-        2026-03-30 14:40:43 UTC-69ca8b6b.867-LOG:  connection received: host=127.0.0.1
-        port=52142
-
-        2026-03-30 14:40:43 UTC-69ca8b6b.867-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:40:43 UTC-69ca8b6b.867-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:40:43 UTC-69ca8b6b.867-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:40:48 UTC-69ca8b5c.858-LOG:  disconnection: session time: 0:00:20.023
-        user=azuresu database=postgres host=127.0.0.1 port=32916
-
-        2026-03-30 14:40:50 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
-        0/6003980, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
-
-        2026-03-30 14:40:50 UTC-69ca8b72.86a-LOG:  connection received: host=127.0.0.1
-        port=40852
-
-        2026-03-30 14:40:50 UTC-69ca8b72.86b-LOG:  connection received: host=127.0.0.1
-        port=40858
-
-        2026-03-30 14:40:50 UTC-69ca8b72.86a-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:40:50 UTC-69ca8b72.86a-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:40:50 UTC-69ca8b72.86a-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:40:50 UTC-69ca8b72.86b-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:40:50 UTC-69ca8b72.86b-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:40:50 UTC-69ca8b72.86b-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:41:03 UTC-69ca8b6b.867-LOG:  disconnection: session time: 0:00:20.022
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=52142
-
-        2026-03-30 14:41:04 UTC-69ca8b80.879-LOG:  connection received: host=127.0.0.1
-        port=48234
-
-        2026-03-30 14:41:04 UTC-69ca8b80.879-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:41:04 UTC-69ca8b80.879-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:41:04 UTC-69ca8b80.879-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:41:04 UTC-69ca8b80.879-LOG:  disconnection: session time: 0:00:00.047
-        user=azuresu database=postgres host=127.0.0.1 port=48234
-
-        2026-03-30 14:41:05 UTC-69ca8b81.88f-LOG:  connection received: host=127.0.0.1
-        port=55844
-
-        2026-03-30 14:41:05 UTC-69ca8b81.88f-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:41:05 UTC-69ca8b81.88f-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:41:05 UTC-69ca8b81.88f-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:41:10 UTC-69ca8b72.86a-LOG:  disconnection: session time: 0:00:20.025
-        user=azuresu database=azure_sys host=127.0.0.1 port=40852
-
-        2026-03-30 14:41:10 UTC-69ca8b72.86b-LOG:  disconnection: session time: 0:00:20.029
-        user=azuresu database=postgres host=127.0.0.1 port=40858
-
-        2026-03-30 14:41:11 UTC-69ca8b87.891-LOG:  connection received: host=127.0.0.1
-        port=55852
-
-        2026-03-30 14:41:11 UTC-69ca8b87.891-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:41:11 UTC-69ca8b87.891-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:41:11 UTC-69ca8b87.891-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:41:21 UTC-69ca8b91.895-LOG:  connection received: host=127.0.0.1
-        port=45320
-
-        2026-03-30 14:41:21 UTC-69ca8b91.895-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:41:21 UTC-69ca8b91.895-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:41:21 UTC-69ca8b91.895-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:41:25 UTC-69ca8b81.88f-LOG:  disconnection: session time: 0:00:20.181
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=55844
-
-        2026-03-30 14:41:27 UTC-69ca8b97.897-LOG:  connection received: host=127.0.0.1
-        port=35850
-
-        2026-03-30 14:41:27 UTC-69ca8b97.897-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:41:27 UTC-69ca8b97.897-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:41:27 UTC-69ca8b97.897-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:41:29 UTC-69ca8b99.8a2-LOG:  connection received: host=127.0.0.1
-        port=35860
-
-        2026-03-30 14:41:29 UTC-69ca8b99.8a2-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:41:29 UTC-69ca8b99.8a2-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:41:29 UTC-69ca8b99.8a2-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:41:29 UTC-69ca8b99.8a2-LOG:  disconnection: session time: 0:00:00.046
-        user=azuresu database=postgres host=127.0.0.1 port=35860
-
-        2026-03-30 14:41:31 UTC-69ca8b87.891-LOG:  disconnection: session time: 0:00:20.028
-        user=azuresu database=postgres host=127.0.0.1 port=55852
-
-        2026-03-30 14:41:32 UTC-69ca8b9c.8a3-LOG:  connection received: host=127.0.0.1
-        port=35864
-
-        2026-03-30 14:41:32 UTC-69ca8b9c.8a3-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:41:32 UTC-69ca8b9c.8a3-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:41:32 UTC-69ca8b9c.8a3-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:41:35 UTC-69ca8b9f.8a6-LOG:  connection received: host=127.0.0.1
-        port=53388
-
-        2026-03-30 14:41:35 UTC-69ca8b9f.8a6-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:41:35 UTC-69ca8b9f.8a6-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:41:35 UTC-69ca8b9f.8a6-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:41:39 UTC-69ca8ba3.8a8-LOG:  connection received: host=127.0.0.1
-        port=53400
-
-        2026-03-30 14:41:39 UTC-69ca8ba3.8a8-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:41:39 UTC-69ca8ba3.8a8-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:41:39 UTC-69ca8ba3.8a8-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:41:41 UTC-69ca8b91.895-LOG:  disconnection: session time: 0:00:20.026
-        user=azuresu database=azure_sys host=127.0.0.1 port=45320
-
-        2026-03-30 14:41:47 UTC-69ca8b97.897-LOG:  disconnection: session time: 0:00:20.025
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=35850
-
-        2026-03-30 14:41:49 UTC-69ca8bad.8ab-LOG:  connection received: host=127.0.0.1
-        port=33994
-
-        2026-03-30 14:41:49 UTC-69ca8bad.8ab-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:41:49 UTC-69ca8bad.8ab-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:41:49 UTC-69ca8bad.8ab-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:41:50 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
-        0/7000600, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
-
-        2026-03-30 14:41:52 UTC-69ca8bb0.8ac-LOG:  connection received: host=127.0.0.1
-        port=34006
-
-        2026-03-30 14:41:52 UTC-69ca8ba3.8a8-LOG:  disconnection: session time: 0:00:13.019
-        user=azuresu database=postgres host=127.0.0.1 port=53400
-
-        2026-03-30 14:41:52 UTC-69ca8b9c.8a3-LOG:  disconnection: session time: 0:00:20.023
-        user=azuresu database=postgres host=127.0.0.1 port=35864
-
-        2026-03-30 14:41:52 UTC-69ca8bb0.8ac-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:41:52 UTC-69ca8bb0.8ac-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:41:52 UTC-69ca8bb0.8ac-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:41:53 UTC-69ca8bb1.8ad-LOG:  connection received: host=127.0.0.1
-        port=34016
-
-        2026-03-30 14:41:53 UTC-69ca8bb1.8ad-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:41:53 UTC-69ca8bb1.8ad-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:41:53 UTC-69ca8bb1.8ad-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:41:54 UTC-69ca8bb2.8b9-LOG:  connection received: host=127.0.0.1
-        port=57350
-
-        2026-03-30 14:41:54 UTC-69ca8bb2.8b9-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:41:54 UTC-69ca8bb2.8b9-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:41:54 UTC-69ca8bb2.8b9-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:41:54 UTC-69ca8bb2.8b9-LOG:  disconnection: session time: 0:00:00.047
-        user=azuresu database=postgres host=127.0.0.1 port=57350
-
-        2026-03-30 14:41:55 UTC-69ca8b9f.8a6-LOG:  disconnection: session time: 0:00:20.025
-        user=azuresu database=azure_sys host=127.0.0.1 port=53388
-
-        2026-03-30 14:42:09 UTC-69ca8bad.8ab-LOG:  disconnection: session time: 0:00:20.025
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=33994
-
-        2026-03-30 14:42:11 UTC-69ca8bc3.8bd-LOG:  connection received: host=127.0.0.1
-        port=42630
-
-        2026-03-30 14:42:11 UTC-69ca8bc3.8bd-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:42:11 UTC-69ca8bc3.8bd-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:42:11 UTC-69ca8bc3.8bd-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:42:12 UTC-69ca8bb0.8ac-LOG:  disconnection: session time: 0:00:20.026
-        user=azuresu database=azure_sys host=127.0.0.1 port=34006
-
-        2026-03-30 14:42:13 UTC-69ca8bb1.8ad-LOG:  disconnection: session time: 0:00:20.023
-        user=azuresu database=postgres host=127.0.0.1 port=34016
-
-        2026-03-30 14:42:13 UTC-69ca8bc5.8be-LOG:  connection received: host=127.0.0.1
-        port=42646
-
-        2026-03-30 14:42:13 UTC-69ca8bc5.8be-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:42:13 UTC-69ca8bc5.8be-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:42:13 UTC-69ca8bc5.8be-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:42:19 UTC-69ca8bcb.8cb-LOG:  connection received: host=127.0.0.1
-        port=42306
-
-        2026-03-30 14:42:19 UTC-69ca8bcb.8cb-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:42:19 UTC-69ca8bcb.8cb-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:42:19 UTC-69ca8bcb.8cb-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:42:19 UTC-69ca8bcb.8cb-LOG:  disconnection: session time: 0:00:00.048
-        user=azuresu database=postgres host=127.0.0.1 port=42306
-
-        2026-03-30 14:42:23 UTC-69ca8bcf.8cc-LOG:  connection received: host=127.0.0.1
-        port=42308
-
-        2026-03-30 14:42:23 UTC-69ca8bcf.8cc-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:42:23 UTC-69ca8bcf.8cc-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:42:23 UTC-69ca8bcf.8cc-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:42:31 UTC-69ca8bc3.8bd-LOG:  disconnection: session time: 0:00:20.025
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=42630
-
-        2026-03-30 14:42:33 UTC-69ca8bc5.8be-LOG:  disconnection: session time: 0:00:20.026
-        user=azuresu database=postgres host=127.0.0.1 port=42646
-
-        2026-03-30 14:42:33 UTC-69ca8bd9.8cf-LOG:  connection received: host=127.0.0.1
-        port=35882
-
-        2026-03-30 14:42:33 UTC-69ca8bd9.8cf-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:42:33 UTC-69ca8bd9.8cf-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:42:33 UTC-69ca8bd9.8cf-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:42:33 UTC-69ca8bd9.8d0-LOG:  connection received: host=127.0.0.1
-        port=35894
-
-        2026-03-30 14:42:33 UTC-69ca8bd9.8d0-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:42:33 UTC-69ca8bd9.8d0-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:42:33 UTC-69ca8bd9.8d0-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:42:43 UTC-69ca8bcf.8cc-LOG:  disconnection: session time: 0:00:20.125
-        user=azuresu database=azure_sys host=127.0.0.1 port=42308
-
-        2026-03-30 14:42:44 UTC-69ca8be4.8de-LOG:  connection received: host=127.0.0.1
-        port=47488
-
-        2026-03-30 14:42:44 UTC-69ca8be4.8de-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:42:44 UTC-69ca8be4.8de-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:42:44 UTC-69ca8be4.8de-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:42:44 UTC-69ca8be4.8de-LOG:  disconnection: session time: 0:00:00.046
-        user=azuresu database=postgres host=127.0.0.1 port=47488
-
-        2026-03-30 14:42:50 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
-        0/7000C68, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
-
-        2026-03-30 14:42:53 UTC-69ca8bd9.8cf-LOG:  disconnection: session time: 0:00:20.023
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=35882
-
-        2026-03-30 14:42:53 UTC-69ca8bd9.8d0-LOG:  disconnection: session time: 0:00:20.023
-        user=azuresu database=postgres host=127.0.0.1 port=35894
-
-        2026-03-30 14:42:53 UTC-69ca8bed.8e1-LOG:  connection received: host=127.0.0.1
-        port=47496
-
-        2026-03-30 14:42:53 UTC-69ca8bed.8e1-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:42:53 UTC-69ca8bed.8e1-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:42:53 UTC-69ca8bed.8e1-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:42:54 UTC-69ca8bee.8e2-LOG:  connection received: host=127.0.0.1
-        port=47502
-
-        2026-03-30 14:42:54 UTC-69ca8bee.8e2-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:42:54 UTC-69ca8bee.8e2-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:42:54 UTC-69ca8bee.8e2-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:42:55 UTC-69ca8bef.8e4-LOG:  connection received: host=127.0.0.1
-        port=48062
-
-        2026-03-30 14:42:55 UTC-69ca8bef.8e4-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:42:55 UTC-69ca8bef.8e4-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:42:55 UTC-69ca8bef.8e4-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:43:09 UTC-69ca8bfd.8f1-LOG:  connection received: host=127.0.0.1
-        port=46370
-
-        2026-03-30 14:43:09 UTC-69ca8bfd.8f1-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:43:09 UTC-69ca8bfd.8f1-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:43:09 UTC-69ca8bfd.8f1-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:43:09 UTC-69ca8bfd.8f1-LOG:  disconnection: session time: 0:00:00.046
-        user=azuresu database=postgres host=127.0.0.1 port=46370
-
-        2026-03-30 14:43:13 UTC-69ca8bed.8e1-LOG:  disconnection: session time: 0:00:20.034
-        user=azuresu database=postgres host=127.0.0.1 port=47496
-
-        2026-03-30 14:43:13 UTC-69ca8c01.8f3-LOG:  connection received: host=127.0.0.1
-        port=46380
-
-        2026-03-30 14:43:13 UTC-69ca8c01.8f3-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:43:13 UTC-69ca8c01.8f3-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:43:13 UTC-69ca8c01.8f3-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:43:14 UTC-69ca8bee.8e2-LOG:  disconnection: session time: 0:00:20.026
-        user=azuresu database=azure_sys host=127.0.0.1 port=47502
-
-        2026-03-30 14:43:15 UTC-69ca8bef.8e4-LOG:  disconnection: session time: 0:00:20.028
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=48062
-
-        2026-03-30 14:43:17 UTC-69ca8c05.8f5-LOG:  connection received: host=127.0.0.1
-        port=57190
-
-        2026-03-30 14:43:17 UTC-69ca8c05.8f5-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:43:17 UTC-69ca8c05.8f5-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:43:17 UTC-69ca8c05.8f5-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:43:25 UTC-69ca8c0d.8f8-LOG:  connection received: host=127.0.0.1
-        port=34478
-
-        2026-03-30 14:43:25 UTC-69ca8c0d.8f8-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:43:25 UTC-69ca8c0d.8f8-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:43:25 UTC-69ca8c0d.8f8-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:43:33 UTC-69ca8c01.8f3-LOG:  disconnection: session time: 0:00:20.032
-        user=azuresu database=postgres host=127.0.0.1 port=46380
-
-        2026-03-30 14:43:33 UTC-69ca8c15.8fb-LOG:  connection received: host=127.0.0.1
-        port=34494
-
-        2026-03-30 14:43:33 UTC-69ca8c15.8fb-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:43:33 UTC-69ca8c15.8fb-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:43:33 UTC-69ca8c15.8fb-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:43:34 UTC-69ca8c16.906-LOG:  connection received: host=127.0.0.1
-        port=50214
-
-        2026-03-30 14:43:35 UTC-69ca8c16.906-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:43:35 UTC-69ca8c16.906-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:43:35 UTC-69ca8c16.906-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:43:35 UTC-69ca8c16.906-LOG:  disconnection: session time: 0:00:00.046
-        user=azuresu database=postgres host=127.0.0.1 port=50214
-
-        2026-03-30 14:43:37 UTC-69ca8c05.8f5-LOG:  disconnection: session time: 0:00:20.022
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=57190
-
-        2026-03-30 14:43:39 UTC-69ca8c1b.908-LOG:  connection received: host=127.0.0.1
-        port=50222
-
-        2026-03-30 14:43:39 UTC-69ca8c1b.908-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:43:39 UTC-69ca8c1b.908-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:43:39 UTC-69ca8c1b.908-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:43:45 UTC-69ca8c0d.8f8-LOG:  disconnection: session time: 0:00:20.025
-        user=azuresu database=azure_sys host=127.0.0.1 port=34478
-
-        2026-03-30 14:43:50 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
-        0/7001308, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
-
-        2026-03-30 14:43:53 UTC-69ca8c15.8fb-LOG:  disconnection: session time: 0:00:20.026
-        user=azuresu database=postgres host=127.0.0.1 port=34494
-
-        2026-03-30 14:43:53 UTC-69ca8c29.90c-LOG:  connection received: host=127.0.0.1
-        port=53104
-
-        2026-03-30 14:43:53 UTC-69ca8c29.90c-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:43:53 UTC-69ca8c29.90c-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:43:53 UTC-69ca8c29.90c-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:43:56 UTC-69ca8c2c.90e-LOG:  connection received: host=127.0.0.1
-        port=53956
-
-        2026-03-30 14:43:56 UTC-69ca8c2c.90e-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:43:56 UTC-69ca8c2c.90e-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:43:56 UTC-69ca8c2c.90e-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:43:59 UTC-69ca8c1b.908-LOG:  disconnection: session time: 0:00:20.023
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=50222
-
-        2026-03-30 14:44:00 UTC-69ca8c30.919-LOG:  connection received: host=127.0.0.1
-        port=53964
-
-        2026-03-30 14:44:00 UTC-69ca8c30.919-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:44:00 UTC-69ca8c30.919-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:44:00 UTC-69ca8c30.919-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:44:00 UTC-69ca8c30.919-LOG:  disconnection: session time: 0:00:00.046
-        user=azuresu database=postgres host=127.0.0.1 port=53964
-
-        2026-03-30 14:44:01 UTC-69ca8c31.91a-LOG:  connection received: host=127.0.0.1
-        port=53976
-
-        2026-03-30 14:44:01 UTC-69ca8c31.91a-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:44:01 UTC-69ca8c31.91a-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:44:01 UTC-69ca8c31.91a-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:44:13 UTC-69ca8c29.90c-LOG:  disconnection: session time: 0:00:20.024
-        user=azuresu database=postgres host=127.0.0.1 port=53104
-
-        2026-03-30 14:44:13 UTC-69ca8c3d.91e-LOG:  connection received: host=127.0.0.1
-        port=35026
-
-        2026-03-30 14:44:13 UTC-69ca8c3d.91e-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:44:13 UTC-69ca8c3d.91e-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:44:13 UTC-69ca8c3d.91e-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:44:16 UTC-69ca8c2c.90e-LOG:  disconnection: session time: 0:00:20.025
-        user=azuresu database=azure_sys host=127.0.0.1 port=53956
-
-        2026-03-30 14:44:21 UTC-69ca8c31.91a-LOG:  disconnection: session time: 0:00:20.027
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=53976
-
-        2026-03-30 14:44:23 UTC-69ca8c47.921-LOG:  connection received: host=127.0.0.1
-        port=34658
-
-        2026-03-30 14:44:23 UTC-69ca8c47.921-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:44:23 UTC-69ca8c47.921-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:44:23 UTC-69ca8c47.921-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:44:25 UTC-69ca8c49.92c-LOG:  connection received: host=127.0.0.1
-        port=53382
-
-        2026-03-30 14:44:25 UTC-69ca8c49.92c-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:44:25 UTC-69ca8c49.92c-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:44:25 UTC-69ca8c49.92c-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:44:25 UTC-69ca8c49.92c-LOG:  disconnection: session time: 0:00:00.049
-        user=azuresu database=postgres host=127.0.0.1 port=53382
-
-        2026-03-30 14:44:27 UTC-69ca8c4b.92d-LOG:  connection received: host=127.0.0.1
-        port=53394
-
-        2026-03-30 14:44:27 UTC-69ca8c4b.92d-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:44:27 UTC-69ca8c4b.92d-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:44:27 UTC-69ca8c4b.92d-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:44:33 UTC-69ca8c3d.91e-LOG:  disconnection: session time: 0:00:20.023
-        user=azuresu database=postgres host=127.0.0.1 port=35026
-
-        2026-03-30 14:44:34 UTC-69ca8c52.930-LOG:  connection received: host=127.0.0.1
-        port=53400
-
-        2026-03-30 14:44:34 UTC-69ca8c52.930-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:44:34 UTC-69ca8c52.930-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:44:34 UTC-69ca8c52.930-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:44:43 UTC-69ca8c47.921-LOG:  disconnection: session time: 0:00:20.023
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=34658
-
-        2026-03-30 14:44:45 UTC-69ca8c5d.934-LOG:  connection received: host=127.0.0.1
-        port=43406
-
-        2026-03-30 14:44:45 UTC-69ca8c5d.934-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:44:45 UTC-69ca8c5d.934-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:44:45 UTC-69ca8c5d.934-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:44:47 UTC-69ca8c4b.92d-LOG:  disconnection: session time: 0:00:20.023
-        user=azuresu database=azure_sys host=127.0.0.1 port=53394
-
-        2026-03-30 14:44:50 UTC-69ca8c62.93f-LOG:  connection received: host=127.0.0.1
-        port=43422
-
-        2026-03-30 14:44:50 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
-        0/70019A8, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
-
-        2026-03-30 14:44:50 UTC-69ca8c62.93f-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:44:50 UTC-69ca8c62.93f-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:44:50 UTC-69ca8c62.93f-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:44:50 UTC-69ca8c62.93f-LOG:  disconnection: session time: 0:00:00.047
-        user=azuresu database=postgres host=127.0.0.1 port=43422
-
-        2026-03-30 14:44:54 UTC-69ca8c52.930-LOG:  disconnection: session time: 0:00:20.023
-        user=azuresu database=postgres host=127.0.0.1 port=53400
-
-        2026-03-30 14:44:54 UTC-69ca8c66.941-LOG:  connection received: host=127.0.0.1
-        port=43434
-
-        2026-03-30 14:44:54 UTC-69ca8c66.941-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:44:54 UTC-69ca8c66.941-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:44:54 UTC-69ca8c66.941-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:44:58 UTC-69ca8c6a.943-LOG:  connection received: host=127.0.0.1
-        port=47446
-
-        2026-03-30 14:44:58 UTC-69ca8c6a.943-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:44:58 UTC-69ca8c6a.943-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:44:58 UTC-69ca8c6a.943-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:45:05 UTC-69ca8c5d.934-LOG:  disconnection: session time: 0:00:20.027
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=43406
-
-        2026-03-30 14:45:07 UTC-69ca8c73.946-LOG:  connection received: host=127.0.0.1
-        port=35420
-
-        2026-03-30 14:45:07 UTC-69ca8c73.946-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:45:07 UTC-69ca8c73.946-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:45:07 UTC-69ca8c73.946-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:45:14 UTC-69ca8c66.941-LOG:  disconnection: session time: 0:00:20.024
-        user=azuresu database=postgres host=127.0.0.1 port=43434
-
-        2026-03-30 14:45:14 UTC-69ca8c7a.94a-LOG:  connection received: host=127.0.0.1
-        port=35430
-
-        2026-03-30 14:45:14 UTC-69ca8c7a.94a-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:45:14 UTC-69ca8c7a.94a-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:45:14 UTC-69ca8c7a.94a-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:45:15 UTC-69ca8c7b.954-LOG:  connection received: host=127.0.0.1
-        port=50924
-
-        2026-03-30 14:45:15 UTC-69ca8c7b.954-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:45:15 UTC-69ca8c7b.954-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:45:15 UTC-69ca8c7b.954-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:45:15 UTC-69ca8c7b.954-LOG:  disconnection: session time: 0:00:00.047
-        user=azuresu database=postgres host=127.0.0.1 port=50924
-
-        2026-03-30 14:45:18 UTC-69ca8c6a.943-LOG:  disconnection: session time: 0:00:20.023
-        user=azuresu database=azure_sys host=127.0.0.1 port=47446
-
-        2026-03-30 14:45:27 UTC-69ca8c73.946-LOG:  disconnection: session time: 0:00:20.031
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=35420
-
-        2026-03-30 14:45:29 UTC-69ca8c89.958-LOG:  connection received: host=127.0.0.1
-        port=34750
-
-        2026-03-30 14:45:29 UTC-69ca8c89.959-LOG:  connection received: host=127.0.0.1
-        port=34764
-
-        2026-03-30 14:45:29 UTC-69ca8c89.958-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:45:29 UTC-69ca8c89.958-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:45:29 UTC-69ca8c89.958-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:45:29 UTC-69ca8c89.959-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:45:29 UTC-69ca8c89.959-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:45:29 UTC-69ca8c89.959-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:45:34 UTC-69ca8c7a.94a-LOG:  disconnection: session time: 0:00:20.024
-        user=azuresu database=postgres host=127.0.0.1 port=35430
-
-        2026-03-30 14:45:34 UTC-69ca8c8e.95c-LOG:  connection received: host=127.0.0.1
-        port=34778
-
-        2026-03-30 14:45:34 UTC-69ca8c8e.95c-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:45:34 UTC-69ca8c8e.95c-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:45:34 UTC-69ca8c8e.95c-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:45:40 UTC-69ca8c94.967-LOG:  connection received: host=127.0.0.1
-        port=35452
-
-        2026-03-30 14:45:40 UTC-69ca8c94.967-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:45:40 UTC-69ca8c94.967-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:45:40 UTC-69ca8c94.967-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:45:40 UTC-69ca8c94.967-LOG:  disconnection: session time: 0:00:00.047
-        user=azuresu database=postgres host=127.0.0.1 port=35452
-
-        2026-03-30 14:45:49 UTC-69ca8c89.958-LOG:  disconnection: session time: 0:00:20.034
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=34750
-
-        2026-03-30 14:45:49 UTC-69ca8c89.959-LOG:  disconnection: session time: 0:00:20.036
-        user=azuresu database=azure_sys host=127.0.0.1 port=34764
-
-        2026-03-30 14:45:50 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
-        0/7007A80, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
-
-        2026-03-30 14:45:51 UTC-69ca8c9f.96a-LOG:  connection received: host=127.0.0.1
-        port=43398
-
-        2026-03-30 14:45:51 UTC-69ca8c9f.96a-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:45:51 UTC-69ca8c9f.96a-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:45:51 UTC-69ca8c9f.96a-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:45:54 UTC-69ca8c8e.95c-LOG:  disconnection: session time: 0:00:20.028
-        user=azuresu database=postgres host=127.0.0.1 port=34778
-
-        2026-03-30 14:45:54 UTC-69ca8ca2.96d-LOG:  connection received: host=127.0.0.1
-        port=55202
-
-        2026-03-30 14:45:54 UTC-69ca8ca2.96d-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:45:54 UTC-69ca8ca2.96d-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:45:54 UTC-69ca8ca2.96d-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:46:00 UTC-69ca8ca8.96f-LOG:  connection received: host=127.0.0.1
-        port=55204
-
-        2026-03-30 14:46:00 UTC-69ca8ca8.96f-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:46:00 UTC-69ca8ca8.96f-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:46:00 UTC-69ca8ca8.96f-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:46:05 UTC-69ca8cad.990-LOG:  connection received: host=127.0.0.1
-        port=54820
-
-        2026-03-30 14:46:05 UTC-69ca8cad.990-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:46:05 UTC-69ca8cad.990-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:46:05 UTC-69ca8cad.990-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:46:05 UTC-69ca8cad.990-LOG:  disconnection: session time: 0:00:00.046
-        user=azuresu database=postgres host=127.0.0.1 port=54820
-
-        2026-03-30 14:46:11 UTC-69ca8c9f.96a-LOG:  disconnection: session time: 0:00:20.030
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=43398
-
-        2026-03-30 14:46:13 UTC-69ca8cb5.992-LOG:  connection received: host=127.0.0.1
-        port=54834
-
-        2026-03-30 14:46:13 UTC-69ca8cb5.992-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:46:13 UTC-69ca8cb5.992-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:46:13 UTC-69ca8cb5.992-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:46:14 UTC-69ca8ca2.96d-LOG:  disconnection: session time: 0:00:20.023
-        user=azuresu database=postgres host=127.0.0.1 port=55202
-
-        2026-03-30 14:46:14 UTC-69ca8cb6.995-LOG:  connection received: host=127.0.0.1
-        port=52630
-
-        2026-03-30 14:46:14 UTC-69ca8cb6.995-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:46:14 UTC-69ca8cb6.995-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:46:14 UTC-69ca8cb6.995-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:46:20 UTC-69ca8ca8.96f-LOG:  disconnection: session time: 0:00:20.025
-        user=azuresu database=azure_sys host=127.0.0.1 port=55204
-
-        2026-03-30 14:46:30 UTC-69ca8cc6.9a2-LOG:  connection received: host=127.0.0.1
-        port=37678
-
-        2026-03-30 14:46:30 UTC-69ca8cc6.9a2-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:46:30 UTC-69ca8cc6.9a2-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:46:30 UTC-69ca8cc6.9a2-LOG:  connection authorized: user=azuresu
-        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:46:30 UTC-69ca8cc6.9a2-LOG:  disconnection: session time: 0:00:00.046
-        user=azuresu database=postgres host=127.0.0.1 port=37678
-
-        2026-03-30 14:46:31 UTC-69ca8cc7.9a3-LOG:  connection received: host=127.0.0.1
-        port=37686
-
-        2026-03-30 14:46:31 UTC-69ca8cc7.9a3-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:46:31 UTC-69ca8cc7.9a3-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:46:31 UTC-69ca8cc7.9a3-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:46:33 UTC-69ca8cb5.992-LOG:  disconnection: session time: 0:00:20.045
-        user=azuresu database=azure_maintenance host=127.0.0.1 port=54834
-
-        2026-03-30 14:46:34 UTC-69ca8cb6.995-LOG:  disconnection: session time: 0:00:20.026
-        user=azuresu database=postgres host=127.0.0.1 port=52630
-
-        2026-03-30 14:46:34 UTC-69ca8cca.9a6-LOG:  connection received: host=127.0.0.1
-        port=41578
-
-        2026-03-30 14:46:34 UTC-69ca8cca.9a6-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:46:34 UTC-69ca8cca.9a6-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:46:34 UTC-69ca8cca.9a6-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:46:35 UTC-69ca8ccb.9a8-LOG:  connection received: host=127.0.0.1
-        port=41604
-
-        2026-03-30 14:46:35 UTC-69ca8ccb.9a7-LOG:  connection received: host=127.0.0.1
-        port=41594
-
-        2026-03-30 14:46:35 UTC-69ca8ccb.9a9-LOG:  connection received: host=127.0.0.1
-        port=41608
-
-        2026-03-30 14:46:35 UTC-69ca8ccb.9a9-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:46:35 UTC-69ca8ccb.9a9-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:46:35 UTC-69ca8ccb.9a9-LOG:  connection authorized: user=azuresu
-        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:46:35 UTC-69ca8ccb.9a8-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:46:35 UTC-69ca8ccb.9a8-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:46:35 UTC-69ca8ccb.9a8-LOG:  connection authorized: user=azuresu
-        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        2026-03-30 14:46:35 UTC-69ca8ccb.9a7-LOG:  [Microsoft Entra] aad_tenant_id
-        is NULL
-
-        2026-03-30 14:46:35 UTC-69ca8ccb.9a7-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
-        method=cert (/datadrive/pg/data/pg_hba.conf:12)
-
-        2026-03-30 14:46:35 UTC-69ca8ccb.9a7-LOG:  connection authorized: user=azuresu
-        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
-        bits=256)
-
-        '
-    headers:
-      accept-ranges:
-      - bytes
-      connection:
-      - close
-      content-length:
-      - '168656'
-      content-md5:
-      - eoUwP0hGnLn+x5kEWNSHWQ==
-      content-type:
-      - text/plain
-      date:
-      - Mon, 30 Mar 2026 14:47:51 GMT
-      etag:
-      - '"0x8DE8E6B26BD597F"'
-      last-modified:
-      - Mon, 30 Mar 2026 14:46:39 GMT
-      server:
-      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      x-ms-access-tier:
-      - Cool
-      x-ms-access-tier-inferred:
-      - 'true'
-      x-ms-blob-type:
-      - BlockBlob
-      x-ms-creation-time:
-      - Mon, 30 Mar 2026 14:36:36 GMT
-      x-ms-lease-state:
-      - available
-      x-ms-lease-status:
-      - unlocked
-      x-ms-server-encrypted:
-      - 'true'
-      x-ms-version:
-      - '2025-05-05'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - postgres flexible-server parameter set
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --server-name --name --value
-      User-Agent:
-      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/configurations/logfiles.download_enable?api-version=2026-01-01-preview
-  response:
-    body:
-      string: '{"properties":{"value":"on","description":"Enables or disables server
-        logs functionality.","defaultValue":"off","dataType":"Boolean","allowedValues":"on,off","source":"user-override","isDynamicConfig":true,"isReadOnly":false,"isConfigPendingRestart":false,"documentationLink":"https://go.microsoft.com/fwlink/?linkid=2274270"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/configurations/logfiles.download_enable","name":"logfiles.download_enable","type":"Microsoft.DBforPostgreSQL/flexibleServers/configurations"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '632'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 30 Mar 2026 14:47:52 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-cache:
-      - CONFIG_NOCACHE
-      x-content-type-options:
-      - nosniff
-      x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/475f7932-1e06-43a1-9264-f81d3cb106c2
-      x-ms-ratelimit-remaining-subscription-global-reads:
-      - '16499'
-      x-msedge-ref:
-      - 'Ref A: D7EF7F9963394D8CB1732ECD0064D4FB Ref B: DUB241062310023 Ref C: 2026-03-30T14:47:52Z'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"value": "off", "source": "user-override"}}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - postgres flexible-server parameter set
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '59'
-      Content-Type:
-      - application/json
-      ParameterSetName:
-      - -g --server-name --name --value
-      User-Agent:
-      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
-    method: PATCH
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/configurations/logfiles.download_enable?api-version=2026-01-01-preview
-  response:
-    body:
-      string: '{"operation":"UpdateOrcasServerParameterManagementOperation","startTime":"2026-03-30T14:47:53.44Z"}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/5248ac38-9aea-4674-8705-35ece5319c3f?api-version=2026-01-01-preview&t=639104788734800213&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=J-hOLX3h0NJ7ufo5EEDGfTjG2zRIkaJVBDDxEO0Vuo-6veFIi5xv80PYXs_PABCQVfnWjxBVBkLUZyXgA0pDTVnXGCIyzQtuSWVVCdkIPeW5O8B2LAd7a4CB9FnUtj5kCN-5XdQA-niM_nhqf7a_XO-aeC4Y5FuK_ZVzp1TG8pnpExd4JbyJ0vRqwRa3cihMyexPhalPGU-gMU3V-HwqdMqtaMhLzSPJMbDRP0F_VuBhXlsaexqPIcxLb1Zs9b-DeUk1d6u_SXOMYnUPceS1i1tOUiqLXEFwRJfBALK1nHlvIl2pn2XVIMI9LYuDFtuESALQaut-qwAnGogNowzpwQ&h=dppahVLn1YK-y0z693IzV2bd4ISdHVvoow_qcOfaDNs
-      cache-control:
-      - no-cache
-      content-length:
-      - '99'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 30 Mar 2026 14:47:52 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/operationResults/5248ac38-9aea-4674-8705-35ece5319c3f?api-version=2026-01-01-preview&t=639104788734800213&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=KialwA7xCLuUjcMrgGLZr5wujBlQV4aeH8C1ps-3qoxG0WIM1go7Qe5ndujUJqGlBy7Rq1oXPxc6x0-vLm_xDQAPkpzlPJP01acTya-dEP-KPsQTmO7KDm_6yEarhiLRP5KP1TwWfJFrphre53DZ56s16OE3wNpDJt8jKp2Lb99CWddqkilkqCEaC6YM0FWzouswxL7TrfSDiponW1yLp1IPRjOUoE42PqseZJvhVk8NbQfC3KjMH4NZ75RIrw58xzJ5kjqfY4tXscyci7PqYJQe5Ur6G-_RB1ExGFDCsFQSC6iCQ4GbESpMicHioVMm60mHdg4NzTu628JX7UBvWQ&h=QMwSR4QZtQNwrnpglqyJTZjkuSBdP2aJ6zX5h5ffPgc
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-cache:
-      - CONFIG_NOCACHE
-      x-content-type-options:
-      - nosniff
-      x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/08e205bd-9f79-4d5c-b650-33d54d54b530
-      x-ms-ratelimit-remaining-subscription-global-writes:
-      - '11999'
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '799'
-      x-msedge-ref:
-      - 'Ref A: FE19DF17F78947EC9229DA9A5308BC39 Ref B: AMS231032609037 Ref C: 2026-03-30T14:47:53Z'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - postgres flexible-server parameter set
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --server-name --name --value
-      User-Agent:
-      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/5248ac38-9aea-4674-8705-35ece5319c3f?api-version=2026-01-01-preview&t=639104788734800213&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=J-hOLX3h0NJ7ufo5EEDGfTjG2zRIkaJVBDDxEO0Vuo-6veFIi5xv80PYXs_PABCQVfnWjxBVBkLUZyXgA0pDTVnXGCIyzQtuSWVVCdkIPeW5O8B2LAd7a4CB9FnUtj5kCN-5XdQA-niM_nhqf7a_XO-aeC4Y5FuK_ZVzp1TG8pnpExd4JbyJ0vRqwRa3cihMyexPhalPGU-gMU3V-HwqdMqtaMhLzSPJMbDRP0F_VuBhXlsaexqPIcxLb1Zs9b-DeUk1d6u_SXOMYnUPceS1i1tOUiqLXEFwRJfBALK1nHlvIl2pn2XVIMI9LYuDFtuESALQaut-qwAnGogNowzpwQ&h=dppahVLn1YK-y0z693IzV2bd4ISdHVvoow_qcOfaDNs
-  response:
-    body:
-      string: '{"name":"5248ac38-9aea-4674-8705-35ece5319c3f","status":"InProgress","startTime":"2026-03-30T14:47:53.44Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '107'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 30 Mar 2026 14:47:53 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-cache:
-      - CONFIG_NOCACHE
-      x-content-type-options:
-      - nosniff
-      x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/bee00500-9bd0-42f1-9262-807ae7a6996e
-      x-ms-ratelimit-remaining-subscription-global-reads:
-      - '16499'
-      x-msedge-ref:
-      - 'Ref A: BA094F2B59B740848CD078DBAF0516B6 Ref B: AMS231020512009 Ref C: 2026-03-30T14:47:53Z'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - postgres flexible-server parameter set
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --server-name --name --value
-      User-Agent:
-      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/5248ac38-9aea-4674-8705-35ece5319c3f?api-version=2026-01-01-preview&t=639104788734800213&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=J-hOLX3h0NJ7ufo5EEDGfTjG2zRIkaJVBDDxEO0Vuo-6veFIi5xv80PYXs_PABCQVfnWjxBVBkLUZyXgA0pDTVnXGCIyzQtuSWVVCdkIPeW5O8B2LAd7a4CB9FnUtj5kCN-5XdQA-niM_nhqf7a_XO-aeC4Y5FuK_ZVzp1TG8pnpExd4JbyJ0vRqwRa3cihMyexPhalPGU-gMU3V-HwqdMqtaMhLzSPJMbDRP0F_VuBhXlsaexqPIcxLb1Zs9b-DeUk1d6u_SXOMYnUPceS1i1tOUiqLXEFwRJfBALK1nHlvIl2pn2XVIMI9LYuDFtuESALQaut-qwAnGogNowzpwQ&h=dppahVLn1YK-y0z693IzV2bd4ISdHVvoow_qcOfaDNs
-  response:
-    body:
-      string: '{"name":"5248ac38-9aea-4674-8705-35ece5319c3f","status":"Succeeded","startTime":"2026-03-30T14:47:53.44Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '106'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 30 Mar 2026 14:48:04 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-cache:
-      - CONFIG_NOCACHE
-      x-content-type-options:
-      - nosniff
-      x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/dc91c65a-b51a-40cc-a107-665cbd072c32
-      x-ms-ratelimit-remaining-subscription-global-reads:
-      - '16499'
-      x-msedge-ref:
-      - 'Ref A: 9F33D77384904E9C86E3AFF33797FC97 Ref B: DUB601080513062 Ref C: 2026-03-30T14:48:04Z'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - postgres flexible-server parameter set
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --server-name --name --value
-      User-Agent:
-      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/configurations/logfiles.download_enable?api-version=2026-01-01-preview
-  response:
-    body:
-      string: '{"properties":{"value":"off","description":"Enables or disables server
-        logs functionality.","defaultValue":"off","dataType":"Boolean","allowedValues":"on,off","source":"user-override","isDynamicConfig":true,"isReadOnly":false,"isConfigPendingRestart":false,"documentationLink":"https://go.microsoft.com/fwlink/?linkid=2274270"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/configurations/logfiles.download_enable","name":"logfiles.download_enable","type":"Microsoft.DBforPostgreSQL/flexibleServers/configurations"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '633'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 30 Mar 2026 14:48:05 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-cache:
-      - CONFIG_NOCACHE
-      x-content-type-options:
-      - nosniff
-      x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/0207c5a0-1009-41d6-9ea1-37e7106cff18
-      x-ms-ratelimit-remaining-subscription-global-reads:
-      - '16499'
-      x-msedge-ref:
-      - 'Ref A: 578F039F86AC436AB3AEF1C997E7EA86 Ref B: AMS231020512045 Ref C: 2026-03-30T14:48:04Z'
+      - 'Ref A: 8B41B2281FA44A65AE0119DF33212DB8 Ref B: AMS231020512011 Ref C: 2026-03-31T21:53:12Z'
     status:
       code: 200
       message: OK
@@ -5174,27 +1112,27 @@ interactions:
       ParameterSetName:
       - -g -n --yes
       User-Agent:
-      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002?api-version=2026-01-01-preview
   response:
     body:
-      string: '{"operation":"DropServerManagementOperation","startTime":"2026-03-30T14:48:06.19Z"}'
+      string: '{"operation":"DropServerManagementOperation","startTime":"2026-03-31T21:53:12.967Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/azureAsyncOperation/c825ff55-99c7-4b1b-b634-3d2b751d5505?api-version=2026-01-01-preview&t=639104788862499093&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=COe2rq3ZYXHoDkxmpL6Apmvjp-VM-7kEqXYFbqPrs39QxI51EzIDjgb8Vdf1NwkqbNP4eaetnSVBV37WIqDyqOmaajPAngH_nBaBXjJPPhoKmQ5zCT5mmPDabzGXSV2uUM-VBGJ7aA1Vra75ydDkkakuDaD0Sh4BtWcg56gDUUWCYONtLiTLv1jWia9SUT5CCbUVBg91fmxGkq3B9v8Wk0eY8qzqbDXdq0CDEcp2eQgp2MQVH92l9aGo41I3Qwadl-gxH0Fq_F1qJjlOuf6wNztgbshpvkWDQqx6JKBY1QH5TsvolEiqgjRXzfNNnHiHT59_jpa3ieTgZbfL2lFfIQ&h=3eKwChnyOr-P3umYYwZVmeZ2Csy9eKbm9kZBY7RA1zQ
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/azureAsyncOperation/21fcbecb-adb2-43eb-909e-f16f4f7e6b5a?api-version=2026-01-01-preview&t=639105907930044005&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=o1w7sX65o0j7n3sd9SHXmb9SQ5eATejzCDUr5hM6t7gMWt8PefHqQqml4-ZleujCdAAzrIqQpknRx4r9-zYrNKo07RY-UbLF8FuOEEZW1NTktvSn12f3x2TjnBcqCh12XCaqUYlWYRo4i1zmSBFXRguDwqoTe2hzrfbEMn4PmkT5bU7jW0ss7gr3dCdvywbixaVo3buU4BCfFb2W33NiD3F4Hk_cw6fjdq6RM5uY2akyoje3Yhqz0odUoMD6JR7BPO4anrkCymdeEJ5y3mMydQu1U-CaJMypuionp5hzH71u9EefcaYdZhKMuFifpr-fpZeCDd7stRkPO1fO0FGOkw&h=-it33wpcyjWvK5is8FoqW3y9f9HrMalaRiX3dK8y-Lw
       cache-control:
       - no-cache
       content-length:
-      - '83'
+      - '84'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 30 Mar 2026 14:48:06 GMT
+      - Tue, 31 Mar 2026 21:53:12 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/operationResults/c825ff55-99c7-4b1b-b634-3d2b751d5505?api-version=2026-01-01-preview&t=639104788862655348&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=RafzRCpJ4eIXPp7DPK6NEOugZXiVktXETzNYAzwQmtZ_2AlP0j6SVnEor9U7IRuVQA0qIeXIKxPH2evgzPVZXZ-ogz0H6SrlsSbjt2WLG85QjC_TXddcyyC4bSMva0OkrMXN8oPNYbx1vtmAqxswzO4dYmnDQK9MXz5-Xs6XBHuHRstA20vI1TiM2UKjHtpDrn_dhxsF1I65JB7-lC-dfUTpCDMFfsA75zkgvxnCP1UXOdFDbEFGBjdtSc5TrFlUZQMmBNBjNn8h6bqIEZu2K62IVT6oWBPOJfeM1JQwTttxnSxnNnVCYDv4dlXrfKZ6ROsOKXKWfrP16s1l6cwhNw&h=JNbukbKjZfixDyfwzCG0YJyib9N1lNDRO962x8VHrZw
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/operationResults/21fcbecb-adb2-43eb-909e-f16f4f7e6b5a?api-version=2026-01-01-preview&t=639105907930044005&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=Zg3qx5Bplsp36QSCvSIFbrKLp8hxaCzWYA4sS6MgwZTpVJIlRMzpNlM7LWSl0NbJaKPQMcVb7UNBvA5T8gcaOtkqaaV-qs7SQmEstzNtSmA2t5PSVdzN_bfAElZ_fYiZuyI4d0ghIa7k2dbPWKX-pKC_y9GcRlh_4Wpusjc6EzkYEJbbIPsx1alW7A89i1tzfB57o7g_U5Os_KSbpjqtwjrseFI8E1A6aTr7vG_G_B3VCFsdRvjPbVF2iDl2R6tFxS9rfF-PYX5wNXhJOmu-WRvZbkpW756OcN-Gcb_bwsHQpQsSn7Do5nwHiTMYbjTO3gaW2UxfryMdSiYCDoAKFA&h=A0Pt5NrDo4LTmcLEnutqnMcnmPdwhKwtCq0bk_ODIus
       pragma:
       - no-cache
       strict-transport-security:
@@ -5204,13 +1142,13 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/32793c29-340e-4008-b387-a0d263584344
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/f6b26355-3c4b-401d-b6cb-abde6a2b10ed
       x-ms-ratelimit-remaining-subscription-deletes:
       - '799'
       x-ms-ratelimit-remaining-subscription-global-deletes:
       - '11999'
       x-msedge-ref:
-      - 'Ref A: AF237432F371467F8D1C480623E82A5E Ref B: AMS231022012027 Ref C: 2026-03-30T14:48:05Z'
+      - 'Ref A: 15EB931E6A5A4A54A360F2A2F30AC7C7 Ref B: AMS231032608019 Ref C: 2026-03-31T21:53:12Z'
     status:
       code: 202
       message: Accepted
@@ -5228,21 +1166,21 @@ interactions:
       ParameterSetName:
       - -g -n --yes
       User-Agent:
-      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/azureAsyncOperation/c825ff55-99c7-4b1b-b634-3d2b751d5505?api-version=2026-01-01-preview&t=639104788862499093&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=COe2rq3ZYXHoDkxmpL6Apmvjp-VM-7kEqXYFbqPrs39QxI51EzIDjgb8Vdf1NwkqbNP4eaetnSVBV37WIqDyqOmaajPAngH_nBaBXjJPPhoKmQ5zCT5mmPDabzGXSV2uUM-VBGJ7aA1Vra75ydDkkakuDaD0Sh4BtWcg56gDUUWCYONtLiTLv1jWia9SUT5CCbUVBg91fmxGkq3B9v8Wk0eY8qzqbDXdq0CDEcp2eQgp2MQVH92l9aGo41I3Qwadl-gxH0Fq_F1qJjlOuf6wNztgbshpvkWDQqx6JKBY1QH5TsvolEiqgjRXzfNNnHiHT59_jpa3ieTgZbfL2lFfIQ&h=3eKwChnyOr-P3umYYwZVmeZ2Csy9eKbm9kZBY7RA1zQ
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/azureAsyncOperation/21fcbecb-adb2-43eb-909e-f16f4f7e6b5a?api-version=2026-01-01-preview&t=639105907930044005&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=o1w7sX65o0j7n3sd9SHXmb9SQ5eATejzCDUr5hM6t7gMWt8PefHqQqml4-ZleujCdAAzrIqQpknRx4r9-zYrNKo07RY-UbLF8FuOEEZW1NTktvSn12f3x2TjnBcqCh12XCaqUYlWYRo4i1zmSBFXRguDwqoTe2hzrfbEMn4PmkT5bU7jW0ss7gr3dCdvywbixaVo3buU4BCfFb2W33NiD3F4Hk_cw6fjdq6RM5uY2akyoje3Yhqz0odUoMD6JR7BPO4anrkCymdeEJ5y3mMydQu1U-CaJMypuionp5hzH71u9EefcaYdZhKMuFifpr-fpZeCDd7stRkPO1fO0FGOkw&h=-it33wpcyjWvK5is8FoqW3y9f9HrMalaRiX3dK8y-Lw
   response:
     body:
-      string: '{"name":"c825ff55-99c7-4b1b-b634-3d2b751d5505","status":"InProgress","startTime":"2026-03-30T14:48:06.19Z"}'
+      string: '{"name":"21fcbecb-adb2-43eb-909e-f16f4f7e6b5a","status":"InProgress","startTime":"2026-03-31T21:53:12.967Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '107'
+      - '108'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 30 Mar 2026 14:48:06 GMT
+      - Tue, 31 Mar 2026 21:53:13 GMT
       expires:
       - '-1'
       pragma:
@@ -5254,11 +1192,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/1ca82d95-ffe2-4ca4-b4a1-fd509fe242ce
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/ukwest/4f1b4655-dfdf-43e2-ba1a-41e93b9a75c6
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: E661AB62F45D42778C9721FAF72E719D Ref B: AMS231020512035 Ref C: 2026-03-30T14:48:06Z'
+      - 'Ref A: 8E6F6FF44604438ABE59ACE688E90AB4 Ref B: AMS231032609021 Ref C: 2026-03-31T21:53:13Z'
     status:
       code: 200
       message: OK
@@ -5276,21 +1214,21 @@ interactions:
       ParameterSetName:
       - -g -n --yes
       User-Agent:
-      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/azureAsyncOperation/c825ff55-99c7-4b1b-b634-3d2b751d5505?api-version=2026-01-01-preview&t=639104788862499093&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=COe2rq3ZYXHoDkxmpL6Apmvjp-VM-7kEqXYFbqPrs39QxI51EzIDjgb8Vdf1NwkqbNP4eaetnSVBV37WIqDyqOmaajPAngH_nBaBXjJPPhoKmQ5zCT5mmPDabzGXSV2uUM-VBGJ7aA1Vra75ydDkkakuDaD0Sh4BtWcg56gDUUWCYONtLiTLv1jWia9SUT5CCbUVBg91fmxGkq3B9v8Wk0eY8qzqbDXdq0CDEcp2eQgp2MQVH92l9aGo41I3Qwadl-gxH0Fq_F1qJjlOuf6wNztgbshpvkWDQqx6JKBY1QH5TsvolEiqgjRXzfNNnHiHT59_jpa3ieTgZbfL2lFfIQ&h=3eKwChnyOr-P3umYYwZVmeZ2Csy9eKbm9kZBY7RA1zQ
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/azureAsyncOperation/21fcbecb-adb2-43eb-909e-f16f4f7e6b5a?api-version=2026-01-01-preview&t=639105907930044005&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=o1w7sX65o0j7n3sd9SHXmb9SQ5eATejzCDUr5hM6t7gMWt8PefHqQqml4-ZleujCdAAzrIqQpknRx4r9-zYrNKo07RY-UbLF8FuOEEZW1NTktvSn12f3x2TjnBcqCh12XCaqUYlWYRo4i1zmSBFXRguDwqoTe2hzrfbEMn4PmkT5bU7jW0ss7gr3dCdvywbixaVo3buU4BCfFb2W33NiD3F4Hk_cw6fjdq6RM5uY2akyoje3Yhqz0odUoMD6JR7BPO4anrkCymdeEJ5y3mMydQu1U-CaJMypuionp5hzH71u9EefcaYdZhKMuFifpr-fpZeCDd7stRkPO1fO0FGOkw&h=-it33wpcyjWvK5is8FoqW3y9f9HrMalaRiX3dK8y-Lw
   response:
     body:
-      string: '{"name":"c825ff55-99c7-4b1b-b634-3d2b751d5505","status":"InProgress","startTime":"2026-03-30T14:48:06.19Z"}'
+      string: '{"name":"21fcbecb-adb2-43eb-909e-f16f4f7e6b5a","status":"InProgress","startTime":"2026-03-31T21:53:12.967Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '107'
+      - '108'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 30 Mar 2026 14:48:21 GMT
+      - Tue, 31 Mar 2026 21:53:28 GMT
       expires:
       - '-1'
       pragma:
@@ -5302,11 +1240,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/86e0bd8a-e3ec-408b-aba0-a44729d61609
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/41a872f7-8420-42f2-9e3f-791537a3bf67
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 16B37198A1AF43B29FD4019855B988BD Ref B: AMS231020614035 Ref C: 2026-03-30T14:48:22Z'
+      - 'Ref A: 12F27B2A13B14A529798314DD53C0075 Ref B: AMS231032607025 Ref C: 2026-03-31T21:53:28Z'
     status:
       code: 200
       message: OK
@@ -5324,21 +1262,21 @@ interactions:
       ParameterSetName:
       - -g -n --yes
       User-Agent:
-      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/azureAsyncOperation/c825ff55-99c7-4b1b-b634-3d2b751d5505?api-version=2026-01-01-preview&t=639104788862499093&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=COe2rq3ZYXHoDkxmpL6Apmvjp-VM-7kEqXYFbqPrs39QxI51EzIDjgb8Vdf1NwkqbNP4eaetnSVBV37WIqDyqOmaajPAngH_nBaBXjJPPhoKmQ5zCT5mmPDabzGXSV2uUM-VBGJ7aA1Vra75ydDkkakuDaD0Sh4BtWcg56gDUUWCYONtLiTLv1jWia9SUT5CCbUVBg91fmxGkq3B9v8Wk0eY8qzqbDXdq0CDEcp2eQgp2MQVH92l9aGo41I3Qwadl-gxH0Fq_F1qJjlOuf6wNztgbshpvkWDQqx6JKBY1QH5TsvolEiqgjRXzfNNnHiHT59_jpa3ieTgZbfL2lFfIQ&h=3eKwChnyOr-P3umYYwZVmeZ2Csy9eKbm9kZBY7RA1zQ
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/azureAsyncOperation/21fcbecb-adb2-43eb-909e-f16f4f7e6b5a?api-version=2026-01-01-preview&t=639105907930044005&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=o1w7sX65o0j7n3sd9SHXmb9SQ5eATejzCDUr5hM6t7gMWt8PefHqQqml4-ZleujCdAAzrIqQpknRx4r9-zYrNKo07RY-UbLF8FuOEEZW1NTktvSn12f3x2TjnBcqCh12XCaqUYlWYRo4i1zmSBFXRguDwqoTe2hzrfbEMn4PmkT5bU7jW0ss7gr3dCdvywbixaVo3buU4BCfFb2W33NiD3F4Hk_cw6fjdq6RM5uY2akyoje3Yhqz0odUoMD6JR7BPO4anrkCymdeEJ5y3mMydQu1U-CaJMypuionp5hzH71u9EefcaYdZhKMuFifpr-fpZeCDd7stRkPO1fO0FGOkw&h=-it33wpcyjWvK5is8FoqW3y9f9HrMalaRiX3dK8y-Lw
   response:
     body:
-      string: '{"name":"c825ff55-99c7-4b1b-b634-3d2b751d5505","status":"InProgress","startTime":"2026-03-30T14:48:06.19Z"}'
+      string: '{"name":"21fcbecb-adb2-43eb-909e-f16f4f7e6b5a","status":"InProgress","startTime":"2026-03-31T21:53:12.967Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '107'
+      - '108'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 30 Mar 2026 14:48:37 GMT
+      - Tue, 31 Mar 2026 21:53:44 GMT
       expires:
       - '-1'
       pragma:
@@ -5350,11 +1288,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/6ea37fee-8a34-4253-80cb-f12529433109
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/22ccf47e-c1bf-4753-901c-3b4fc43abdb2
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 31DC7EDD4BFB43EAA87D01E404010AD9 Ref B: AMS231022012039 Ref C: 2026-03-30T14:48:37Z'
+      - 'Ref A: 0C94C25FB72F48EF8DF8727EEC22D286 Ref B: AMS231020614051 Ref C: 2026-03-31T21:53:44Z'
     status:
       code: 200
       message: OK
@@ -5372,21 +1310,21 @@ interactions:
       ParameterSetName:
       - -g -n --yes
       User-Agent:
-      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/azureAsyncOperation/c825ff55-99c7-4b1b-b634-3d2b751d5505?api-version=2026-01-01-preview&t=639104788862499093&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=COe2rq3ZYXHoDkxmpL6Apmvjp-VM-7kEqXYFbqPrs39QxI51EzIDjgb8Vdf1NwkqbNP4eaetnSVBV37WIqDyqOmaajPAngH_nBaBXjJPPhoKmQ5zCT5mmPDabzGXSV2uUM-VBGJ7aA1Vra75ydDkkakuDaD0Sh4BtWcg56gDUUWCYONtLiTLv1jWia9SUT5CCbUVBg91fmxGkq3B9v8Wk0eY8qzqbDXdq0CDEcp2eQgp2MQVH92l9aGo41I3Qwadl-gxH0Fq_F1qJjlOuf6wNztgbshpvkWDQqx6JKBY1QH5TsvolEiqgjRXzfNNnHiHT59_jpa3ieTgZbfL2lFfIQ&h=3eKwChnyOr-P3umYYwZVmeZ2Csy9eKbm9kZBY7RA1zQ
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/azureAsyncOperation/21fcbecb-adb2-43eb-909e-f16f4f7e6b5a?api-version=2026-01-01-preview&t=639105907930044005&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=o1w7sX65o0j7n3sd9SHXmb9SQ5eATejzCDUr5hM6t7gMWt8PefHqQqml4-ZleujCdAAzrIqQpknRx4r9-zYrNKo07RY-UbLF8FuOEEZW1NTktvSn12f3x2TjnBcqCh12XCaqUYlWYRo4i1zmSBFXRguDwqoTe2hzrfbEMn4PmkT5bU7jW0ss7gr3dCdvywbixaVo3buU4BCfFb2W33NiD3F4Hk_cw6fjdq6RM5uY2akyoje3Yhqz0odUoMD6JR7BPO4anrkCymdeEJ5y3mMydQu1U-CaJMypuionp5hzH71u9EefcaYdZhKMuFifpr-fpZeCDd7stRkPO1fO0FGOkw&h=-it33wpcyjWvK5is8FoqW3y9f9HrMalaRiX3dK8y-Lw
   response:
     body:
-      string: '{"name":"c825ff55-99c7-4b1b-b634-3d2b751d5505","status":"InProgress","startTime":"2026-03-30T14:48:06.19Z"}'
+      string: '{"name":"21fcbecb-adb2-43eb-909e-f16f4f7e6b5a","status":"InProgress","startTime":"2026-03-31T21:53:12.967Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '107'
+      - '108'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 30 Mar 2026 14:48:53 GMT
+      - Tue, 31 Mar 2026 21:53:59 GMT
       expires:
       - '-1'
       pragma:
@@ -5398,11 +1336,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/aa296567-4ed4-4ec4-9cc1-50539566e130
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/3039d13f-6a4e-4e07-a64d-d69e92ae5cc7
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: A8BFDE237F934C248DDF28EC9F004215 Ref B: AMS231022012053 Ref C: 2026-03-30T14:48:53Z'
+      - 'Ref A: 459457C23A9C451BA6B4E30C93F9A147 Ref B: AMS231020512039 Ref C: 2026-03-31T21:54:00Z'
     status:
       code: 200
       message: OK
@@ -5420,21 +1358,21 @@ interactions:
       ParameterSetName:
       - -g -n --yes
       User-Agent:
-      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/azureAsyncOperation/c825ff55-99c7-4b1b-b634-3d2b751d5505?api-version=2026-01-01-preview&t=639104788862499093&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=COe2rq3ZYXHoDkxmpL6Apmvjp-VM-7kEqXYFbqPrs39QxI51EzIDjgb8Vdf1NwkqbNP4eaetnSVBV37WIqDyqOmaajPAngH_nBaBXjJPPhoKmQ5zCT5mmPDabzGXSV2uUM-VBGJ7aA1Vra75ydDkkakuDaD0Sh4BtWcg56gDUUWCYONtLiTLv1jWia9SUT5CCbUVBg91fmxGkq3B9v8Wk0eY8qzqbDXdq0CDEcp2eQgp2MQVH92l9aGo41I3Qwadl-gxH0Fq_F1qJjlOuf6wNztgbshpvkWDQqx6JKBY1QH5TsvolEiqgjRXzfNNnHiHT59_jpa3ieTgZbfL2lFfIQ&h=3eKwChnyOr-P3umYYwZVmeZ2Csy9eKbm9kZBY7RA1zQ
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/azureAsyncOperation/21fcbecb-adb2-43eb-909e-f16f4f7e6b5a?api-version=2026-01-01-preview&t=639105907930044005&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=o1w7sX65o0j7n3sd9SHXmb9SQ5eATejzCDUr5hM6t7gMWt8PefHqQqml4-ZleujCdAAzrIqQpknRx4r9-zYrNKo07RY-UbLF8FuOEEZW1NTktvSn12f3x2TjnBcqCh12XCaqUYlWYRo4i1zmSBFXRguDwqoTe2hzrfbEMn4PmkT5bU7jW0ss7gr3dCdvywbixaVo3buU4BCfFb2W33NiD3F4Hk_cw6fjdq6RM5uY2akyoje3Yhqz0odUoMD6JR7BPO4anrkCymdeEJ5y3mMydQu1U-CaJMypuionp5hzH71u9EefcaYdZhKMuFifpr-fpZeCDd7stRkPO1fO0FGOkw&h=-it33wpcyjWvK5is8FoqW3y9f9HrMalaRiX3dK8y-Lw
   response:
     body:
-      string: '{"name":"c825ff55-99c7-4b1b-b634-3d2b751d5505","status":"Succeeded","startTime":"2026-03-30T14:48:06.19Z"}'
+      string: '{"name":"21fcbecb-adb2-43eb-909e-f16f4f7e6b5a","status":"Succeeded","startTime":"2026-03-31T21:53:12.967Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '106'
+      - '107'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 30 Mar 2026 14:49:08 GMT
+      - Tue, 31 Mar 2026 21:54:15 GMT
       expires:
       - '-1'
       pragma:
@@ -5446,11 +1384,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/5761c01e-3627-495a-abd1-cccdef4e8d36
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/ukwest/5af1ab1d-0707-4a61-9c8f-f01a83b1311a
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 65DEA2C59844405A9F41BB9B9993E215 Ref B: AMS231032609023 Ref C: 2026-03-30T14:49:08Z'
+      - 'Ref A: D86B357B11444659B3A5F68D42D55846 Ref B: AMS231032607029 Ref C: 2026-03-31T21:54:15Z'
     status:
       code: 200
       message: OK

--- a/src/azure-cli/azure/cli/command_modules/postgresql/tests/latest/recordings/test_postgres_flexible_server_logs_mgmt.yaml
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/tests/latest/recordings/test_postgres_flexible_server_logs_mgmt.yaml
@@ -13,7 +13,7 @@ interactions:
       ParameterSetName:
       - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: HEAD
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2024-11-01
   response:
@@ -25,7 +25,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 31 Mar 2026 21:47:36 GMT
+      - Tue, 07 Apr 2026 22:02:18 GMT
       expires:
       - '-1'
       pragma:
@@ -39,7 +39,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 15B1D982B8C444FEBAE9B398390AAE33 Ref B: AMS231022012053 Ref C: 2026-03-31T21:47:37Z'
+      - 'Ref A: 5DEFC9916D0E4790A8D090934BCDF089 Ref B: AMS231022012017 Ref C: 2026-04-07T22:02:18Z'
     status:
       code: 204
       message: No Content
@@ -57,12 +57,12 @@ interactions:
       ParameterSetName:
       - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2024-11-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"canadacentral","tags":{"product":"azurecli","cause":"automation","test":"test_postgres_flexible_server_logs_mgmt","date":"2026-03-31T21:47:33Z","module":"postgresql"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"canadacentral","tags":{"product":"azurecli","cause":"automation","test":"test_postgres_flexible_server_logs_mgmt","date":"2026-04-07T22:02:14Z","module":"postgresql"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -71,7 +71,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 31 Mar 2026 21:47:36 GMT
+      - Tue, 07 Apr 2026 22:02:18 GMT
       expires:
       - '-1'
       pragma:
@@ -85,7 +85,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: D8B01322C4094C1C9A4DC5228FCD7A18 Ref B: AMS231032608031 Ref C: 2026-03-31T21:47:37Z'
+      - 'Ref A: 0D707579A37A439A971658B3BAFF313D Ref B: AMS231022012045 Ref C: 2026-04-07T22:02:18Z'
     status:
       code: 200
       message: OK
@@ -107,7 +107,7 @@ interactions:
       ParameterSetName:
       - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/checkNameAvailability?api-version=2026-01-01-preview
   response:
@@ -121,7 +121,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 31 Mar 2026 21:47:37 GMT
+      - Tue, 07 Apr 2026 22:02:20 GMT
       expires:
       - '-1'
       pragma:
@@ -133,13 +133,13 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/9e0ef41a-721e-4c56-9caf-896f6a3472a4
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/ukwest/485afd2f-1c72-4e55-952a-5502ce37abfb
       x-ms-ratelimit-remaining-subscription-global-writes:
       - '11999'
       x-ms-ratelimit-remaining-subscription-writes:
       - '799'
       x-msedge-ref:
-      - 'Ref A: 9AC1F481AED945F292EC960358E0C94C Ref B: AMS231020614037 Ref C: 2026-03-31T21:47:37Z'
+      - 'Ref A: 276615BBBA33428AA27CD44D17E5721D Ref B: AMS231032609009 Ref C: 2026-04-07T22:02:19Z'
     status:
       code: 200
       message: OK
@@ -157,7 +157,7 @@ interactions:
       ParameterSetName:
       - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/capabilities?api-version=2026-01-01-preview
   response:
@@ -173,7 +173,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 31 Mar 2026 21:47:40 GMT
+      - Tue, 07 Apr 2026 22:02:22 GMT
       expires:
       - '-1'
       pragma:
@@ -185,22 +185,22 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/b740467f-9cb3-44d5-bf81-16a9ca6c4dc8
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/ukwest/89f122a0-2e4b-46a7-877c-25a06d6d0aa3
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: AC708787A83A4576A583A4B07F6436EB Ref B: AMS231020615025 Ref C: 2026-03-31T21:47:38Z'
+      - 'Ref A: 3D475A8199564D05915084F6322E227B Ref B: AMS231032607025 Ref C: 2026-04-07T22:02:20Z'
     status:
       code: 200
       message: OK
 - request:
     body: '{"location": "canadacentral", "sku": {"name": "Standard_D2ds_v5", "tier":
-      "GeneralPurpose"}, "properties": {"authConfig": {"activeDirectoryAuth": "Disabled",
-      "passwordAuth": "Enabled"}, "administratorLogin": "amusedeggs1", "administratorLoginPassword":
-      "OwqeUbQ5Tu_Ta_VSj5L6Fw", "network": {"publicNetworkAccess": "Disabled"}, "highAvailability":
-      {"mode": "Disabled"}, "createMode": "Create", "storage": {"storageSizeGB": 128,
-      "autoGrow": "Disabled"}, "backup": {"backupRetentionDays": 7, "geoRedundantBackup":
-      "Disabled"}, "version": "17"}}'
+      "GeneralPurpose"}, "properties": {"highAvailability": {"mode": "Disabled"},
+      "administratorLoginPassword": "275jxzbn6zHagVgScD5wyg", "version": "17", "storage":
+      {"storageSizeGB": 128, "autoGrow": "Disabled"}, "authConfig": {"activeDirectoryAuth":
+      "Disabled", "passwordAuth": "Enabled"}, "administratorLogin": "hostilemoth2",
+      "network": {"publicNetworkAccess": "Disabled"}, "backup": {"backupRetentionDays":
+      7, "geoRedundantBackup": "Disabled"}, "createMode": "Create"}}'
     headers:
       Accept:
       - '*/*'
@@ -211,21 +211,21 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '541'
+      - '542'
       Content-Type:
       - application/json
       ParameterSetName:
       - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002?api-version=2026-01-01-preview
   response:
     body:
-      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2026-03-31T21:47:41.577Z"}'
+      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2026-04-07T22:02:22.897Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/4d32f3dd-88e0-4c75-8151-af8a124659c9?api-version=2026-01-01-preview&t=639105904616933354&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=rPZQDWr1PVETImg15rqV73rQG7elimeZdaMmrAxUdcZM56UT46mSKCuKyTXzWVzN_Az5bSoPJBYYz3Vh53t4lCYu1j25ZC2vScLHSHBnYRvq2ZR63-_OuNke85PqwnBp9ghHMg-tVwY66cmnNOGIdd61hrzrCdoBGyI8iJiv6jDTUqzJf2Yj9BUUF88Dsq5Oq31r2NlkihuE3PQv08zSgWi9bDwxtmt5_0IYfgzsYBxo27NoaGhDNvMiL32aALCzfo17U9iSG-ENmzh1ws_Gl_FP74BZHZlmFgKmcH3ol-uzKPpuB2raEn-pXm2SDtuqpgvin4_sL_pEHxnFKjeScA&h=R4NrL547ygVfoyktfS1t_fYPRAw26FawnJDYvsi5Zzk
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/b16ca3d7-a377-4a6b-8ec7-74308cbe32cb?api-version=2026-01-01-preview&t=639111961430809856&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=wHmz-8GCvNRWFHYDnFTMpZQZz9wiybjyiph6T-Ts-teefUvDimt58oWjbUVJ-kEz9wyJzt5EzwV9Q8W-BN33yk512jIvInmoZPY0ekJj2wmEtJQ3l3r86Xzqh53Cebw4v-ySkjGuPS_InDx2iQYXQglBDm7YXJ4Ep3_Z61wpWPL_vTa74BpEy_ghTRUx3jNoLQ7te23aghh0AUZMxLsiPf9ueC7ubsbrbGBqV3po01oF_OGTACT0V0fm629YYnKQdcCbPT3rcd15hjuWkXOgFlLYEqKuf8QuvEWgqLpx1LM1fjzd_TznHBA2Pn16Y73JNSZHBTE1RlZqO97vXxxF1w&h=jPl0qQl8eELbKBR1TpfN7VqK-APE87c0sNnTLIyd5Io
       cache-control:
       - no-cache
       content-length:
@@ -233,11 +233,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 31 Mar 2026 21:47:41 GMT
+      - Tue, 07 Apr 2026 22:02:22 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/operationResults/4d32f3dd-88e0-4c75-8151-af8a124659c9?api-version=2026-01-01-preview&t=639105904617089594&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=EeCZGezrPiNicD8tYXJmi36TnKVeJKthzX8a-Q4ykk7w9VStGI0qm-mI5zzxaNHhIqRp3RfS7NPgHQvP2S69UoA-lZJ72YDfHd3TjdeqESLFKFyIZS1KPlFSaFAsVj0waEdXn-K7GpkPJ6h1Kfu-5izg7nNQ1QCPrGH_vJxZ8zLp4FVNy-NRLzsAY6oKmXeBaTBSNsVEjaivFwXpg_LTQlPxBPSL9pbGED3m0kRDmEohlOQoBQoODRk-9PPrdWzApUtR_k0Fnx2pK3t9LgZr7XG2DK6eh2nuLKINQxEM81DO7zWXF3Udxx9qdyc8m5o1cw2ga30px9UW2EfGxiWgIQ&h=oC9LdH2U6uYuHU7jOmgZeQYAlsGt1hjD2FztSkkHTz8
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/operationResults/b16ca3d7-a377-4a6b-8ec7-74308cbe32cb?api-version=2026-01-01-preview&t=639111961430809856&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=N7gmtaZUctsTCUd-Cy742V_owx1g2ONbFl0hP-IoHLqvDwDiWtKC0_FVPG2-fhDyMk1ncukfGinyg_DxH6F2JTwzcJQvJhGVeBmlfID6-u4Qui0VSSioYWAzHEuNkk55t5w_6JOrRNWkiu8AeX7ZiMbaZZBxrPIAq8S7CD1VTKC-UiefYFTz9gDVc8ih5-2xLvP2Di8BDSbEfLqNXxw6t_342iUEZcZTQx4tvr6YmzAR4r32mgKLjEPuhJLWIGbVrFL6Pl4v4whaeTqqTJZj1yrM5OCDHhLAnOGcI_LRqugBre486xKlXXGUoIgwR_zT_5O0O3hmycePOU0wvc6IUA&h=b4yYSMsj-_Wz34lLmc-0suaFDFfiPrPlciTQ5dtsPbo
       pragma:
       - no-cache
       strict-transport-security:
@@ -247,13 +247,13 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/8c248779-7720-449b-9e1d-674ff084a80c
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/8c0c7e33-6a0b-40e5-8de9-f1f61d8aeda7
       x-ms-ratelimit-remaining-subscription-global-writes:
       - '11999'
       x-ms-ratelimit-remaining-subscription-writes:
       - '799'
       x-msedge-ref:
-      - 'Ref A: 69BEF648B0AD4989BD15426837AF99AD Ref B: AMS231020614021 Ref C: 2026-03-31T21:47:41Z'
+      - 'Ref A: CDC715C1552443B5BAFFCBC7A477DB63 Ref B: AMS231032609031 Ref C: 2026-04-07T22:02:22Z'
     status:
       code: 202
       message: Accepted
@@ -271,12 +271,12 @@ interactions:
       ParameterSetName:
       - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/4d32f3dd-88e0-4c75-8151-af8a124659c9?api-version=2026-01-01-preview&t=639105904616933354&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=rPZQDWr1PVETImg15rqV73rQG7elimeZdaMmrAxUdcZM56UT46mSKCuKyTXzWVzN_Az5bSoPJBYYz3Vh53t4lCYu1j25ZC2vScLHSHBnYRvq2ZR63-_OuNke85PqwnBp9ghHMg-tVwY66cmnNOGIdd61hrzrCdoBGyI8iJiv6jDTUqzJf2Yj9BUUF88Dsq5Oq31r2NlkihuE3PQv08zSgWi9bDwxtmt5_0IYfgzsYBxo27NoaGhDNvMiL32aALCzfo17U9iSG-ENmzh1ws_Gl_FP74BZHZlmFgKmcH3ol-uzKPpuB2raEn-pXm2SDtuqpgvin4_sL_pEHxnFKjeScA&h=R4NrL547ygVfoyktfS1t_fYPRAw26FawnJDYvsi5Zzk
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/b16ca3d7-a377-4a6b-8ec7-74308cbe32cb?api-version=2026-01-01-preview&t=639111961430809856&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=wHmz-8GCvNRWFHYDnFTMpZQZz9wiybjyiph6T-Ts-teefUvDimt58oWjbUVJ-kEz9wyJzt5EzwV9Q8W-BN33yk512jIvInmoZPY0ekJj2wmEtJQ3l3r86Xzqh53Cebw4v-ySkjGuPS_InDx2iQYXQglBDm7YXJ4Ep3_Z61wpWPL_vTa74BpEy_ghTRUx3jNoLQ7te23aghh0AUZMxLsiPf9ueC7ubsbrbGBqV3po01oF_OGTACT0V0fm629YYnKQdcCbPT3rcd15hjuWkXOgFlLYEqKuf8QuvEWgqLpx1LM1fjzd_TznHBA2Pn16Y73JNSZHBTE1RlZqO97vXxxF1w&h=jPl0qQl8eELbKBR1TpfN7VqK-APE87c0sNnTLIyd5Io
   response:
     body:
-      string: '{"name":"4d32f3dd-88e0-4c75-8151-af8a124659c9","status":"InProgress","startTime":"2026-03-31T21:47:41.577Z"}'
+      string: '{"name":"b16ca3d7-a377-4a6b-8ec7-74308cbe32cb","status":"InProgress","startTime":"2026-04-07T22:02:22.897Z"}'
     headers:
       cache-control:
       - no-cache
@@ -285,7 +285,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 31 Mar 2026 21:47:41 GMT
+      - Tue, 07 Apr 2026 22:02:23 GMT
       expires:
       - '-1'
       pragma:
@@ -297,11 +297,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/7ae36553-448c-4712-9818-966c18a3878a
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/53b429be-ef18-4b0b-a28e-3ed57eef40ec
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 0C056EFD534A4315A89D30A5B6C5DD5B Ref B: AMS231020512009 Ref C: 2026-03-31T21:47:42Z'
+      - 'Ref A: 8DCAA4EB5CCA4486930A22E6A6157B05 Ref B: AMS231032607023 Ref C: 2026-04-07T22:02:23Z'
     status:
       code: 200
       message: OK
@@ -319,12 +319,12 @@ interactions:
       ParameterSetName:
       - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/4d32f3dd-88e0-4c75-8151-af8a124659c9?api-version=2026-01-01-preview&t=639105904616933354&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=rPZQDWr1PVETImg15rqV73rQG7elimeZdaMmrAxUdcZM56UT46mSKCuKyTXzWVzN_Az5bSoPJBYYz3Vh53t4lCYu1j25ZC2vScLHSHBnYRvq2ZR63-_OuNke85PqwnBp9ghHMg-tVwY66cmnNOGIdd61hrzrCdoBGyI8iJiv6jDTUqzJf2Yj9BUUF88Dsq5Oq31r2NlkihuE3PQv08zSgWi9bDwxtmt5_0IYfgzsYBxo27NoaGhDNvMiL32aALCzfo17U9iSG-ENmzh1ws_Gl_FP74BZHZlmFgKmcH3ol-uzKPpuB2raEn-pXm2SDtuqpgvin4_sL_pEHxnFKjeScA&h=R4NrL547ygVfoyktfS1t_fYPRAw26FawnJDYvsi5Zzk
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/b16ca3d7-a377-4a6b-8ec7-74308cbe32cb?api-version=2026-01-01-preview&t=639111961430809856&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=wHmz-8GCvNRWFHYDnFTMpZQZz9wiybjyiph6T-Ts-teefUvDimt58oWjbUVJ-kEz9wyJzt5EzwV9Q8W-BN33yk512jIvInmoZPY0ekJj2wmEtJQ3l3r86Xzqh53Cebw4v-ySkjGuPS_InDx2iQYXQglBDm7YXJ4Ep3_Z61wpWPL_vTa74BpEy_ghTRUx3jNoLQ7te23aghh0AUZMxLsiPf9ueC7ubsbrbGBqV3po01oF_OGTACT0V0fm629YYnKQdcCbPT3rcd15hjuWkXOgFlLYEqKuf8QuvEWgqLpx1LM1fjzd_TznHBA2Pn16Y73JNSZHBTE1RlZqO97vXxxF1w&h=jPl0qQl8eELbKBR1TpfN7VqK-APE87c0sNnTLIyd5Io
   response:
     body:
-      string: '{"name":"4d32f3dd-88e0-4c75-8151-af8a124659c9","status":"InProgress","startTime":"2026-03-31T21:47:41.577Z"}'
+      string: '{"name":"b16ca3d7-a377-4a6b-8ec7-74308cbe32cb","status":"InProgress","startTime":"2026-04-07T22:02:22.897Z"}'
     headers:
       cache-control:
       - no-cache
@@ -333,7 +333,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 31 Mar 2026 21:48:42 GMT
+      - Tue, 07 Apr 2026 22:03:24 GMT
       expires:
       - '-1'
       pragma:
@@ -345,11 +345,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/f38d1504-96ae-4cb3-95a1-6d735dc30885
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/8172ab33-ba45-4724-a89e-c18ecb3095c2
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: B680C6B804374C90ACBE996D3C645128 Ref B: AMS231022012027 Ref C: 2026-03-31T21:48:42Z'
+      - 'Ref A: BA465F93F678420DA71B9444F242B4C1 Ref B: AMS231032609039 Ref C: 2026-04-07T22:03:24Z'
     status:
       code: 200
       message: OK
@@ -367,12 +367,12 @@ interactions:
       ParameterSetName:
       - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/4d32f3dd-88e0-4c75-8151-af8a124659c9?api-version=2026-01-01-preview&t=639105904616933354&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=rPZQDWr1PVETImg15rqV73rQG7elimeZdaMmrAxUdcZM56UT46mSKCuKyTXzWVzN_Az5bSoPJBYYz3Vh53t4lCYu1j25ZC2vScLHSHBnYRvq2ZR63-_OuNke85PqwnBp9ghHMg-tVwY66cmnNOGIdd61hrzrCdoBGyI8iJiv6jDTUqzJf2Yj9BUUF88Dsq5Oq31r2NlkihuE3PQv08zSgWi9bDwxtmt5_0IYfgzsYBxo27NoaGhDNvMiL32aALCzfo17U9iSG-ENmzh1ws_Gl_FP74BZHZlmFgKmcH3ol-uzKPpuB2raEn-pXm2SDtuqpgvin4_sL_pEHxnFKjeScA&h=R4NrL547ygVfoyktfS1t_fYPRAw26FawnJDYvsi5Zzk
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/b16ca3d7-a377-4a6b-8ec7-74308cbe32cb?api-version=2026-01-01-preview&t=639111961430809856&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=wHmz-8GCvNRWFHYDnFTMpZQZz9wiybjyiph6T-Ts-teefUvDimt58oWjbUVJ-kEz9wyJzt5EzwV9Q8W-BN33yk512jIvInmoZPY0ekJj2wmEtJQ3l3r86Xzqh53Cebw4v-ySkjGuPS_InDx2iQYXQglBDm7YXJ4Ep3_Z61wpWPL_vTa74BpEy_ghTRUx3jNoLQ7te23aghh0AUZMxLsiPf9ueC7ubsbrbGBqV3po01oF_OGTACT0V0fm629YYnKQdcCbPT3rcd15hjuWkXOgFlLYEqKuf8QuvEWgqLpx1LM1fjzd_TznHBA2Pn16Y73JNSZHBTE1RlZqO97vXxxF1w&h=jPl0qQl8eELbKBR1TpfN7VqK-APE87c0sNnTLIyd5Io
   response:
     body:
-      string: '{"name":"4d32f3dd-88e0-4c75-8151-af8a124659c9","status":"InProgress","startTime":"2026-03-31T21:47:41.577Z"}'
+      string: '{"name":"b16ca3d7-a377-4a6b-8ec7-74308cbe32cb","status":"InProgress","startTime":"2026-04-07T22:02:22.897Z"}'
     headers:
       cache-control:
       - no-cache
@@ -381,7 +381,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 31 Mar 2026 21:49:42 GMT
+      - Tue, 07 Apr 2026 22:04:24 GMT
       expires:
       - '-1'
       pragma:
@@ -393,11 +393,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/ddf334e2-3e54-46c8-8afd-5282c99d7ff5
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/ukwest/6dd2e03a-d369-4486-a04b-b0d96c5e6f64
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: EDD3D4BE3BE34CB7BD218AAB334F386F Ref B: AMS231032608049 Ref C: 2026-03-31T21:49:43Z'
+      - 'Ref A: A9FB7F20F9254D92BAF5C0A3E3C32E0E Ref B: AMS231020614009 Ref C: 2026-04-07T22:04:24Z'
     status:
       code: 200
       message: OK
@@ -415,12 +415,12 @@ interactions:
       ParameterSetName:
       - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/4d32f3dd-88e0-4c75-8151-af8a124659c9?api-version=2026-01-01-preview&t=639105904616933354&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=rPZQDWr1PVETImg15rqV73rQG7elimeZdaMmrAxUdcZM56UT46mSKCuKyTXzWVzN_Az5bSoPJBYYz3Vh53t4lCYu1j25ZC2vScLHSHBnYRvq2ZR63-_OuNke85PqwnBp9ghHMg-tVwY66cmnNOGIdd61hrzrCdoBGyI8iJiv6jDTUqzJf2Yj9BUUF88Dsq5Oq31r2NlkihuE3PQv08zSgWi9bDwxtmt5_0IYfgzsYBxo27NoaGhDNvMiL32aALCzfo17U9iSG-ENmzh1ws_Gl_FP74BZHZlmFgKmcH3ol-uzKPpuB2raEn-pXm2SDtuqpgvin4_sL_pEHxnFKjeScA&h=R4NrL547ygVfoyktfS1t_fYPRAw26FawnJDYvsi5Zzk
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/b16ca3d7-a377-4a6b-8ec7-74308cbe32cb?api-version=2026-01-01-preview&t=639111961430809856&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=wHmz-8GCvNRWFHYDnFTMpZQZz9wiybjyiph6T-Ts-teefUvDimt58oWjbUVJ-kEz9wyJzt5EzwV9Q8W-BN33yk512jIvInmoZPY0ekJj2wmEtJQ3l3r86Xzqh53Cebw4v-ySkjGuPS_InDx2iQYXQglBDm7YXJ4Ep3_Z61wpWPL_vTa74BpEy_ghTRUx3jNoLQ7te23aghh0AUZMxLsiPf9ueC7ubsbrbGBqV3po01oF_OGTACT0V0fm629YYnKQdcCbPT3rcd15hjuWkXOgFlLYEqKuf8QuvEWgqLpx1LM1fjzd_TznHBA2Pn16Y73JNSZHBTE1RlZqO97vXxxF1w&h=jPl0qQl8eELbKBR1TpfN7VqK-APE87c0sNnTLIyd5Io
   response:
     body:
-      string: '{"name":"4d32f3dd-88e0-4c75-8151-af8a124659c9","status":"InProgress","startTime":"2026-03-31T21:47:41.577Z"}'
+      string: '{"name":"b16ca3d7-a377-4a6b-8ec7-74308cbe32cb","status":"InProgress","startTime":"2026-04-07T22:02:22.897Z"}'
     headers:
       cache-control:
       - no-cache
@@ -429,7 +429,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 31 Mar 2026 21:50:43 GMT
+      - Tue, 07 Apr 2026 22:05:25 GMT
       expires:
       - '-1'
       pragma:
@@ -441,11 +441,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/ukwest/10fd1178-7a79-4cc8-aac1-4a9f62627f9b
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/29d32c3f-08e0-4575-9805-6773b7079a51
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 9344C576A289437E8D4CDD01E98590C1 Ref B: AMS231022012009 Ref C: 2026-03-31T21:50:43Z'
+      - 'Ref A: 9E4D5F9C19A34F26A598EA13B8825ED9 Ref B: AMS231020512021 Ref C: 2026-04-07T22:05:25Z'
     status:
       code: 200
       message: OK
@@ -463,12 +463,12 @@ interactions:
       ParameterSetName:
       - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/4d32f3dd-88e0-4c75-8151-af8a124659c9?api-version=2026-01-01-preview&t=639105904616933354&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=rPZQDWr1PVETImg15rqV73rQG7elimeZdaMmrAxUdcZM56UT46mSKCuKyTXzWVzN_Az5bSoPJBYYz3Vh53t4lCYu1j25ZC2vScLHSHBnYRvq2ZR63-_OuNke85PqwnBp9ghHMg-tVwY66cmnNOGIdd61hrzrCdoBGyI8iJiv6jDTUqzJf2Yj9BUUF88Dsq5Oq31r2NlkihuE3PQv08zSgWi9bDwxtmt5_0IYfgzsYBxo27NoaGhDNvMiL32aALCzfo17U9iSG-ENmzh1ws_Gl_FP74BZHZlmFgKmcH3ol-uzKPpuB2raEn-pXm2SDtuqpgvin4_sL_pEHxnFKjeScA&h=R4NrL547ygVfoyktfS1t_fYPRAw26FawnJDYvsi5Zzk
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/b16ca3d7-a377-4a6b-8ec7-74308cbe32cb?api-version=2026-01-01-preview&t=639111961430809856&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=wHmz-8GCvNRWFHYDnFTMpZQZz9wiybjyiph6T-Ts-teefUvDimt58oWjbUVJ-kEz9wyJzt5EzwV9Q8W-BN33yk512jIvInmoZPY0ekJj2wmEtJQ3l3r86Xzqh53Cebw4v-ySkjGuPS_InDx2iQYXQglBDm7YXJ4Ep3_Z61wpWPL_vTa74BpEy_ghTRUx3jNoLQ7te23aghh0AUZMxLsiPf9ueC7ubsbrbGBqV3po01oF_OGTACT0V0fm629YYnKQdcCbPT3rcd15hjuWkXOgFlLYEqKuf8QuvEWgqLpx1LM1fjzd_TznHBA2Pn16Y73JNSZHBTE1RlZqO97vXxxF1w&h=jPl0qQl8eELbKBR1TpfN7VqK-APE87c0sNnTLIyd5Io
   response:
     body:
-      string: '{"name":"4d32f3dd-88e0-4c75-8151-af8a124659c9","status":"InProgress","startTime":"2026-03-31T21:47:41.577Z"}'
+      string: '{"name":"b16ca3d7-a377-4a6b-8ec7-74308cbe32cb","status":"InProgress","startTime":"2026-04-07T22:02:22.897Z"}'
     headers:
       cache-control:
       - no-cache
@@ -477,7 +477,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 31 Mar 2026 21:51:44 GMT
+      - Tue, 07 Apr 2026 22:06:26 GMT
       expires:
       - '-1'
       pragma:
@@ -489,11 +489,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/d8b730ed-be3d-4dc2-af9f-92b1b3292f71
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/ukwest/031e77ae-5d5b-4bb1-89eb-f8f3069b3117
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: B8DE07CFC9B840CDA6CC00337C82E0AC Ref B: AMS231032608037 Ref C: 2026-03-31T21:51:44Z'
+      - 'Ref A: 5BC0CAC2C84E4C41B4891EEF61DE2FD7 Ref B: AMS231032608037 Ref C: 2026-04-07T22:06:26Z'
     status:
       code: 200
       message: OK
@@ -511,12 +511,12 @@ interactions:
       ParameterSetName:
       - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/4d32f3dd-88e0-4c75-8151-af8a124659c9?api-version=2026-01-01-preview&t=639105904616933354&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=rPZQDWr1PVETImg15rqV73rQG7elimeZdaMmrAxUdcZM56UT46mSKCuKyTXzWVzN_Az5bSoPJBYYz3Vh53t4lCYu1j25ZC2vScLHSHBnYRvq2ZR63-_OuNke85PqwnBp9ghHMg-tVwY66cmnNOGIdd61hrzrCdoBGyI8iJiv6jDTUqzJf2Yj9BUUF88Dsq5Oq31r2NlkihuE3PQv08zSgWi9bDwxtmt5_0IYfgzsYBxo27NoaGhDNvMiL32aALCzfo17U9iSG-ENmzh1ws_Gl_FP74BZHZlmFgKmcH3ol-uzKPpuB2raEn-pXm2SDtuqpgvin4_sL_pEHxnFKjeScA&h=R4NrL547ygVfoyktfS1t_fYPRAw26FawnJDYvsi5Zzk
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/b16ca3d7-a377-4a6b-8ec7-74308cbe32cb?api-version=2026-01-01-preview&t=639111961430809856&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=wHmz-8GCvNRWFHYDnFTMpZQZz9wiybjyiph6T-Ts-teefUvDimt58oWjbUVJ-kEz9wyJzt5EzwV9Q8W-BN33yk512jIvInmoZPY0ekJj2wmEtJQ3l3r86Xzqh53Cebw4v-ySkjGuPS_InDx2iQYXQglBDm7YXJ4Ep3_Z61wpWPL_vTa74BpEy_ghTRUx3jNoLQ7te23aghh0AUZMxLsiPf9ueC7ubsbrbGBqV3po01oF_OGTACT0V0fm629YYnKQdcCbPT3rcd15hjuWkXOgFlLYEqKuf8QuvEWgqLpx1LM1fjzd_TznHBA2Pn16Y73JNSZHBTE1RlZqO97vXxxF1w&h=jPl0qQl8eELbKBR1TpfN7VqK-APE87c0sNnTLIyd5Io
   response:
     body:
-      string: '{"name":"4d32f3dd-88e0-4c75-8151-af8a124659c9","status":"Succeeded","startTime":"2026-03-31T21:47:41.577Z"}'
+      string: '{"name":"b16ca3d7-a377-4a6b-8ec7-74308cbe32cb","status":"Succeeded","startTime":"2026-04-07T22:02:22.897Z"}'
     headers:
       cache-control:
       - no-cache
@@ -525,7 +525,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 31 Mar 2026 21:52:45 GMT
+      - Tue, 07 Apr 2026 22:07:26 GMT
       expires:
       - '-1'
       pragma:
@@ -537,11 +537,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/09abd17a-0b29-4a1f-9c16-b9fd64ac820f
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/ukwest/edb9f5aa-70f6-4fb4-8d7f-64e0f6f64506
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 4BEDA02EE3CD46C5AC47CF8D0804E599 Ref B: AMS231020614021 Ref C: 2026-03-31T21:52:45Z'
+      - 'Ref A: 1A9020FAF94A4D23B75D4B1CF0305903 Ref B: AMS231022012017 Ref C: 2026-04-07T22:07:26Z'
     status:
       code: 200
       message: OK
@@ -559,22 +559,22 @@ interactions:
       ParameterSetName:
       - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002?api-version=2026-01-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v5","tier":"GeneralPurpose"},"systemData":{"createdAt":"2026-03-31T21:47:53.2079992Z"},"properties":{"dataEncryption":{"type":"SystemManaged"},"replica":{"role":"Primary","capacity":5},"storage":{"type":"","iops":500,"tier":"P10","storageSizeGB":128,"autoGrow":"Disabled"},"network":{"publicNetworkAccess":"Disabled"},"privateEndpointConnections":[],"authConfig":{"activeDirectoryAuth":"Disabled","passwordAuth":"Enabled"},"fullyQualifiedDomainName":"azuredbclitest-000002.postgres.database.azure.com","version":"17","minorVersion":"9","administratorLogin":"amusedeggs1","state":"Ready","availabilityZone":"1","backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"},"maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Primary","replicaCapacity":5},"location":"Canada
+      string: '{"sku":{"name":"Standard_D2ds_v5","tier":"GeneralPurpose"},"systemData":{"createdAt":"2026-04-07T22:02:33.8051693Z"},"properties":{"dataEncryption":{"type":"SystemManaged"},"replica":{"role":"Primary","capacity":5},"storage":{"type":"","iops":500,"tier":"P10","storageSizeGB":128,"autoGrow":"Disabled"},"network":{"publicNetworkAccess":"Disabled"},"privateEndpointConnections":[],"authConfig":{"activeDirectoryAuth":"Disabled","passwordAuth":"Enabled"},"fullyQualifiedDomainName":"azuredbclitest-000002.postgres.database.azure.com","version":"17","minorVersion":"9","administratorLogin":"hostilemoth2","state":"Ready","availabilityZone":"1","backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"},"maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Primary","replicaCapacity":5},"location":"Canada
         Central","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforPostgreSQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1183'
+      - '1184'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 31 Mar 2026 21:52:46 GMT
+      - Tue, 07 Apr 2026 22:07:27 GMT
       expires:
       - '-1'
       pragma:
@@ -588,7 +588,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: F1555A8FFAAD4788803ACCF97A9B7649 Ref B: AMS231020512037 Ref C: 2026-03-31T21:52:45Z'
+      - 'Ref A: C3B8449831EA40689D8913E56AF4086D Ref B: AMS231032609019 Ref C: 2026-04-07T22:07:27Z'
     status:
       code: 200
       message: OK
@@ -606,7 +606,7 @@ interactions:
       ParameterSetName:
       - -g --server-name --name --value
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/configurations/logfiles.download_enable?api-version=2026-01-01-preview
   response:
@@ -621,7 +621,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 31 Mar 2026 21:52:46 GMT
+      - Tue, 07 Apr 2026 22:07:27 GMT
       expires:
       - '-1'
       pragma:
@@ -633,11 +633,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/4856977e-0849-4898-a378-451fee6470a8
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/ee9da3c4-81a0-405c-b626-c620913d772b
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 22CBF0CDC07C41B5ACDA2A487DE037E5 Ref B: AMS231020512045 Ref C: 2026-03-31T21:52:46Z'
+      - 'Ref A: 1296D66F6FA84018BD54FCEF7B20A571 Ref B: AMS231032609037 Ref C: 2026-04-07T22:07:27Z'
     status:
       code: 200
       message: OK
@@ -659,27 +659,27 @@ interactions:
       ParameterSetName:
       - -g --server-name --name --value
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/configurations/logfiles.download_enable?api-version=2026-01-01-preview
   response:
     body:
-      string: '{"operation":"UpdateOrcasServerParameterManagementOperation","startTime":"2026-03-31T21:52:47.503Z"}'
+      string: '{"operation":"UpdateOrcasServerParameterManagementOperation","startTime":"2026-04-07T22:07:28.73Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/1abb990b-8bce-4f6c-8f1e-f67d90fd8b4e?api-version=2026-01-01-preview&t=639105907675269972&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=NVjP2dcc5NIlOHSDHoBYbmhzhpXvZSLeGUsIBzvM8YFzpR8S9Hsp9sAGbHn95nHo4NK8i0zeDpo-Oe-UmFMxaBB2QfkUT84Tf4xzHI2WCtxWgCWMEQNNDS2-X2rh453uAd3_soH6LFQcgkmkCHVdILg1FQZSdFAWKiW6sHDMtby6dFpHvkQSRZxLDIR64Rjg-PGb6PA-JYKWvOLA8UOGhc5ukCtruc_KdmnsjYx-GxwBuDRyuDpcC8P3GUghvqRNvHoPGrvbTOLiRKfbrZf-0-AWjX92nOcpDaeP3MoIUXnk8q_0i_hob14yy9eUU11JQhY1Z_5wo-t3X0kbZWzMog&h=Y9190tAue9Q0p8UB0dmLqw1Nx79P0xr2-5bqvIzjvNU
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/b6215a19-dbed-418f-92e6-6be4f62685dc?api-version=2026-01-01-preview&t=639111964488584633&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=d8gxrQeUvIMDDdfuMGCPXSYjGKG7P5tTtY92MX_gYgmmKNLm9rqXCKVbZYRxjJ-egSAJXc8mrGlkfx-sQ0Ab2ivCqWBn9hD_buPv80KScHzKXQnMvfvQFKAg6tdtLbNvtY1NpUE7HBivL7vIRpGLJamz-cySrLrbGZqq2yGX_66enQROmGtxZOizup8tpb2wbJazsJj-dLV3RpDJdcsdikfZ0-6stBIIuj-SDTV4zzT4V0mhXwMuFi8-fJVID62QEAqM4ZWxQ5tBbzr4Il9h8JqLZCBO4og1QATkthh1qBqIpMLGV2xhiZXrPSMT6dnNdB0P9NC_NNfL40ga0Ado8A&h=PQCaIbHIFdi6W33QEovCuO29J6gXoHfjbQMqWz9ys2Y
       cache-control:
       - no-cache
       content-length:
-      - '100'
+      - '99'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 31 Mar 2026 21:52:47 GMT
+      - Tue, 07 Apr 2026 22:07:28 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/operationResults/1abb990b-8bce-4f6c-8f1e-f67d90fd8b4e?api-version=2026-01-01-preview&t=639105907675427168&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=xXXLqQ8Omo_NGTwKp3sYuNdS7fS1u-_p7vAykj_jwRpgfEeoDjkfh-sVCP1iCi77XwldI2yISrCXmuwg-dowQtmC7qbfB3qorZOGKuZxuBruQT65zEdK4wdXrlyKATJSvg0E5I7EAUoktDehMhNu1wCkuuXZW3ikspQiXDP6lglyi-m9loy6TQoNiTPkJSXOJQxmajgF98E5_PagnqFi1nQA5RK576-tVPqu4xtGOqxgULdmt0kxT8LnE6g5VCXboY9pEWGtlS6ULnkrZuIn734SLpJtyJUqx6618tklCVF3Z6bwKsmcUz_Cq_HK59IylGgRGGYSVxBbW_j-2C8teQ&h=y4pB56t0gcJsVg9i8EADEkGOiLNslZos1WHv5F1R1h8
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/operationResults/b6215a19-dbed-418f-92e6-6be4f62685dc?api-version=2026-01-01-preview&t=639111964488584633&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=eGTvc_2Sk7fylvxorIBZZrBQa_EDzUfFNeAAhv1YcP3Djo3nahdJRP5-0z2irtGOWtWl3s7oVRZKWnDbRBLwWMfgbP_VnojsMNHpdfLRHVAggE5A6ixfNas1WLGZaTCwr13GsEIOC6m30ZL_lxdECbcY8UQHSsnqNgqq9Je8TwlMnscOabuM5hLtKt20Qbm9MOCBvLOjvNg0D-3jnkSp7twjX0GWz1kOQJcIMvXVTrQRuvM6Je4JdtyFrHm6YX1umP71usMZDY3GKFqhJgP_kh_-zsZpdLbyzLXAQMzOSP31awiqfTJiXxKBy43xWfl0Vm9YAtIuMbPZ5VnWg9Y4bA&h=SGEkHzOWzcWWLARajbSYMu9BFD2fquyZjumuxRvdtfA
       pragma:
       - no-cache
       strict-transport-security:
@@ -689,13 +689,13 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/f18af6ef-5841-4f3d-b6d6-595daa62cad4
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/bbaaa509-f3e6-4baa-8a10-fe475c73f7e3
       x-ms-ratelimit-remaining-subscription-global-writes:
       - '11999'
       x-ms-ratelimit-remaining-subscription-writes:
       - '799'
       x-msedge-ref:
-      - 'Ref A: ECD1F28A99434BDE90099773EF513723 Ref B: AMS231022012017 Ref C: 2026-03-31T21:52:47Z'
+      - 'Ref A: 1292EC6B41DC48DF9B80FF91E34775FD Ref B: AMS231020614037 Ref C: 2026-04-07T22:07:28Z'
     status:
       code: 202
       message: Accepted
@@ -713,60 +713,12 @@ interactions:
       ParameterSetName:
       - -g --server-name --name --value
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/1abb990b-8bce-4f6c-8f1e-f67d90fd8b4e?api-version=2026-01-01-preview&t=639105907675269972&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=NVjP2dcc5NIlOHSDHoBYbmhzhpXvZSLeGUsIBzvM8YFzpR8S9Hsp9sAGbHn95nHo4NK8i0zeDpo-Oe-UmFMxaBB2QfkUT84Tf4xzHI2WCtxWgCWMEQNNDS2-X2rh453uAd3_soH6LFQcgkmkCHVdILg1FQZSdFAWKiW6sHDMtby6dFpHvkQSRZxLDIR64Rjg-PGb6PA-JYKWvOLA8UOGhc5ukCtruc_KdmnsjYx-GxwBuDRyuDpcC8P3GUghvqRNvHoPGrvbTOLiRKfbrZf-0-AWjX92nOcpDaeP3MoIUXnk8q_0i_hob14yy9eUU11JQhY1Z_5wo-t3X0kbZWzMog&h=Y9190tAue9Q0p8UB0dmLqw1Nx79P0xr2-5bqvIzjvNU
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/b6215a19-dbed-418f-92e6-6be4f62685dc?api-version=2026-01-01-preview&t=639111964488584633&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=d8gxrQeUvIMDDdfuMGCPXSYjGKG7P5tTtY92MX_gYgmmKNLm9rqXCKVbZYRxjJ-egSAJXc8mrGlkfx-sQ0Ab2ivCqWBn9hD_buPv80KScHzKXQnMvfvQFKAg6tdtLbNvtY1NpUE7HBivL7vIRpGLJamz-cySrLrbGZqq2yGX_66enQROmGtxZOizup8tpb2wbJazsJj-dLV3RpDJdcsdikfZ0-6stBIIuj-SDTV4zzT4V0mhXwMuFi8-fJVID62QEAqM4ZWxQ5tBbzr4Il9h8JqLZCBO4og1QATkthh1qBqIpMLGV2xhiZXrPSMT6dnNdB0P9NC_NNfL40ga0Ado8A&h=PQCaIbHIFdi6W33QEovCuO29J6gXoHfjbQMqWz9ys2Y
   response:
     body:
-      string: '{"name":"1abb990b-8bce-4f6c-8f1e-f67d90fd8b4e","status":"InProgress","startTime":"2026-03-31T21:52:47.503Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '108'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 31 Mar 2026 21:52:47 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-cache:
-      - CONFIG_NOCACHE
-      x-content-type-options:
-      - nosniff
-      x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/ukwest/8b41b0ef-4c8e-408e-9436-aef843d2c9b9
-      x-ms-ratelimit-remaining-subscription-global-reads:
-      - '16499'
-      x-msedge-ref:
-      - 'Ref A: 923BB228F92747889C91D41E95A6D5DF Ref B: AMS231020615007 Ref C: 2026-03-31T21:52:47Z'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - postgres flexible-server parameter set
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --server-name --name --value
-      User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/1abb990b-8bce-4f6c-8f1e-f67d90fd8b4e?api-version=2026-01-01-preview&t=639105907675269972&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=NVjP2dcc5NIlOHSDHoBYbmhzhpXvZSLeGUsIBzvM8YFzpR8S9Hsp9sAGbHn95nHo4NK8i0zeDpo-Oe-UmFMxaBB2QfkUT84Tf4xzHI2WCtxWgCWMEQNNDS2-X2rh453uAd3_soH6LFQcgkmkCHVdILg1FQZSdFAWKiW6sHDMtby6dFpHvkQSRZxLDIR64Rjg-PGb6PA-JYKWvOLA8UOGhc5ukCtruc_KdmnsjYx-GxwBuDRyuDpcC8P3GUghvqRNvHoPGrvbTOLiRKfbrZf-0-AWjX92nOcpDaeP3MoIUXnk8q_0i_hob14yy9eUU11JQhY1Z_5wo-t3X0kbZWzMog&h=Y9190tAue9Q0p8UB0dmLqw1Nx79P0xr2-5bqvIzjvNU
-  response:
-    body:
-      string: '{"name":"1abb990b-8bce-4f6c-8f1e-f67d90fd8b4e","status":"Succeeded","startTime":"2026-03-31T21:52:47.503Z"}'
+      string: '{"name":"b6215a19-dbed-418f-92e6-6be4f62685dc","status":"InProgress","startTime":"2026-04-07T22:07:28.73Z"}'
     headers:
       cache-control:
       - no-cache
@@ -775,7 +727,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 31 Mar 2026 21:52:58 GMT
+      - Tue, 07 Apr 2026 22:07:29 GMT
       expires:
       - '-1'
       pragma:
@@ -787,11 +739,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/e14843da-b23d-413a-86c1-6a997bafced8
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/c31e0b64-57f9-439c-8fa8-8df07b28c6f2
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 07595B5BDC98420E91C9947A4577AE10 Ref B: AMS231022012039 Ref C: 2026-03-31T21:52:58Z'
+      - 'Ref A: B09BD674381A4EA5A424C432BEDA77D4 Ref B: AMS231020512049 Ref C: 2026-04-07T22:07:29Z'
     status:
       code: 200
       message: OK
@@ -809,7 +761,55 @@ interactions:
       ParameterSetName:
       - -g --server-name --name --value
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/b6215a19-dbed-418f-92e6-6be4f62685dc?api-version=2026-01-01-preview&t=639111964488584633&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=d8gxrQeUvIMDDdfuMGCPXSYjGKG7P5tTtY92MX_gYgmmKNLm9rqXCKVbZYRxjJ-egSAJXc8mrGlkfx-sQ0Ab2ivCqWBn9hD_buPv80KScHzKXQnMvfvQFKAg6tdtLbNvtY1NpUE7HBivL7vIRpGLJamz-cySrLrbGZqq2yGX_66enQROmGtxZOizup8tpb2wbJazsJj-dLV3RpDJdcsdikfZ0-6stBIIuj-SDTV4zzT4V0mhXwMuFi8-fJVID62QEAqM4ZWxQ5tBbzr4Il9h8JqLZCBO4og1QATkthh1qBqIpMLGV2xhiZXrPSMT6dnNdB0P9NC_NNfL40ga0Ado8A&h=PQCaIbHIFdi6W33QEovCuO29J6gXoHfjbQMqWz9ys2Y
+  response:
+    body:
+      string: '{"name":"b6215a19-dbed-418f-92e6-6be4f62685dc","status":"Succeeded","startTime":"2026-04-07T22:07:28.73Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '106'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 07 Apr 2026 22:07:39 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/ukwest/998758b2-5c5b-467c-b134-8735694bfb21
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 6C9349FF829A4E248A607595D692139A Ref B: AMS231032609051 Ref C: 2026-04-07T22:07:39Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - postgres flexible-server parameter set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --server-name --name --value
+      User-Agent:
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/configurations/logfiles.download_enable?api-version=2026-01-01-preview
   response:
@@ -824,7 +824,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 31 Mar 2026 21:52:58 GMT
+      - Tue, 07 Apr 2026 22:07:40 GMT
       expires:
       - '-1'
       pragma:
@@ -836,11 +836,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/3d18cd81-b1f1-4ada-a90d-7da39bf470aa
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/fcca03cd-b543-4266-8eae-f2e05d06a61e
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: A88AD7E9C37B46F6ADC815B6067456C4 Ref B: AMS231032607021 Ref C: 2026-03-31T21:52:59Z'
+      - 'Ref A: AB9C4237472949409D986FA60A145B8A Ref B: AMS231020615033 Ref C: 2026-04-07T22:07:40Z'
     status:
       code: 200
       message: OK
@@ -858,7 +858,7 @@ interactions:
       ParameterSetName:
       - -g --server-name --name --value
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/configurations/logfiles.retention_days?api-version=2026-01-01-preview
   response:
@@ -873,7 +873,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 31 Mar 2026 21:52:59 GMT
+      - Tue, 07 Apr 2026 22:07:41 GMT
       expires:
       - '-1'
       pragma:
@@ -885,11 +885,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/ce40026e-60c7-4632-806a-2918de330505
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/5bd6b530-ae40-4327-aea7-475e60459b68
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 6E18668F29E04A9DB47DABB92E782F93 Ref B: AMS231032607007 Ref C: 2026-03-31T21:52:59Z'
+      - 'Ref A: 52346CAA53B343BE9FA65FBB12DFF310 Ref B: AMS231032607033 Ref C: 2026-04-07T22:07:41Z'
     status:
       code: 200
       message: OK
@@ -911,27 +911,27 @@ interactions:
       ParameterSetName:
       - -g --server-name --name --value
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/configurations/logfiles.retention_days?api-version=2026-01-01-preview
   response:
     body:
-      string: '{"operation":"UpdateOrcasServerParameterManagementOperation","startTime":"2026-03-31T21:53:00.52Z"}'
+      string: '{"operation":"UpdateOrcasServerParameterManagementOperation","startTime":"2026-04-07T22:07:41.967Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/6cd7953a-2df2-4280-9b9e-6f140d1f6b23?api-version=2026-01-01-preview&t=639105907805494394&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=woZFtLv0Bv3XYvNUQ9LUAQypcPAuktn9KSXTySQQF3OfokJ8Z_GoDHjdwKfAsfV6HbxnXzF2ZDjxRUkxN__rbJz1RnMMzHpizN17WwNomPnpX3EzDPOOOEWD0LlbkMHgWg2ll3AbG9TR39KEbxwSqI0z46MDuCqG6Z_fZUUc7fhc_9BA0b0EEyU2NqXDMZYJa4TkQPOTDMm0I4yZEZd0HFEBQqVLqYe3iAy9u3e2Wa-so1HHLq-My-XdZ8FoRkr2UltltL4NZXImIicy5dtZdHt2NIw_AyIG8ijkz-maKBxrefC41L7epTXs8R7GTmj4TGE8wS7vjfvbfDZXHZbZ8w&h=vflfzRbzpxci8lPoYmgtr-vDstWF1D0V51cFWQEEJvw
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/615d592c-3903-48b3-bcf2-61ad1bd7f4ef?api-version=2026-01-01-preview&t=639111964620394603&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=Vmxf8eckCvZcS6jyX5kuRJVfXwIiMYYfcrwTqiwT_UdKYxyy35ErwowQhLsbvoJHdYkjy2jo_quVvgTTlP5D0zA4qZPcSM1sG2D6qNY1dMnueuG6_1GNhFUptXuF_xPFPwt6HUhg4B9-ipMuKQYKqzLE8MOs51ifpjZt0MgYNYmCYQwjQ8zTW1GC-FmcDA2Cz1qZEhrq0gFe9BT_GLCm8IDrJ5F02wJeZotNQ_VHJ13I0m60ogqr4HP5XTAv892wuTIgo4ZS6VIhZamA7KOL0AIsoqIuH_4miZ61o4WoMh7ABjT4lCqZPBMY_mwXD-ArVXO0HZeqv7CtqShYnDbGQQ&h=n8Rvyhxv7b6lr4NwOynQPXrUFwOHoFzmptpEO10e1HY
       cache-control:
       - no-cache
       content-length:
-      - '99'
+      - '100'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 31 Mar 2026 21:53:00 GMT
+      - Tue, 07 Apr 2026 22:07:41 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/operationResults/6cd7953a-2df2-4280-9b9e-6f140d1f6b23?api-version=2026-01-01-preview&t=639105907805650665&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=Yt2h4gu1RSnwRoUat-Nw7SB-R5H6zr_xoqKuCPThqh-iwkh9FDs50VCEWj9m2EXtxXTC7yJNm0yIoXVSnfYrlplEZPa4B0qoz5egeklPu45KSB5qbGuIzLbY3_MuZQ1qNgZYlYp2CB6d8BLN2Kj7U7lacnSWRSWEp1IF0_ygzD0n8exL18msFspPZlwaX447Ot9LRGgHVCfOI87zXAfMbbJLzFVdJKp5gGXCNVeaNJyUvO1IHlGDb_P0vcYd4K5TGC4vR-mcIQf67Qe5iUtwSwd0K3NIsP70-E_EVqAxF4JegDH-_zXhrWgpfH7tTXzyEZGG7EjfvY1QNvFryBxaXg&h=D3_YQKTl3rz3b4-WF7gPvJOxyYOIFuCoDFiXLRf9HUY
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/operationResults/615d592c-3903-48b3-bcf2-61ad1bd7f4ef?api-version=2026-01-01-preview&t=639111964620550835&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=ObcfWW2UVGM5wI6ilIq48tdORIObI09FDrbPDVD7-D70yJQT90qWnU-jxnaKCxBMr-DMEI3FAXy-6ZjmC56JwoM0id7zl4x9JoYSt0ccc700WTpOu8DGfGfmivhZ9QB7HG9YxQKMNb6bf_OtCKsLSBXdFxgDXD07nMIMmUIZCIxulWqMh5A7SRfZUvKmWcNUA-Gbi4_Z5iYq0tt4170zpfyLFyRkuRFVLdBXOLoUHuWX_XYe0zWRN1t8Bw2EnUGQWT72RAlHOCF2z7J8iHyCjkpfjMwfY8uzHf7LOdJSu_6rl6hjG7FPlLyS6YDF9YgVlTY7nCWR1iF8u5V-yNUB6g&h=uXLW5kWS4RZGQMxarqiGXrG5WPEVtf-XIeL84be_O7A
       pragma:
       - no-cache
       strict-transport-security:
@@ -941,13 +941,13 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/7f92bc52-e076-445b-89c1-e60475fbe8c7
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/cf3e11eb-ef7e-44b0-ace4-6adfaae0f1ea
       x-ms-ratelimit-remaining-subscription-global-writes:
       - '11999'
       x-ms-ratelimit-remaining-subscription-writes:
       - '799'
       x-msedge-ref:
-      - 'Ref A: BC69EAF167FE41CA982559B75FCA4FFF Ref B: AMS231032607025 Ref C: 2026-03-31T21:53:00Z'
+      - 'Ref A: F2E034582BCB427B80167EDC535E917E Ref B: AMS231032609051 Ref C: 2026-04-07T22:07:41Z'
     status:
       code: 202
       message: Accepted
@@ -965,12 +965,60 @@ interactions:
       ParameterSetName:
       - -g --server-name --name --value
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/6cd7953a-2df2-4280-9b9e-6f140d1f6b23?api-version=2026-01-01-preview&t=639105907805494394&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=woZFtLv0Bv3XYvNUQ9LUAQypcPAuktn9KSXTySQQF3OfokJ8Z_GoDHjdwKfAsfV6HbxnXzF2ZDjxRUkxN__rbJz1RnMMzHpizN17WwNomPnpX3EzDPOOOEWD0LlbkMHgWg2ll3AbG9TR39KEbxwSqI0z46MDuCqG6Z_fZUUc7fhc_9BA0b0EEyU2NqXDMZYJa4TkQPOTDMm0I4yZEZd0HFEBQqVLqYe3iAy9u3e2Wa-so1HHLq-My-XdZ8FoRkr2UltltL4NZXImIicy5dtZdHt2NIw_AyIG8ijkz-maKBxrefC41L7epTXs8R7GTmj4TGE8wS7vjfvbfDZXHZbZ8w&h=vflfzRbzpxci8lPoYmgtr-vDstWF1D0V51cFWQEEJvw
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/615d592c-3903-48b3-bcf2-61ad1bd7f4ef?api-version=2026-01-01-preview&t=639111964620394603&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=Vmxf8eckCvZcS6jyX5kuRJVfXwIiMYYfcrwTqiwT_UdKYxyy35ErwowQhLsbvoJHdYkjy2jo_quVvgTTlP5D0zA4qZPcSM1sG2D6qNY1dMnueuG6_1GNhFUptXuF_xPFPwt6HUhg4B9-ipMuKQYKqzLE8MOs51ifpjZt0MgYNYmCYQwjQ8zTW1GC-FmcDA2Cz1qZEhrq0gFe9BT_GLCm8IDrJ5F02wJeZotNQ_VHJ13I0m60ogqr4HP5XTAv892wuTIgo4ZS6VIhZamA7KOL0AIsoqIuH_4miZ61o4WoMh7ABjT4lCqZPBMY_mwXD-ArVXO0HZeqv7CtqShYnDbGQQ&h=n8Rvyhxv7b6lr4NwOynQPXrUFwOHoFzmptpEO10e1HY
   response:
     body:
-      string: '{"name":"6cd7953a-2df2-4280-9b9e-6f140d1f6b23","status":"InProgress","startTime":"2026-03-31T21:53:00.52Z"}'
+      string: '{"name":"615d592c-3903-48b3-bcf2-61ad1bd7f4ef","status":"InProgress","startTime":"2026-04-07T22:07:41.967Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 07 Apr 2026 22:07:42 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/ee40c4e0-b958-4072-afa2-a3db8891e278
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: CC16F99F021747D187E5D2DE97BCB2DE Ref B: AMS231032608047 Ref C: 2026-04-07T22:07:42Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - postgres flexible-server parameter set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --server-name --name --value
+      User-Agent:
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/615d592c-3903-48b3-bcf2-61ad1bd7f4ef?api-version=2026-01-01-preview&t=639111964620394603&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=Vmxf8eckCvZcS6jyX5kuRJVfXwIiMYYfcrwTqiwT_UdKYxyy35ErwowQhLsbvoJHdYkjy2jo_quVvgTTlP5D0zA4qZPcSM1sG2D6qNY1dMnueuG6_1GNhFUptXuF_xPFPwt6HUhg4B9-ipMuKQYKqzLE8MOs51ifpjZt0MgYNYmCYQwjQ8zTW1GC-FmcDA2Cz1qZEhrq0gFe9BT_GLCm8IDrJ5F02wJeZotNQ_VHJ13I0m60ogqr4HP5XTAv892wuTIgo4ZS6VIhZamA7KOL0AIsoqIuH_4miZ61o4WoMh7ABjT4lCqZPBMY_mwXD-ArVXO0HZeqv7CtqShYnDbGQQ&h=n8Rvyhxv7b6lr4NwOynQPXrUFwOHoFzmptpEO10e1HY
+  response:
+    body:
+      string: '{"name":"615d592c-3903-48b3-bcf2-61ad1bd7f4ef","status":"Succeeded","startTime":"2026-04-07T22:07:41.967Z"}'
     headers:
       cache-control:
       - no-cache
@@ -979,7 +1027,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 31 Mar 2026 21:53:00 GMT
+      - Tue, 07 Apr 2026 22:07:52 GMT
       expires:
       - '-1'
       pragma:
@@ -991,11 +1039,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/ukwest/527cd67e-cd4d-4d5c-bf7b-edaa370c4edc
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/b79f0fbf-1719-47ba-ab33-aa6faca6902b
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 2C55C2FDF19541B4B846E88CCE827386 Ref B: AMS231020614053 Ref C: 2026-03-31T21:53:00Z'
+      - 'Ref A: CE32375D1FCE4CCD81D03F6291397DBB Ref B: AMS231032608033 Ref C: 2026-04-07T22:07:52Z'
     status:
       code: 200
       message: OK
@@ -1013,55 +1061,7 @@ interactions:
       ParameterSetName:
       - -g --server-name --name --value
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/6cd7953a-2df2-4280-9b9e-6f140d1f6b23?api-version=2026-01-01-preview&t=639105907805494394&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=woZFtLv0Bv3XYvNUQ9LUAQypcPAuktn9KSXTySQQF3OfokJ8Z_GoDHjdwKfAsfV6HbxnXzF2ZDjxRUkxN__rbJz1RnMMzHpizN17WwNomPnpX3EzDPOOOEWD0LlbkMHgWg2ll3AbG9TR39KEbxwSqI0z46MDuCqG6Z_fZUUc7fhc_9BA0b0EEyU2NqXDMZYJa4TkQPOTDMm0I4yZEZd0HFEBQqVLqYe3iAy9u3e2Wa-so1HHLq-My-XdZ8FoRkr2UltltL4NZXImIicy5dtZdHt2NIw_AyIG8ijkz-maKBxrefC41L7epTXs8R7GTmj4TGE8wS7vjfvbfDZXHZbZ8w&h=vflfzRbzpxci8lPoYmgtr-vDstWF1D0V51cFWQEEJvw
-  response:
-    body:
-      string: '{"name":"6cd7953a-2df2-4280-9b9e-6f140d1f6b23","status":"Succeeded","startTime":"2026-03-31T21:53:00.52Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '106'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 31 Mar 2026 21:53:11 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-cache:
-      - CONFIG_NOCACHE
-      x-content-type-options:
-      - nosniff
-      x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/ukwest/c7dce134-97ac-4c24-abb0-46866c88132e
-      x-ms-ratelimit-remaining-subscription-global-reads:
-      - '16499'
-      x-msedge-ref:
-      - 'Ref A: 1BC6FA9DD5AB449FB6216979656BB270 Ref B: AMS231020512049 Ref C: 2026-03-31T21:53:11Z'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - postgres flexible-server parameter set
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --server-name --name --value
-      User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/configurations/logfiles.retention_days?api-version=2026-01-01-preview
   response:
@@ -1076,7 +1076,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 31 Mar 2026 21:53:11 GMT
+      - Tue, 07 Apr 2026 22:07:53 GMT
       expires:
       - '-1'
       pragma:
@@ -1088,11 +1088,4046 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/bcb300b5-0263-454d-8d1f-15dcf19ffb53
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/edc9ffa8-10e7-461c-b6e8-a052e2e68d24
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 8B41B2281FA44A65AE0119DF33212DB8 Ref B: AMS231020512011 Ref C: 2026-03-31T21:53:12Z'
+      - 'Ref A: 54E5EDA14CBA475596573B8D295144B4 Ref B: AMS231022012035 Ref C: 2026-04-07T22:07:53Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - postgres flexible-server server-logs list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --server-name
+      User-Agent:
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/logFiles?api-version=2026-01-01-preview
+  response:
+    body:
+      string: '{"value":[{"properties":{"sizeInKb":167,"createdTime":"2026-04-07T22:26:31+00:00","lastModifiedTime":"2026-04-07T22:36:34+00:00","type":"ServerLogs","url":"https://ef63a06f662bsa.blob.core.windows.net/6ee560879f2e4be8a46085a8c6720516bak/serverlogs/postgresql_2026_04_07_22_00_00.log?sv=2025-05-05&se=2026-04-07T22%3A42%3A55Z&sr=b&sp=rdl&sig=9sMrAWsawObYTs7oEt2MG7i7LDhTXVjSP%2FMq5dCyEOY%3D"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/logFiles","name":"postgresql_2026_04_07_22_00_00.log","type":"Microsoft.DBforPostgreSQL/flexibleServers/logFiles"}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '672'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 07 Apr 2026 22:37:55 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/2a02b053-55f7-4bbf-8a36-e0b958dfb32b
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 8A4240FE48044F0782ACE0317BFE00C1 Ref B: AMS231022012039 Ref C: 2026-04-07T22:37:55Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - postgres flexible-server server-logs download
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --server-name --name
+      User-Agent:
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/logFiles?api-version=2026-01-01-preview
+  response:
+    body:
+      string: '{"value":[{"properties":{"sizeInKb":167,"createdTime":"2026-04-07T22:26:31+00:00","lastModifiedTime":"2026-04-07T22:36:34+00:00","type":"ServerLogs","url":"https://ef63a06f662bsa.blob.core.windows.net/6ee560879f2e4be8a46085a8c6720516bak/serverlogs/postgresql_2026_04_07_22_00_00.log?sv=2025-05-05&se=2026-04-07T22%3A42%3A56Z&sr=b&sp=rdl&sig=bTKjBR3BaecQC7jTiCHIx1lY6tTjcB1P5LwTBMV7Sjs%3D"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/logFiles","name":"postgresql_2026_04_07_22_00_00.log","type":"Microsoft.DBforPostgreSQL/flexibleServers/logFiles"}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '670'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 07 Apr 2026 22:37:56 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/26360220-2de6-474c-b9d8-fc5ace8f2f76
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: C8F3F8DC81604EC1A68B4586A36BFF7C Ref B: AMS231020614017 Ref C: 2026-04-07T22:37:56Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - ef63a06f662bsa.blob.core.windows.net
+      User-Agent:
+      - Python-urllib/3.13
+    method: GET
+    uri: https://ef63a06f662bsa.blob.core.windows.net/6ee560879f2e4be8a46085a8c6720516bak/serverlogs/postgresql_2026_04_07_22_00_00.log?sv=2025-05-05&se=2026-04-07T22%3A42%3A56Z&sr=b&sp=rdl&sig=bTKjBR3BaecQC7jTiCHIx1lY6tTjcB1P5LwTBMV7Sjs%3D
+  response:
+    body:
+      string: '2026-04-07 22:16:35 UTC-69d5822f.556-LOG:  disconnection: session time:
+        0:00:20.025 user=azuresu database=azure_sys host=127.0.0.1 port=43444
+
+        2026-04-07 22:16:40 UTC-69d57ff0.2ee-LOG:  [pg-availability]: current_lsn:
+        0/40001F8, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-04-07 22:16:41 UTC-69d58235.562-LOG:  disconnection: session time: 0:00:20.021
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=43468
+
+        2026-04-07 22:16:41 UTC-69d58249.589-LOG:  connection received: host=127.0.0.1
+        port=33148
+
+        2026-04-07 22:16:41 UTC-69d58249.589-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:16:41 UTC-69d58249.589-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:16:41 UTC-69d58249.589-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:16:41 UTC-69d58249.589-LOG:  disconnection: session time: 0:00:00.045
+        user=azuresu database=postgres host=127.0.0.1 port=33148
+
+        2026-04-07 22:16:41 UTC-69d58235.563-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=postgres host=127.0.0.1 port=43484
+
+        2026-04-07 22:16:41 UTC-69d58249.58a-LOG:  connection received: host=127.0.0.1
+        port=33164
+
+        2026-04-07 22:16:41 UTC-69d58249.58a-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:16:41 UTC-69d58249.58a-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:16:41 UTC-69d58249.58a-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:16:43 UTC-69d5824b.58b-LOG:  connection received: host=127.0.0.1
+        port=49986
+
+        2026-04-07 22:16:43 UTC-69d5824b.58b-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:16:43 UTC-69d5824b.58b-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:16:43 UTC-69d5824b.58b-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:16:46 UTC-69d5824e.58e-LOG:  connection received: host=127.0.0.1
+        port=50002
+
+        2026-04-07 22:16:46 UTC-69d5824e.58e-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:16:46 UTC-69d5824e.58e-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:16:46 UTC-69d5824e.58e-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:16:48 UTC-69d5823c.57c-LOG:  disconnection: session time: 0:00:20.028
+        user=azuresu database=azure_sys host=127.0.0.1 port=46804
+
+        2026-04-07 22:17:01 UTC-69d58249.58a-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=postgres host=127.0.0.1 port=33164
+
+        2026-04-07 22:17:02 UTC-69d5825e.592-LOG:  connection received: host=127.0.0.1
+        port=57278
+
+        2026-04-07 22:17:02 UTC-69d5825e.592-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:17:02 UTC-69d5825e.592-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:17:02 UTC-69d5825e.592-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:17:03 UTC-69d5824b.58b-LOG:  disconnection: session time: 0:00:20.028
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=49986
+
+        2026-04-07 22:17:05 UTC-69d58261.595-LOG:  connection received: host=127.0.0.1
+        port=57294
+
+        2026-04-07 22:17:05 UTC-69d58261.595-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:17:05 UTC-69d58261.595-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:17:05 UTC-69d58261.595-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:17:06 UTC-69d5824e.58e-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=azure_sys host=127.0.0.1 port=50002
+
+        2026-04-07 22:17:06 UTC-69d58262.59f-LOG:  connection received: host=127.0.0.1
+        port=57300
+
+        2026-04-07 22:17:06 UTC-69d58262.59f-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:17:06 UTC-69d58262.59f-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:17:06 UTC-69d58262.59f-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:17:06 UTC-69d58262.59f-LOG:  disconnection: session time: 0:00:00.048
+        user=azuresu database=postgres host=127.0.0.1 port=57300
+
+        2026-04-07 22:17:17 UTC-69d5826d.5a2-LOG:  connection received: host=127.0.0.1
+        port=52544
+
+        2026-04-07 22:17:17 UTC-69d5826d.5a2-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:17:17 UTC-69d5826d.5a2-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:17:17 UTC-69d5826d.5a2-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:17:22 UTC-69d5825e.592-LOG:  disconnection: session time: 0:00:20.150
+        user=azuresu database=postgres host=127.0.0.1 port=57278
+
+        2026-04-07 22:17:25 UTC-69d58261.595-LOG:  disconnection: session time: 0:00:20.025
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=57294
+
+        2026-04-07 22:17:27 UTC-69d58277.5a6-LOG:  connection received: host=127.0.0.1
+        port=60542
+
+        2026-04-07 22:17:27 UTC-69d58277.5a6-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:17:27 UTC-69d58277.5a6-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:17:27 UTC-69d58277.5a6-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:17:31 UTC-69d5827b.5b1-LOG:  connection received: host=127.0.0.1
+        port=60546
+
+        2026-04-07 22:17:31 UTC-69d5827b.5b1-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:17:31 UTC-69d5827b.5b1-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:17:31 UTC-69d5827b.5b1-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:17:31 UTC-69d5827b.5b1-LOG:  disconnection: session time: 0:00:00.048
+        user=azuresu database=postgres host=127.0.0.1 port=60546
+
+        2026-04-07 22:17:32 UTC-69d5827c.5b2-LOG:  connection received: host=127.0.0.1
+        port=57850
+
+        2026-04-07 22:17:32 UTC-69d5827c.5b2-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:17:32 UTC-69d5827c.5b2-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:17:32 UTC-69d5827c.5b2-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:17:37 UTC-69d5826d.5a2-LOG:  disconnection: session time: 0:00:20.035
+        user=azuresu database=azure_sys host=127.0.0.1 port=52544
+
+        2026-04-07 22:17:40 UTC-69d57ff0.2ee-LOG:  [pg-availability]: current_lsn:
+        0/4000898, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-04-07 22:17:47 UTC-69d58277.5a6-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=60542
+
+        2026-04-07 22:17:48 UTC-69d5828c.5b7-LOG:  connection received: host=127.0.0.1
+        port=35638
+
+        2026-04-07 22:17:48 UTC-69d5828c.5b7-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:17:48 UTC-69d5828c.5b7-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:17:48 UTC-69d5828c.5b7-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:17:49 UTC-69d5828d.5b8-LOG:  connection received: host=127.0.0.1
+        port=35654
+
+        2026-04-07 22:17:49 UTC-69d5828d.5b8-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:17:49 UTC-69d5828d.5b8-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:17:49 UTC-69d5828d.5b8-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:17:52 UTC-69d5827c.5b2-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=postgres host=127.0.0.1 port=57850
+
+        2026-04-07 22:17:52 UTC-69d58290.5ba-LOG:  connection received: host=127.0.0.1
+        port=60044
+
+        2026-04-07 22:17:52 UTC-69d58290.5ba-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:17:52 UTC-69d58290.5ba-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:17:52 UTC-69d58290.5ba-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:17:57 UTC-69d58294.5c5-LOG:  connection received: host=127.0.0.1
+        port=60046
+
+        2026-04-07 22:17:57 UTC-69d58294.5c5-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:17:57 UTC-69d58294.5c5-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:17:57 UTC-69d58294.5c5-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:17:57 UTC-69d58294.5c5-LOG:  disconnection: session time: 0:00:00.045
+        user=azuresu database=postgres host=127.0.0.1 port=60046
+
+        2026-04-07 22:18:08 UTC-69d5828c.5b7-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=azure_sys host=127.0.0.1 port=35638
+
+        2026-04-07 22:18:09 UTC-69d5828d.5b8-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=35654
+
+        2026-04-07 22:18:11 UTC-69d582a3.5ca-LOG:  connection received: host=127.0.0.1
+        port=51330
+
+        2026-04-07 22:18:11 UTC-69d582a3.5ca-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:18:11 UTC-69d582a3.5ca-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:18:11 UTC-69d582a3.5ca-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:18:12 UTC-69d58290.5ba-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=postgres host=127.0.0.1 port=60044
+
+        2026-04-07 22:18:12 UTC-69d582a4.5cb-LOG:  connection received: host=127.0.0.1
+        port=56874
+
+        2026-04-07 22:18:12 UTC-69d582a4.5cb-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:18:12 UTC-69d582a4.5cb-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:18:12 UTC-69d582a4.5cb-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:18:19 UTC-69d582ab.5cd-LOG:  connection received: host=127.0.0.1
+        port=56878
+
+        2026-04-07 22:18:19 UTC-69d582ab.5cd-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:18:19 UTC-69d582ab.5cd-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:18:19 UTC-69d582ab.5cd-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:18:22 UTC-69d582ae.5d8-LOG:  connection received: host=127.0.0.1
+        port=60278
+
+        2026-04-07 22:18:22 UTC-69d582ae.5d8-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:18:22 UTC-69d582ae.5d8-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:18:22 UTC-69d582ae.5d8-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:18:22 UTC-69d582ae.5d8-LOG:  disconnection: session time: 0:00:00.046
+        user=azuresu database=postgres host=127.0.0.1 port=60278
+
+        2026-04-07 22:18:31 UTC-69d582a3.5ca-LOG:  disconnection: session time: 0:00:20.043
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=51330
+
+        2026-04-07 22:18:32 UTC-69d582a4.5cb-LOG:  disconnection: session time: 0:00:20.023
+        user=azuresu database=postgres host=127.0.0.1 port=56874
+
+        2026-04-07 22:18:32 UTC-69d582b8.5dc-LOG:  connection received: host=127.0.0.1
+        port=50090
+
+        2026-04-07 22:18:32 UTC-69d582b8.5dc-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:18:32 UTC-69d582b8.5dc-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:18:32 UTC-69d582b8.5dc-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:18:33 UTC-69d582b9.5dd-LOG:  connection received: host=127.0.0.1
+        port=50106
+
+        2026-04-07 22:18:33 UTC-69d582b9.5dd-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:18:33 UTC-69d582b9.5dd-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:18:33 UTC-69d582b9.5dd-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:18:39 UTC-69d582ab.5cd-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=azure_sys host=127.0.0.1 port=56878
+
+        2026-04-07 22:18:40 UTC-69d57ff0.2ee-LOG:  [pg-availability]: current_lsn:
+        0/4000F38, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-04-07 22:18:47 UTC-69d582c7.5eb-LOG:  connection received: host=127.0.0.1
+        port=59808
+
+        2026-04-07 22:18:47 UTC-69d582c7.5eb-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:18:47 UTC-69d582c7.5eb-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:18:47 UTC-69d582c7.5eb-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:18:47 UTC-69d582c7.5eb-LOG:  disconnection: session time: 0:00:00.046
+        user=azuresu database=postgres host=127.0.0.1 port=59808
+
+        2026-04-07 22:18:50 UTC-69d582ca.5ed-LOG:  connection received: host=127.0.0.1
+        port=59822
+
+        2026-04-07 22:18:50 UTC-69d582ca.5ed-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:18:50 UTC-69d582ca.5ed-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:18:50 UTC-69d582ca.5ed-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:18:52 UTC-69d582b8.5dc-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=postgres host=127.0.0.1 port=50090
+
+        2026-04-07 22:18:52 UTC-69d582cc.5ee-LOG:  connection received: host=127.0.0.1
+        port=58936
+
+        2026-04-07 22:18:52 UTC-69d582cc.5ee-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:18:52 UTC-69d582cc.5ee-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:18:52 UTC-69d582cc.5ee-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:18:53 UTC-69d582b9.5dd-LOG:  disconnection: session time: 0:00:20.025
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=50106
+
+        2026-04-07 22:18:56 UTC-69d582d0.5f0-LOG:  connection received: host=127.0.0.1
+        port=58944
+
+        2026-04-07 22:18:56 UTC-69d582d0.5f0-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:18:56 UTC-69d582d0.5f0-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:18:56 UTC-69d582d0.5f0-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:19:10 UTC-69d582ca.5ed-LOG:  disconnection: session time: 0:00:20.043
+        user=azuresu database=azure_sys host=127.0.0.1 port=59822
+
+        2026-04-07 22:19:12 UTC-69d582e0.5fe-LOG:  connection received: host=127.0.0.1
+        port=55884
+
+        2026-04-07 22:19:12 UTC-69d582e0.5fe-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:19:12 UTC-69d582e0.5fe-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:19:12 UTC-69d582e0.5fe-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:19:12 UTC-69d582e0.5fe-LOG:  disconnection: session time: 0:00:00.047
+        user=azuresu database=postgres host=127.0.0.1 port=55884
+
+        2026-04-07 22:19:12 UTC-69d582cc.5ee-LOG:  disconnection: session time: 0:00:20.025
+        user=azuresu database=postgres host=127.0.0.1 port=58936
+
+        2026-04-07 22:19:12 UTC-69d582e0.5ff-LOG:  connection received: host=127.0.0.1
+        port=55896
+
+        2026-04-07 22:19:12 UTC-69d582e0.5ff-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:19:12 UTC-69d582e0.5ff-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:19:12 UTC-69d582e0.5ff-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:19:16 UTC-69d582d0.5f0-LOG:  disconnection: session time: 0:00:20.025
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=58944
+
+        2026-04-07 22:19:18 UTC-69d582e6.601-LOG:  connection received: host=127.0.0.1
+        port=55910
+
+        2026-04-07 22:19:18 UTC-69d582e6.601-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:19:18 UTC-69d582e6.601-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:19:18 UTC-69d582e6.601-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:19:21 UTC-69d582e9.603-LOG:  connection received: host=127.0.0.1
+        port=55918
+
+        2026-04-07 22:19:21 UTC-69d582e9.603-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:19:21 UTC-69d582e9.603-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:19:21 UTC-69d582e9.603-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:19:32 UTC-69d582e0.5ff-LOG:  disconnection: session time: 0:00:20.047
+        user=azuresu database=postgres host=127.0.0.1 port=55896
+
+        2026-04-07 22:19:32 UTC-69d582f4.607-LOG:  connection received: host=127.0.0.1
+        port=35478
+
+        2026-04-07 22:19:32 UTC-69d582f4.607-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:19:32 UTC-69d582f4.607-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:19:32 UTC-69d582f4.607-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:19:37 UTC-69d582f9.612-LOG:  connection received: host=127.0.0.1
+        port=35482
+
+        2026-04-07 22:19:37 UTC-69d582f9.612-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:19:37 UTC-69d582f9.612-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:19:37 UTC-69d582f9.612-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:19:37 UTC-69d582f9.612-LOG:  disconnection: session time: 0:00:00.046
+        user=azuresu database=postgres host=127.0.0.1 port=35482
+
+        2026-04-07 22:19:38 UTC-69d582e6.601-LOG:  disconnection: session time: 0:00:20.029
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=55910
+
+        2026-04-07 22:19:40 UTC-69d582fc.614-LOG:  connection received: host=127.0.0.1
+        port=35498
+
+        2026-04-07 22:19:40 UTC-69d582fc.614-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:19:40 UTC-69d582fc.614-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:19:40 UTC-69d582fc.614-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:19:40 UTC-69d57ff0.2ee-LOG:  [pg-availability]: current_lsn:
+        0/4001658, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-04-07 22:19:41 UTC-69d582e9.603-LOG:  disconnection: session time: 0:00:20.057
+        user=azuresu database=azure_sys host=127.0.0.1 port=55918
+
+        2026-04-07 22:19:52 UTC-69d58308.618-LOG:  connection received: host=127.0.0.1
+        port=50386
+
+        2026-04-07 22:19:52 UTC-69d58308.618-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:19:52 UTC-69d58308.618-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:19:52 UTC-69d58308.618-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:19:52 UTC-69d582f4.607-LOG:  disconnection: session time: 0:00:20.030
+        user=azuresu database=postgres host=127.0.0.1 port=35478
+
+        2026-04-07 22:19:53 UTC-69d58309.619-LOG:  connection received: host=127.0.0.1
+        port=50388
+
+        2026-04-07 22:19:53 UTC-69d58309.619-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:19:53 UTC-69d58309.619-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:19:53 UTC-69d58309.619-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:20:00 UTC-69d582fc.614-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=35498
+
+        2026-04-07 22:20:02 UTC-69d58312.623-LOG:  connection received: host=127.0.0.1
+        port=49756
+
+        2026-04-07 22:20:02 UTC-69d58312.623-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:20:02 UTC-69d58312.623-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:20:02 UTC-69d58312.623-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:20:02 UTC-69d58312.62d-LOG:  connection received: host=127.0.0.1
+        port=49770
+
+        2026-04-07 22:20:02 UTC-69d58312.62d-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:20:02 UTC-69d58312.62d-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:20:02 UTC-69d58312.62d-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:20:02 UTC-69d58312.62d-LOG:  disconnection: session time: 0:00:00.046
+        user=azuresu database=postgres host=127.0.0.1 port=49770
+
+        2026-04-07 22:20:12 UTC-69d58308.618-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=azure_sys host=127.0.0.1 port=50386
+
+        2026-04-07 22:20:13 UTC-69d58309.619-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=postgres host=127.0.0.1 port=50388
+
+        2026-04-07 22:20:13 UTC-69d5831d.631-LOG:  connection received: host=127.0.0.1
+        port=43542
+
+        2026-04-07 22:20:13 UTC-69d5831d.631-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:20:13 UTC-69d5831d.631-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:20:13 UTC-69d5831d.631-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:20:22 UTC-69d58312.623-LOG:  disconnection: session time: 0:00:20.023
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=49756
+
+        2026-04-07 22:20:23 UTC-69d58327.634-LOG:  connection received: host=127.0.0.1
+        port=44756
+
+        2026-04-07 22:20:23 UTC-69d58327.634-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:20:23 UTC-69d58327.634-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:20:23 UTC-69d58327.634-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:20:24 UTC-69d58328.635-LOG:  connection received: host=127.0.0.1
+        port=44766
+
+        2026-04-07 22:20:24 UTC-69d58328.635-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:20:24 UTC-69d58328.635-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:20:24 UTC-69d58328.635-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:20:27 UTC-69d5832b.641-LOG:  connection received: host=127.0.0.1
+        port=44782
+
+        2026-04-07 22:20:27 UTC-69d5832b.641-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:20:27 UTC-69d5832b.641-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:20:27 UTC-69d5832b.641-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:20:27 UTC-69d5832b.641-LOG:  disconnection: session time: 0:00:00.045
+        user=azuresu database=postgres host=127.0.0.1 port=44782
+
+        2026-04-07 22:20:33 UTC-69d5831d.631-LOG:  disconnection: session time: 0:00:20.022
+        user=azuresu database=postgres host=127.0.0.1 port=43542
+
+        2026-04-07 22:20:33 UTC-69d58331.643-LOG:  connection received: host=127.0.0.1
+        port=56744
+
+        2026-04-07 22:20:33 UTC-69d58331.643-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:20:33 UTC-69d58331.643-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:20:33 UTC-69d58331.643-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:20:40 UTC-69d57ff0.2ee-LOG:  [pg-availability]: current_lsn:
+        0/4004EE8, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-04-07 22:20:41 UTC-69d57ff0.2e7-LOG:  checkpoint starting: time
+
+        2026-04-07 22:20:43 UTC-69d58327.634-LOG:  disconnection: session time: 0:00:20.027
+        user=azuresu database=azure_sys host=127.0.0.1 port=44756
+
+        2026-04-07 22:20:44 UTC-69d58328.635-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=44766
+
+        2026-04-07 22:20:44 UTC-69d57ff0.2e7-LOG:  checkpoint complete: wrote 34 buffers
+        (0.0%); 0 WAL file(s) added, 0 removed, 0 recycled; write=3.315 s, sync=0.005
+        s, total=3.333 s; sync files=22, longest=0.003 s, average=0.001 s; distance=32787
+        kB, estimate=32787 kB; lsn=0/4004F78, redo lsn=0/4004EE8
+
+        2026-04-07 22:20:46 UTC-69d5833e.648-LOG:  connection received: host=127.0.0.1
+        port=38240
+
+        2026-04-07 22:20:46 UTC-69d5833e.648-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:20:46 UTC-69d5833e.648-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:20:46 UTC-69d5833e.648-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:20:50 UTC-69d58342.64a-LOG:  connection received: host=127.0.0.1
+        port=38250
+
+        2026-04-07 22:20:50 UTC-69d58342.64a-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:20:50 UTC-69d58342.64a-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:20:50 UTC-69d58342.64a-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:20:52 UTC-69d58344.654-LOG:  connection received: host=127.0.0.1
+        port=58136
+
+        2026-04-07 22:20:52 UTC-69d58344.654-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:20:52 UTC-69d58344.654-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:20:52 UTC-69d58344.654-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:20:52 UTC-69d58344.654-LOG:  disconnection: session time: 0:00:00.045
+        user=azuresu database=postgres host=127.0.0.1 port=58136
+
+        2026-04-07 22:20:53 UTC-69d58331.643-LOG:  disconnection: session time: 0:00:20.029
+        user=azuresu database=postgres host=127.0.0.1 port=56744
+
+        2026-04-07 22:20:54 UTC-69d58346.655-LOG:  connection received: host=127.0.0.1
+        port=58144
+
+        2026-04-07 22:20:54 UTC-69d58346.655-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:20:54 UTC-69d58346.655-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:20:54 UTC-69d58346.655-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:21:06 UTC-69d5833e.648-LOG:  disconnection: session time: 0:00:20.027
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=38240
+
+        2026-04-07 22:21:08 UTC-69d58354.65a-LOG:  connection received: host=127.0.0.1
+        port=52370
+
+        2026-04-07 22:21:08 UTC-69d58354.65a-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:21:08 UTC-69d58354.65a-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:21:08 UTC-69d58354.65a-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:21:13 UTC-69d58342.64a-LOG:  disconnection: session time: 0:00:23.062
+        user=azuresu database=postgres host=127.0.0.1 port=38250
+
+        2026-04-07 22:21:13 UTC-69d58359.65c-LOG:  connection received: host=127.0.0.1
+        port=34578
+
+        2026-04-07 22:21:13 UTC-69d58359.65c-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:21:13 UTC-69d58359.65c-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:21:13 UTC-69d58359.65c-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:21:14 UTC-69d58346.655-LOG:  disconnection: session time: 0:00:20.025
+        user=azuresu database=azure_sys host=127.0.0.1 port=58144
+
+        2026-04-07 22:21:17 UTC-69d5835d.666-LOG:  connection received: host=127.0.0.1
+        port=34594
+
+        2026-04-07 22:21:17 UTC-69d5835d.666-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:21:17 UTC-69d5835d.666-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:21:17 UTC-69d5835d.666-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:21:17 UTC-69d5835d.666-LOG:  disconnection: session time: 0:00:00.045
+        user=azuresu database=postgres host=127.0.0.1 port=34594
+
+        2026-04-07 22:21:25 UTC-69d58365.66a-LOG:  connection received: host=127.0.0.1
+        port=60348
+
+        2026-04-07 22:21:25 UTC-69d58365.66a-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:21:25 UTC-69d58365.66a-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:21:25 UTC-69d58365.66a-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:21:28 UTC-69d58368.682-LOG:  connection received: host=127.0.0.1
+        port=60356
+
+        2026-04-07 22:21:28 UTC-69d58354.65a-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=52370
+
+        2026-04-07 22:21:28 UTC-69d58368.682-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:21:28 UTC-69d58368.682-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:21:28 UTC-69d58368.682-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:21:30 UTC-69d5836a.685-LOG:  connection received: host=127.0.0.1
+        port=60360
+
+        2026-04-07 22:21:30 UTC-69d5836a.685-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:21:30 UTC-69d5836a.685-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:21:30 UTC-69d5836a.685-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:21:33 UTC-69d58359.65c-LOG:  disconnection: session time: 0:00:20.022
+        user=azuresu database=postgres host=127.0.0.1 port=34578
+
+        2026-04-07 22:21:33 UTC-69d5836d.686-LOG:  connection received: host=127.0.0.1
+        port=33678
+
+        2026-04-07 22:21:33 UTC-69d5836d.686-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:21:33 UTC-69d5836d.686-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:21:33 UTC-69d5836d.686-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:21:41 UTC-69d57ff0.2ee-LOG:  [pg-availability]: current_lsn:
+        0/5006C30, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-04-07 22:21:42 UTC-69d58376.693-LOG:  connection received: host=127.0.0.1
+        port=53618
+
+        2026-04-07 22:21:42 UTC-69d58376.693-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:21:42 UTC-69d58376.693-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:21:42 UTC-69d58376.693-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:21:42 UTC-69d58376.693-LOG:  disconnection: session time: 0:00:00.046
+        user=azuresu database=postgres host=127.0.0.1 port=53618
+
+        2026-04-07 22:21:45 UTC-69d58365.66a-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=azure_sys host=127.0.0.1 port=60348
+
+        2026-04-07 22:21:48 UTC-69d58368.682-LOG:  disconnection: session time: 0:00:20.031
+        user=azuresu database=azure_sys host=127.0.0.1 port=60356
+
+        2026-04-07 22:21:50 UTC-69d5836a.685-LOG:  disconnection: session time: 0:00:20.030
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=60360
+
+        2026-04-07 22:21:50 UTC-69d57ffa.362-LOG:  pg_qs: qs bgworker: worker woke
+        up and performed operations, with query data store as on
+
+        2026-04-07 22:21:50 UTC-69d57ffa.362-LOG:  pg_qs: qs bgworker: instanceType=primary,
+        default_transaction_read_only=false
+
+        2026-04-07 22:21:50 UTC-69d57ffa.362-LOG:  pg_qs: pg_qs_staging_data: Shall
+        collect the minimum of pg_qs.max_captured_queries (500) and pg_qs.max_queries
+        (1000).","context": "SQL statement \"SELECT *\n        FROM query_store.staging_data_1_4(showtext)\"\nPL/pgSQL
+        function query_store.staging_data(boolean) line 15 at RETURN QUERY\nSQL statement
+        \"WITH staging_data AS(\n\t\t\tSELECT * FROM query_store.staging_data(true)\n\t\t),\n\t\tdummyData
+        AS(\n\t\t\tINSERT INTO query_store.query_texts (query_text_id, query_sql_text,
+        query_type)\n\t\t\t\tSELECT query_id, CAST(query AS varchar(10000)) AS query,
+        query_type\n\t\t\t\tFROM staging_data\n\t\t\t\tON CONFLICT DO NOTHING\n\t\t\t\tRETURNING
+        query_text_id\n\t\t),\n\t\tdummyData2 AS(\n\t\t\tUPDATE query_store.query_texts
+        AS qt\n\t\t\t\tSET query_type = sd.query_type\n\t\t\t\tFROM staging_data AS
+        sd\n\t\t\t\tWHERE qt.query_text_id = sd.query_id\n\t\t\t\tRETURNING qt.query_text_id\n\t\t),
+        aux_interval_variables AS(\n            INSERT INTO query_store.runtime_stats_intervals
+        (start_time, end_time, comment) VALUES (current_timestamp - $1::INTERVAL,
+        current_timestamp, null) RETURNING runtime_stats_interval_id\n        ), aux_runtime_stats_variables
+        AS(\n            INSERT INTO query_store.runtime_stats_entries (user_id, db_id,
+        query_id, search_path, plan_id, runtime_stats_interval_id, query_parameters,
+        parameters_capture_status, search_path_capture_status)\n                SELECT
+        user_id, db_id, query_id, search_path, plan_id, aux_interval_variables.runtime_stats_interval_id,
+        query_parameters, parameters_capture_status, search_path_capture_status\n                FROM
+        aux_interval_variables, staging_data\n                RETURNING runtime_stats_entry_id,
+        user_id, db_id, query_id\n        ),\n\t\taux_runtime_stats_ws_entries AS(\n            INSERT
+        INTO query_store.runtime_stats_ws_entries (user_id, db_id, query_id, event_type,
+        event, runtime_stats_interval_id)\n                SELECT user_id, db_id,
+        query_id, event_type, event, aux_interval_variables.runtime_stats_interval_id\n                FROM
+        aux_interval_variables, query_store.staging_ws_data()\n                RETURNING
+        runtime_stats_ws_entry_id, user_id, db_id, query_id, event_type, event\n        ),\n\t\taux_runtime_stats_ws_values
+        AS\n\t\t(\n\t\t\tINSERT INTO query_store.runtime_stats_ws_values (runtime_stats_ws_entry_id,
+        calls)\n\t\t\t\tSELECT\n                aux_runtime_stats_ws_entries.runtime_stats_ws_entry_id,
+        calls\n\t\t\t\tFROM aux_runtime_stats_ws_entries JOIN query_store.staging_ws_data()
+        AS t1\n\t\t\t\tON\n\t\t\t\t\taux_runtime_stats_ws_entries.query_id = t1.query_id
+        AND\n\t\t\t\t\taux_runtime_stats_ws_entries.user_id = t1.user_id AND\n\t\t\t\t\taux_runtime_stats_ws_entries.db_id
+        = t1.db_id AND\n\t\t\t\t\taux_runtime_stats_ws_entries.event = t1.event AND\n\t\t\t\t\taux_runtime_stats_ws_entries.event_type
+        = t1.event_type\n\t\t),\n        plans AS\n\t\t(\n            INSERT INTO
+        query_store.query_plans (plan_id, db_id, query_id, plan_text)\n                SELECT
+        plan_id, db_id, query_id, CAST(plan_text AS varchar(10000)) AS plan_text\n                FROM
+        staging_data\n                WHERE plan_text IS NOT NULL AND query_id IS
+        NOT NULL AND plan_id IS NOT NULL\n                ON CONFLICT(plan_id, db_id,
+        query_id) DO NOTHING\n                returning plan_id, plan_text, query_id\n        )\n        INSERT
+        INTO query_store.runtime_stats (\n            runtime_stats_entry_id,\n            calls,\n            total_time,\n            min_time,\n            max_time,\n            mean_time,\n            stddev_time,\n            rows,\n            shared_blks_hit,\n            shared_blks_read,\n            shared_blks_dirtied,\n            shared_blks_written,\n            local_blks_hit,\n            local_blks_read,\n            local_blks_dirtied,\n            local_blks_written,\n            temp_blks_read,\n            temp_blks_written,\n            blk_read_time,\n            blk_write_time\n        )\n        SELECT\n            runtime_stats_entry_id,\n            calls,\n            total_time,\n            min_time,\n            max_time,\n            mean_time,\n            stddev_time,\n            rows,\n            shared_blks_hit,\n            shared_blks_read,\n            shared_blks_dirtied,\n            shared_blks_written,\n            local_blks_hit,\n            local_blks_read,\n            local_blks_dirtied,\n            local_blks_written,\n            temp_blks_read,\n            temp_blks_written,\n            blk_read_time,\n            blk_write_time\n        FROM\n            aux_runtime_stats_variables
+        JOIN staging_data AS t1 ON aux_runtime_stats_variables.user_id = t1.user_id
+        AND aux_runtime_stats_variables.db_id = t1.db_id AND aux_runtime_stats_variables.query_id
+        = t1.query_id\n\t\t\tLEFT OUTER JOIN plans p\n            ON aux_runtime_stats_variables.query_id
+        = p.query_id\"\nPL/pgSQL function query_store.collect_data(text,text) line
+        9 at SQL statement\nSQL statement \"SELECT query_store.collect_data(''15 minutes'',
+        ''7 days'')\"
+
+        2026-04-07 22:21:50 UTC-69d57ffa.362-LOG:  pg_qs: pg_qs_staging_data: number
+        of hash entries (114) is within the limit (500), returning all","context":
+        "SQL statement \"SELECT *\n        FROM query_store.staging_data_1_4(showtext)\"\nPL/pgSQL
+        function query_store.staging_data(boolean) line 15 at RETURN QUERY\nSQL statement
+        \"WITH staging_data AS(\n\t\t\tSELECT * FROM query_store.staging_data(true)\n\t\t),\n\t\tdummyData
+        AS(\n\t\t\tINSERT INTO query_store.query_texts (query_text_id, query_sql_text,
+        query_type)\n\t\t\t\tSELECT query_id, CAST(query AS varchar(10000)) AS query,
+        query_type\n\t\t\t\tFROM staging_data\n\t\t\t\tON CONFLICT DO NOTHING\n\t\t\t\tRETURNING
+        query_text_id\n\t\t),\n\t\tdummyData2 AS(\n\t\t\tUPDATE query_store.query_texts
+        AS qt\n\t\t\t\tSET query_type = sd.query_type\n\t\t\t\tFROM staging_data AS
+        sd\n\t\t\t\tWHERE qt.query_text_id = sd.query_id\n\t\t\t\tRETURNING qt.query_text_id\n\t\t),
+        aux_interval_variables AS(\n            INSERT INTO query_store.runtime_stats_intervals
+        (start_time, end_time, comment) VALUES (current_timestamp - $1::INTERVAL,
+        current_timestamp, null) RETURNING runtime_stats_interval_id\n        ), aux_runtime_stats_variables
+        AS(\n            INSERT INTO query_store.runtime_stats_entries (user_id, db_id,
+        query_id, search_path, plan_id, runtime_stats_interval_id, query_parameters,
+        parameters_capture_status, search_path_capture_status)\n                SELECT
+        user_id, db_id, query_id, search_path, plan_id, aux_interval_variables.runtime_stats_interval_id,
+        query_parameters, parameters_capture_status, search_path_capture_status\n                FROM
+        aux_interval_variables, staging_data\n                RETURNING runtime_stats_entry_id,
+        user_id, db_id, query_id\n        ),\n\t\taux_runtime_stats_ws_entries AS(\n            INSERT
+        INTO query_store.runtime_stats_ws_entries (user_id, db_id, query_id, event_type,
+        event, runtime_stats_interval_id)\n                SELECT user_id, db_id,
+        query_id, event_type, event, aux_interval_variables.runtime_stats_interval_id\n                FROM
+        aux_interval_variables, query_store.staging_ws_data()\n                RETURNING
+        runtime_stats_ws_entry_id, user_id, db_id, query_id, event_type, event\n        ),\n\t\taux_runtime_stats_ws_values
+        AS\n\t\t(\n\t\t\tINSERT INTO query_store.runtime_stats_ws_values (runtime_stats_ws_entry_id,
+        calls)\n\t\t\t\tSELECT\n                aux_runtime_stats_ws_entries.runtime_stats_ws_entry_id,
+        calls\n\t\t\t\tFROM aux_runtime_stats_ws_entries JOIN query_store.staging_ws_data()
+        AS t1\n\t\t\t\tON\n\t\t\t\t\taux_runtime_stats_ws_entries.query_id = t1.query_id
+        AND\n\t\t\t\t\taux_runtime_stats_ws_entries.user_id = t1.user_id AND\n\t\t\t\t\taux_runtime_stats_ws_entries.db_id
+        = t1.db_id AND\n\t\t\t\t\taux_runtime_stats_ws_entries.event = t1.event AND\n\t\t\t\t\taux_runtime_stats_ws_entries.event_type
+        = t1.event_type\n\t\t),\n        plans AS\n\t\t(\n            INSERT INTO
+        query_store.query_plans (plan_id, db_id, query_id, plan_text)\n                SELECT
+        plan_id, db_id, query_id, CAST(plan_text AS varchar(10000)) AS plan_text\n                FROM
+        staging_data\n                WHERE plan_text IS NOT NULL AND query_id IS
+        NOT NULL AND plan_id IS NOT NULL\n                ON CONFLICT(plan_id, db_id,
+        query_id) DO NOTHING\n                returning plan_id, plan_text, query_id\n        )\n        INSERT
+        INTO query_store.runtime_stats (\n            runtime_stats_entry_id,\n            calls,\n            total_time,\n            min_time,\n            max_time,\n            mean_time,\n            stddev_time,\n            rows,\n            shared_blks_hit,\n            shared_blks_read,\n            shared_blks_dirtied,\n            shared_blks_written,\n            local_blks_hit,\n            local_blks_read,\n            local_blks_dirtied,\n            local_blks_written,\n            temp_blks_read,\n            temp_blks_written,\n            blk_read_time,\n            blk_write_time\n        )\n        SELECT\n            runtime_stats_entry_id,\n            calls,\n            total_time,\n            min_time,\n            max_time,\n            mean_time,\n            stddev_time,\n            rows,\n            shared_blks_hit,\n            shared_blks_read,\n            shared_blks_dirtied,\n            shared_blks_written,\n            local_blks_hit,\n            local_blks_read,\n            local_blks_dirtied,\n            local_blks_written,\n            temp_blks_read,\n            temp_blks_written,\n            blk_read_time,\n            blk_write_time\n        FROM\n            aux_runtime_stats_variables
+        JOIN staging_data AS t1 ON aux_runtime_stats_variables.user_id = t1.user_id
+        AND aux_runtime_stats_variables.db_id = t1.db_id AND aux_runtime_stats_variables.query_id
+        = t1.query_id\n\t\t\tLEFT OUTER JOIN plans p\n            ON aux_runtime_stats_variables.query_id
+        = p.query_id\"\nPL/pgSQL function query_store.collect_data(text,text) line
+        9 at SQL statement\nSQL statement \"SELECT query_store.collect_data(''15 minutes'',
+        ''7 days'')\"
+
+        2026-04-07 22:21:50 UTC-69d57ffa.362-LOG:  pg_qs: pg_qs_staging_data: emitted
+        114 entries.","context": "SQL statement \"SELECT *\n        FROM query_store.staging_data_1_4(showtext)\"\nPL/pgSQL
+        function query_store.staging_data(boolean) line 15 at RETURN QUERY\nSQL statement
+        \"WITH staging_data AS(\n\t\t\tSELECT * FROM query_store.staging_data(true)\n\t\t),\n\t\tdummyData
+        AS(\n\t\t\tINSERT INTO query_store.query_texts (query_text_id, query_sql_text,
+        query_type)\n\t\t\t\tSELECT query_id, CAST(query AS varchar(10000)) AS query,
+        query_type\n\t\t\t\tFROM staging_data\n\t\t\t\tON CONFLICT DO NOTHING\n\t\t\t\tRETURNING
+        query_text_id\n\t\t),\n\t\tdummyData2 AS(\n\t\t\tUPDATE query_store.query_texts
+        AS qt\n\t\t\t\tSET query_type = sd.query_type\n\t\t\t\tFROM staging_data AS
+        sd\n\t\t\t\tWHERE qt.query_text_id = sd.query_id\n\t\t\t\tRETURNING qt.query_text_id\n\t\t),
+        aux_interval_variables AS(\n            INSERT INTO query_store.runtime_stats_intervals
+        (start_time, end_time, comment) VALUES (current_timestamp - $1::INTERVAL,
+        current_timestamp, null) RETURNING runtime_stats_interval_id\n        ), aux_runtime_stats_variables
+        AS(\n            INSERT INTO query_store.runtime_stats_entries (user_id, db_id,
+        query_id, search_path, plan_id, runtime_stats_interval_id, query_parameters,
+        parameters_capture_status, search_path_capture_status)\n                SELECT
+        user_id, db_id, query_id, search_path, plan_id, aux_interval_variables.runtime_stats_interval_id,
+        query_parameters, parameters_capture_status, search_path_capture_status\n                FROM
+        aux_interval_variables, staging_data\n                RETURNING runtime_stats_entry_id,
+        user_id, db_id, query_id\n        ),\n\t\taux_runtime_stats_ws_entries AS(\n            INSERT
+        INTO query_store.runtime_stats_ws_entries (user_id, db_id, query_id, event_type,
+        event, runtime_stats_interval_id)\n                SELECT user_id, db_id,
+        query_id, event_type, event, aux_interval_variables.runtime_stats_interval_id\n                FROM
+        aux_interval_variables, query_store.staging_ws_data()\n                RETURNING
+        runtime_stats_ws_entry_id, user_id, db_id, query_id, event_type, event\n        ),\n\t\taux_runtime_stats_ws_values
+        AS\n\t\t(\n\t\t\tINSERT INTO query_store.runtime_stats_ws_values (runtime_stats_ws_entry_id,
+        calls)\n\t\t\t\tSELECT\n                aux_runtime_stats_ws_entries.runtime_stats_ws_entry_id,
+        calls\n\t\t\t\tFROM aux_runtime_stats_ws_entries JOIN query_store.staging_ws_data()
+        AS t1\n\t\t\t\tON\n\t\t\t\t\taux_runtime_stats_ws_entries.query_id = t1.query_id
+        AND\n\t\t\t\t\taux_runtime_stats_ws_entries.user_id = t1.user_id AND\n\t\t\t\t\taux_runtime_stats_ws_entries.db_id
+        = t1.db_id AND\n\t\t\t\t\taux_runtime_stats_ws_entries.event = t1.event AND\n\t\t\t\t\taux_runtime_stats_ws_entries.event_type
+        = t1.event_type\n\t\t),\n        plans AS\n\t\t(\n            INSERT INTO
+        query_store.query_plans (plan_id, db_id, query_id, plan_text)\n                SELECT
+        plan_id, db_id, query_id, CAST(plan_text AS varchar(10000)) AS plan_text\n                FROM
+        staging_data\n                WHERE plan_text IS NOT NULL AND query_id IS
+        NOT NULL AND plan_id IS NOT NULL\n                ON CONFLICT(plan_id, db_id,
+        query_id) DO NOTHING\n                returning plan_id, plan_text, query_id\n        )\n        INSERT
+        INTO query_store.runtime_stats (\n            runtime_stats_entry_id,\n            calls,\n            total_time,\n            min_time,\n            max_time,\n            mean_time,\n            stddev_time,\n            rows,\n            shared_blks_hit,\n            shared_blks_read,\n            shared_blks_dirtied,\n            shared_blks_written,\n            local_blks_hit,\n            local_blks_read,\n            local_blks_dirtied,\n            local_blks_written,\n            temp_blks_read,\n            temp_blks_written,\n            blk_read_time,\n            blk_write_time\n        )\n        SELECT\n            runtime_stats_entry_id,\n            calls,\n            total_time,\n            min_time,\n            max_time,\n            mean_time,\n            stddev_time,\n            rows,\n            shared_blks_hit,\n            shared_blks_read,\n            shared_blks_dirtied,\n            shared_blks_written,\n            local_blks_hit,\n            local_blks_read,\n            local_blks_dirtied,\n            local_blks_written,\n            temp_blks_read,\n            temp_blks_written,\n            blk_read_time,\n            blk_write_time\n        FROM\n            aux_runtime_stats_variables
+        JOIN staging_data AS t1 ON aux_runtime_stats_variables.user_id = t1.user_id
+        AND aux_runtime_stats_variables.db_id = t1.db_id AND aux_runtime_stats_variables.query_id
+        = t1.query_id\n\t\t\tLEFT OUTER JOIN plans p\n            ON aux_runtime_stats_variables.query_id
+        = p.query_id\"\nPL/pgSQL function query_store.collect_data(text,text) line
+        9 at SQL statement\nSQL statement \"SELECT query_store.collect_data(''15 minutes'',
+        ''7 days'')\"
+
+        2026-04-07 22:21:50 UTC-69d57ffa.362-LOG:  pgms_wait_sampling: num_entries
+        in table before calling collect_data: 24.","context": "SQL statement \"WITH
+        staging_data AS(\n\t\t\tSELECT * FROM query_store.staging_data(true)\n\t\t),\n\t\tdummyData
+        AS(\n\t\t\tINSERT INTO query_store.query_texts (query_text_id, query_sql_text,
+        query_type)\n\t\t\t\tSELECT query_id, CAST(query AS varchar(10000)) AS query,
+        query_type\n\t\t\t\tFROM staging_data\n\t\t\t\tON CONFLICT DO NOTHING\n\t\t\t\tRETURNING
+        query_text_id\n\t\t),\n\t\tdummyData2 AS(\n\t\t\tUPDATE query_store.query_texts
+        AS qt\n\t\t\t\tSET query_type = sd.query_type\n\t\t\t\tFROM staging_data AS
+        sd\n\t\t\t\tWHERE qt.query_text_id = sd.query_id\n\t\t\t\tRETURNING qt.query_text_id\n\t\t),
+        aux_interval_variables AS(\n            INSERT INTO query_store.runtime_stats_intervals
+        (start_time, end_time, comment) VALUES (current_timestamp - $1::INTERVAL,
+        current_timestamp, null) RETURNING runtime_stats_interval_id\n        ), aux_runtime_stats_variables
+        AS(\n            INSERT INTO query_store.runtime_stats_entries (user_id, db_id,
+        query_id, search_path, plan_id, runtime_stats_interval_id, query_parameters,
+        parameters_capture_status, search_path_capture_status)\n                SELECT
+        user_id, db_id, query_id, search_path, plan_id, aux_interval_variables.runtime_stats_interval_id,
+        query_parameters, parameters_capture_status, search_path_capture_status\n                FROM
+        aux_interval_variables, staging_data\n                RETURNING runtime_stats_entry_id,
+        user_id, db_id, query_id\n        ),\n\t\taux_runtime_stats_ws_entries AS(\n            INSERT
+        INTO query_store.runtime_stats_ws_entries (user_id, db_id, query_id, event_type,
+        event, runtime_stats_interval_id)\n                SELECT user_id, db_id,
+        query_id, event_type, event, aux_interval_variables.runtime_stats_interval_id\n                FROM
+        aux_interval_variables, query_store.staging_ws_data()\n                RETURNING
+        runtime_stats_ws_entry_id, user_id, db_id, query_id, event_type, event\n        ),\n\t\taux_runtime_stats_ws_values
+        AS\n\t\t(\n\t\t\tINSERT INTO query_store.runtime_stats_ws_values (runtime_stats_ws_entry_id,
+        calls)\n\t\t\t\tSELECT\n                aux_runtime_stats_ws_entries.runtime_stats_ws_entry_id,
+        calls\n\t\t\t\tFROM aux_runtime_stats_ws_entries JOIN query_store.staging_ws_data()
+        AS t1\n\t\t\t\tON\n\t\t\t\t\taux_runtime_stats_ws_entries.query_id = t1.query_id
+        AND\n\t\t\t\t\taux_runtime_stats_ws_entries.user_id = t1.user_id AND\n\t\t\t\t\taux_runtime_stats_ws_entries.db_id
+        = t1.db_id AND\n\t\t\t\t\taux_runtime_stats_ws_entries.event = t1.event AND\n\t\t\t\t\taux_runtime_stats_ws_entries.event_type
+        = t1.event_type\n\t\t),\n        plans AS\n\t\t(\n            INSERT INTO
+        query_store.query_plans (plan_id, db_id, query_id, plan_text)\n                SELECT
+        plan_id, db_id, query_id, CAST(plan_text AS varchar(10000)) AS plan_text\n                FROM
+        staging_data\n                WHERE plan_text IS NOT NULL AND query_id IS
+        NOT NULL AND plan_id IS NOT NULL\n                ON CONFLICT(plan_id, db_id,
+        query_id) DO NOTHING\n                returning plan_id, plan_text, query_id\n        )\n        INSERT
+        INTO query_store.runtime_stats (\n            runtime_stats_entry_id,\n            calls,\n            total_time,\n            min_time,\n            max_time,\n            mean_time,\n            stddev_time,\n            rows,\n            shared_blks_hit,\n            shared_blks_read,\n            shared_blks_dirtied,\n            shared_blks_written,\n            local_blks_hit,\n            local_blks_read,\n            local_blks_dirtied,\n            local_blks_written,\n            temp_blks_read,\n            temp_blks_written,\n            blk_read_time,\n            blk_write_time\n        )\n        SELECT\n            runtime_stats_entry_id,\n            calls,\n            total_time,\n            min_time,\n            max_time,\n            mean_time,\n            stddev_time,\n            rows,\n            shared_blks_hit,\n            shared_blks_read,\n            shared_blks_dirtied,\n            shared_blks_written,\n            local_blks_hit,\n            local_blks_read,\n            local_blks_dirtied,\n            local_blks_written,\n            temp_blks_read,\n            temp_blks_written,\n            blk_read_time,\n            blk_write_time\n        FROM\n            aux_runtime_stats_variables
+        JOIN staging_data AS t1 ON aux_runtime_stats_variables.user_id = t1.user_id
+        AND aux_runtime_stats_variables.db_id = t1.db_id AND aux_runtime_stats_variables.query_id
+        = t1.query_id\n\t\t\tLEFT OUTER JOIN plans p\n            ON aux_runtime_stats_variables.query_id
+        = p.query_id\"\nPL/pgSQL function query_store.collect_data(text,text) line
+        9 at SQL statement\nSQL statement \"SELECT query_store.collect_data(''15 minutes'',
+        ''7 days'')\"
+
+        2026-04-07 22:21:50 UTC-69d57ffa.362-LOG:  pgms_wait_sampling: num_entries
+        in table before calling collect_data: 24.","context": "SQL statement \"WITH
+        staging_data AS(\n\t\t\tSELECT * FROM query_store.staging_data(true)\n\t\t),\n\t\tdummyData
+        AS(\n\t\t\tINSERT INTO query_store.query_texts (query_text_id, query_sql_text,
+        query_type)\n\t\t\t\tSELECT query_id, CAST(query AS varchar(10000)) AS query,
+        query_type\n\t\t\t\tFROM staging_data\n\t\t\t\tON CONFLICT DO NOTHING\n\t\t\t\tRETURNING
+        query_text_id\n\t\t),\n\t\tdummyData2 AS(\n\t\t\tUPDATE query_store.query_texts
+        AS qt\n\t\t\t\tSET query_type = sd.query_type\n\t\t\t\tFROM staging_data AS
+        sd\n\t\t\t\tWHERE qt.query_text_id = sd.query_id\n\t\t\t\tRETURNING qt.query_text_id\n\t\t),
+        aux_interval_variables AS(\n            INSERT INTO query_store.runtime_stats_intervals
+        (start_time, end_time, comment) VALUES (current_timestamp - $1::INTERVAL,
+        current_timestamp, null) RETURNING runtime_stats_interval_id\n        ), aux_runtime_stats_variables
+        AS(\n            INSERT INTO query_store.runtime_stats_entries (user_id, db_id,
+        query_id, search_path, plan_id, runtime_stats_interval_id, query_parameters,
+        parameters_capture_status, search_path_capture_status)\n                SELECT
+        user_id, db_id, query_id, search_path, plan_id, aux_interval_variables.runtime_stats_interval_id,
+        query_parameters, parameters_capture_status, search_path_capture_status\n                FROM
+        aux_interval_variables, staging_data\n                RETURNING runtime_stats_entry_id,
+        user_id, db_id, query_id\n        ),\n\t\taux_runtime_stats_ws_entries AS(\n            INSERT
+        INTO query_store.runtime_stats_ws_entries (user_id, db_id, query_id, event_type,
+        event, runtime_stats_interval_id)\n                SELECT user_id, db_id,
+        query_id, event_type, event, aux_interval_variables.runtime_stats_interval_id\n                FROM
+        aux_interval_variables, query_store.staging_ws_data()\n                RETURNING
+        runtime_stats_ws_entry_id, user_id, db_id, query_id, event_type, event\n        ),\n\t\taux_runtime_stats_ws_values
+        AS\n\t\t(\n\t\t\tINSERT INTO query_store.runtime_stats_ws_values (runtime_stats_ws_entry_id,
+        calls)\n\t\t\t\tSELECT\n                aux_runtime_stats_ws_entries.runtime_stats_ws_entry_id,
+        calls\n\t\t\t\tFROM aux_runtime_stats_ws_entries JOIN query_store.staging_ws_data()
+        AS t1\n\t\t\t\tON\n\t\t\t\t\taux_runtime_stats_ws_entries.query_id = t1.query_id
+        AND\n\t\t\t\t\taux_runtime_stats_ws_entries.user_id = t1.user_id AND\n\t\t\t\t\taux_runtime_stats_ws_entries.db_id
+        = t1.db_id AND\n\t\t\t\t\taux_runtime_stats_ws_entries.event = t1.event AND\n\t\t\t\t\taux_runtime_stats_ws_entries.event_type
+        = t1.event_type\n\t\t),\n        plans AS\n\t\t(\n            INSERT INTO
+        query_store.query_plans (plan_id, db_id, query_id, plan_text)\n                SELECT
+        plan_id, db_id, query_id, CAST(plan_text AS varchar(10000)) AS plan_text\n                FROM
+        staging_data\n                WHERE plan_text IS NOT NULL AND query_id IS
+        NOT NULL AND plan_id IS NOT NULL\n                ON CONFLICT(plan_id, db_id,
+        query_id) DO NOTHING\n                returning plan_id, plan_text, query_id\n        )\n        INSERT
+        INTO query_store.runtime_stats (\n            runtime_stats_entry_id,\n            calls,\n            total_time,\n            min_time,\n            max_time,\n            mean_time,\n            stddev_time,\n            rows,\n            shared_blks_hit,\n            shared_blks_read,\n            shared_blks_dirtied,\n            shared_blks_written,\n            local_blks_hit,\n            local_blks_read,\n            local_blks_dirtied,\n            local_blks_written,\n            temp_blks_read,\n            temp_blks_written,\n            blk_read_time,\n            blk_write_time\n        )\n        SELECT\n            runtime_stats_entry_id,\n            calls,\n            total_time,\n            min_time,\n            max_time,\n            mean_time,\n            stddev_time,\n            rows,\n            shared_blks_hit,\n            shared_blks_read,\n            shared_blks_dirtied,\n            shared_blks_written,\n            local_blks_hit,\n            local_blks_read,\n            local_blks_dirtied,\n            local_blks_written,\n            temp_blks_read,\n            temp_blks_written,\n            blk_read_time,\n            blk_write_time\n        FROM\n            aux_runtime_stats_variables
+        JOIN staging_data AS t1 ON aux_runtime_stats_variables.user_id = t1.user_id
+        AND aux_runtime_stats_variables.db_id = t1.db_id AND aux_runtime_stats_variables.query_id
+        = t1.query_id\n\t\t\tLEFT OUTER JOIN plans p\n            ON aux_runtime_stats_variables.query_id
+        = p.query_id\"\nPL/pgSQL function query_store.collect_data(text,text) line
+        9 at SQL statement\nSQL statement \"SELECT query_store.collect_data(''15 minutes'',
+        ''7 days'')\"
+
+        2026-04-07 22:21:50 UTC-69d57ffa.362-LOG:  pg_qs: number of rows inserted
+        into runtime_stats: 114","context": "PL/pgSQL function query_store.collect_data(text,text)
+        line 110 at RAISE\nSQL statement \"SELECT query_store.collect_data(''15 minutes'',
+        ''7 days'')\"
+
+        2026-04-07 22:21:50 UTC-69d57ffa.362-LOG:  pgms_wait_sampling: entry_reset
+        called","context": "SQL statement \"SELECT query_store.staging_ws_data_reset()\"\nPL/pgSQL
+        function query_store.collect_data(text,text) line 129 at PERFORM\nSQL statement
+        \"SELECT query_store.collect_data(''15 minutes'', ''7 days'')\"
+
+        2026-04-07 22:21:50 UTC-69d57ffa.362-LOG:  pgms_wait_sampling: entry_reset
+        called","context": "SQL statement \"SELECT query_store.staging_ws_data_reset()\"
+
+        2026-04-07 22:21:50 UTC-69d57ffa.362-LOG:  pg_qs: qs bgworker: worker finished
+        successfully in 13.829295 ms, with query store as on, is_writable_instance
+        as on and having_schema as true
+
+        2026-04-07 22:21:50 UTC-69d57ffa.362-LOG:  pg_qs: qs bgworker: entry limit:
+        1000, tracked entries: 114, collected entries: 114, hash overflows: 0, entry
+        creation failures: 0, lock partitions: 32, spinlock buckets: on
+
+        2026-04-07 22:21:52 UTC-69d58380.697-LOG:  connection received: host=127.0.0.1
+        port=54938
+
+        2026-04-07 22:21:52 UTC-69d58380.697-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:21:52 UTC-69d58380.697-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:21:52 UTC-69d58380.697-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:21:53 UTC-69d5836d.686-LOG:  disconnection: session time: 0:00:20.031
+        user=azuresu database=postgres host=127.0.0.1 port=33678
+
+        2026-04-07 22:21:53 UTC-69d58381.698-LOG:  connection received: host=127.0.0.1
+        port=54944
+
+        2026-04-07 22:21:53 UTC-69d58381.698-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:21:53 UTC-69d58381.698-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:21:53 UTC-69d58381.698-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:21:56 UTC-69d58384.69a-LOG:  connection received: host=127.0.0.1
+        port=54956
+
+        2026-04-07 22:21:56 UTC-69d58384.69a-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:21:56 UTC-69d58384.69a-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:21:56 UTC-69d58384.69a-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:22:08 UTC-69d58390.6a7-LOG:  connection received: host=127.0.0.1
+        port=38810
+
+        2026-04-07 22:22:08 UTC-69d58390.6a7-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:22:08 UTC-69d58390.6a7-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:22:08 UTC-69d58390.6a7-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:22:08 UTC-69d58390.6a7-LOG:  disconnection: session time: 0:00:00.046
+        user=azuresu database=postgres host=127.0.0.1 port=38810
+
+        2026-04-07 22:22:12 UTC-69d58380.697-LOG:  disconnection: session time: 0:00:20.038
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=54938
+
+        2026-04-07 22:22:13 UTC-69d58381.698-LOG:  disconnection: session time: 0:00:20.025
+        user=azuresu database=postgres host=127.0.0.1 port=54944
+
+        2026-04-07 22:22:13 UTC-69d58395.6a9-LOG:  connection received: host=127.0.0.1
+        port=50788
+
+        2026-04-07 22:22:13 UTC-69d58395.6a9-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:22:13 UTC-69d58395.6a9-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:22:13 UTC-69d58395.6a9-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:22:14 UTC-69d58396.6aa-LOG:  connection received: host=127.0.0.1
+        port=50796
+
+        2026-04-07 22:22:14 UTC-69d58396.6aa-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:22:14 UTC-69d58396.6aa-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:22:14 UTC-69d58396.6aa-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:22:16 UTC-69d58384.69a-LOG:  disconnection: session time: 0:00:20.027
+        user=azuresu database=azure_sys host=127.0.0.1 port=54956
+
+        2026-04-07 22:22:27 UTC-69d583a3.6af-LOG:  connection received: host=127.0.0.1
+        port=56258
+
+        2026-04-07 22:22:27 UTC-69d583a3.6af-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:22:27 UTC-69d583a3.6af-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:22:27 UTC-69d583a3.6af-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:22:33 UTC-69d583a9.6ba-LOG:  connection received: host=127.0.0.1
+        port=40232
+
+        2026-04-07 22:22:33 UTC-69d583a9.6ba-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:22:33 UTC-69d583a9.6ba-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:22:33 UTC-69d583a9.6ba-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:22:33 UTC-69d583a9.6ba-LOG:  disconnection: session time: 0:00:00.045
+        user=azuresu database=postgres host=127.0.0.1 port=40232
+
+        2026-04-07 22:22:33 UTC-69d58395.6a9-LOG:  disconnection: session time: 0:00:20.135
+        user=azuresu database=postgres host=127.0.0.1 port=50788
+
+        2026-04-07 22:22:34 UTC-69d58396.6aa-LOG:  disconnection: session time: 0:00:20.034
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=50796
+
+        2026-04-07 22:22:35 UTC-69d583ab.6bc-LOG:  connection received: host=127.0.0.1
+        port=40238
+
+        2026-04-07 22:22:35 UTC-69d583ab.6bc-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:22:35 UTC-69d583ab.6bc-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:22:35 UTC-69d583ab.6bc-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:22:36 UTC-69d583ac.6bd-LOG:  connection received: host=127.0.0.1
+        port=40248
+
+        2026-04-07 22:22:36 UTC-69d583ac.6bd-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:22:36 UTC-69d583ac.6bd-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:22:36 UTC-69d583ac.6bd-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:22:41 UTC-69d57ff0.2ee-LOG:  [pg-availability]: current_lsn:
+        0/5024CE0, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-04-07 22:22:47 UTC-69d583a3.6af-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=azure_sys host=127.0.0.1 port=56258
+
+        2026-04-07 22:22:55 UTC-69d583ab.6bc-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=postgres host=127.0.0.1 port=40238
+
+        2026-04-07 22:22:56 UTC-69d583c0.6c3-LOG:  connection received: host=127.0.0.1
+        port=51214
+
+        2026-04-07 22:22:56 UTC-69d583ac.6bd-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=40248
+
+        2026-04-07 22:22:56 UTC-69d583c0.6c3-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:22:56 UTC-69d583c0.6c3-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:22:56 UTC-69d583c0.6c3-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:22:58 UTC-69d583c2.6cb-LOG:  connection received: host=127.0.0.1
+        port=51222
+
+        2026-04-07 22:22:58 UTC-69d583c2.6ca-LOG:  connection received: host=127.0.0.1
+        port=51218
+
+        2026-04-07 22:22:58 UTC-69d583c2.6cb-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:22:58 UTC-69d583c2.6cb-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:22:58 UTC-69d583c2.6cb-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:22:58 UTC-69d583c2.6ca-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:22:58 UTC-69d583c2.6ca-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:22:58 UTC-69d583c2.6ca-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:22:58 UTC-69d583c2.6cf-LOG:  connection received: host=127.0.0.1
+        port=51234
+
+        2026-04-07 22:22:58 UTC-69d583c2.6cf-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:22:58 UTC-69d583c2.6cf-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:22:58 UTC-69d583c2.6cf-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:22:58 UTC-69d583c2.6cf-LOG:  disconnection: session time: 0:00:00.057
+        user=azuresu database=postgres host=127.0.0.1 port=51234
+
+        2026-04-07 22:23:16 UTC-69d583c0.6c3-LOG:  disconnection: session time: 0:00:20.046
+        user=azuresu database=postgres host=127.0.0.1 port=51214
+
+        2026-04-07 22:23:17 UTC-69d583d5.6d5-LOG:  connection received: host=127.0.0.1
+        port=52992
+
+        2026-04-07 22:23:17 UTC-69d583d5.6d5-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:23:17 UTC-69d583d5.6d5-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:23:17 UTC-69d583d5.6d5-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:23:18 UTC-69d583c2.6cb-LOG:  disconnection: session time: 0:00:20.060
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=51222
+
+        2026-04-07 22:23:18 UTC-69d583c2.6ca-LOG:  disconnection: session time: 0:00:20.063
+        user=azuresu database=azure_sys host=127.0.0.1 port=51218
+
+        2026-04-07 22:23:20 UTC-69d583d8.6d7-LOG:  connection received: host=127.0.0.1
+        port=53002
+
+        2026-04-07 22:23:20 UTC-69d583d8.6d7-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:23:20 UTC-69d583d8.6d7-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:23:20 UTC-69d583d8.6d7-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:23:23 UTC-69d583db.6e1-LOG:  connection received: host=127.0.0.1
+        port=36340
+
+        2026-04-07 22:23:23 UTC-69d583db.6e1-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:23:23 UTC-69d583db.6e1-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:23:23 UTC-69d583db.6e1-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:23:23 UTC-69d583db.6e1-LOG:  disconnection: session time: 0:00:00.048
+        user=azuresu database=postgres host=127.0.0.1 port=36340
+
+        2026-04-07 22:23:29 UTC-69d583e1.6e4-LOG:  connection received: host=127.0.0.1
+        port=36350
+
+        2026-04-07 22:23:29 UTC-69d583e1.6e4-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:23:29 UTC-69d583e1.6e4-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:23:29 UTC-69d583e1.6e4-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:23:37 UTC-69d583d5.6d5-LOG:  disconnection: session time: 0:00:20.030
+        user=azuresu database=postgres host=127.0.0.1 port=52992
+
+        2026-04-07 22:23:38 UTC-69d583ea.6e7-LOG:  connection received: host=127.0.0.1
+        port=35572
+
+        2026-04-07 22:23:38 UTC-69d583ea.6e7-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:23:38 UTC-69d583ea.6e7-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:23:38 UTC-69d583ea.6e7-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:23:40 UTC-69d583d8.6d7-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=53002
+
+        2026-04-07 22:23:41 UTC-69d57ff0.2ee-LOG:  [pg-availability]: current_lsn:
+        0/502F5C0, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-04-07 22:23:42 UTC-69d583ee.6e9-LOG:  connection received: host=127.0.0.1
+        port=52718
+
+        2026-04-07 22:23:42 UTC-69d583ee.6e9-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:23:42 UTC-69d583ee.6e9-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:23:42 UTC-69d583ee.6e9-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:23:48 UTC-69d583f4.6f5-LOG:  connection received: host=127.0.0.1
+        port=52726
+
+        2026-04-07 22:23:48 UTC-69d583f4.6f5-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:23:48 UTC-69d583f4.6f5-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:23:48 UTC-69d583f4.6f5-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:23:48 UTC-69d583f4.6f5-LOG:  disconnection: session time: 0:00:00.045
+        user=azuresu database=postgres host=127.0.0.1 port=52726
+
+        2026-04-07 22:23:49 UTC-69d583e1.6e4-LOG:  disconnection: session time: 0:00:20.022
+        user=azuresu database=azure_sys host=127.0.0.1 port=36350
+
+        2026-04-07 22:23:58 UTC-69d583ea.6e7-LOG:  disconnection: session time: 0:00:20.046
+        user=azuresu database=postgres host=127.0.0.1 port=35572
+
+        2026-04-07 22:23:59 UTC-69d583ff.6f8-LOG:  connection received: host=127.0.0.1
+        port=48664
+
+        2026-04-07 22:23:59 UTC-69d583ff.6f8-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:23:59 UTC-69d583ff.6f8-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:23:59 UTC-69d583ff.6f8-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:24:00 UTC-69d58400.6fa-LOG:  connection received: host=127.0.0.1
+        port=48678
+
+        2026-04-07 22:24:00 UTC-69d58400.6fa-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:24:00 UTC-69d58400.6fa-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:24:00 UTC-69d58400.6fa-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:24:02 UTC-69d583ee.6e9-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=52718
+
+        2026-04-07 22:24:04 UTC-69d58404.6fb-LOG:  connection received: host=127.0.0.1
+        port=46954
+
+        2026-04-07 22:24:04 UTC-69d58404.6fb-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:24:04 UTC-69d58404.6fb-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:24:04 UTC-69d58404.6fb-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:24:13 UTC-69d5840d.708-LOG:  connection received: host=127.0.0.1
+        port=57124
+
+        2026-04-07 22:24:13 UTC-69d5840d.708-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:24:13 UTC-69d5840d.708-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:24:13 UTC-69d5840d.708-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:24:13 UTC-69d5840d.708-LOG:  disconnection: session time: 0:00:00.045
+        user=azuresu database=postgres host=127.0.0.1 port=57124
+
+        2026-04-07 22:24:19 UTC-69d583ff.6f8-LOG:  disconnection: session time: 0:00:20.037
+        user=azuresu database=postgres host=127.0.0.1 port=48664
+
+        2026-04-07 22:24:20 UTC-69d58414.70b-LOG:  connection received: host=127.0.0.1
+        port=57136
+
+        2026-04-07 22:24:20 UTC-69d58400.6fa-LOG:  disconnection: session time: 0:00:20.025
+        user=azuresu database=azure_sys host=127.0.0.1 port=48678
+
+        2026-04-07 22:24:20 UTC-69d58414.70b-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:24:20 UTC-69d58414.70b-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:24:20 UTC-69d58414.70b-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:24:24 UTC-69d58404.6fb-LOG:  disconnection: session time: 0:00:20.023
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=46954
+
+        2026-04-07 22:24:26 UTC-69d5841a.70e-LOG:  connection received: host=127.0.0.1
+        port=37596
+
+        2026-04-07 22:24:26 UTC-69d5841a.70e-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:24:26 UTC-69d5841a.70e-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:24:26 UTC-69d5841a.70e-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:24:31 UTC-69d5841f.710-LOG:  connection received: host=127.0.0.1
+        port=37608
+
+        2026-04-07 22:24:31 UTC-69d5841f.710-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:24:31 UTC-69d5841f.710-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:24:31 UTC-69d5841f.710-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:24:38 UTC-69d58426.71b-LOG:  connection received: host=127.0.0.1
+        port=48652
+
+        2026-04-07 22:24:38 UTC-69d58426.71b-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:24:38 UTC-69d58426.71b-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:24:38 UTC-69d58426.71b-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:24:38 UTC-69d58426.71b-LOG:  disconnection: session time: 0:00:00.045
+        user=azuresu database=postgres host=127.0.0.1 port=48652
+
+        2026-04-07 22:24:40 UTC-69d58414.70b-LOG:  disconnection: session time: 0:00:20.045
+        user=azuresu database=postgres host=127.0.0.1 port=57136
+
+        2026-04-07 22:24:41 UTC-69d57ff0.2ee-LOG:  [pg-availability]: current_lsn:
+        0/502FC60, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-04-07 22:24:41 UTC-69d58429.71d-LOG:  connection received: host=127.0.0.1
+        port=48668
+
+        2026-04-07 22:24:41 UTC-69d58429.71d-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:24:41 UTC-69d58429.71d-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:24:41 UTC-69d58429.71d-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:24:46 UTC-69d5841a.70e-LOG:  disconnection: session time: 0:00:20.022
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=37596
+
+        2026-04-07 22:24:48 UTC-69d58430.720-LOG:  connection received: host=127.0.0.1
+        port=45982
+
+        2026-04-07 22:24:48 UTC-69d58430.720-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:24:48 UTC-69d58430.720-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:24:48 UTC-69d58430.720-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:24:51 UTC-69d5841f.710-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=azure_sys host=127.0.0.1 port=37608
+
+        2026-04-07 22:25:01 UTC-69d58429.71d-LOG:  disconnection: session time: 0:00:20.028
+        user=azuresu database=postgres host=127.0.0.1 port=48668
+
+        2026-04-07 22:25:02 UTC-69d5843e.724-LOG:  connection received: host=127.0.0.1
+        port=43348
+
+        2026-04-07 22:25:02 UTC-69d5843e.724-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:25:02 UTC-69d5843e.724-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:25:02 UTC-69d5843e.724-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:25:03 UTC-69d5843f.725-LOG:  connection received: host=127.0.0.1
+        port=43358
+
+        2026-04-07 22:25:03 UTC-69d5843f.725-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:25:03 UTC-69d5843f.725-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:25:03 UTC-69d5843f.725-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:25:03 UTC-69d5843f.72f-LOG:  connection received: host=127.0.0.1
+        port=43362
+
+        2026-04-07 22:25:03 UTC-69d5843f.72f-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:25:03 UTC-69d5843f.72f-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:25:03 UTC-69d5843f.72f-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:25:03 UTC-69d5843f.72f-LOG:  disconnection: session time: 0:00:00.046
+        user=azuresu database=postgres host=127.0.0.1 port=43362
+
+        2026-04-07 22:25:08 UTC-69d58430.720-LOG:  disconnection: session time: 0:00:20.022
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=45982
+
+        2026-04-07 22:25:11 UTC-69d58447.733-LOG:  connection received: host=127.0.0.1
+        port=43376
+
+        2026-04-07 22:25:11 UTC-69d58447.733-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:25:11 UTC-69d58447.733-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:25:11 UTC-69d58447.733-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:25:22 UTC-69d5843e.724-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=azure_sys host=127.0.0.1 port=43348
+
+        2026-04-07 22:25:23 UTC-69d5843f.725-LOG:  disconnection: session time: 0:00:20.029
+        user=azuresu database=postgres host=127.0.0.1 port=43358
+
+        2026-04-07 22:25:24 UTC-69d58454.736-LOG:  connection received: host=127.0.0.1
+        port=45276
+
+        2026-04-07 22:25:24 UTC-69d58454.736-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:25:24 UTC-69d58454.736-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:25:24 UTC-69d58454.736-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:25:28 UTC-69d58458.742-LOG:  connection received: host=127.0.0.1
+        port=45278
+
+        2026-04-07 22:25:28 UTC-69d58458.742-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:25:28 UTC-69d58458.742-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:25:28 UTC-69d58458.742-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:25:28 UTC-69d58458.742-LOG:  disconnection: session time: 0:00:00.045
+        user=azuresu database=postgres host=127.0.0.1 port=45278
+
+        2026-04-07 22:25:31 UTC-69d58447.733-LOG:  disconnection: session time: 0:00:20.029
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=43376
+
+        2026-04-07 22:25:33 UTC-69d5845d.744-LOG:  connection received: host=127.0.0.1
+        port=56038
+
+        2026-04-07 22:25:33 UTC-69d5845d.745-LOG:  connection received: host=127.0.0.1
+        port=56036
+
+        2026-04-07 22:25:33 UTC-69d5845d.744-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:25:33 UTC-69d5845d.744-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:25:33 UTC-69d5845d.744-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:25:33 UTC-69d5845d.745-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:25:33 UTC-69d5845d.745-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:25:33 UTC-69d5845d.745-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:25:41 UTC-69d57ff0.2ee-LOG:  [pg-availability]: current_lsn:
+        0/5030318, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-04-07 22:25:44 UTC-69d58454.736-LOG:  disconnection: session time: 0:00:20.028
+        user=azuresu database=postgres host=127.0.0.1 port=45276
+
+        2026-04-07 22:25:45 UTC-69d58469.74a-LOG:  connection received: host=127.0.0.1
+        port=44688
+
+        2026-04-07 22:25:45 UTC-69d58469.74a-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:25:45 UTC-69d58469.74a-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:25:45 UTC-69d58469.74a-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:25:53 UTC-69d5845d.744-LOG:  disconnection: session time: 0:00:20.038
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=56038
+
+        2026-04-07 22:25:53 UTC-69d5845d.745-LOG:  disconnection: session time: 0:00:20.041
+        user=azuresu database=azure_sys host=127.0.0.1 port=56036
+
+        2026-04-07 22:25:54 UTC-69d58472.755-LOG:  connection received: host=127.0.0.1
+        port=44366
+
+        2026-04-07 22:25:54 UTC-69d58472.755-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:25:54 UTC-69d58472.755-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:25:54 UTC-69d58472.755-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:25:54 UTC-69d58472.755-LOG:  disconnection: session time: 0:00:00.047
+        user=azuresu database=postgres host=127.0.0.1 port=44366
+
+        2026-04-07 22:25:56 UTC-69d58474.757-LOG:  connection received: host=127.0.0.1
+        port=44370
+
+        2026-04-07 22:25:56 UTC-69d58474.757-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:25:56 UTC-69d58474.757-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:25:56 UTC-69d58474.757-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:26:04 UTC-69d5847c.759-LOG:  connection received: host=127.0.0.1
+        port=34722
+
+        2026-04-07 22:26:04 UTC-69d5847c.759-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:26:04 UTC-69d5847c.759-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:26:04 UTC-69d5847c.759-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:26:05 UTC-69d58469.74a-LOG:  disconnection: session time: 0:00:20.151
+        user=azuresu database=postgres host=127.0.0.1 port=44688
+
+        2026-04-07 22:26:06 UTC-69d5847e.75c-LOG:  connection received: host=127.0.0.1
+        port=34738
+
+        2026-04-07 22:26:06 UTC-69d5847e.75c-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:26:06 UTC-69d5847e.75c-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:26:06 UTC-69d5847e.75c-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:26:16 UTC-69d58474.757-LOG:  disconnection: session time: 0:00:20.025
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=44370
+
+        2026-04-07 22:26:18 UTC-69d5848a.75f-LOG:  connection received: host=127.0.0.1
+        port=53132
+
+        2026-04-07 22:26:18 UTC-69d5848a.75f-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:26:18 UTC-69d5848a.75f-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:26:18 UTC-69d5848a.75f-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:26:19 UTC-69d5848b.769-LOG:  connection received: host=127.0.0.1
+        port=53138
+
+        2026-04-07 22:26:19 UTC-69d5848b.769-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:26:19 UTC-69d5848b.769-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:26:19 UTC-69d5848b.769-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:26:19 UTC-69d5848b.769-LOG:  disconnection: session time: 0:00:00.045
+        user=azuresu database=postgres host=127.0.0.1 port=53138
+
+        2026-04-07 22:26:24 UTC-69d5847c.759-LOG:  disconnection: session time: 0:00:20.028
+        user=azuresu database=azure_sys host=127.0.0.1 port=34722
+
+        2026-04-07 22:26:26 UTC-69d5847e.75c-LOG:  disconnection: session time: 0:00:20.023
+        user=azuresu database=postgres host=127.0.0.1 port=34738
+
+        2026-04-07 22:26:27 UTC-69d58493.783-LOG:  connection received: host=127.0.0.1
+        port=44692
+
+        2026-04-07 22:26:27 UTC-69d58493.783-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:26:27 UTC-69d58493.783-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:26:27 UTC-69d58493.783-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:26:28 UTC-69d58494.785-LOG:  connection received: host=127.0.0.1
+        port=44694
+
+        2026-04-07 22:26:28 UTC-69d58494.786-LOG:  connection received: host=127.0.0.1
+        port=44700
+
+        2026-04-07 22:26:28 UTC-69d58494.785-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:26:28 UTC-69d58494.785-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:26:28 UTC-69d58494.785-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:26:28 UTC-69d58494.786-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:26:28 UTC-69d58494.786-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:26:28 UTC-69d58494.786-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:26:28 UTC-69d58494.787-LOG:  connection received: host=127.0.0.1
+        port=44710
+
+        2026-04-07 22:26:28 UTC-69d58494.787-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:26:28 UTC-69d58494.787-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:26:28 UTC-69d58494.787-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:26:35 UTC-69d5849b.78b-LOG:  connection received: host=127.0.0.1
+        port=57486
+
+        2026-04-07 22:26:35 UTC-69d5849b.78b-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:26:35 UTC-69d5849b.78b-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:26:35 UTC-69d5849b.78b-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:26:38 UTC-69d5848a.75f-LOG:  disconnection: session time: 0:00:20.027
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=53132
+
+        2026-04-07 22:26:40 UTC-69d584a0.78d-LOG:  connection received: host=127.0.0.1
+        port=57490
+
+        2026-04-07 22:26:40 UTC-69d584a0.78d-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:26:40 UTC-69d584a0.78d-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:26:40 UTC-69d584a0.78d-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:26:41 UTC-69d57ff0.2ee-LOG:  [pg-availability]: current_lsn:
+        0/60002B0, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-04-07 22:26:44 UTC-69d584a4.797-LOG:  connection received: host=127.0.0.1
+        port=43572
+
+        2026-04-07 22:26:44 UTC-69d584a4.797-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:26:44 UTC-69d584a4.797-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:26:44 UTC-69d584a4.797-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:26:44 UTC-69d584a4.797-LOG:  disconnection: session time: 0:00:00.046
+        user=azuresu database=postgres host=127.0.0.1 port=43572
+
+        2026-04-07 22:26:47 UTC-69d58494.787-LOG:  disconnection: session time: 0:00:18.959
+        user=azuresu database=postgres host=127.0.0.1 port=44710
+
+        2026-04-07 22:26:47 UTC-69d58493.783-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=postgres host=127.0.0.1 port=44692
+
+        2026-04-07 22:26:47 UTC-69d58494.786-LOG:  disconnection: session time: 0:00:19.000
+        user=azuresu database=postgres host=127.0.0.1 port=44700
+
+        2026-04-07 22:26:48 UTC-69d584a8.79a-LOG:  connection received: host=127.0.0.1
+        port=43584
+
+        2026-04-07 22:26:48 UTC-69d584a8.79a-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:26:48 UTC-69d584a8.79a-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:26:48 UTC-69d584a8.79a-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:26:48 UTC-69d58494.785-LOG:  disconnection: session time: 0:00:20.058
+        user=azuresu database=azure_sys host=127.0.0.1 port=44694
+
+        2026-04-07 22:26:55 UTC-69d5849b.78b-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=azure_sys host=127.0.0.1 port=57486
+
+        2026-04-07 22:27:00 UTC-69d584a0.78d-LOG:  disconnection: session time: 0:00:20.027
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=57490
+
+        2026-04-07 22:27:02 UTC-69d584b6.79e-LOG:  connection received: host=127.0.0.1
+        port=41608
+
+        2026-04-07 22:27:02 UTC-69d584b6.79e-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:27:02 UTC-69d584b6.79e-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:27:02 UTC-69d584b6.79e-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:27:06 UTC-69d584ba.7a1-LOG:  connection received: host=127.0.0.1
+        port=41614
+
+        2026-04-07 22:27:06 UTC-69d584ba.7a1-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:27:06 UTC-69d584ba.7a1-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:27:06 UTC-69d584ba.7a1-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:27:08 UTC-69d584a8.79a-LOG:  disconnection: session time: 0:00:20.028
+        user=azuresu database=postgres host=127.0.0.1 port=43584
+
+        2026-04-07 22:27:09 UTC-69d584bd.7a2-LOG:  connection received: host=127.0.0.1
+        port=41620
+
+        2026-04-07 22:27:09 UTC-69d584bd.7a2-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:27:09 UTC-69d584bd.7a2-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:27:09 UTC-69d584bd.7a2-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:27:09 UTC-69d584bd.7ac-LOG:  connection received: host=127.0.0.1
+        port=41628
+
+        2026-04-07 22:27:09 UTC-69d584bd.7ac-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:27:09 UTC-69d584bd.7ac-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:27:09 UTC-69d584bd.7ac-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:27:09 UTC-69d584bd.7ac-LOG:  disconnection: session time: 0:00:00.048
+        user=azuresu database=postgres host=127.0.0.1 port=41628
+
+        2026-04-07 22:27:22 UTC-69d584b6.79e-LOG:  disconnection: session time: 0:00:20.031
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=41608
+
+        2026-04-07 22:27:24 UTC-69d584cc.7b0-LOG:  connection received: host=127.0.0.1
+        port=56230
+
+        2026-04-07 22:27:24 UTC-69d584cc.7b0-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:27:24 UTC-69d584cc.7b0-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:27:24 UTC-69d584cc.7b0-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:27:26 UTC-69d584ba.7a1-LOG:  disconnection: session time: 0:00:20.030
+        user=azuresu database=azure_sys host=127.0.0.1 port=41614
+
+        2026-04-07 22:27:29 UTC-69d584bd.7a2-LOG:  disconnection: session time: 0:00:20.053
+        user=azuresu database=postgres host=127.0.0.1 port=41620
+
+        2026-04-07 22:27:30 UTC-69d584d2.7b4-LOG:  connection received: host=127.0.0.1
+        port=56240
+
+        2026-04-07 22:27:30 UTC-69d584d2.7b4-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:27:30 UTC-69d584d2.7b4-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:27:30 UTC-69d584d2.7b4-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:27:34 UTC-69d584d6.7be-LOG:  connection received: host=127.0.0.1
+        port=55622
+
+        2026-04-07 22:27:34 UTC-69d584d6.7be-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:27:34 UTC-69d584d6.7be-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:27:34 UTC-69d584d6.7be-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:27:34 UTC-69d584d6.7be-LOG:  disconnection: session time: 0:00:00.045
+        user=azuresu database=postgres host=127.0.0.1 port=55622
+
+        2026-04-07 22:27:37 UTC-69d584d9.7c0-LOG:  connection received: host=127.0.0.1
+        port=55632
+
+        2026-04-07 22:27:37 UTC-69d584d9.7c0-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:27:37 UTC-69d584d9.7c0-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:27:37 UTC-69d584d9.7c0-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:27:41 UTC-69d57ff0.2ee-LOG:  [pg-availability]: current_lsn:
+        0/6008788, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-04-07 22:27:44 UTC-69d584cc.7b0-LOG:  disconnection: session time: 0:00:20.120
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=56230
+
+        2026-04-07 22:27:46 UTC-69d584e2.7c4-LOG:  connection received: host=127.0.0.1
+        port=37134
+
+        2026-04-07 22:27:46 UTC-69d584e2.7c4-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:27:46 UTC-69d584e2.7c4-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:27:46 UTC-69d584e2.7c4-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:27:50 UTC-69d584d2.7b4-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=postgres host=127.0.0.1 port=56240
+
+        2026-04-07 22:27:51 UTC-69d584e7.7c6-LOG:  connection received: host=127.0.0.1
+        port=37148
+
+        2026-04-07 22:27:51 UTC-69d584e7.7c6-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:27:51 UTC-69d584e7.7c6-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:27:51 UTC-69d584e7.7c6-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:27:57 UTC-69d584d9.7c0-LOG:  disconnection: session time: 0:00:20.027
+        user=azuresu database=azure_sys host=127.0.0.1 port=55632
+
+        2026-04-07 22:27:59 UTC-69d584ef.7d2-LOG:  connection received: host=127.0.0.1
+        port=54388
+
+        2026-04-07 22:27:59 UTC-69d584ef.7d2-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:27:59 UTC-69d584ef.7d2-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:27:59 UTC-69d584ef.7d2-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:27:59 UTC-69d584ef.7d2-LOG:  disconnection: session time: 0:00:00.045
+        user=azuresu database=postgres host=127.0.0.1 port=54388
+
+        2026-04-07 22:28:06 UTC-69d584e2.7c4-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=37134
+
+        2026-04-07 22:28:08 UTC-69d584f8.7d5-LOG:  connection received: host=127.0.0.1
+        port=49352
+
+        2026-04-07 22:28:08 UTC-69d584f8.7d6-LOG:  connection received: host=127.0.0.1
+        port=49362
+
+        2026-04-07 22:28:08 UTC-69d584f8.7d5-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:28:08 UTC-69d584f8.7d5-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:28:08 UTC-69d584f8.7d5-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:28:08 UTC-69d584f8.7d6-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:28:08 UTC-69d584f8.7d6-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:28:08 UTC-69d584f8.7d6-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:28:11 UTC-69d584e7.7c6-LOG:  disconnection: session time: 0:00:20.023
+        user=azuresu database=postgres host=127.0.0.1 port=37148
+
+        2026-04-07 22:28:12 UTC-69d584fc.7d8-LOG:  connection received: host=127.0.0.1
+        port=57830
+
+        2026-04-07 22:28:12 UTC-69d584fc.7d8-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:28:12 UTC-69d584fc.7d8-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:28:12 UTC-69d584fc.7d8-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:28:24 UTC-69d58508.7e6-LOG:  connection received: host=127.0.0.1
+        port=47086
+
+        2026-04-07 22:28:24 UTC-69d58508.7e6-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:28:24 UTC-69d58508.7e6-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:28:24 UTC-69d58508.7e6-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:28:24 UTC-69d58508.7e6-LOG:  disconnection: session time: 0:00:00.045
+        user=azuresu database=postgres host=127.0.0.1 port=47086
+
+        2026-04-07 22:28:28 UTC-69d584f8.7d5-LOG:  disconnection: session time: 0:00:20.048
+        user=azuresu database=azure_sys host=127.0.0.1 port=49352
+
+        2026-04-07 22:28:28 UTC-69d584f8.7d6-LOG:  disconnection: session time: 0:00:20.047
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=49362
+
+        2026-04-07 22:28:31 UTC-69d5850f.7e8-LOG:  connection received: host=127.0.0.1
+        port=47102
+
+        2026-04-07 22:28:31 UTC-69d5850f.7e8-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:28:31 UTC-69d5850f.7e8-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:28:31 UTC-69d5850f.7e8-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:28:32 UTC-69d584fc.7d8-LOG:  disconnection: session time: 0:00:20.070
+        user=azuresu database=postgres host=127.0.0.1 port=57830
+
+        2026-04-07 22:28:33 UTC-69d58511.7e9-LOG:  connection received: host=127.0.0.1
+        port=53194
+
+        2026-04-07 22:28:33 UTC-69d58511.7e9-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:28:33 UTC-69d58511.7e9-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:28:33 UTC-69d58511.7e9-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:28:39 UTC-69d58517.7eb-LOG:  connection received: host=127.0.0.1
+        port=53202
+
+        2026-04-07 22:28:39 UTC-69d58517.7eb-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:28:39 UTC-69d58517.7eb-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:28:39 UTC-69d58517.7eb-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:28:41 UTC-69d57ff0.2ee-LOG:  [pg-availability]: current_lsn:
+        0/6008E28, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-04-07 22:28:49 UTC-69d58521.7f9-LOG:  connection received: host=127.0.0.1
+        port=36796
+
+        2026-04-07 22:28:49 UTC-69d58521.7f9-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:28:49 UTC-69d58521.7f9-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:28:49 UTC-69d58521.7f9-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:28:49 UTC-69d58521.7f9-LOG:  disconnection: session time: 0:00:00.045
+        user=azuresu database=postgres host=127.0.0.1 port=36796
+
+        2026-04-07 22:28:51 UTC-69d5850f.7e8-LOG:  disconnection: session time: 0:00:20.062
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=47102
+
+        2026-04-07 22:28:53 UTC-69d58511.7e9-LOG:  disconnection: session time: 0:00:20.031
+        user=azuresu database=postgres host=127.0.0.1 port=53194
+
+        2026-04-07 22:28:54 UTC-69d58526.7fa-LOG:  connection received: host=127.0.0.1
+        port=49968
+
+        2026-04-07 22:28:54 UTC-69d58526.7fb-LOG:  connection received: host=127.0.0.1
+        port=49970
+
+        2026-04-07 22:28:54 UTC-69d58526.7fa-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:28:54 UTC-69d58526.7fa-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:28:54 UTC-69d58526.7fa-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:28:54 UTC-69d58526.7fb-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:28:54 UTC-69d58526.7fb-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:28:54 UTC-69d58526.7fb-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:28:59 UTC-69d58517.7eb-LOG:  disconnection: session time: 0:00:20.028
+        user=azuresu database=azure_sys host=127.0.0.1 port=53202
+
+        2026-04-07 22:29:10 UTC-69d58536.801-LOG:  connection received: host=127.0.0.1
+        port=46064
+
+        2026-04-07 22:29:10 UTC-69d58536.801-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:29:10 UTC-69d58536.801-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:29:10 UTC-69d58536.801-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:29:14 UTC-69d58526.7fa-LOG:  disconnection: session time: 0:00:20.035
+        user=azuresu database=postgres host=127.0.0.1 port=49968
+
+        2026-04-07 22:29:14 UTC-69d58526.7fb-LOG:  disconnection: session time: 0:00:20.044
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=49970
+
+        2026-04-07 22:29:14 UTC-69d5853a.80c-LOG:  connection received: host=127.0.0.1
+        port=43474
+
+        2026-04-07 22:29:14 UTC-69d5853a.80c-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:29:14 UTC-69d5853a.80c-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:29:14 UTC-69d5853a.80c-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:29:14 UTC-69d5853a.80c-LOG:  disconnection: session time: 0:00:00.045
+        user=azuresu database=postgres host=127.0.0.1 port=43474
+
+        2026-04-07 22:29:15 UTC-69d5853b.80d-LOG:  connection received: host=127.0.0.1
+        port=43490
+
+        2026-04-07 22:29:15 UTC-69d5853b.80d-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:29:15 UTC-69d5853b.80d-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:29:15 UTC-69d5853b.80d-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:29:16 UTC-69d5853c.80e-LOG:  connection received: host=127.0.0.1
+        port=43502
+
+        2026-04-07 22:29:16 UTC-69d5853c.80e-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:29:16 UTC-69d5853c.80e-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:29:16 UTC-69d5853c.80e-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:29:30 UTC-69d58536.801-LOG:  disconnection: session time: 0:00:20.025
+        user=azuresu database=azure_sys host=127.0.0.1 port=46064
+
+        2026-04-07 22:29:35 UTC-69d5853b.80d-LOG:  disconnection: session time: 0:00:20.057
+        user=azuresu database=postgres host=127.0.0.1 port=43490
+
+        2026-04-07 22:29:36 UTC-69d58550.814-LOG:  connection received: host=127.0.0.1
+        port=39434
+
+        2026-04-07 22:29:36 UTC-69d5853c.80e-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=43502
+
+        2026-04-07 22:29:36 UTC-69d58550.814-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:29:36 UTC-69d58550.814-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:29:36 UTC-69d58550.814-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:29:39 UTC-69d58553.815-LOG:  connection received: host=127.0.0.1
+        port=39438
+
+        2026-04-07 22:29:39 UTC-69d58553.815-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:29:39 UTC-69d58553.815-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:29:39 UTC-69d58553.815-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:29:40 UTC-69d58554.81f-LOG:  connection received: host=127.0.0.1
+        port=39448
+
+        2026-04-07 22:29:40 UTC-69d58554.81f-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:29:40 UTC-69d58554.81f-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:29:40 UTC-69d58554.81f-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:29:40 UTC-69d58554.81f-LOG:  disconnection: session time: 0:00:00.048
+        user=azuresu database=postgres host=127.0.0.1 port=39448
+
+        2026-04-07 22:29:41 UTC-69d58555.820-LOG:  connection received: host=127.0.0.1
+        port=39458
+
+        2026-04-07 22:29:41 UTC-69d58555.820-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:29:41 UTC-69d58555.820-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:29:41 UTC-69d58555.820-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:29:41 UTC-69d57ff0.2ee-LOG:  [pg-availability]: current_lsn:
+        0/60094C8, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-04-07 22:29:56 UTC-69d58550.814-LOG:  disconnection: session time: 0:00:20.071
+        user=azuresu database=postgres host=127.0.0.1 port=39434
+
+        2026-04-07 22:29:56 UTC-69d58564.825-LOG:  connection received: host=127.0.0.1
+        port=50074
+
+        2026-04-07 22:29:56 UTC-69d58564.825-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:29:56 UTC-69d58564.825-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:29:56 UTC-69d58564.825-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:29:59 UTC-69d58553.815-LOG:  disconnection: session time: 0:00:20.038
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=39438
+
+        2026-04-07 22:30:01 UTC-69d58569.827-LOG:  connection received: host=127.0.0.1
+        port=50082
+
+        2026-04-07 22:30:01 UTC-69d58555.820-LOG:  disconnection: session time: 0:00:20.022
+        user=azuresu database=azure_sys host=127.0.0.1 port=39458
+
+        2026-04-07 22:30:01 UTC-69d58569.827-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:30:01 UTC-69d58569.827-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:30:01 UTC-69d58569.827-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:30:05 UTC-69d5856d.833-LOG:  connection received: host=127.0.0.1
+        port=44980
+
+        2026-04-07 22:30:05 UTC-69d5856d.833-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:30:05 UTC-69d5856d.833-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:30:05 UTC-69d5856d.833-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:30:05 UTC-69d5856d.833-LOG:  disconnection: session time: 0:00:00.045
+        user=azuresu database=postgres host=127.0.0.1 port=44980
+
+        2026-04-07 22:30:12 UTC-69d58574.835-LOG:  connection received: host=127.0.0.1
+        port=57352
+
+        2026-04-07 22:30:12 UTC-69d58574.835-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:30:12 UTC-69d58574.835-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:30:12 UTC-69d58574.835-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:30:16 UTC-69d58564.825-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=postgres host=127.0.0.1 port=50074
+
+        2026-04-07 22:30:16 UTC-69d58578.837-LOG:  connection received: host=127.0.0.1
+        port=57360
+
+        2026-04-07 22:30:16 UTC-69d58578.837-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:30:16 UTC-69d58578.837-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:30:16 UTC-69d58578.837-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:30:21 UTC-69d58569.827-LOG:  disconnection: session time: 0:00:20.031
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=50082
+
+        2026-04-07 22:30:23 UTC-69d5857f.839-LOG:  connection received: host=127.0.0.1
+        port=42646
+
+        2026-04-07 22:30:23 UTC-69d5857f.839-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:30:23 UTC-69d5857f.839-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:30:23 UTC-69d5857f.839-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:30:30 UTC-69d58586.846-LOG:  connection received: host=127.0.0.1
+        port=42660
+
+        2026-04-07 22:30:30 UTC-69d58586.846-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:30:30 UTC-69d58586.846-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:30:30 UTC-69d58586.846-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:30:30 UTC-69d58586.846-LOG:  disconnection: session time: 0:00:00.046
+        user=azuresu database=postgres host=127.0.0.1 port=42660
+
+        2026-04-07 22:30:32 UTC-69d58574.835-LOG:  disconnection: session time: 0:00:20.027
+        user=azuresu database=azure_sys host=127.0.0.1 port=57352
+
+        2026-04-07 22:30:36 UTC-69d58578.837-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=postgres host=127.0.0.1 port=57360
+
+        2026-04-07 22:30:36 UTC-69d5858c.848-LOG:  connection received: host=127.0.0.1
+        port=54304
+
+        2026-04-07 22:30:36 UTC-69d5858c.848-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:30:36 UTC-69d5858c.848-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:30:36 UTC-69d5858c.848-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:30:41 UTC-69d57ff0.2ee-LOG:  [pg-availability]: current_lsn:
+        0/6009B68, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-04-07 22:30:41 UTC-69d57ff0.2e7-LOG:  checkpoint starting: time
+
+        2026-04-07 22:30:43 UTC-69d58593.84a-LOG:  connection received: host=127.0.0.1
+        port=54356
+
+        2026-04-07 22:30:43 UTC-69d5857f.839-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=42646
+
+        2026-04-07 22:30:43 UTC-69d58593.84a-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:30:43 UTC-69d58593.84a-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:30:43 UTC-69d58593.84a-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:30:45 UTC-69d58595.84d-LOG:  connection received: host=127.0.0.1
+        port=54372
+
+        2026-04-07 22:30:45 UTC-69d58595.84d-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:30:45 UTC-69d58595.84d-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:30:45 UTC-69d58595.84d-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:30:50 UTC-69d57ff0.2e7-LOG:  checkpoint complete: wrote 88 buffers
+        (0.0%); 0 WAL file(s) added, 0 removed, 0 recycled; write=8.728 s, sync=0.004
+        s, total=8.746 s; sync files=49, longest=0.003 s, average=0.001 s; distance=32787
+        kB, estimate=32787 kB; lsn=0/6009F60, redo lsn=0/6009B68
+
+        2026-04-07 22:30:55 UTC-69d5859f.859-LOG:  connection received: host=127.0.0.1
+        port=54374
+
+        2026-04-07 22:30:55 UTC-69d5859f.859-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:30:55 UTC-69d5859f.859-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:30:55 UTC-69d5859f.859-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:30:55 UTC-69d5859f.859-LOG:  disconnection: session time: 0:00:00.047
+        user=azuresu database=postgres host=127.0.0.1 port=54374
+
+        2026-04-07 22:30:56 UTC-69d5858c.848-LOG:  disconnection: session time: 0:00:20.028
+        user=azuresu database=postgres host=127.0.0.1 port=54304
+
+        2026-04-07 22:30:56 UTC-69d585a0.85a-LOG:  connection received: host=127.0.0.1
+        port=54378
+
+        2026-04-07 22:30:56 UTC-69d585a0.85a-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:30:56 UTC-69d585a0.85a-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:30:56 UTC-69d585a0.85a-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:31:03 UTC-69d58593.84a-LOG:  disconnection: session time: 0:00:20.031
+        user=azuresu database=azure_sys host=127.0.0.1 port=54356
+
+        2026-04-07 22:31:05 UTC-69d58595.84d-LOG:  disconnection: session time: 0:00:20.027
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=54372
+
+        2026-04-07 22:31:07 UTC-69d585ab.85e-LOG:  connection received: host=127.0.0.1
+        port=58346
+
+        2026-04-07 22:31:07 UTC-69d585ab.85e-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:31:07 UTC-69d585ab.85e-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:31:07 UTC-69d585ab.85e-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:31:14 UTC-69d585b2.860-LOG:  connection received: host=127.0.0.1
+        port=55242
+
+        2026-04-07 22:31:14 UTC-69d585b2.860-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:31:14 UTC-69d585b2.860-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:31:14 UTC-69d585b2.860-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:31:16 UTC-69d585a0.85a-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=postgres host=127.0.0.1 port=54378
+
+        2026-04-07 22:31:16 UTC-69d585b4.862-LOG:  connection received: host=127.0.0.1
+        port=55248
+
+        2026-04-07 22:31:17 UTC-69d585b4.862-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:31:17 UTC-69d585b4.862-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:31:17 UTC-69d585b4.862-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:31:20 UTC-69d585b8.86d-LOG:  connection received: host=127.0.0.1
+        port=55252
+
+        2026-04-07 22:31:20 UTC-69d585b8.86d-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:31:20 UTC-69d585b8.86d-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:31:20 UTC-69d585b8.86d-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:31:20 UTC-69d585b8.86d-LOG:  disconnection: session time: 0:00:00.045
+        user=azuresu database=postgres host=127.0.0.1 port=55252
+
+        2026-04-07 22:31:27 UTC-69d585ab.85e-LOG:  disconnection: session time: 0:00:20.025
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=58346
+
+        2026-04-07 22:31:29 UTC-69d585c1.888-LOG:  connection received: host=127.0.0.1
+        port=34858
+
+        2026-04-07 22:31:29 UTC-69d585c1.888-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:31:29 UTC-69d585c1.888-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:31:29 UTC-69d585c1.888-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:31:30 UTC-69d585c2.88b-LOG:  connection received: host=127.0.0.1
+        port=34870
+
+        2026-04-07 22:31:30 UTC-69d585c2.88b-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:31:30 UTC-69d585c2.88b-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:31:30 UTC-69d585c2.88b-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:31:34 UTC-69d585b2.860-LOG:  disconnection: session time: 0:00:20.023
+        user=azuresu database=azure_sys host=127.0.0.1 port=55242
+
+        2026-04-07 22:31:37 UTC-69d585b4.862-LOG:  disconnection: session time: 0:00:20.027
+        user=azuresu database=postgres host=127.0.0.1 port=55248
+
+        2026-04-07 22:31:37 UTC-69d585c9.88d-LOG:  connection received: host=127.0.0.1
+        port=47802
+
+        2026-04-07 22:31:37 UTC-69d585c9.88d-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:31:37 UTC-69d585c9.88d-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:31:37 UTC-69d585c9.88d-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:31:41 UTC-69d57ff0.2ee-LOG:  [pg-availability]: current_lsn:
+        0/70001F8, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-04-07 22:31:45 UTC-69d585d1.891-LOG:  connection received: host=127.0.0.1
+        port=43306
+
+        2026-04-07 22:31:45 UTC-69d585d1.891-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:31:45 UTC-69d585d1.891-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:31:45 UTC-69d585d1.891-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:31:45 UTC-69d585d1.89b-LOG:  connection received: host=127.0.0.1
+        port=43322
+
+        2026-04-07 22:31:45 UTC-69d585d1.89b-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:31:45 UTC-69d585d1.89b-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:31:45 UTC-69d585d1.89b-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:31:45 UTC-69d585d1.89b-LOG:  disconnection: session time: 0:00:00.045
+        user=azuresu database=postgres host=127.0.0.1 port=43322
+
+        2026-04-07 22:31:49 UTC-69d585c1.888-LOG:  disconnection: session time: 0:00:20.033
+        user=azuresu database=azure_sys host=127.0.0.1 port=34858
+
+        2026-04-07 22:31:50 UTC-69d585c2.88b-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=34870
+
+        2026-04-07 22:31:53 UTC-69d585d9.89d-LOG:  connection received: host=127.0.0.1
+        port=60036
+
+        2026-04-07 22:31:53 UTC-69d585d9.89d-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:31:53 UTC-69d585d9.89d-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:31:53 UTC-69d585d9.89d-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:31:57 UTC-69d585c9.88d-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=postgres host=127.0.0.1 port=47802
+
+        2026-04-07 22:31:57 UTC-69d585dd.89f-LOG:  connection received: host=127.0.0.1
+        port=60044
+
+        2026-04-07 22:31:57 UTC-69d585dd.89f-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:31:57 UTC-69d585dd.89f-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:31:57 UTC-69d585dd.89f-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:32:05 UTC-69d585d1.891-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=azure_sys host=127.0.0.1 port=43306
+
+        2026-04-07 22:32:10 UTC-69d585ea.8ad-LOG:  connection received: host=127.0.0.1
+        port=57714
+
+        2026-04-07 22:32:10 UTC-69d585ea.8ad-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:32:10 UTC-69d585ea.8ad-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:32:10 UTC-69d585ea.8ad-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:32:10 UTC-69d585ea.8ad-LOG:  disconnection: session time: 0:00:00.047
+        user=azuresu database=postgres host=127.0.0.1 port=57714
+
+        2026-04-07 22:32:13 UTC-69d585d9.89d-LOG:  disconnection: session time: 0:00:20.023
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=60036
+
+        2026-04-07 22:32:16 UTC-69d585f0.8af-LOG:  connection received: host=127.0.0.1
+        port=59724
+
+        2026-04-07 22:32:16 UTC-69d585f0.8b0-LOG:  connection received: host=127.0.0.1
+        port=59740
+
+        2026-04-07 22:32:16 UTC-69d585f0.8b0-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:32:16 UTC-69d585f0.8b0-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:32:16 UTC-69d585f0.8b0-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:32:16 UTC-69d585f0.8af-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:32:16 UTC-69d585f0.8af-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:32:16 UTC-69d585f0.8af-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:32:17 UTC-69d585dd.89f-LOG:  disconnection: session time: 0:00:20.029
+        user=azuresu database=postgres host=127.0.0.1 port=60044
+
+        2026-04-07 22:32:17 UTC-69d585f1.8b1-LOG:  connection received: host=127.0.0.1
+        port=59756
+
+        2026-04-07 22:32:17 UTC-69d585f1.8b1-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:32:17 UTC-69d585f1.8b1-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:32:17 UTC-69d585f1.8b1-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:32:35 UTC-69d58603.8c0-LOG:  connection received: host=127.0.0.1
+        port=36568
+
+        2026-04-07 22:32:35 UTC-69d58603.8c0-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:32:35 UTC-69d58603.8c0-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:32:35 UTC-69d58603.8c0-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:32:35 UTC-69d58603.8c0-LOG:  disconnection: session time: 0:00:00.045
+        user=azuresu database=postgres host=127.0.0.1 port=36568
+
+        2026-04-07 22:32:36 UTC-69d585f0.8b0-LOG:  disconnection: session time: 0:00:20.049
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=59740
+
+        2026-04-07 22:32:36 UTC-69d585f0.8af-LOG:  disconnection: session time: 0:00:20.058
+        user=azuresu database=azure_sys host=127.0.0.1 port=59724
+
+        2026-04-07 22:32:37 UTC-69d585f1.8b1-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=postgres host=127.0.0.1 port=59756
+
+        2026-04-07 22:32:37 UTC-69d58605.8c1-LOG:  connection received: host=127.0.0.1
+        port=36582
+
+        2026-04-07 22:32:37 UTC-69d58605.8c1-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:32:37 UTC-69d58605.8c1-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:32:37 UTC-69d58605.8c1-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:32:38 UTC-69d58606.8c2-LOG:  connection received: host=127.0.0.1
+        port=36590
+
+        2026-04-07 22:32:38 UTC-69d58606.8c2-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:32:38 UTC-69d58606.8c2-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:32:38 UTC-69d58606.8c2-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:32:41 UTC-69d57ff0.2ee-LOG:  [pg-availability]: current_lsn:
+        0/7000860, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-04-07 22:32:47 UTC-69d5860f.8c6-LOG:  connection received: host=127.0.0.1
+        port=42584
+
+        2026-04-07 22:32:47 UTC-69d5860f.8c6-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:32:47 UTC-69d5860f.8c6-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:32:47 UTC-69d5860f.8c6-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:32:57 UTC-69d58605.8c1-LOG:  disconnection: session time: 0:00:20.133
+        user=azuresu database=postgres host=127.0.0.1 port=36582
+
+        2026-04-07 22:32:58 UTC-69d58606.8c2-LOG:  disconnection: session time: 0:00:20.036
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=36590
+
+        2026-04-07 22:33:00 UTC-69d5861c.8ca-LOG:  connection received: host=127.0.0.1
+        port=59198
+
+        2026-04-07 22:33:00 UTC-69d5861c.8ca-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:33:00 UTC-69d5861c.8ca-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:33:00 UTC-69d5861c.8ca-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:33:00 UTC-69d5861c.8d4-LOG:  connection received: host=127.0.0.1
+        port=59214
+
+        2026-04-07 22:33:00 UTC-69d5861c.8d4-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:33:00 UTC-69d5861c.8d4-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:33:00 UTC-69d5861c.8d4-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:33:00 UTC-69d5861c.8d4-LOG:  disconnection: session time: 0:00:00.046
+        user=azuresu database=postgres host=127.0.0.1 port=59214
+
+        2026-04-07 22:33:07 UTC-69d58623.8d7-LOG:  connection received: host=127.0.0.1
+        port=36624
+
+        2026-04-07 22:33:07 UTC-69d58623.8d7-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:33:07 UTC-69d58623.8d7-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:33:07 UTC-69d58623.8d7-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:33:07 UTC-69d5860f.8c6-LOG:  disconnection: session time: 0:00:20.030
+        user=azuresu database=azure_sys host=127.0.0.1 port=42584
+
+        2026-04-07 22:33:18 UTC-69d5862e.8da-LOG:  connection received: host=127.0.0.1
+        port=53852
+
+        2026-04-07 22:33:18 UTC-69d5862e.8da-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:33:18 UTC-69d5862e.8da-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:33:18 UTC-69d5862e.8da-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:33:20 UTC-69d5861c.8ca-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=59198
+
+        2026-04-07 22:33:22 UTC-69d58632.8dc-LOG:  connection received: host=127.0.0.1
+        port=45078
+
+        2026-04-07 22:33:22 UTC-69d58632.8dc-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:33:22 UTC-69d58632.8dc-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:33:22 UTC-69d58632.8dc-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:33:25 UTC-69d58635.8e8-LOG:  connection received: host=127.0.0.1
+        port=45082
+
+        2026-04-07 22:33:25 UTC-69d58635.8e8-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:33:25 UTC-69d58635.8e8-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:33:25 UTC-69d58635.8e8-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:33:25 UTC-69d58635.8e8-LOG:  disconnection: session time: 0:00:00.045
+        user=azuresu database=postgres host=127.0.0.1 port=45082
+
+        2026-04-07 22:33:27 UTC-69d58623.8d7-LOG:  disconnection: session time: 0:00:20.028
+        user=azuresu database=postgres host=127.0.0.1 port=36624
+
+        2026-04-07 22:33:27 UTC-69d58637.8e9-LOG:  connection received: host=127.0.0.1
+        port=45098
+
+        2026-04-07 22:33:27 UTC-69d58637.8e9-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:33:27 UTC-69d58637.8e9-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:33:27 UTC-69d58637.8e9-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:33:38 UTC-69d5862e.8da-LOG:  disconnection: session time: 0:00:20.027
+        user=azuresu database=azure_sys host=127.0.0.1 port=53852
+
+        2026-04-07 22:33:41 UTC-69d57ff0.2ee-LOG:  [pg-availability]: current_lsn:
+        0/7000F00, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-04-07 22:33:42 UTC-69d58632.8dc-LOG:  disconnection: session time: 0:00:20.031
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=45078
+
+        2026-04-07 22:33:44 UTC-69d58648.8ed-LOG:  connection received: host=127.0.0.1
+        port=39780
+
+        2026-04-07 22:33:44 UTC-69d58648.8ed-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:33:44 UTC-69d58648.8ed-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:33:44 UTC-69d58648.8ed-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:33:47 UTC-69d58637.8e9-LOG:  disconnection: session time: 0:00:20.023
+        user=azuresu database=postgres host=127.0.0.1 port=45098
+
+        2026-04-07 22:33:47 UTC-69d5864b.8f0-LOG:  connection received: host=127.0.0.1
+        port=39790
+
+        2026-04-07 22:33:47 UTC-69d5864b.8f0-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:33:47 UTC-69d5864b.8f0-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:33:47 UTC-69d5864b.8f0-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:33:49 UTC-69d5864d.8f1-LOG:  connection received: host=127.0.0.1
+        port=39802
+
+        2026-04-07 22:33:49 UTC-69d5864d.8f1-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:33:49 UTC-69d5864d.8f1-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:33:49 UTC-69d5864d.8f1-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:33:51 UTC-69d5864f.8fc-LOG:  connection received: host=127.0.0.1
+        port=39806
+
+        2026-04-07 22:33:51 UTC-69d5864f.8fc-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:33:51 UTC-69d5864f.8fc-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:33:51 UTC-69d5864f.8fc-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:33:51 UTC-69d5864f.8fc-LOG:  disconnection: session time: 0:00:00.045
+        user=azuresu database=postgres host=127.0.0.1 port=39806
+
+        2026-04-07 22:34:04 UTC-69d58648.8ed-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=39780
+
+        2026-04-07 22:34:06 UTC-69d5865e.901-LOG:  connection received: host=127.0.0.1
+        port=33202
+
+        2026-04-07 22:34:06 UTC-69d5865e.901-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:34:06 UTC-69d5865e.901-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:34:06 UTC-69d5865e.901-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:34:07 UTC-69d5864b.8f0-LOG:  disconnection: session time: 0:00:20.030
+        user=azuresu database=postgres host=127.0.0.1 port=39790
+
+        2026-04-07 22:34:07 UTC-69d5865f.902-LOG:  connection received: host=127.0.0.1
+        port=33218
+
+        2026-04-07 22:34:07 UTC-69d5865f.902-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:34:07 UTC-69d5865f.902-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:34:07 UTC-69d5865f.902-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:34:09 UTC-69d5864d.8f1-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=azure_sys host=127.0.0.1 port=39802
+
+        2026-04-07 22:34:11 UTC-69d58663.904-LOG:  connection received: host=127.0.0.1
+        port=33226
+
+        2026-04-07 22:34:11 UTC-69d58663.904-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:34:11 UTC-69d58663.904-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:34:11 UTC-69d58663.904-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:34:16 UTC-69d58668.910-LOG:  connection received: host=127.0.0.1
+        port=59120
+
+        2026-04-07 22:34:16 UTC-69d58668.910-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:34:16 UTC-69d58668.910-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:34:16 UTC-69d58668.910-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:34:16 UTC-69d58668.910-LOG:  disconnection: session time: 0:00:00.047
+        user=azuresu database=postgres host=127.0.0.1 port=59120
+
+        2026-04-07 22:34:20 UTC-69d5866c.912-LOG:  connection received: host=127.0.0.1
+        port=59126
+
+        2026-04-07 22:34:20 UTC-69d5866c.912-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:34:20 UTC-69d5866c.912-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:34:20 UTC-69d5866c.912-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:34:26 UTC-69d5865e.901-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=33202
+
+        2026-04-07 22:34:27 UTC-69d58663.904-LOG:  disconnection: session time: 0:00:16.423
+        user=azuresu database=postgres host=127.0.0.1 port=33226
+
+        2026-04-07 22:34:27 UTC-69d5865f.902-LOG:  disconnection: session time: 0:00:20.025
+        user=azuresu database=postgres host=127.0.0.1 port=33218
+
+        2026-04-07 22:34:27 UTC-69d58673.915-LOG:  connection received: host=127.0.0.1
+        port=51702
+
+        2026-04-07 22:34:27 UTC-69d58673.915-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:34:27 UTC-69d58673.915-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:34:27 UTC-69d58673.915-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:34:28 UTC-69d58674.916-LOG:  connection received: host=127.0.0.1
+        port=51714
+
+        2026-04-07 22:34:28 UTC-69d58674.916-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:34:28 UTC-69d58674.916-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:34:28 UTC-69d58674.916-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:34:40 UTC-69d5866c.912-LOG:  disconnection: session time: 0:00:20.030
+        user=azuresu database=azure_sys host=127.0.0.1 port=59126
+
+        2026-04-07 22:34:41 UTC-69d58681.923-LOG:  connection received: host=127.0.0.1
+        port=51250
+
+        2026-04-07 22:34:41 UTC-69d58681.923-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:34:41 UTC-69d58681.923-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:34:41 UTC-69d58681.923-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:34:41 UTC-69d58681.923-LOG:  disconnection: session time: 0:00:00.046
+        user=azuresu database=postgres host=127.0.0.1 port=51250
+
+        2026-04-07 22:34:41 UTC-69d57ff0.2ee-LOG:  [pg-availability]: current_lsn:
+        0/7006FD8, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-04-07 22:34:47 UTC-69d58673.915-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=postgres host=127.0.0.1 port=51702
+
+        2026-04-07 22:34:48 UTC-69d58688.926-LOG:  connection received: host=127.0.0.1
+        port=47632
+
+        2026-04-07 22:34:48 UTC-69d58688.926-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:34:48 UTC-69d58688.926-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:34:48 UTC-69d58688.926-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:34:48 UTC-69d58674.916-LOG:  disconnection: session time: 0:00:20.028
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=51714
+
+        2026-04-07 22:34:50 UTC-69d5868a.928-LOG:  connection received: host=127.0.0.1
+        port=47636
+
+        2026-04-07 22:34:50 UTC-69d5868a.928-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:34:50 UTC-69d5868a.928-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:34:50 UTC-69d5868a.928-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:34:51 UTC-69d5868b.929-LOG:  connection received: host=127.0.0.1
+        port=47646
+
+        2026-04-07 22:34:51 UTC-69d5868b.929-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:34:51 UTC-69d5868b.929-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:34:51 UTC-69d5868b.929-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:35:06 UTC-69d5869a.937-LOG:  connection received: host=127.0.0.1
+        port=56726
+
+        2026-04-07 22:35:06 UTC-69d5869a.937-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:35:06 UTC-69d5869a.937-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:35:06 UTC-69d5869a.937-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:35:06 UTC-69d5869a.937-LOG:  disconnection: session time: 0:00:00.048
+        user=azuresu database=postgres host=127.0.0.1 port=56726
+
+        2026-04-07 22:35:08 UTC-69d58688.926-LOG:  disconnection: session time: 0:00:20.035
+        user=azuresu database=postgres host=127.0.0.1 port=47632
+
+        2026-04-07 22:35:08 UTC-69d5869c.938-LOG:  connection received: host=127.0.0.1
+        port=56734
+
+        2026-04-07 22:35:08 UTC-69d5869c.938-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:35:08 UTC-69d5869c.938-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:35:08 UTC-69d5869c.938-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:35:10 UTC-69d5868a.928-LOG:  disconnection: session time: 0:00:20.022
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=47636
+
+        2026-04-07 22:35:11 UTC-69d5868b.929-LOG:  disconnection: session time: 0:00:20.022
+        user=azuresu database=azure_sys host=127.0.0.1 port=47646
+
+        2026-04-07 22:35:12 UTC-69d586a0.93a-LOG:  connection received: host=127.0.0.1
+        port=54150
+
+        2026-04-07 22:35:12 UTC-69d586a0.93a-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:35:12 UTC-69d586a0.93a-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:35:12 UTC-69d586a0.93a-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:35:22 UTC-69d586aa.93d-LOG:  connection received: host=127.0.0.1
+        port=57570
+
+        2026-04-07 22:35:22 UTC-69d586aa.93d-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:35:22 UTC-69d586aa.93d-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:35:22 UTC-69d586aa.93d-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:35:28 UTC-69d5869c.938-LOG:  disconnection: session time: 0:00:20.051
+        user=azuresu database=postgres host=127.0.0.1 port=56734
+
+        2026-04-07 22:35:28 UTC-69d586b0.940-LOG:  connection received: host=127.0.0.1
+        port=57580
+
+        2026-04-07 22:35:28 UTC-69d586b0.940-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:35:28 UTC-69d586b0.940-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:35:28 UTC-69d586b0.940-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:35:31 UTC-69d586b3.94b-LOG:  connection received: host=127.0.0.1
+        port=57588
+
+        2026-04-07 22:35:31 UTC-69d586b3.94b-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:35:31 UTC-69d586b3.94b-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:35:31 UTC-69d586b3.94b-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:35:31 UTC-69d586b3.94b-LOG:  disconnection: session time: 0:00:00.048
+        user=azuresu database=postgres host=127.0.0.1 port=57588
+
+        2026-04-07 22:35:32 UTC-69d586a0.93a-LOG:  disconnection: session time: 0:00:20.028
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=54150
+
+        2026-04-07 22:35:34 UTC-69d586b6.94c-LOG:  connection received: host=127.0.0.1
+        port=43316
+
+        2026-04-07 22:35:34 UTC-69d586b6.94c-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:35:34 UTC-69d586b6.94c-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:35:34 UTC-69d586b6.94c-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:35:41 UTC-69d57ff0.2ee-LOG:  [pg-availability]: current_lsn:
+        0/7007678, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-04-07 22:35:42 UTC-69d586aa.93d-LOG:  disconnection: session time: 0:00:20.028
+        user=azuresu database=azure_sys host=127.0.0.1 port=57570
+
+        2026-04-07 22:35:48 UTC-69d586b0.940-LOG:  disconnection: session time: 0:00:20.027
+        user=azuresu database=postgres host=127.0.0.1 port=57580
+
+        2026-04-07 22:35:48 UTC-69d586c4.951-LOG:  connection received: host=127.0.0.1
+        port=40794
+
+        2026-04-07 22:35:48 UTC-69d586c4.951-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:35:48 UTC-69d586c4.951-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:35:48 UTC-69d586c4.951-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:35:53 UTC-69d586c9.953-LOG:  connection received: host=127.0.0.1
+        port=45722
+
+        2026-04-07 22:35:53 UTC-69d586c9.953-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:35:53 UTC-69d586c9.953-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:35:53 UTC-69d586c9.953-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:35:54 UTC-69d586b6.94c-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=43316
+
+        2026-04-07 22:35:56 UTC-69d586cc.955-LOG:  connection received: host=127.0.0.1
+        port=45730
+
+        2026-04-07 22:35:56 UTC-69d586cc.955-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:35:56 UTC-69d586cc.955-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:35:56 UTC-69d586cc.955-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:35:56 UTC-69d586cc.95f-LOG:  connection received: host=127.0.0.1
+        port=45734
+
+        2026-04-07 22:35:56 UTC-69d586cc.95f-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:35:56 UTC-69d586cc.95f-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:35:56 UTC-69d586cc.95f-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:35:56 UTC-69d586cc.95f-LOG:  disconnection: session time: 0:00:00.046
+        user=azuresu database=postgres host=127.0.0.1 port=45734
+
+        2026-04-07 22:36:08 UTC-69d586c4.951-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=postgres host=127.0.0.1 port=40794
+
+        2026-04-07 22:36:08 UTC-69d586d8.963-LOG:  connection received: host=127.0.0.1
+        port=37334
+
+        2026-04-07 22:36:08 UTC-69d586d8.963-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:36:08 UTC-69d586d8.963-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:36:08 UTC-69d586d8.963-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:36:13 UTC-69d586c9.953-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=azure_sys host=127.0.0.1 port=45722
+
+        2026-04-07 22:36:16 UTC-69d586cc.955-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=45730
+
+        2026-04-07 22:36:18 UTC-69d586e2.966-LOG:  connection received: host=127.0.0.1
+        port=35924
+
+        2026-04-07 22:36:18 UTC-69d586e2.966-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:36:18 UTC-69d586e2.966-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:36:18 UTC-69d586e2.966-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:36:21 UTC-69d586e5.971-LOG:  connection received: host=127.0.0.1
+        port=35932
+
+        2026-04-07 22:36:21 UTC-69d586e5.971-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:36:21 UTC-69d586e5.971-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:36:21 UTC-69d586e5.971-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:36:21 UTC-69d586e5.971-LOG:  disconnection: session time: 0:00:00.050
+        user=azuresu database=postgres host=127.0.0.1 port=35932
+
+        2026-04-07 22:36:24 UTC-69d586e8.972-LOG:  connection received: host=127.0.0.1
+        port=35560
+
+        2026-04-07 22:36:24 UTC-69d586e8.972-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:36:24 UTC-69d586e8.972-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:36:24 UTC-69d586e8.972-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:36:28 UTC-69d586d8.963-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=postgres host=127.0.0.1 port=37334
+
+        2026-04-07 22:36:28 UTC-69d586ec.98c-LOG:  connection received: host=127.0.0.1
+        port=35576
+
+        2026-04-07 22:36:28 UTC-69d586ec.98c-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:36:28 UTC-69d586ec.98c-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:36:28 UTC-69d586ec.98c-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:36:29 UTC-69d586ed.98e-LOG:  connection received: host=127.0.0.1
+        port=35584
+
+        2026-04-07 22:36:29 UTC-69d586ed.98e-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:36:29 UTC-69d586ed.98e-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:36:29 UTC-69d586ed.98e-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-04-07 22:36:30 UTC-69d586ee.991-LOG:  connection received: host=127.0.0.1
+        port=35588
+
+        2026-04-07 22:36:30 UTC-69d586ee.991-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-04-07 22:36:30 UTC-69d586ee.991-LOG:  connection authenticated: identity=\"CN=azuresu.ef63a06f662b.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-04-07 22:36:30 UTC-69d586ee.991-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        '
+    headers:
+      accept-ranges:
+      - bytes
+      connection:
+      - close
+      content-length:
+      - '167466'
+      content-md5:
+      - JJuvtpgt+EQxYDViO3q7ZQ==
+      content-type:
+      - text/plain
+      date:
+      - Tue, 07 Apr 2026 22:37:56 GMT
+      etag:
+      - '"0x8DE94F61FB02929"'
+      last-modified:
+      - Tue, 07 Apr 2026 22:36:34 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-access-tier:
+      - Cool
+      x-ms-access-tier-inferred:
+      - 'true'
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-creation-time:
+      - Tue, 07 Apr 2026 22:26:31 GMT
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2025-05-05'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - postgres flexible-server parameter set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --server-name --name --value
+      User-Agent:
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/configurations/logfiles.download_enable?api-version=2026-01-01-preview
+  response:
+    body:
+      string: '{"properties":{"value":"on","description":"Enables or disables server
+        logs functionality.","defaultValue":"off","dataType":"Boolean","allowedValues":"on,off","source":"user-override","isDynamicConfig":true,"isReadOnly":false,"isConfigPendingRestart":false,"documentationLink":"https://go.microsoft.com/fwlink/?linkid=2274270"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/configurations/logfiles.download_enable","name":"logfiles.download_enable","type":"Microsoft.DBforPostgreSQL/flexibleServers/configurations"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '632'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 07 Apr 2026 22:37:57 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/691d7a39-f024-466a-bfa8-1277dc476643
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: A080ECCBD37D4718B75F1B7EBBC47777 Ref B: AMS231032607007 Ref C: 2026-04-07T22:37:57Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"value": "off", "source": "user-override"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - postgres flexible-server parameter set
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '59'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g --server-name --name --value
+      User-Agent:
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+    method: PATCH
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/configurations/logfiles.download_enable?api-version=2026-01-01-preview
+  response:
+    body:
+      string: '{"operation":"UpdateOrcasServerParameterManagementOperation","startTime":"2026-04-07T22:37:58.227Z"}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/29658368-3914-437f-bdc0-7b80c283ea2e?api-version=2026-01-01-preview&t=639111982782656996&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=oxQRU37Ya0Oh9pNZnTfmbwCB8nYv1kpfuOdSylf6ZDXMhN-kq8x0ZRsbq2cDm2Q2riUHkWY3y1t4pRNcnCA1yeuvuW9F1BVQplJO0sPLNPcJPXngNYIVjK_fMTcYdUrZocoMarNnywsJS6KpYq-odrjDuhVATkvTMzXd9DGjTKsR9Xv3b-B4ljjAooYfliYhNYz_p97HBn-7f_4uj7ut1TYpJcVLdmIUF1Hb7uPNSXt9EtylK2t8tHZwcxhansvM9nzLMmvnPuqg7Q_is8KboM_7EhFT0NHUyryVGCYsKsTEA4_q6ot5FaSwujCjgyG5FsIpUdg4mQsb21exF4LkgA&h=b0q3YsmyiLAD_cRxl8hccoWrP4V5eM1cgHRl36mT_c4
+      cache-control:
+      - no-cache
+      content-length:
+      - '100'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 07 Apr 2026 22:37:57 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/operationResults/29658368-3914-437f-bdc0-7b80c283ea2e?api-version=2026-01-01-preview&t=639111982782813250&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=eBtEhhd62Oo5g0iM70VHszFlnD05uc4LOsjwsxRmVHzEsmuannt_gIuYDULY36AIps-kdfBbFyUpOoR07o5uBrZdzJizD4F-DWwgrDCniSDEU0ZnXgKEp42Cbh1xs6eAhcljF4--MFaFoORctJ2jKOUcNJkpxIEiqFbYQJ2jH1tH-UEPxC5fS6xYcnajrzy657ztzTmUqCNSTFbTl315-G1YcfWowBXNNEkLSBN567ZfVTNvpKjCx5yG5Igp60XxZHIW6Sw2zjPOqAfSbvsYMqHuGJpnSMBcPFucWVym-aZgdz9Ud-brUlx1egF4XR-07q81aRBgZ8SWtjpjE2EJSg&h=_ymOq_QG63PeOHekfp6jrncpFLf8ShKxRDrT8OSbQ-M
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/c0e64c9b-e18b-4c84-a8a1-eafed145e771
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '11999'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: BC704AB6CE8E4A62A64333A427495176 Ref B: AMS231032608033 Ref C: 2026-04-07T22:37:57Z'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - postgres flexible-server parameter set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --server-name --name --value
+      User-Agent:
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/29658368-3914-437f-bdc0-7b80c283ea2e?api-version=2026-01-01-preview&t=639111982782656996&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=oxQRU37Ya0Oh9pNZnTfmbwCB8nYv1kpfuOdSylf6ZDXMhN-kq8x0ZRsbq2cDm2Q2riUHkWY3y1t4pRNcnCA1yeuvuW9F1BVQplJO0sPLNPcJPXngNYIVjK_fMTcYdUrZocoMarNnywsJS6KpYq-odrjDuhVATkvTMzXd9DGjTKsR9Xv3b-B4ljjAooYfliYhNYz_p97HBn-7f_4uj7ut1TYpJcVLdmIUF1Hb7uPNSXt9EtylK2t8tHZwcxhansvM9nzLMmvnPuqg7Q_is8KboM_7EhFT0NHUyryVGCYsKsTEA4_q6ot5FaSwujCjgyG5FsIpUdg4mQsb21exF4LkgA&h=b0q3YsmyiLAD_cRxl8hccoWrP4V5eM1cgHRl36mT_c4
+  response:
+    body:
+      string: '{"name":"29658368-3914-437f-bdc0-7b80c283ea2e","status":"InProgress","startTime":"2026-04-07T22:37:58.227Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 07 Apr 2026 22:37:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/b4cbc9a8-9756-4dc6-8367-9c11f736f37f
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: EAC731657C3D46BE81E852679140387E Ref B: AMS231032607019 Ref C: 2026-04-07T22:37:58Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - postgres flexible-server parameter set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --server-name --name --value
+      User-Agent:
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/29658368-3914-437f-bdc0-7b80c283ea2e?api-version=2026-01-01-preview&t=639111982782656996&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=oxQRU37Ya0Oh9pNZnTfmbwCB8nYv1kpfuOdSylf6ZDXMhN-kq8x0ZRsbq2cDm2Q2riUHkWY3y1t4pRNcnCA1yeuvuW9F1BVQplJO0sPLNPcJPXngNYIVjK_fMTcYdUrZocoMarNnywsJS6KpYq-odrjDuhVATkvTMzXd9DGjTKsR9Xv3b-B4ljjAooYfliYhNYz_p97HBn-7f_4uj7ut1TYpJcVLdmIUF1Hb7uPNSXt9EtylK2t8tHZwcxhansvM9nzLMmvnPuqg7Q_is8KboM_7EhFT0NHUyryVGCYsKsTEA4_q6ot5FaSwujCjgyG5FsIpUdg4mQsb21exF4LkgA&h=b0q3YsmyiLAD_cRxl8hccoWrP4V5eM1cgHRl36mT_c4
+  response:
+    body:
+      string: '{"name":"29658368-3914-437f-bdc0-7b80c283ea2e","status":"Succeeded","startTime":"2026-04-07T22:37:58.227Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 07 Apr 2026 22:38:09 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/21bde26d-1f38-4f4e-a4a4-99a357666e09
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: F2B783EB8ED64EECB768F53996CEC674 Ref B: AMS231032607053 Ref C: 2026-04-07T22:38:09Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - postgres flexible-server parameter set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --server-name --name --value
+      User-Agent:
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/configurations/logfiles.download_enable?api-version=2026-01-01-preview
+  response:
+    body:
+      string: '{"properties":{"value":"off","description":"Enables or disables server
+        logs functionality.","defaultValue":"off","dataType":"Boolean","allowedValues":"on,off","source":"user-override","isDynamicConfig":true,"isReadOnly":false,"isConfigPendingRestart":false,"documentationLink":"https://go.microsoft.com/fwlink/?linkid=2274270"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/configurations/logfiles.download_enable","name":"logfiles.download_enable","type":"Microsoft.DBforPostgreSQL/flexibleServers/configurations"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '633'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 07 Apr 2026 22:38:10 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/148dc72f-2798-4807-a1c5-08de2d979ef2
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: BF02FA1594714EB890516BEC4A48FC99 Ref B: AMS231020614039 Ref C: 2026-04-07T22:38:09Z'
     status:
       code: 200
       message: OK
@@ -1112,15 +5147,15 @@ interactions:
       ParameterSetName:
       - -g -n --yes
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002?api-version=2026-01-01-preview
   response:
     body:
-      string: '{"operation":"DropServerManagementOperation","startTime":"2026-03-31T21:53:12.967Z"}'
+      string: '{"operation":"DropServerManagementOperation","startTime":"2026-04-07T22:38:11.353Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/azureAsyncOperation/21fcbecb-adb2-43eb-909e-f16f4f7e6b5a?api-version=2026-01-01-preview&t=639105907930044005&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=o1w7sX65o0j7n3sd9SHXmb9SQ5eATejzCDUr5hM6t7gMWt8PefHqQqml4-ZleujCdAAzrIqQpknRx4r9-zYrNKo07RY-UbLF8FuOEEZW1NTktvSn12f3x2TjnBcqCh12XCaqUYlWYRo4i1zmSBFXRguDwqoTe2hzrfbEMn4PmkT5bU7jW0ss7gr3dCdvywbixaVo3buU4BCfFb2W33NiD3F4Hk_cw6fjdq6RM5uY2akyoje3Yhqz0odUoMD6JR7BPO4anrkCymdeEJ5y3mMydQu1U-CaJMypuionp5hzH71u9EefcaYdZhKMuFifpr-fpZeCDd7stRkPO1fO0FGOkw&h=-it33wpcyjWvK5is8FoqW3y9f9HrMalaRiX3dK8y-Lw
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/azureAsyncOperation/c7ab005f-1271-4a89-a6c2-802cf6939290?api-version=2026-01-01-preview&t=639111982914066455&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=igNIV1KRLdfGI51FFKlqUvqQO4UQERN16dMB6xgpudD7imAr08-J_3tYNdmVtvYrqpG9Rw_J0FbIsuVVH11_F4I_T728rTbfycSUo7xUScyxDdOAdRLXUqmQCw30LNukLIPoNpYkCxPpcIDZkQKvCrvP2InQlQ4opK2D4uuLHuz1jETL9JODj0pImK642ej7pBOV4g9CIZ_eegyXauWI7EusrPSR1aeTvugZ-YhWst_kHzdCP6docKBF8xnJ4t-k6KoW3teXEmj1P53NjbvxH-XnWddCITgIXUC6MO6Ew3gsHqY1gozXklaZpXubWzzlVVpFWbmSBl8BIdW_nEOcTQ&h=_z3pnWtoxdr9cgTJMixptKqMzr0Z69gjGaa8Xj4Hnpo
       cache-control:
       - no-cache
       content-length:
@@ -1128,11 +5163,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 31 Mar 2026 21:53:12 GMT
+      - Tue, 07 Apr 2026 22:38:10 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/operationResults/21fcbecb-adb2-43eb-909e-f16f4f7e6b5a?api-version=2026-01-01-preview&t=639105907930044005&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=Zg3qx5Bplsp36QSCvSIFbrKLp8hxaCzWYA4sS6MgwZTpVJIlRMzpNlM7LWSl0NbJaKPQMcVb7UNBvA5T8gcaOtkqaaV-qs7SQmEstzNtSmA2t5PSVdzN_bfAElZ_fYiZuyI4d0ghIa7k2dbPWKX-pKC_y9GcRlh_4Wpusjc6EzkYEJbbIPsx1alW7A89i1tzfB57o7g_U5Os_KSbpjqtwjrseFI8E1A6aTr7vG_G_B3VCFsdRvjPbVF2iDl2R6tFxS9rfF-PYX5wNXhJOmu-WRvZbkpW756OcN-Gcb_bwsHQpQsSn7Do5nwHiTMYbjTO3gaW2UxfryMdSiYCDoAKFA&h=A0Pt5NrDo4LTmcLEnutqnMcnmPdwhKwtCq0bk_ODIus
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/operationResults/c7ab005f-1271-4a89-a6c2-802cf6939290?api-version=2026-01-01-preview&t=639111982914066455&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=bxZFQs5PJqpfdczh8ZW3zZV86LSffK36xGfItWumk6Dm8iGo0Uf99K4wKBfU8zidx9zwlUyVA8AWX-GdHuHZnrKwHsz3Y_OO_xF2vMrP7kt_QsAzV--9dZnOCxSOGk_tNkbBnI3rVSmpsmwO1lo0MUKpFGfRmsuwZnhWoYirfwNm4IA3UFEWNKyKX-2Mn6OlMlpz95l93D10_ECRdEc2YUw3PQm-I0sceSuW8gBGeOTReBP5J7NL41MJcylIsiCkY6Wo4OtZvU89o8LWfTQlWDLVS5m_yDhqLx8SVSpYXbTzySrTaX1qCMfMfyG3CCLW-8SknQiBXS9vXnazRKD8Bg&h=p1Q2XvNDnA4elEdcsJASOD_uH6NRuWo45ulCBGRKLHQ
       pragma:
       - no-cache
       strict-transport-security:
@@ -1142,13 +5177,13 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/f6b26355-3c4b-401d-b6cb-abde6a2b10ed
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/ac7ee89f-d618-4f8f-bc4f-bef36b5dc4f3
       x-ms-ratelimit-remaining-subscription-deletes:
       - '799'
       x-ms-ratelimit-remaining-subscription-global-deletes:
       - '11999'
       x-msedge-ref:
-      - 'Ref A: 15EB931E6A5A4A54A360F2A2F30AC7C7 Ref B: AMS231032608019 Ref C: 2026-03-31T21:53:12Z'
+      - 'Ref A: 655270B74A1447399E11F4E054A2F125 Ref B: AMS231020512033 Ref C: 2026-04-07T22:38:10Z'
     status:
       code: 202
       message: Accepted
@@ -1166,12 +5201,12 @@ interactions:
       ParameterSetName:
       - -g -n --yes
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/azureAsyncOperation/21fcbecb-adb2-43eb-909e-f16f4f7e6b5a?api-version=2026-01-01-preview&t=639105907930044005&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=o1w7sX65o0j7n3sd9SHXmb9SQ5eATejzCDUr5hM6t7gMWt8PefHqQqml4-ZleujCdAAzrIqQpknRx4r9-zYrNKo07RY-UbLF8FuOEEZW1NTktvSn12f3x2TjnBcqCh12XCaqUYlWYRo4i1zmSBFXRguDwqoTe2hzrfbEMn4PmkT5bU7jW0ss7gr3dCdvywbixaVo3buU4BCfFb2W33NiD3F4Hk_cw6fjdq6RM5uY2akyoje3Yhqz0odUoMD6JR7BPO4anrkCymdeEJ5y3mMydQu1U-CaJMypuionp5hzH71u9EefcaYdZhKMuFifpr-fpZeCDd7stRkPO1fO0FGOkw&h=-it33wpcyjWvK5is8FoqW3y9f9HrMalaRiX3dK8y-Lw
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/azureAsyncOperation/c7ab005f-1271-4a89-a6c2-802cf6939290?api-version=2026-01-01-preview&t=639111982914066455&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=igNIV1KRLdfGI51FFKlqUvqQO4UQERN16dMB6xgpudD7imAr08-J_3tYNdmVtvYrqpG9Rw_J0FbIsuVVH11_F4I_T728rTbfycSUo7xUScyxDdOAdRLXUqmQCw30LNukLIPoNpYkCxPpcIDZkQKvCrvP2InQlQ4opK2D4uuLHuz1jETL9JODj0pImK642ej7pBOV4g9CIZ_eegyXauWI7EusrPSR1aeTvugZ-YhWst_kHzdCP6docKBF8xnJ4t-k6KoW3teXEmj1P53NjbvxH-XnWddCITgIXUC6MO6Ew3gsHqY1gozXklaZpXubWzzlVVpFWbmSBl8BIdW_nEOcTQ&h=_z3pnWtoxdr9cgTJMixptKqMzr0Z69gjGaa8Xj4Hnpo
   response:
     body:
-      string: '{"name":"21fcbecb-adb2-43eb-909e-f16f4f7e6b5a","status":"InProgress","startTime":"2026-03-31T21:53:12.967Z"}'
+      string: '{"name":"c7ab005f-1271-4a89-a6c2-802cf6939290","status":"InProgress","startTime":"2026-04-07T22:38:11.353Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1180,7 +5215,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 31 Mar 2026 21:53:13 GMT
+      - Tue, 07 Apr 2026 22:38:11 GMT
       expires:
       - '-1'
       pragma:
@@ -1192,11 +5227,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/ukwest/4f1b4655-dfdf-43e2-ba1a-41e93b9a75c6
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/ukwest/a0ebfabf-9c22-4c90-81e4-299dea7a5c6d
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 8E6F6FF44604438ABE59ACE688E90AB4 Ref B: AMS231032609021 Ref C: 2026-03-31T21:53:13Z'
+      - 'Ref A: 81B46EABB1DB4185AFA7BF6F351EF4CA Ref B: AMS231020512047 Ref C: 2026-04-07T22:38:11Z'
     status:
       code: 200
       message: OK
@@ -1214,12 +5249,12 @@ interactions:
       ParameterSetName:
       - -g -n --yes
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/azureAsyncOperation/21fcbecb-adb2-43eb-909e-f16f4f7e6b5a?api-version=2026-01-01-preview&t=639105907930044005&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=o1w7sX65o0j7n3sd9SHXmb9SQ5eATejzCDUr5hM6t7gMWt8PefHqQqml4-ZleujCdAAzrIqQpknRx4r9-zYrNKo07RY-UbLF8FuOEEZW1NTktvSn12f3x2TjnBcqCh12XCaqUYlWYRo4i1zmSBFXRguDwqoTe2hzrfbEMn4PmkT5bU7jW0ss7gr3dCdvywbixaVo3buU4BCfFb2W33NiD3F4Hk_cw6fjdq6RM5uY2akyoje3Yhqz0odUoMD6JR7BPO4anrkCymdeEJ5y3mMydQu1U-CaJMypuionp5hzH71u9EefcaYdZhKMuFifpr-fpZeCDd7stRkPO1fO0FGOkw&h=-it33wpcyjWvK5is8FoqW3y9f9HrMalaRiX3dK8y-Lw
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/azureAsyncOperation/c7ab005f-1271-4a89-a6c2-802cf6939290?api-version=2026-01-01-preview&t=639111982914066455&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=igNIV1KRLdfGI51FFKlqUvqQO4UQERN16dMB6xgpudD7imAr08-J_3tYNdmVtvYrqpG9Rw_J0FbIsuVVH11_F4I_T728rTbfycSUo7xUScyxDdOAdRLXUqmQCw30LNukLIPoNpYkCxPpcIDZkQKvCrvP2InQlQ4opK2D4uuLHuz1jETL9JODj0pImK642ej7pBOV4g9CIZ_eegyXauWI7EusrPSR1aeTvugZ-YhWst_kHzdCP6docKBF8xnJ4t-k6KoW3teXEmj1P53NjbvxH-XnWddCITgIXUC6MO6Ew3gsHqY1gozXklaZpXubWzzlVVpFWbmSBl8BIdW_nEOcTQ&h=_z3pnWtoxdr9cgTJMixptKqMzr0Z69gjGaa8Xj4Hnpo
   response:
     body:
-      string: '{"name":"21fcbecb-adb2-43eb-909e-f16f4f7e6b5a","status":"InProgress","startTime":"2026-03-31T21:53:12.967Z"}'
+      string: '{"name":"c7ab005f-1271-4a89-a6c2-802cf6939290","status":"InProgress","startTime":"2026-04-07T22:38:11.353Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1228,7 +5263,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 31 Mar 2026 21:53:28 GMT
+      - Tue, 07 Apr 2026 22:38:27 GMT
       expires:
       - '-1'
       pragma:
@@ -1240,11 +5275,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/41a872f7-8420-42f2-9e3f-791537a3bf67
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/65e116d8-689e-492a-bf97-78a72ec77fac
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 12F27B2A13B14A529798314DD53C0075 Ref B: AMS231032607025 Ref C: 2026-03-31T21:53:28Z'
+      - 'Ref A: 33D7E47C906240B8BA36AD31F66D0848 Ref B: AMS231020512017 Ref C: 2026-04-07T22:38:27Z'
     status:
       code: 200
       message: OK
@@ -1262,12 +5297,12 @@ interactions:
       ParameterSetName:
       - -g -n --yes
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/azureAsyncOperation/21fcbecb-adb2-43eb-909e-f16f4f7e6b5a?api-version=2026-01-01-preview&t=639105907930044005&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=o1w7sX65o0j7n3sd9SHXmb9SQ5eATejzCDUr5hM6t7gMWt8PefHqQqml4-ZleujCdAAzrIqQpknRx4r9-zYrNKo07RY-UbLF8FuOEEZW1NTktvSn12f3x2TjnBcqCh12XCaqUYlWYRo4i1zmSBFXRguDwqoTe2hzrfbEMn4PmkT5bU7jW0ss7gr3dCdvywbixaVo3buU4BCfFb2W33NiD3F4Hk_cw6fjdq6RM5uY2akyoje3Yhqz0odUoMD6JR7BPO4anrkCymdeEJ5y3mMydQu1U-CaJMypuionp5hzH71u9EefcaYdZhKMuFifpr-fpZeCDd7stRkPO1fO0FGOkw&h=-it33wpcyjWvK5is8FoqW3y9f9HrMalaRiX3dK8y-Lw
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/azureAsyncOperation/c7ab005f-1271-4a89-a6c2-802cf6939290?api-version=2026-01-01-preview&t=639111982914066455&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=igNIV1KRLdfGI51FFKlqUvqQO4UQERN16dMB6xgpudD7imAr08-J_3tYNdmVtvYrqpG9Rw_J0FbIsuVVH11_F4I_T728rTbfycSUo7xUScyxDdOAdRLXUqmQCw30LNukLIPoNpYkCxPpcIDZkQKvCrvP2InQlQ4opK2D4uuLHuz1jETL9JODj0pImK642ej7pBOV4g9CIZ_eegyXauWI7EusrPSR1aeTvugZ-YhWst_kHzdCP6docKBF8xnJ4t-k6KoW3teXEmj1P53NjbvxH-XnWddCITgIXUC6MO6Ew3gsHqY1gozXklaZpXubWzzlVVpFWbmSBl8BIdW_nEOcTQ&h=_z3pnWtoxdr9cgTJMixptKqMzr0Z69gjGaa8Xj4Hnpo
   response:
     body:
-      string: '{"name":"21fcbecb-adb2-43eb-909e-f16f4f7e6b5a","status":"InProgress","startTime":"2026-03-31T21:53:12.967Z"}'
+      string: '{"name":"c7ab005f-1271-4a89-a6c2-802cf6939290","status":"InProgress","startTime":"2026-04-07T22:38:11.353Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1276,7 +5311,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 31 Mar 2026 21:53:44 GMT
+      - Tue, 07 Apr 2026 22:38:43 GMT
       expires:
       - '-1'
       pragma:
@@ -1288,11 +5323,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/22ccf47e-c1bf-4753-901c-3b4fc43abdb2
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/46dcd159-c9e4-4036-b0f5-26f083b53367
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 0C94C25FB72F48EF8DF8727EEC22D286 Ref B: AMS231020614051 Ref C: 2026-03-31T21:53:44Z'
+      - 'Ref A: 70420ED89BE840B08380C3E254E9FC4E Ref B: AMS231032608047 Ref C: 2026-04-07T22:38:43Z'
     status:
       code: 200
       message: OK
@@ -1310,12 +5345,12 @@ interactions:
       ParameterSetName:
       - -g -n --yes
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/azureAsyncOperation/21fcbecb-adb2-43eb-909e-f16f4f7e6b5a?api-version=2026-01-01-preview&t=639105907930044005&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=o1w7sX65o0j7n3sd9SHXmb9SQ5eATejzCDUr5hM6t7gMWt8PefHqQqml4-ZleujCdAAzrIqQpknRx4r9-zYrNKo07RY-UbLF8FuOEEZW1NTktvSn12f3x2TjnBcqCh12XCaqUYlWYRo4i1zmSBFXRguDwqoTe2hzrfbEMn4PmkT5bU7jW0ss7gr3dCdvywbixaVo3buU4BCfFb2W33NiD3F4Hk_cw6fjdq6RM5uY2akyoje3Yhqz0odUoMD6JR7BPO4anrkCymdeEJ5y3mMydQu1U-CaJMypuionp5hzH71u9EefcaYdZhKMuFifpr-fpZeCDd7stRkPO1fO0FGOkw&h=-it33wpcyjWvK5is8FoqW3y9f9HrMalaRiX3dK8y-Lw
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/azureAsyncOperation/c7ab005f-1271-4a89-a6c2-802cf6939290?api-version=2026-01-01-preview&t=639111982914066455&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=igNIV1KRLdfGI51FFKlqUvqQO4UQERN16dMB6xgpudD7imAr08-J_3tYNdmVtvYrqpG9Rw_J0FbIsuVVH11_F4I_T728rTbfycSUo7xUScyxDdOAdRLXUqmQCw30LNukLIPoNpYkCxPpcIDZkQKvCrvP2InQlQ4opK2D4uuLHuz1jETL9JODj0pImK642ej7pBOV4g9CIZ_eegyXauWI7EusrPSR1aeTvugZ-YhWst_kHzdCP6docKBF8xnJ4t-k6KoW3teXEmj1P53NjbvxH-XnWddCITgIXUC6MO6Ew3gsHqY1gozXklaZpXubWzzlVVpFWbmSBl8BIdW_nEOcTQ&h=_z3pnWtoxdr9cgTJMixptKqMzr0Z69gjGaa8Xj4Hnpo
   response:
     body:
-      string: '{"name":"21fcbecb-adb2-43eb-909e-f16f4f7e6b5a","status":"InProgress","startTime":"2026-03-31T21:53:12.967Z"}'
+      string: '{"name":"c7ab005f-1271-4a89-a6c2-802cf6939290","status":"InProgress","startTime":"2026-04-07T22:38:11.353Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1324,7 +5359,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 31 Mar 2026 21:53:59 GMT
+      - Tue, 07 Apr 2026 22:38:58 GMT
       expires:
       - '-1'
       pragma:
@@ -1336,11 +5371,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/3039d13f-6a4e-4e07-a64d-d69e92ae5cc7
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/e8035091-c32f-4275-81ff-ac5525c81aaf
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 459457C23A9C451BA6B4E30C93F9A147 Ref B: AMS231020512039 Ref C: 2026-03-31T21:54:00Z'
+      - 'Ref A: 9692DAA43ACA4CE89D52B75C35641B76 Ref B: AMS231020512035 Ref C: 2026-04-07T22:38:58Z'
     status:
       code: 200
       message: OK
@@ -1358,12 +5393,12 @@ interactions:
       ParameterSetName:
       - -g -n --yes
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/azureAsyncOperation/21fcbecb-adb2-43eb-909e-f16f4f7e6b5a?api-version=2026-01-01-preview&t=639105907930044005&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=o1w7sX65o0j7n3sd9SHXmb9SQ5eATejzCDUr5hM6t7gMWt8PefHqQqml4-ZleujCdAAzrIqQpknRx4r9-zYrNKo07RY-UbLF8FuOEEZW1NTktvSn12f3x2TjnBcqCh12XCaqUYlWYRo4i1zmSBFXRguDwqoTe2hzrfbEMn4PmkT5bU7jW0ss7gr3dCdvywbixaVo3buU4BCfFb2W33NiD3F4Hk_cw6fjdq6RM5uY2akyoje3Yhqz0odUoMD6JR7BPO4anrkCymdeEJ5y3mMydQu1U-CaJMypuionp5hzH71u9EefcaYdZhKMuFifpr-fpZeCDd7stRkPO1fO0FGOkw&h=-it33wpcyjWvK5is8FoqW3y9f9HrMalaRiX3dK8y-Lw
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/azureAsyncOperation/c7ab005f-1271-4a89-a6c2-802cf6939290?api-version=2026-01-01-preview&t=639111982914066455&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=igNIV1KRLdfGI51FFKlqUvqQO4UQERN16dMB6xgpudD7imAr08-J_3tYNdmVtvYrqpG9Rw_J0FbIsuVVH11_F4I_T728rTbfycSUo7xUScyxDdOAdRLXUqmQCw30LNukLIPoNpYkCxPpcIDZkQKvCrvP2InQlQ4opK2D4uuLHuz1jETL9JODj0pImK642ej7pBOV4g9CIZ_eegyXauWI7EusrPSR1aeTvugZ-YhWst_kHzdCP6docKBF8xnJ4t-k6KoW3teXEmj1P53NjbvxH-XnWddCITgIXUC6MO6Ew3gsHqY1gozXklaZpXubWzzlVVpFWbmSBl8BIdW_nEOcTQ&h=_z3pnWtoxdr9cgTJMixptKqMzr0Z69gjGaa8Xj4Hnpo
   response:
     body:
-      string: '{"name":"21fcbecb-adb2-43eb-909e-f16f4f7e6b5a","status":"Succeeded","startTime":"2026-03-31T21:53:12.967Z"}'
+      string: '{"name":"c7ab005f-1271-4a89-a6c2-802cf6939290","status":"Succeeded","startTime":"2026-04-07T22:38:11.353Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1372,7 +5407,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 31 Mar 2026 21:54:15 GMT
+      - Tue, 07 Apr 2026 22:39:14 GMT
       expires:
       - '-1'
       pragma:
@@ -1384,11 +5419,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/ukwest/5af1ab1d-0707-4a61-9c8f-f01a83b1311a
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/b26e589a-73e7-4d9f-a3de-17cbd3605cfe
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: D86B357B11444659B3A5F68D42D55846 Ref B: AMS231032607029 Ref C: 2026-03-31T21:54:15Z'
+      - 'Ref A: ACA06845098F472A868F174A408D96A7 Ref B: AMS231022012047 Ref C: 2026-04-07T22:39:14Z'
     status:
       code: 200
       message: OK

--- a/src/azure-cli/azure/cli/command_modules/postgresql/tests/latest/recordings/test_postgres_flexible_server_logs_mgmt.yaml
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/tests/latest/recordings/test_postgres_flexible_server_logs_mgmt.yaml
@@ -13,7 +13,7 @@ interactions:
       ParameterSetName:
       - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
       User-Agent:
-      - AZURECLI/2.83.0 azsdk-python-core/1.38.0 Python/3.13.10 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: HEAD
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2024-11-01
   response:
@@ -25,7 +25,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 18 Feb 2026 03:26:39 GMT
+      - Mon, 30 Mar 2026 14:12:12 GMT
       expires:
       - '-1'
       pragma:
@@ -39,7 +39,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 27FA554F277149E8ADB76B264E27E3D5 Ref B: MNZ221060618029 Ref C: 2026-02-18T03:26:39Z'
+      - 'Ref A: 32835CC0E3EF452C9E0FD42965627EB2 Ref B: DUB241062309031 Ref C: 2026-03-30T14:12:13Z'
     status:
       code: 204
       message: No Content
@@ -57,12 +57,12 @@ interactions:
       ParameterSetName:
       - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
       User-Agent:
-      - AZURECLI/2.83.0 azsdk-python-core/1.38.0 Python/3.13.10 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2024-11-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"canadacentral","tags":{"product":"azurecli","cause":"automation","test":"test_postgres_flexible_server_logs_mgmt","date":"2026-02-18T03:26:38Z","module":"postgresql"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"canadacentral","tags":{"product":"azurecli","cause":"automation","test":"test_postgres_flexible_server_logs_mgmt","date":"2026-03-30T14:12:09Z","module":"postgresql"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -71,7 +71,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Feb 2026 03:26:39 GMT
+      - Mon, 30 Mar 2026 14:12:13 GMT
       expires:
       - '-1'
       pragma:
@@ -85,7 +85,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: E550EEEC192749AF8AE1BEA5FD0C46C8 Ref B: MNZ221060610009 Ref C: 2026-02-18T03:26:40Z'
+      - 'Ref A: 90E4C0917D3D444FB712E52D46E71041 Ref B: AMS231032608017 Ref C: 2026-03-30T14:12:13Z'
     status:
       code: 200
       message: OK
@@ -107,7 +107,7 @@ interactions:
       ParameterSetName:
       - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
       User-Agent:
-      - AZURECLI/2.83.0 azsdk-python-core/1.38.0 Python/3.13.10 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/checkNameAvailability?api-version=2026-01-01-preview
   response:
@@ -121,7 +121,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Feb 2026 03:26:40 GMT
+      - Mon, 30 Mar 2026 14:12:14 GMT
       expires:
       - '-1'
       pragma:
@@ -133,13 +133,13 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f57d2932-2a78-450f-958a-e65997c3253b/eastus/9e92e81a-a35f-41dd-8905-7f311b50881d
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/377ff9f1-ed38-412d-886b-930c38a60bf6
       x-ms-ratelimit-remaining-subscription-global-writes:
       - '11999'
       x-ms-ratelimit-remaining-subscription-writes:
       - '799'
       x-msedge-ref:
-      - 'Ref A: 7048981E7D674DC8929337D513628D92 Ref B: BL2AA2011002042 Ref C: 2026-02-18T03:26:40Z'
+      - 'Ref A: 7B112200D63943F5A3CF48B1DB8A9014 Ref B: DUB601080510042 Ref C: 2026-03-30T14:12:14Z'
     status:
       code: 200
       message: OK
@@ -157,23 +157,21 @@ interactions:
       ParameterSetName:
       - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
       User-Agent:
-      - AZURECLI/2.83.0 azsdk-python-core/1.38.0 Python/3.13.10 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/capabilities?api-version=2026-01-01-preview
   response:
     body:
-      string: '{"value":[{"name":"FlexibleServerCapabilities","supportedServerEditions":[{"supportedServerSkus":[{"supportedFeatures":[],"name":"Standard_B1ms","vCores":1,"supportedIops":640,"supportedMemoryPerVcoreMb":2048,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_B2s","vCores":2,"supportedIops":1280,"supportedMemoryPerVcoreMb":2048,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_B2ms","vCores":2,"supportedIops":1920,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_B4ms","vCores":4,"supportedIops":2880,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_B8ms","vCores":8,"supportedIops":4320,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_B12ms","vCores":12,"supportedIops":4320,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_B16ms","vCores":16,"supportedIops":4320,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_B20ms","vCores":20,"supportedIops":4320,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]}],"name":"Burstable","defaultSkuName":"Standard_B2s","supportedStorageEditions":[{"name":"ManagedDisk","defaultStorageSizeMb":32768,"supportedStorageMb":[{"supportedIops":120,"storageSizeMb":32768,"defaultIopsTier":"P4","supportedIopsTiers":[{"name":"P4","iops":120},{"name":"P6","iops":240},{"name":"P10","iops":500},{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":240,"storageSizeMb":65536,"defaultIopsTier":"P6","supportedIopsTiers":[{"name":"P6","iops":240},{"name":"P10","iops":500},{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":500,"storageSizeMb":131072,"defaultIopsTier":"P10","supportedIopsTiers":[{"name":"P10","iops":500},{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":1100,"storageSizeMb":262144,"defaultIopsTier":"P15","supportedIopsTiers":[{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":2300,"storageSizeMb":524288,"defaultIopsTier":"P20","supportedIopsTiers":[{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":5000,"storageSizeMb":1048576,"defaultIopsTier":"P30","supportedIopsTiers":[{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":7500,"storageSizeMb":2097152,"defaultIopsTier":"P40","supportedIopsTiers":[{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":7500,"storageSizeMb":4193280,"defaultIopsTier":"P50","supportedIopsTiers":[{"name":"P50","iops":7500}]},{"supportedIops":7500,"storageSizeMb":4194304,"defaultIopsTier":"P50","supportedIopsTiers":[{"name":"P50","iops":7500}]},{"supportedIops":16000,"storageSizeMb":8388608,"defaultIopsTier":"P60","supportedIopsTiers":[{"name":"P60","iops":16000},{"name":"P70","iops":18000},{"name":"P80","iops":20000}]},{"supportedIops":18000,"storageSizeMb":16777216,"defaultIopsTier":"P70","supportedIopsTiers":[{"name":"P70","iops":18000},{"name":"P80","iops":20000}]},{"supportedIops":20000,"storageSizeMb":33553408,"defaultIopsTier":"P80","supportedIopsTiers":[{"name":"P80","iops":20000}]}]},{"name":"ManagedDiskV2","defaultStorageSizeMb":32768,"supportedStorageMb":[{"supportedIops":3000,"supportedMaximumIops":80000,"storageSizeMb":32768,"maximumStorageSizeMb":67108864,"supportedThroughput":125,"supportedMaximumThroughput":1200,"defaultIopsTier":"None","supportedIopsTiers":[{"name":"None","iops":0}]}]}]},{"supportedServerSkus":[{"supportedFeatures":[],"name":"Standard_D2s_v3","vCores":2,"supportedIops":3200,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D4s_v3","vCores":4,"supportedIops":6400,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D8s_v3","vCores":8,"supportedIops":12800,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D16s_v3","vCores":16,"supportedIops":25600,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D32s_v3","vCores":32,"supportedIops":51200,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D48s_v3","vCores":48,"supportedIops":76800,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D64s_v3","vCores":64,"supportedIops":80000,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D2ds_v4","vCores":2,"supportedIops":3200,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D4ds_v4","vCores":4,"supportedIops":6400,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D8ds_v4","vCores":8,"supportedIops":12800,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D16ds_v4","vCores":16,"supportedIops":25600,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D32ds_v4","vCores":32,"supportedIops":51200,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D48ds_v4","vCores":48,"supportedIops":76800,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D64ds_v4","vCores":64,"supportedIops":80000,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D2ads_v5","vCores":2,"supportedIops":3200,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D4ads_v5","vCores":4,"supportedIops":6400,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D8ads_v5","vCores":8,"supportedIops":12800,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D16ads_v5","vCores":16,"supportedIops":25600,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D32ads_v5","vCores":32,"supportedIops":51200,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D48ads_v5","vCores":48,"supportedIops":76800,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D64ads_v5","vCores":64,"supportedIops":80000,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D96ads_v5","vCores":96,"supportedIops":80000,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D2ds_v5","vCores":2,"supportedIops":3750,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D4ds_v5","vCores":4,"supportedIops":6400,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D8ds_v5","vCores":8,"supportedIops":12800,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D16ds_v5","vCores":16,"supportedIops":25600,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D32ds_v5","vCores":32,"supportedIops":51200,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D48ds_v5","vCores":48,"supportedIops":76800,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D64ds_v5","vCores":64,"supportedIops":80000,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D96ds_v5","vCores":96,"supportedIops":80000,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]}],"name":"GeneralPurpose","defaultSkuName":"Standard_D4ads_v5","supportedStorageEditions":[{"name":"ManagedDisk","defaultStorageSizeMb":65536,"supportedStorageMb":[{"supportedIops":120,"storageSizeMb":32768,"defaultIopsTier":"P4","supportedIopsTiers":[{"name":"P4","iops":120},{"name":"P6","iops":240},{"name":"P10","iops":500},{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":240,"storageSizeMb":65536,"defaultIopsTier":"P6","supportedIopsTiers":[{"name":"P6","iops":240},{"name":"P10","iops":500},{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":500,"storageSizeMb":131072,"defaultIopsTier":"P10","supportedIopsTiers":[{"name":"P10","iops":500},{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":1100,"storageSizeMb":262144,"defaultIopsTier":"P15","supportedIopsTiers":[{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":2300,"storageSizeMb":524288,"defaultIopsTier":"P20","supportedIopsTiers":[{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":5000,"storageSizeMb":1048576,"defaultIopsTier":"P30","supportedIopsTiers":[{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":7500,"storageSizeMb":2097152,"defaultIopsTier":"P40","supportedIopsTiers":[{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":7500,"storageSizeMb":4193280,"defaultIopsTier":"P50","supportedIopsTiers":[{"name":"P50","iops":7500}]},{"supportedIops":7500,"storageSizeMb":4194304,"defaultIopsTier":"P50","supportedIopsTiers":[{"name":"P50","iops":7500}]},{"supportedIops":16000,"storageSizeMb":8388608,"defaultIopsTier":"P60","supportedIopsTiers":[{"name":"P60","iops":16000},{"name":"P70","iops":18000},{"name":"P80","iops":20000}]},{"supportedIops":18000,"storageSizeMb":16777216,"defaultIopsTier":"P70","supportedIopsTiers":[{"name":"P70","iops":18000},{"name":"P80","iops":20000}]},{"supportedIops":20000,"storageSizeMb":33553408,"defaultIopsTier":"P80","supportedIopsTiers":[{"name":"P80","iops":20000}]}]},{"name":"ManagedDiskV2","defaultStorageSizeMb":65536,"supportedStorageMb":[{"supportedIops":3000,"supportedMaximumIops":80000,"storageSizeMb":32768,"maximumStorageSizeMb":67108864,"supportedThroughput":125,"supportedMaximumThroughput":1200,"defaultIopsTier":"None","supportedIopsTiers":[{"name":"None","iops":0}]}]},{"name":"UltraDisk","defaultStorageSizeMb":65536,"supportedStorageMb":[],"reason":"Specified
-        Storage Edition not supported in this region."}]},{"supportedServerSkus":[{"supportedFeatures":[],"name":"Standard_E2s_v3","vCores":2,"supportedIops":3200,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E4s_v3","vCores":4,"supportedIops":6400,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E8s_v3","vCores":8,"supportedIops":12800,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E16s_v3","vCores":16,"supportedIops":25600,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E32s_v3","vCores":32,"supportedIops":32000,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E48s_v3","vCores":48,"supportedIops":51200,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E64s_v3","vCores":64,"supportedIops":76800,"supportedMemoryPerVcoreMb":6912,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E2ds_v4","vCores":2,"supportedIops":3200,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E4ds_v4","vCores":4,"supportedIops":6400,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E8ds_v4","vCores":8,"supportedIops":12800,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E16ds_v4","vCores":16,"supportedIops":25600,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E20ds_v4","vCores":20,"supportedIops":32000,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E32ds_v4","vCores":32,"supportedIops":51200,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E48ds_v4","vCores":48,"supportedIops":76800,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E64ds_v4","vCores":64,"supportedIops":80000,"supportedMemoryPerVcoreMb":6912,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E2ads_v5","vCores":2,"supportedIops":3750,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E4ads_v5","vCores":4,"supportedIops":6400,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E8ads_v5","vCores":8,"supportedIops":12800,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E16ads_v5","vCores":16,"supportedIops":25600,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E20ads_v5","vCores":20,"supportedIops":32000,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E32ads_v5","vCores":32,"supportedIops":51200,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E48ads_v5","vCores":48,"supportedIops":76800,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E64ads_v5","vCores":64,"supportedIops":80000,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E96ads_v5","vCores":96,"supportedIops":80000,"supportedMemoryPerVcoreMb":7168,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E2ds_v5","vCores":2,"supportedIops":3750,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E4ds_v5","vCores":4,"supportedIops":6400,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E8ds_v5","vCores":8,"supportedIops":12800,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E16ds_v5","vCores":16,"supportedIops":25600,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E20ds_v5","vCores":20,"supportedIops":32000,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E32ds_v5","vCores":32,"supportedIops":51200,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E48ds_v5","vCores":48,"supportedIops":76800,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E64ds_v5","vCores":64,"supportedIops":80000,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E96ds_v5","vCores":96,"supportedIops":80000,"supportedMemoryPerVcoreMb":7168,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]}],"name":"MemoryOptimized","defaultSkuName":"Standard_E4ads_v5","supportedStorageEditions":[{"name":"ManagedDisk","defaultStorageSizeMb":131072,"supportedStorageMb":[{"supportedIops":120,"storageSizeMb":32768,"defaultIopsTier":"P4","supportedIopsTiers":[{"name":"P4","iops":120},{"name":"P6","iops":240},{"name":"P10","iops":500},{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":240,"storageSizeMb":65536,"defaultIopsTier":"P6","supportedIopsTiers":[{"name":"P6","iops":240},{"name":"P10","iops":500},{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":500,"storageSizeMb":131072,"defaultIopsTier":"P10","supportedIopsTiers":[{"name":"P10","iops":500},{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":1100,"storageSizeMb":262144,"defaultIopsTier":"P15","supportedIopsTiers":[{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":2300,"storageSizeMb":524288,"defaultIopsTier":"P20","supportedIopsTiers":[{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":5000,"storageSizeMb":1048576,"defaultIopsTier":"P30","supportedIopsTiers":[{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":7500,"storageSizeMb":2097152,"defaultIopsTier":"P40","supportedIopsTiers":[{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":7500,"storageSizeMb":4193280,"defaultIopsTier":"P50","supportedIopsTiers":[{"name":"P50","iops":7500}]},{"supportedIops":7500,"storageSizeMb":4194304,"defaultIopsTier":"P50","supportedIopsTiers":[{"name":"P50","iops":7500}]},{"supportedIops":16000,"storageSizeMb":8388608,"defaultIopsTier":"P60","supportedIopsTiers":[{"name":"P60","iops":16000},{"name":"P70","iops":18000},{"name":"P80","iops":20000}]},{"supportedIops":18000,"storageSizeMb":16777216,"defaultIopsTier":"P70","supportedIopsTiers":[{"name":"P70","iops":18000},{"name":"P80","iops":20000}]},{"supportedIops":20000,"storageSizeMb":33553408,"defaultIopsTier":"P80","supportedIopsTiers":[{"name":"P80","iops":20000}]}]},{"name":"ManagedDiskV2","defaultStorageSizeMb":131072,"supportedStorageMb":[{"supportedIops":3000,"supportedMaximumIops":80000,"storageSizeMb":32768,"maximumStorageSizeMb":67108864,"supportedThroughput":125,"supportedMaximumThroughput":1200,"defaultIopsTier":"None","supportedIopsTiers":[{"name":"None","iops":0}]}]},{"name":"UltraDisk","defaultStorageSizeMb":131072,"supportedStorageMb":[],"reason":"Specified
-        Storage Edition not supported in this region."}]}],"supportedServerVersions":[{"supportedFeatures":[],"name":"11","supportedVersionsToUpgrade":["12","13","14","15","16","17","18"]},{"supportedFeatures":[],"name":"12","supportedVersionsToUpgrade":["13","14","15","16","17","18"]},{"supportedFeatures":[],"name":"13","supportedVersionsToUpgrade":["14","15","16","17","18"]},{"supportedFeatures":[],"name":"14","supportedVersionsToUpgrade":["15","16","17","18"]},{"supportedFeatures":[],"name":"15","supportedVersionsToUpgrade":["16","17","18"]},{"supportedFeatures":[],"name":"16","supportedVersionsToUpgrade":["17","18"]},{"supportedFeatures":[],"name":"17","supportedVersionsToUpgrade":["18"]},{"supportedFeatures":[],"name":"18","supportedVersionsToUpgrade":[]}],"supportedFastProvisioningEditions":[],"supportedFeatures":[{"name":"FastProvisioning","status":"Disabled"},{"name":"ZoneRedundantHa","status":"Enabled"},{"name":"GeoBackup","status":"Enabled"},{"name":"ZoneRedundantHaAndGeoBackup","status":"Enabled"},{"name":"StorageAutoGrowth","status":"Enabled"},{"name":"OnlineResize","status":"Enabled"},{"name":"OfferRestricted","status":"Disabled"},{"name":"IndexTuning","status":"Enabled"},{"name":"Clusters","status":"Enabled"},{"name":"AdaptiveAutoVacuumAutoApply","status":"Disabled"},{"name":"ConfigTuning","status":"Disabled"}],"fastProvisioningSupported":"Disabled","geoBackupSupported":"Enabled","zoneRedundantHaSupported":"Enabled","zoneRedundantHaAndGeoBackupSupported":"Enabled","storageAutoGrowthSupported":"Enabled","onlineResizeSupported":"Enabled","indexTuningSupported":"Enabled"}]}'
+      string: '{"value":[{"name":"FlexibleServerCapabilities","supportedServerEditions":[{"supportedServerSkus":[{"supportedFeatures":[],"name":"Standard_B1ms","vCores":1,"supportedIops":640,"supportedMemoryPerVcoreMb":2048,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_B2s","vCores":2,"supportedIops":1280,"supportedMemoryPerVcoreMb":2048,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_B2ms","vCores":2,"supportedIops":1920,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_B4ms","vCores":4,"supportedIops":2880,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_B8ms","vCores":8,"supportedIops":4320,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_B12ms","vCores":12,"supportedIops":4320,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_B16ms","vCores":16,"supportedIops":4320,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_B20ms","vCores":20,"supportedIops":4320,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]}],"name":"Burstable","defaultSkuName":"Standard_B2s","supportedStorageEditions":[{"name":"ManagedDisk","defaultStorageSizeMb":32768,"supportedStorageMb":[{"supportedIops":120,"storageSizeMb":32768,"defaultIopsTier":"P4","supportedIopsTiers":[{"name":"P4","iops":120},{"name":"P6","iops":240},{"name":"P10","iops":500},{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":240,"storageSizeMb":65536,"defaultIopsTier":"P6","supportedIopsTiers":[{"name":"P6","iops":240},{"name":"P10","iops":500},{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":500,"storageSizeMb":131072,"defaultIopsTier":"P10","supportedIopsTiers":[{"name":"P10","iops":500},{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":1100,"storageSizeMb":262144,"defaultIopsTier":"P15","supportedIopsTiers":[{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":2300,"storageSizeMb":524288,"defaultIopsTier":"P20","supportedIopsTiers":[{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":5000,"storageSizeMb":1048576,"defaultIopsTier":"P30","supportedIopsTiers":[{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":7500,"storageSizeMb":2097152,"defaultIopsTier":"P40","supportedIopsTiers":[{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":7500,"storageSizeMb":4193280,"defaultIopsTier":"P50","supportedIopsTiers":[{"name":"P50","iops":7500}]},{"supportedIops":7500,"storageSizeMb":4194304,"defaultIopsTier":"P50","supportedIopsTiers":[{"name":"P50","iops":7500}]},{"supportedIops":16000,"storageSizeMb":8388608,"defaultIopsTier":"P60","supportedIopsTiers":[{"name":"P60","iops":16000},{"name":"P70","iops":18000},{"name":"P80","iops":20000}]},{"supportedIops":18000,"storageSizeMb":16777216,"defaultIopsTier":"P70","supportedIopsTiers":[{"name":"P70","iops":18000},{"name":"P80","iops":20000}]},{"supportedIops":20000,"storageSizeMb":33553408,"defaultIopsTier":"P80","supportedIopsTiers":[{"name":"P80","iops":20000}]}]},{"name":"ManagedDiskV2","defaultStorageSizeMb":32768,"supportedStorageMb":[{"supportedIops":3000,"supportedMaximumIops":80000,"storageSizeMb":32768,"maximumStorageSizeMb":67108864,"supportedThroughput":125,"supportedMaximumThroughput":1200,"defaultIopsTier":"None","supportedIopsTiers":[{"name":"None","iops":0}]}]}]},{"supportedServerSkus":[{"supportedFeatures":[],"name":"Standard_D2s_v3","vCores":2,"supportedIops":3200,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D4s_v3","vCores":4,"supportedIops":6400,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D8s_v3","vCores":8,"supportedIops":12800,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D16s_v3","vCores":16,"supportedIops":25600,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D32s_v3","vCores":32,"supportedIops":51200,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D48s_v3","vCores":48,"supportedIops":76800,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D64s_v3","vCores":64,"supportedIops":80000,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D2ds_v4","vCores":2,"supportedIops":3200,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D4ds_v4","vCores":4,"supportedIops":6400,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D8ds_v4","vCores":8,"supportedIops":12800,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D16ds_v4","vCores":16,"supportedIops":25600,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D32ds_v4","vCores":32,"supportedIops":51200,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D48ds_v4","vCores":48,"supportedIops":76800,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D64ds_v4","vCores":64,"supportedIops":80000,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D2ads_v5","vCores":2,"supportedIops":3200,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D4ads_v5","vCores":4,"supportedIops":6400,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D8ads_v5","vCores":8,"supportedIops":12800,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D16ads_v5","vCores":16,"supportedIops":25600,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D32ads_v5","vCores":32,"supportedIops":51200,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D48ads_v5","vCores":48,"supportedIops":76800,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D64ads_v5","vCores":64,"supportedIops":80000,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D96ads_v5","vCores":96,"supportedIops":80000,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D2ds_v5","vCores":2,"supportedIops":3750,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D4ds_v5","vCores":4,"supportedIops":6400,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D8ds_v5","vCores":8,"supportedIops":12800,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D16ds_v5","vCores":16,"supportedIops":25600,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D32ds_v5","vCores":32,"supportedIops":51200,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D48ds_v5","vCores":48,"supportedIops":76800,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D64ds_v5","vCores":64,"supportedIops":80000,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_D96ds_v5","vCores":96,"supportedIops":80000,"supportedMemoryPerVcoreMb":4096,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]}],"name":"GeneralPurpose","defaultSkuName":"Standard_D4ads_v5","supportedStorageEditions":[{"name":"ManagedDisk","defaultStorageSizeMb":65536,"supportedStorageMb":[{"supportedIops":120,"storageSizeMb":32768,"defaultIopsTier":"P4","supportedIopsTiers":[{"name":"P4","iops":120},{"name":"P6","iops":240},{"name":"P10","iops":500},{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":240,"storageSizeMb":65536,"defaultIopsTier":"P6","supportedIopsTiers":[{"name":"P6","iops":240},{"name":"P10","iops":500},{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":500,"storageSizeMb":131072,"defaultIopsTier":"P10","supportedIopsTiers":[{"name":"P10","iops":500},{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":1100,"storageSizeMb":262144,"defaultIopsTier":"P15","supportedIopsTiers":[{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":2300,"storageSizeMb":524288,"defaultIopsTier":"P20","supportedIopsTiers":[{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":5000,"storageSizeMb":1048576,"defaultIopsTier":"P30","supportedIopsTiers":[{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":7500,"storageSizeMb":2097152,"defaultIopsTier":"P40","supportedIopsTiers":[{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":7500,"storageSizeMb":4193280,"defaultIopsTier":"P50","supportedIopsTiers":[{"name":"P50","iops":7500}]},{"supportedIops":7500,"storageSizeMb":4194304,"defaultIopsTier":"P50","supportedIopsTiers":[{"name":"P50","iops":7500}]},{"supportedIops":16000,"storageSizeMb":8388608,"defaultIopsTier":"P60","supportedIopsTiers":[{"name":"P60","iops":16000},{"name":"P70","iops":18000},{"name":"P80","iops":20000}]},{"supportedIops":18000,"storageSizeMb":16777216,"defaultIopsTier":"P70","supportedIopsTiers":[{"name":"P70","iops":18000},{"name":"P80","iops":20000}]},{"supportedIops":20000,"storageSizeMb":33553408,"defaultIopsTier":"P80","supportedIopsTiers":[{"name":"P80","iops":20000}]}]},{"name":"ManagedDiskV2","defaultStorageSizeMb":65536,"supportedStorageMb":[{"supportedIops":3000,"supportedMaximumIops":80000,"storageSizeMb":32768,"maximumStorageSizeMb":67108864,"supportedThroughput":125,"supportedMaximumThroughput":1200,"defaultIopsTier":"None","supportedIopsTiers":[{"name":"None","iops":0}]}]},{"name":"UltraDisk","defaultStorageSizeMb":65536,"supportedStorageMb":[{"supportedIops":4800,"supportedMaximumIops":400000,"storageSizeMb":32768,"maximumStorageSizeMb":67108864,"supportedThroughput":1200,"supportedMaximumThroughput":10000,"defaultIopsTier":"None","supportedIopsTiers":[{"name":"None","iops":0}]}]}]},{"supportedServerSkus":[{"supportedFeatures":[],"name":"Standard_E2s_v3","vCores":2,"supportedIops":3200,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E4s_v3","vCores":4,"supportedIops":6400,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E8s_v3","vCores":8,"supportedIops":12800,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E16s_v3","vCores":16,"supportedIops":25600,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E32s_v3","vCores":32,"supportedIops":32000,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E48s_v3","vCores":48,"supportedIops":51200,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E64s_v3","vCores":64,"supportedIops":76800,"supportedMemoryPerVcoreMb":6912,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E2ds_v4","vCores":2,"supportedIops":3200,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E4ds_v4","vCores":4,"supportedIops":6400,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E8ds_v4","vCores":8,"supportedIops":12800,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E16ds_v4","vCores":16,"supportedIops":25600,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E20ds_v4","vCores":20,"supportedIops":32000,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E32ds_v4","vCores":32,"supportedIops":51200,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E48ds_v4","vCores":48,"supportedIops":76800,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E64ds_v4","vCores":64,"supportedIops":80000,"supportedMemoryPerVcoreMb":6912,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E2ads_v5","vCores":2,"supportedIops":3750,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E4ads_v5","vCores":4,"supportedIops":6400,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E8ads_v5","vCores":8,"supportedIops":12800,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E16ads_v5","vCores":16,"supportedIops":25600,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E20ads_v5","vCores":20,"supportedIops":32000,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E32ads_v5","vCores":32,"supportedIops":51200,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E48ads_v5","vCores":48,"supportedIops":76800,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E64ads_v5","vCores":64,"supportedIops":80000,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E96ads_v5","vCores":96,"supportedIops":80000,"supportedMemoryPerVcoreMb":7168,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E2ds_v5","vCores":2,"supportedIops":3750,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E4ds_v5","vCores":4,"supportedIops":6400,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E8ds_v5","vCores":8,"supportedIops":12800,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E16ds_v5","vCores":16,"supportedIops":25600,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E20ds_v5","vCores":20,"supportedIops":32000,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E32ds_v5","vCores":32,"supportedIops":51200,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E48ds_v5","vCores":48,"supportedIops":76800,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E64ds_v5","vCores":64,"supportedIops":80000,"supportedMemoryPerVcoreMb":8192,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E96ds_v5","vCores":96,"supportedIops":80000,"supportedMemoryPerVcoreMb":7168,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]},{"supportedFeatures":[],"name":"Standard_E96bds_v5","vCores":96,"supportedIops":160000,"supportedMemoryPerVcoreMb":7168,"supportedZones":["1","2","3"],"supportedHaMode":["SameZone","ZoneRedundant"]}],"name":"MemoryOptimized","defaultSkuName":"Standard_E4ads_v5","supportedStorageEditions":[{"name":"ManagedDisk","defaultStorageSizeMb":131072,"supportedStorageMb":[{"supportedIops":120,"storageSizeMb":32768,"defaultIopsTier":"P4","supportedIopsTiers":[{"name":"P4","iops":120},{"name":"P6","iops":240},{"name":"P10","iops":500},{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":240,"storageSizeMb":65536,"defaultIopsTier":"P6","supportedIopsTiers":[{"name":"P6","iops":240},{"name":"P10","iops":500},{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":500,"storageSizeMb":131072,"defaultIopsTier":"P10","supportedIopsTiers":[{"name":"P10","iops":500},{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":1100,"storageSizeMb":262144,"defaultIopsTier":"P15","supportedIopsTiers":[{"name":"P15","iops":1100},{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":2300,"storageSizeMb":524288,"defaultIopsTier":"P20","supportedIopsTiers":[{"name":"P20","iops":2300},{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":5000,"storageSizeMb":1048576,"defaultIopsTier":"P30","supportedIopsTiers":[{"name":"P30","iops":5000},{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":7500,"storageSizeMb":2097152,"defaultIopsTier":"P40","supportedIopsTiers":[{"name":"P40","iops":7500},{"name":"P50","iops":7500}]},{"supportedIops":7500,"storageSizeMb":4193280,"defaultIopsTier":"P50","supportedIopsTiers":[{"name":"P50","iops":7500}]},{"supportedIops":7500,"storageSizeMb":4194304,"defaultIopsTier":"P50","supportedIopsTiers":[{"name":"P50","iops":7500}]},{"supportedIops":16000,"storageSizeMb":8388608,"defaultIopsTier":"P60","supportedIopsTiers":[{"name":"P60","iops":16000},{"name":"P70","iops":18000},{"name":"P80","iops":20000}]},{"supportedIops":18000,"storageSizeMb":16777216,"defaultIopsTier":"P70","supportedIopsTiers":[{"name":"P70","iops":18000},{"name":"P80","iops":20000}]},{"supportedIops":20000,"storageSizeMb":33553408,"defaultIopsTier":"P80","supportedIopsTiers":[{"name":"P80","iops":20000}]}]},{"name":"ManagedDiskV2","defaultStorageSizeMb":131072,"supportedStorageMb":[{"supportedIops":3000,"supportedMaximumIops":80000,"storageSizeMb":32768,"maximumStorageSizeMb":67108864,"supportedThroughput":125,"supportedMaximumThroughput":1200,"defaultIopsTier":"None","supportedIopsTiers":[{"name":"None","iops":0}]}]},{"name":"UltraDisk","defaultStorageSizeMb":131072,"supportedStorageMb":[{"supportedIops":4800,"supportedMaximumIops":400000,"storageSizeMb":32768,"maximumStorageSizeMb":67108864,"supportedThroughput":1200,"supportedMaximumThroughput":10000,"defaultIopsTier":"None","supportedIopsTiers":[{"name":"None","iops":0}]}]}]}],"supportedServerVersions":[{"supportedFeatures":[],"name":"11","supportedVersionsToUpgrade":["12","13","14","15","16","17","18"]},{"supportedFeatures":[],"name":"12","supportedVersionsToUpgrade":["13","14","15","16","17","18"]},{"supportedFeatures":[],"name":"13","supportedVersionsToUpgrade":["14","15","16","17","18"]},{"supportedFeatures":[],"name":"14","supportedVersionsToUpgrade":["15","16","17","18"]},{"supportedFeatures":[],"name":"15","supportedVersionsToUpgrade":["16","17","18"]},{"supportedFeatures":[],"name":"16","supportedVersionsToUpgrade":["17","18"]},{"supportedFeatures":[],"name":"17","supportedVersionsToUpgrade":["18"]},{"supportedFeatures":[],"name":"18","supportedVersionsToUpgrade":[]}],"supportedFastProvisioningEditions":[],"supportedFeatures":[{"name":"FastProvisioning","status":"Disabled"},{"name":"ZoneRedundantHa","status":"Enabled"},{"name":"GeoBackup","status":"Enabled"},{"name":"ZoneRedundantHaAndGeoBackup","status":"Enabled"},{"name":"StorageAutoGrowth","status":"Enabled"},{"name":"OnlineResize","status":"Enabled"},{"name":"OfferRestricted","status":"Disabled"},{"name":"IndexTuning","status":"Enabled"},{"name":"Clusters","status":"Enabled"},{"name":"AdaptiveAutoVacuumAutoApply","status":"Disabled"},{"name":"ConfigTuning","status":"Disabled"}],"fastProvisioningSupported":"Disabled","geoBackupSupported":"Enabled","zoneRedundantHaSupported":"Enabled","zoneRedundantHaAndGeoBackupSupported":"Enabled","storageAutoGrowthSupported":"Enabled","onlineResizeSupported":"Enabled","indexTuningSupported":"Enabled"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '24143'
+      - '24690'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Feb 2026 03:26:43 GMT
+      - Mon, 30 Mar 2026 14:12:16 GMT
       expires:
       - '-1'
       pragma:
@@ -185,22 +183,22 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f57d2932-2a78-450f-958a-e65997c3253b/eastus2/3e84fdf3-b6ee-4437-9a68-d07b5de2fbfc
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/87160815-89c2-45ee-96fd-2f1de347c3d5
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 69C6483439AC422A900B0601EB635F0D Ref B: MNZ221060610011 Ref C: 2026-02-18T03:26:41Z'
+      - 'Ref A: CC66B4FF5E504D5D83FF6A194E23CE22 Ref B: AMS231020512033 Ref C: 2026-03-30T14:12:15Z'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"location": "canadacentral", "sku": {"name": "Standard_D4ds_v4", "tier":
-      "GeneralPurpose"}, "properties": {"backup": {"backupRetentionDays": 7, "geoRedundantBackup":
-      "Disabled"}, "createMode": "Create", "authConfig": {"activeDirectoryAuth": "Disabled",
-      "passwordAuth": "Enabled"}, "administratorLoginPassword": "803J8Hdc90Ls3dTB5b08SQ",
-      "version": "17", "administratorLogin": "wornoutlizard2", "highAvailability":
-      {"mode": "Disabled"}, "storage": {"storageSizeGB": 128, "autoGrow": "Disabled"},
-      "network": {"publicNetworkAccess": "Disabled"}}}'
+    body: '{"location": "canadacentral", "sku": {"name": "Standard_D4ads_v5", "tier":
+      "GeneralPurpose"}, "properties": {"administratorLogin": "unlinedparrot3", "backup":
+      {"backupRetentionDays": 7, "geoRedundantBackup": "Disabled"}, "version": "17",
+      "highAvailability": {"mode": "Disabled"}, "network": {"publicNetworkAccess":
+      "Disabled"}, "storage": {"storageSizeGB": 128, "autoGrow": "Disabled"}, "createMode":
+      "Create", "administratorLoginPassword": "K1lfnFRaaDetyuuMaG2k0w", "authConfig":
+      {"activeDirectoryAuth": "Disabled", "passwordAuth": "Enabled"}}}'
     headers:
       Accept:
       - '*/*'
@@ -211,33 +209,33 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '544'
+      - '545'
       Content-Type:
       - application/json
       ParameterSetName:
       - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
       User-Agent:
-      - AZURECLI/2.83.0 azsdk-python-core/1.38.0 Python/3.13.10 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002?api-version=2026-01-01-preview
   response:
     body:
-      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2026-02-18T03:26:44.477Z"}'
+      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2026-03-30T14:12:18.98Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/95988fff-11cc-4e06-8e82-76773f53af45?api-version=2026-01-01-preview&t=639069820045481199&c=MIIHhzCCBm-gAwIBAgITHgfeaAthBF252mKMUQAAB95oCzANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDYwHhcNMjYwMTE1MTIwMzEzWhcNMjYwNTI0MjI1NzAzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALF5UwB1TCaUQryWnLemNoR1STogfj5BkURewSVKqF6BNmNVe6OPy7h3BMUV8wQPDRcx564kcpxInHjnJ91C2HdWhYtJC9mQ-KfRTHGro-eDtjIDA_m8ZoQaG1t8ZDyGTw3sg-le416DRx--vNLJWTcJ5pPQrNGLHgukyEBEGqcperL--6vkuDR8piARKeWdPub4QGpdJgULAoKm577o9Yeour0AbDe48KV8DaKqEhZAqTR021tTIU5-OVtQTAIuOTVnkBLtraUBYl6qbV603_iHP0-lxSiAdoOKRc9hnw5EIzdh4P3k57bkUUGKXBcEaDzqiXI4zT2s2PpLMdlJGrECAwEAAaOCBHQwggRwMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFghfmRS4WsmTQCAWQCAQcwggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MB0GA1UdDgQWBBQpx7wy64aZi3bga5mYDPjiPc4VjDAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwIwDAYKKwYBBAGCN3sEAjAfBgNVHSMEGDAWgBTxRmjG8cPwKy19i2rhsvm-NfzRQTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAESi3AgZNii4-yX1M8j9s1tnNVejdi-hvwe3tGOyTBjO6vi2tuQDoyQ-t6WDcAY8Suwhm0D6N6beb9niA0Z4KG-xN1jzJx-JF23mcbREASBP-H_Sk80BObD4a0FrOXY0dcNg2oK5FAuM8bwFfqHTRPNqCqL20uzuAyXhTgbwYJ7v6R0YYYv67aIj096-6dGUEKCXLHUtQfPNpvGOCnyvW5-kJ2GJ6ImpJvVnBPvU6JNVR7QMnSEtf7vlMFKguYoC7kAalHyr4UMxGBU6PpqOlJca6U_3ehNgwPuIFln_3JxNqtpyIWd5YpWGPRtAqGYE8y2NyTMrJQcUCkfHIqOHVFk&s=LP0kSlI4ks9UXXhaWvSTLCiLpQlKKPp_dvNaR1FjDN7s54KEQGsAXP6els9Nekr8XWUYxu-ZqC8qHtk5FiZh74dAPSEpCrIr1pNPa7yZ3fhjKe0fpUigcRLvJkAFsT2db1u8HTBKULQhz3bt2QKtnx9356f_Wgu0a0H5Q6CLeXpKPnBytMQyZD7c8pnxRtabZrxAwalnTPdn48u3DQAvgAPggnHXf-Oet_-mC8bVSBkqkXyA1eyVwtaO7yMMOY_I8eiLTopcEsqPfyUwAof6hcTXkMc6itI-cB50WnwrjKn173vhwFCHm5Ewfunutyx2826CmWnqiR930BPOGpswfA&h=bcMiPQM-ZUGGuT4QNShj4ZUU7bqjKyj6s09FD8BJHIM
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/a9b6af9f-8c5f-411b-9087-11a46647c67f?api-version=2026-01-01-preview&t=639104767394137249&c=MIIHlTCCBn2gAwIBAgIRAMrMZgep9-LTubYuD5c1bMgwDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgRVVTMiBDQSAwMTAeFw0yNjAyMjQxMzAxMjBaFw0yNjA4MTkxOTAxMjBaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtc9VqEvVV-f6_yUuDcAswQOf3pY-Y8bo2vLNVJr1CPCcGcMSxZtU9_kSwuHc77o3SYmOurgLtp6WdXT4o-p6NrDTkTl4KV4uY6pssTu-K6TasXs4zEWA4TN1ivwt0dt28Rl9RL-iTYepHyDjf7TsPethzhl3Yea9Bye2ACwkc4mI1PM1dSuDybmebI78BA3xYA6_LqSlF1-Pjk5qFuqHwPEIuiZCm7r8dtCGdMAyv075r86onD9M06bLHeKFbD0PsqtV9xwcaIM1wl6LdKNpYkkmcleFSWjil1F44HliNV85aG4ULUFhSxymugnZDV1k4dLp2b-NFd0ErNAMc8l2DQIDAQABo4IEkjCCBI4wgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQUAs4IkRNNSi2LOcksFd0_oJ9LnTwwHwYDVR0jBBgwFoAU_Ow-26p8H4IeBbihBvlD5wKzCrkwggGyBgNVHR8EggGpMIIBpTBpoGegZYZjaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzg5L2N1cnJlbnQuY3JsMGugaaBnhmVodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NybHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS84OS9jdXJyZW50LmNybDBaoFigVoZUaHR0cDovL2NybC5taWNyb3NvZnQuY29tL2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzg5L2N1cnJlbnQuY3JsMG-gbaBrhmlodHRwOi8vY2NtZWVhc3R1czJwa2kuZWFzdHVzMi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVlYXN0dXMyaWNhMDEvODkvY3VycmVudC5jcmwwggG3BggrBgEFBQcBAQSCAakwggGlMGwGCCsGAQUFBzAChmBodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwbgYIKwYBBQUHMAKGYmh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY2FjZXJ0cy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxL2NlcnQuY2VyMF0GCCsGAQUFBzAChlFodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwZgYIKwYBBQUHMAKGWmh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMTANBgkqhkiG9w0BAQsFAAOCAQEAEKc49KJHc6By0YpRr-FLth5Lupbcfj855fKMIxBRydPRMy2ML_NCOORdCclSMJOOS8fT_jyVfAgWbuOJjQqmoinjcf_Dn5apduFtwmTSWlJ00RLrD0f2x3veqrW9aqy0unjq5PVrwEgPAUXX4ng_iKGUKLjXcJHqB54M8_ZZwND8cZGmd0QuZ1lOsLua3ztb331S21nKgR84tkH51d2vGzWTRlnPbWwuXOJyAiVoPBJ5wQ9oxLFDAUtreJJDinMpHVPA6UOCg4x0k07b02_tycryA5zghFvFX-Vaw7F5Vm0bwz7vrYdS1dl478O8qtnRvMAvaIFNwkeB6HV29ubjUg&s=GYmyM_7hodJoMDy6Vcg3IV4vIMlpM4GMMT7TaH19mj9IyZQtPBvqv4HY4IGXP7KoiezGJ-e1ZnWF8kjBubhZyh4lSqnwxBaStpL8QIcaA92TY9ePxVJgZkF7IH6ZyYPE56ve0-u_6WJ16nG_SRPqFC5xJJdq40iX4Mc_J-AuhHuKyjV3SQgjiwwCqTbOBswn_kS60zzKdN82oEyJrKKePtiRawrpnl7XRvr2b9tkKRsJ0hxyHInHbVOqiLI8iQ8qBChxmTjmmpzzu5G2SrG30wfK2udgWz1ViMxaBtBGHflOj1lEIdwaEGDKTAQ32fqzLJhlekhmvCrxgyTTdT3YAw&h=Rd-91wJdq06ezIal_utYXgyD8ZbyZwDVBwmwnen9giM
       cache-control:
       - no-cache
       content-length:
-      - '88'
+      - '87'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Feb 2026 03:26:44 GMT
+      - Mon, 30 Mar 2026 14:12:18 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/operationResults/95988fff-11cc-4e06-8e82-76773f53af45?api-version=2026-01-01-preview&t=639069820045481199&c=MIIHhzCCBm-gAwIBAgITHgfeaAthBF252mKMUQAAB95oCzANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDYwHhcNMjYwMTE1MTIwMzEzWhcNMjYwNTI0MjI1NzAzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALF5UwB1TCaUQryWnLemNoR1STogfj5BkURewSVKqF6BNmNVe6OPy7h3BMUV8wQPDRcx564kcpxInHjnJ91C2HdWhYtJC9mQ-KfRTHGro-eDtjIDA_m8ZoQaG1t8ZDyGTw3sg-le416DRx--vNLJWTcJ5pPQrNGLHgukyEBEGqcperL--6vkuDR8piARKeWdPub4QGpdJgULAoKm577o9Yeour0AbDe48KV8DaKqEhZAqTR021tTIU5-OVtQTAIuOTVnkBLtraUBYl6qbV603_iHP0-lxSiAdoOKRc9hnw5EIzdh4P3k57bkUUGKXBcEaDzqiXI4zT2s2PpLMdlJGrECAwEAAaOCBHQwggRwMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFghfmRS4WsmTQCAWQCAQcwggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MB0GA1UdDgQWBBQpx7wy64aZi3bga5mYDPjiPc4VjDAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwIwDAYKKwYBBAGCN3sEAjAfBgNVHSMEGDAWgBTxRmjG8cPwKy19i2rhsvm-NfzRQTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAESi3AgZNii4-yX1M8j9s1tnNVejdi-hvwe3tGOyTBjO6vi2tuQDoyQ-t6WDcAY8Suwhm0D6N6beb9niA0Z4KG-xN1jzJx-JF23mcbREASBP-H_Sk80BObD4a0FrOXY0dcNg2oK5FAuM8bwFfqHTRPNqCqL20uzuAyXhTgbwYJ7v6R0YYYv67aIj096-6dGUEKCXLHUtQfPNpvGOCnyvW5-kJ2GJ6ImpJvVnBPvU6JNVR7QMnSEtf7vlMFKguYoC7kAalHyr4UMxGBU6PpqOlJca6U_3ehNgwPuIFln_3JxNqtpyIWd5YpWGPRtAqGYE8y2NyTMrJQcUCkfHIqOHVFk&s=mheJd9a89VY-53cwMIWS_Yppcc0P4zEtAYgNLOUDvpfyP-QlqTPMbtDO19CikqQHDg4lqPoE_5-5PiXXFizwxixwJaOCoIw5jPlyp6fbFLBEeYvUP8A_2TNCaW3JTSqvoeTNS7urmpKnFDE69ii6nu-nycW1tQpSfbSFHVb5u4IuftJ706OhS5T5vYTJk_UwhupvxpSQ_UtaFK5dnRRL_3tMr5kDAYNxxbB7VvnRP-ipCV-dkogmHtm0bZc5rvY7pFxQ0OD_P2ES1UFdMawHJJrvv5yC_3rM2d4qf66bNWXkOuhzrLgfnZpySo191b2lC5lEW_xu3SUwHv7lwyUsow&h=nUJ5kTO245LmFXsH7qkCeXEu2kqSQMe1DNMWJYSiTF4
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/operationResults/a9b6af9f-8c5f-411b-9087-11a46647c67f?api-version=2026-01-01-preview&t=639104767394294820&c=MIIHlTCCBn2gAwIBAgIRAMrMZgep9-LTubYuD5c1bMgwDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgRVVTMiBDQSAwMTAeFw0yNjAyMjQxMzAxMjBaFw0yNjA4MTkxOTAxMjBaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtc9VqEvVV-f6_yUuDcAswQOf3pY-Y8bo2vLNVJr1CPCcGcMSxZtU9_kSwuHc77o3SYmOurgLtp6WdXT4o-p6NrDTkTl4KV4uY6pssTu-K6TasXs4zEWA4TN1ivwt0dt28Rl9RL-iTYepHyDjf7TsPethzhl3Yea9Bye2ACwkc4mI1PM1dSuDybmebI78BA3xYA6_LqSlF1-Pjk5qFuqHwPEIuiZCm7r8dtCGdMAyv075r86onD9M06bLHeKFbD0PsqtV9xwcaIM1wl6LdKNpYkkmcleFSWjil1F44HliNV85aG4ULUFhSxymugnZDV1k4dLp2b-NFd0ErNAMc8l2DQIDAQABo4IEkjCCBI4wgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQUAs4IkRNNSi2LOcksFd0_oJ9LnTwwHwYDVR0jBBgwFoAU_Ow-26p8H4IeBbihBvlD5wKzCrkwggGyBgNVHR8EggGpMIIBpTBpoGegZYZjaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzg5L2N1cnJlbnQuY3JsMGugaaBnhmVodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NybHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS84OS9jdXJyZW50LmNybDBaoFigVoZUaHR0cDovL2NybC5taWNyb3NvZnQuY29tL2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzg5L2N1cnJlbnQuY3JsMG-gbaBrhmlodHRwOi8vY2NtZWVhc3R1czJwa2kuZWFzdHVzMi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVlYXN0dXMyaWNhMDEvODkvY3VycmVudC5jcmwwggG3BggrBgEFBQcBAQSCAakwggGlMGwGCCsGAQUFBzAChmBodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwbgYIKwYBBQUHMAKGYmh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY2FjZXJ0cy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxL2NlcnQuY2VyMF0GCCsGAQUFBzAChlFodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwZgYIKwYBBQUHMAKGWmh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMTANBgkqhkiG9w0BAQsFAAOCAQEAEKc49KJHc6By0YpRr-FLth5Lupbcfj855fKMIxBRydPRMy2ML_NCOORdCclSMJOOS8fT_jyVfAgWbuOJjQqmoinjcf_Dn5apduFtwmTSWlJ00RLrD0f2x3veqrW9aqy0unjq5PVrwEgPAUXX4ng_iKGUKLjXcJHqB54M8_ZZwND8cZGmd0QuZ1lOsLua3ztb331S21nKgR84tkH51d2vGzWTRlnPbWwuXOJyAiVoPBJ5wQ9oxLFDAUtreJJDinMpHVPA6UOCg4x0k07b02_tycryA5zghFvFX-Vaw7F5Vm0bwz7vrYdS1dl478O8qtnRvMAvaIFNwkeB6HV29ubjUg&s=g_2js2iWZ_dXjl-KSrh2aZiSmly3WzNHaVnU3NoYy7X_g9iVLGGizAMvlgpEmGKqmIorRmaB2KZRttE4OmovUu1ksGIT-9dr5gFv9lTO31xjgR2egluOLPCQS8FiQUevBoNvq5CIuq49mEe1WAewIg_48FMivF1Vih0vpfWHZ5abe2dlO46V_9pS0Kh1XyW5Gy9ATvXaoTzdlusGLAP0aSiEUfHyvQWauQCk1af9SWVt6eryXzF1bM6je-smxUy8HC1Cl-c2T_qHZDwiFuhcx3iL8KtywJKwvH3MQ5JbvRPQbBHv0P1Rd51wSTWUinxmzcwAQhHdbv9R5ULANXUQjQ&h=afjGkG0eD9YN9cYRpMC-SQQLkUqzeWTgRP6cDD-NLLc
       pragma:
       - no-cache
       strict-transport-security:
@@ -247,13 +245,13 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f57d2932-2a78-450f-958a-e65997c3253b/canadacentral/b5d9a5f0-0a07-40cb-9f96-6a03b996bacb
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/ukwest/2433fc5f-af44-4a61-842b-12614ee5f779
       x-ms-ratelimit-remaining-subscription-global-writes:
       - '11999'
       x-ms-ratelimit-remaining-subscription-writes:
       - '799'
       x-msedge-ref:
-      - 'Ref A: ED127724309147D0865556D49D2628FA Ref B: MNZ221060618037 Ref C: 2026-02-18T03:26:44Z'
+      - 'Ref A: F9B778328E604C68ADF2B7ADD9444126 Ref B: DUB601080513042 Ref C: 2026-03-30T14:12:17Z'
     status:
       code: 202
       message: Accepted
@@ -271,252 +269,12 @@ interactions:
       ParameterSetName:
       - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
       User-Agent:
-      - AZURECLI/2.83.0 azsdk-python-core/1.38.0 Python/3.13.10 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/95988fff-11cc-4e06-8e82-76773f53af45?api-version=2026-01-01-preview&t=639069820045481199&c=MIIHhzCCBm-gAwIBAgITHgfeaAthBF252mKMUQAAB95oCzANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDYwHhcNMjYwMTE1MTIwMzEzWhcNMjYwNTI0MjI1NzAzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALF5UwB1TCaUQryWnLemNoR1STogfj5BkURewSVKqF6BNmNVe6OPy7h3BMUV8wQPDRcx564kcpxInHjnJ91C2HdWhYtJC9mQ-KfRTHGro-eDtjIDA_m8ZoQaG1t8ZDyGTw3sg-le416DRx--vNLJWTcJ5pPQrNGLHgukyEBEGqcperL--6vkuDR8piARKeWdPub4QGpdJgULAoKm577o9Yeour0AbDe48KV8DaKqEhZAqTR021tTIU5-OVtQTAIuOTVnkBLtraUBYl6qbV603_iHP0-lxSiAdoOKRc9hnw5EIzdh4P3k57bkUUGKXBcEaDzqiXI4zT2s2PpLMdlJGrECAwEAAaOCBHQwggRwMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFghfmRS4WsmTQCAWQCAQcwggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MB0GA1UdDgQWBBQpx7wy64aZi3bga5mYDPjiPc4VjDAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwIwDAYKKwYBBAGCN3sEAjAfBgNVHSMEGDAWgBTxRmjG8cPwKy19i2rhsvm-NfzRQTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAESi3AgZNii4-yX1M8j9s1tnNVejdi-hvwe3tGOyTBjO6vi2tuQDoyQ-t6WDcAY8Suwhm0D6N6beb9niA0Z4KG-xN1jzJx-JF23mcbREASBP-H_Sk80BObD4a0FrOXY0dcNg2oK5FAuM8bwFfqHTRPNqCqL20uzuAyXhTgbwYJ7v6R0YYYv67aIj096-6dGUEKCXLHUtQfPNpvGOCnyvW5-kJ2GJ6ImpJvVnBPvU6JNVR7QMnSEtf7vlMFKguYoC7kAalHyr4UMxGBU6PpqOlJca6U_3ehNgwPuIFln_3JxNqtpyIWd5YpWGPRtAqGYE8y2NyTMrJQcUCkfHIqOHVFk&s=LP0kSlI4ks9UXXhaWvSTLCiLpQlKKPp_dvNaR1FjDN7s54KEQGsAXP6els9Nekr8XWUYxu-ZqC8qHtk5FiZh74dAPSEpCrIr1pNPa7yZ3fhjKe0fpUigcRLvJkAFsT2db1u8HTBKULQhz3bt2QKtnx9356f_Wgu0a0H5Q6CLeXpKPnBytMQyZD7c8pnxRtabZrxAwalnTPdn48u3DQAvgAPggnHXf-Oet_-mC8bVSBkqkXyA1eyVwtaO7yMMOY_I8eiLTopcEsqPfyUwAof6hcTXkMc6itI-cB50WnwrjKn173vhwFCHm5Ewfunutyx2826CmWnqiR930BPOGpswfA&h=bcMiPQM-ZUGGuT4QNShj4ZUU7bqjKyj6s09FD8BJHIM
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/a9b6af9f-8c5f-411b-9087-11a46647c67f?api-version=2026-01-01-preview&t=639104767394137249&c=MIIHlTCCBn2gAwIBAgIRAMrMZgep9-LTubYuD5c1bMgwDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgRVVTMiBDQSAwMTAeFw0yNjAyMjQxMzAxMjBaFw0yNjA4MTkxOTAxMjBaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtc9VqEvVV-f6_yUuDcAswQOf3pY-Y8bo2vLNVJr1CPCcGcMSxZtU9_kSwuHc77o3SYmOurgLtp6WdXT4o-p6NrDTkTl4KV4uY6pssTu-K6TasXs4zEWA4TN1ivwt0dt28Rl9RL-iTYepHyDjf7TsPethzhl3Yea9Bye2ACwkc4mI1PM1dSuDybmebI78BA3xYA6_LqSlF1-Pjk5qFuqHwPEIuiZCm7r8dtCGdMAyv075r86onD9M06bLHeKFbD0PsqtV9xwcaIM1wl6LdKNpYkkmcleFSWjil1F44HliNV85aG4ULUFhSxymugnZDV1k4dLp2b-NFd0ErNAMc8l2DQIDAQABo4IEkjCCBI4wgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQUAs4IkRNNSi2LOcksFd0_oJ9LnTwwHwYDVR0jBBgwFoAU_Ow-26p8H4IeBbihBvlD5wKzCrkwggGyBgNVHR8EggGpMIIBpTBpoGegZYZjaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzg5L2N1cnJlbnQuY3JsMGugaaBnhmVodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NybHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS84OS9jdXJyZW50LmNybDBaoFigVoZUaHR0cDovL2NybC5taWNyb3NvZnQuY29tL2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzg5L2N1cnJlbnQuY3JsMG-gbaBrhmlodHRwOi8vY2NtZWVhc3R1czJwa2kuZWFzdHVzMi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVlYXN0dXMyaWNhMDEvODkvY3VycmVudC5jcmwwggG3BggrBgEFBQcBAQSCAakwggGlMGwGCCsGAQUFBzAChmBodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwbgYIKwYBBQUHMAKGYmh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY2FjZXJ0cy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxL2NlcnQuY2VyMF0GCCsGAQUFBzAChlFodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwZgYIKwYBBQUHMAKGWmh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMTANBgkqhkiG9w0BAQsFAAOCAQEAEKc49KJHc6By0YpRr-FLth5Lupbcfj855fKMIxBRydPRMy2ML_NCOORdCclSMJOOS8fT_jyVfAgWbuOJjQqmoinjcf_Dn5apduFtwmTSWlJ00RLrD0f2x3veqrW9aqy0unjq5PVrwEgPAUXX4ng_iKGUKLjXcJHqB54M8_ZZwND8cZGmd0QuZ1lOsLua3ztb331S21nKgR84tkH51d2vGzWTRlnPbWwuXOJyAiVoPBJ5wQ9oxLFDAUtreJJDinMpHVPA6UOCg4x0k07b02_tycryA5zghFvFX-Vaw7F5Vm0bwz7vrYdS1dl478O8qtnRvMAvaIFNwkeB6HV29ubjUg&s=GYmyM_7hodJoMDy6Vcg3IV4vIMlpM4GMMT7TaH19mj9IyZQtPBvqv4HY4IGXP7KoiezGJ-e1ZnWF8kjBubhZyh4lSqnwxBaStpL8QIcaA92TY9ePxVJgZkF7IH6ZyYPE56ve0-u_6WJ16nG_SRPqFC5xJJdq40iX4Mc_J-AuhHuKyjV3SQgjiwwCqTbOBswn_kS60zzKdN82oEyJrKKePtiRawrpnl7XRvr2b9tkKRsJ0hxyHInHbVOqiLI8iQ8qBChxmTjmmpzzu5G2SrG30wfK2udgWz1ViMxaBtBGHflOj1lEIdwaEGDKTAQ32fqzLJhlekhmvCrxgyTTdT3YAw&h=Rd-91wJdq06ezIal_utYXgyD8ZbyZwDVBwmwnen9giM
   response:
     body:
-      string: '{"name":"95988fff-11cc-4e06-8e82-76773f53af45","status":"InProgress","startTime":"2026-02-18T03:26:44.477Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '108'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Feb 2026 03:26:44 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-cache:
-      - CONFIG_NOCACHE
-      x-content-type-options:
-      - nosniff
-      x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f57d2932-2a78-450f-958a-e65997c3253b/eastus/44f74a4e-13d2-4fdb-aa21-a918d4949282
-      x-ms-ratelimit-remaining-subscription-global-reads:
-      - '16499'
-      x-msedge-ref:
-      - 'Ref A: 1E1077D325854AA686A8E674C1B6D03B Ref B: BL2AA2011006040 Ref C: 2026-02-18T03:26:44Z'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - postgres flexible-server create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
-      User-Agent:
-      - AZURECLI/2.83.0 azsdk-python-core/1.38.0 Python/3.13.10 (Windows-11-10.0.26200-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/95988fff-11cc-4e06-8e82-76773f53af45?api-version=2026-01-01-preview&t=639069820045481199&c=MIIHhzCCBm-gAwIBAgITHgfeaAthBF252mKMUQAAB95oCzANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDYwHhcNMjYwMTE1MTIwMzEzWhcNMjYwNTI0MjI1NzAzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALF5UwB1TCaUQryWnLemNoR1STogfj5BkURewSVKqF6BNmNVe6OPy7h3BMUV8wQPDRcx564kcpxInHjnJ91C2HdWhYtJC9mQ-KfRTHGro-eDtjIDA_m8ZoQaG1t8ZDyGTw3sg-le416DRx--vNLJWTcJ5pPQrNGLHgukyEBEGqcperL--6vkuDR8piARKeWdPub4QGpdJgULAoKm577o9Yeour0AbDe48KV8DaKqEhZAqTR021tTIU5-OVtQTAIuOTVnkBLtraUBYl6qbV603_iHP0-lxSiAdoOKRc9hnw5EIzdh4P3k57bkUUGKXBcEaDzqiXI4zT2s2PpLMdlJGrECAwEAAaOCBHQwggRwMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFghfmRS4WsmTQCAWQCAQcwggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MB0GA1UdDgQWBBQpx7wy64aZi3bga5mYDPjiPc4VjDAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwIwDAYKKwYBBAGCN3sEAjAfBgNVHSMEGDAWgBTxRmjG8cPwKy19i2rhsvm-NfzRQTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAESi3AgZNii4-yX1M8j9s1tnNVejdi-hvwe3tGOyTBjO6vi2tuQDoyQ-t6WDcAY8Suwhm0D6N6beb9niA0Z4KG-xN1jzJx-JF23mcbREASBP-H_Sk80BObD4a0FrOXY0dcNg2oK5FAuM8bwFfqHTRPNqCqL20uzuAyXhTgbwYJ7v6R0YYYv67aIj096-6dGUEKCXLHUtQfPNpvGOCnyvW5-kJ2GJ6ImpJvVnBPvU6JNVR7QMnSEtf7vlMFKguYoC7kAalHyr4UMxGBU6PpqOlJca6U_3ehNgwPuIFln_3JxNqtpyIWd5YpWGPRtAqGYE8y2NyTMrJQcUCkfHIqOHVFk&s=LP0kSlI4ks9UXXhaWvSTLCiLpQlKKPp_dvNaR1FjDN7s54KEQGsAXP6els9Nekr8XWUYxu-ZqC8qHtk5FiZh74dAPSEpCrIr1pNPa7yZ3fhjKe0fpUigcRLvJkAFsT2db1u8HTBKULQhz3bt2QKtnx9356f_Wgu0a0H5Q6CLeXpKPnBytMQyZD7c8pnxRtabZrxAwalnTPdn48u3DQAvgAPggnHXf-Oet_-mC8bVSBkqkXyA1eyVwtaO7yMMOY_I8eiLTopcEsqPfyUwAof6hcTXkMc6itI-cB50WnwrjKn173vhwFCHm5Ewfunutyx2826CmWnqiR930BPOGpswfA&h=bcMiPQM-ZUGGuT4QNShj4ZUU7bqjKyj6s09FD8BJHIM
-  response:
-    body:
-      string: '{"name":"95988fff-11cc-4e06-8e82-76773f53af45","status":"InProgress","startTime":"2026-02-18T03:26:44.477Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '108'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Feb 2026 03:27:44 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-cache:
-      - CONFIG_NOCACHE
-      x-content-type-options:
-      - nosniff
-      x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f57d2932-2a78-450f-958a-e65997c3253b/eastus2/1420583b-a161-4b86-bf21-c429877ad641
-      x-ms-ratelimit-remaining-subscription-global-reads:
-      - '16499'
-      x-msedge-ref:
-      - 'Ref A: 8DE85BF60CE941569A8DC75CFE3438E6 Ref B: MNZ221060609009 Ref C: 2026-02-18T03:27:45Z'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - postgres flexible-server create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
-      User-Agent:
-      - AZURECLI/2.83.0 azsdk-python-core/1.38.0 Python/3.13.10 (Windows-11-10.0.26200-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/95988fff-11cc-4e06-8e82-76773f53af45?api-version=2026-01-01-preview&t=639069820045481199&c=MIIHhzCCBm-gAwIBAgITHgfeaAthBF252mKMUQAAB95oCzANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDYwHhcNMjYwMTE1MTIwMzEzWhcNMjYwNTI0MjI1NzAzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALF5UwB1TCaUQryWnLemNoR1STogfj5BkURewSVKqF6BNmNVe6OPy7h3BMUV8wQPDRcx564kcpxInHjnJ91C2HdWhYtJC9mQ-KfRTHGro-eDtjIDA_m8ZoQaG1t8ZDyGTw3sg-le416DRx--vNLJWTcJ5pPQrNGLHgukyEBEGqcperL--6vkuDR8piARKeWdPub4QGpdJgULAoKm577o9Yeour0AbDe48KV8DaKqEhZAqTR021tTIU5-OVtQTAIuOTVnkBLtraUBYl6qbV603_iHP0-lxSiAdoOKRc9hnw5EIzdh4P3k57bkUUGKXBcEaDzqiXI4zT2s2PpLMdlJGrECAwEAAaOCBHQwggRwMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFghfmRS4WsmTQCAWQCAQcwggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MB0GA1UdDgQWBBQpx7wy64aZi3bga5mYDPjiPc4VjDAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwIwDAYKKwYBBAGCN3sEAjAfBgNVHSMEGDAWgBTxRmjG8cPwKy19i2rhsvm-NfzRQTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAESi3AgZNii4-yX1M8j9s1tnNVejdi-hvwe3tGOyTBjO6vi2tuQDoyQ-t6WDcAY8Suwhm0D6N6beb9niA0Z4KG-xN1jzJx-JF23mcbREASBP-H_Sk80BObD4a0FrOXY0dcNg2oK5FAuM8bwFfqHTRPNqCqL20uzuAyXhTgbwYJ7v6R0YYYv67aIj096-6dGUEKCXLHUtQfPNpvGOCnyvW5-kJ2GJ6ImpJvVnBPvU6JNVR7QMnSEtf7vlMFKguYoC7kAalHyr4UMxGBU6PpqOlJca6U_3ehNgwPuIFln_3JxNqtpyIWd5YpWGPRtAqGYE8y2NyTMrJQcUCkfHIqOHVFk&s=LP0kSlI4ks9UXXhaWvSTLCiLpQlKKPp_dvNaR1FjDN7s54KEQGsAXP6els9Nekr8XWUYxu-ZqC8qHtk5FiZh74dAPSEpCrIr1pNPa7yZ3fhjKe0fpUigcRLvJkAFsT2db1u8HTBKULQhz3bt2QKtnx9356f_Wgu0a0H5Q6CLeXpKPnBytMQyZD7c8pnxRtabZrxAwalnTPdn48u3DQAvgAPggnHXf-Oet_-mC8bVSBkqkXyA1eyVwtaO7yMMOY_I8eiLTopcEsqPfyUwAof6hcTXkMc6itI-cB50WnwrjKn173vhwFCHm5Ewfunutyx2826CmWnqiR930BPOGpswfA&h=bcMiPQM-ZUGGuT4QNShj4ZUU7bqjKyj6s09FD8BJHIM
-  response:
-    body:
-      string: '{"name":"95988fff-11cc-4e06-8e82-76773f53af45","status":"InProgress","startTime":"2026-02-18T03:26:44.477Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '108'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Feb 2026 03:28:45 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-cache:
-      - CONFIG_NOCACHE
-      x-content-type-options:
-      - nosniff
-      x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f57d2932-2a78-450f-958a-e65997c3253b/eastus/1355fdaa-a42f-4844-b9cf-7827e6c665dc
-      x-ms-ratelimit-remaining-subscription-global-reads:
-      - '16499'
-      x-msedge-ref:
-      - 'Ref A: C2CBDDDC2F6F4C54951B745CFA7888A3 Ref B: BL2AA2011002036 Ref C: 2026-02-18T03:28:45Z'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - postgres flexible-server create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
-      User-Agent:
-      - AZURECLI/2.83.0 azsdk-python-core/1.38.0 Python/3.13.10 (Windows-11-10.0.26200-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/95988fff-11cc-4e06-8e82-76773f53af45?api-version=2026-01-01-preview&t=639069820045481199&c=MIIHhzCCBm-gAwIBAgITHgfeaAthBF252mKMUQAAB95oCzANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDYwHhcNMjYwMTE1MTIwMzEzWhcNMjYwNTI0MjI1NzAzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALF5UwB1TCaUQryWnLemNoR1STogfj5BkURewSVKqF6BNmNVe6OPy7h3BMUV8wQPDRcx564kcpxInHjnJ91C2HdWhYtJC9mQ-KfRTHGro-eDtjIDA_m8ZoQaG1t8ZDyGTw3sg-le416DRx--vNLJWTcJ5pPQrNGLHgukyEBEGqcperL--6vkuDR8piARKeWdPub4QGpdJgULAoKm577o9Yeour0AbDe48KV8DaKqEhZAqTR021tTIU5-OVtQTAIuOTVnkBLtraUBYl6qbV603_iHP0-lxSiAdoOKRc9hnw5EIzdh4P3k57bkUUGKXBcEaDzqiXI4zT2s2PpLMdlJGrECAwEAAaOCBHQwggRwMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFghfmRS4WsmTQCAWQCAQcwggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MB0GA1UdDgQWBBQpx7wy64aZi3bga5mYDPjiPc4VjDAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwIwDAYKKwYBBAGCN3sEAjAfBgNVHSMEGDAWgBTxRmjG8cPwKy19i2rhsvm-NfzRQTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAESi3AgZNii4-yX1M8j9s1tnNVejdi-hvwe3tGOyTBjO6vi2tuQDoyQ-t6WDcAY8Suwhm0D6N6beb9niA0Z4KG-xN1jzJx-JF23mcbREASBP-H_Sk80BObD4a0FrOXY0dcNg2oK5FAuM8bwFfqHTRPNqCqL20uzuAyXhTgbwYJ7v6R0YYYv67aIj096-6dGUEKCXLHUtQfPNpvGOCnyvW5-kJ2GJ6ImpJvVnBPvU6JNVR7QMnSEtf7vlMFKguYoC7kAalHyr4UMxGBU6PpqOlJca6U_3ehNgwPuIFln_3JxNqtpyIWd5YpWGPRtAqGYE8y2NyTMrJQcUCkfHIqOHVFk&s=LP0kSlI4ks9UXXhaWvSTLCiLpQlKKPp_dvNaR1FjDN7s54KEQGsAXP6els9Nekr8XWUYxu-ZqC8qHtk5FiZh74dAPSEpCrIr1pNPa7yZ3fhjKe0fpUigcRLvJkAFsT2db1u8HTBKULQhz3bt2QKtnx9356f_Wgu0a0H5Q6CLeXpKPnBytMQyZD7c8pnxRtabZrxAwalnTPdn48u3DQAvgAPggnHXf-Oet_-mC8bVSBkqkXyA1eyVwtaO7yMMOY_I8eiLTopcEsqPfyUwAof6hcTXkMc6itI-cB50WnwrjKn173vhwFCHm5Ewfunutyx2826CmWnqiR930BPOGpswfA&h=bcMiPQM-ZUGGuT4QNShj4ZUU7bqjKyj6s09FD8BJHIM
-  response:
-    body:
-      string: '{"name":"95988fff-11cc-4e06-8e82-76773f53af45","status":"InProgress","startTime":"2026-02-18T03:26:44.477Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '108'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Feb 2026 03:29:46 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-cache:
-      - CONFIG_NOCACHE
-      x-content-type-options:
-      - nosniff
-      x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f57d2932-2a78-450f-958a-e65997c3253b/eastus2/f667b2ba-28e1-40fc-8e91-fff994dbac9a
-      x-ms-ratelimit-remaining-subscription-global-reads:
-      - '16499'
-      x-msedge-ref:
-      - 'Ref A: D2DC0FE31B6B4585A77D3A4D3EBC3413 Ref B: BL2AA2011006062 Ref C: 2026-02-18T03:29:45Z'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - postgres flexible-server create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
-      User-Agent:
-      - AZURECLI/2.83.0 azsdk-python-core/1.38.0 Python/3.13.10 (Windows-11-10.0.26200-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/95988fff-11cc-4e06-8e82-76773f53af45?api-version=2026-01-01-preview&t=639069820045481199&c=MIIHhzCCBm-gAwIBAgITHgfeaAthBF252mKMUQAAB95oCzANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDYwHhcNMjYwMTE1MTIwMzEzWhcNMjYwNTI0MjI1NzAzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALF5UwB1TCaUQryWnLemNoR1STogfj5BkURewSVKqF6BNmNVe6OPy7h3BMUV8wQPDRcx564kcpxInHjnJ91C2HdWhYtJC9mQ-KfRTHGro-eDtjIDA_m8ZoQaG1t8ZDyGTw3sg-le416DRx--vNLJWTcJ5pPQrNGLHgukyEBEGqcperL--6vkuDR8piARKeWdPub4QGpdJgULAoKm577o9Yeour0AbDe48KV8DaKqEhZAqTR021tTIU5-OVtQTAIuOTVnkBLtraUBYl6qbV603_iHP0-lxSiAdoOKRc9hnw5EIzdh4P3k57bkUUGKXBcEaDzqiXI4zT2s2PpLMdlJGrECAwEAAaOCBHQwggRwMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFghfmRS4WsmTQCAWQCAQcwggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MB0GA1UdDgQWBBQpx7wy64aZi3bga5mYDPjiPc4VjDAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwIwDAYKKwYBBAGCN3sEAjAfBgNVHSMEGDAWgBTxRmjG8cPwKy19i2rhsvm-NfzRQTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAESi3AgZNii4-yX1M8j9s1tnNVejdi-hvwe3tGOyTBjO6vi2tuQDoyQ-t6WDcAY8Suwhm0D6N6beb9niA0Z4KG-xN1jzJx-JF23mcbREASBP-H_Sk80BObD4a0FrOXY0dcNg2oK5FAuM8bwFfqHTRPNqCqL20uzuAyXhTgbwYJ7v6R0YYYv67aIj096-6dGUEKCXLHUtQfPNpvGOCnyvW5-kJ2GJ6ImpJvVnBPvU6JNVR7QMnSEtf7vlMFKguYoC7kAalHyr4UMxGBU6PpqOlJca6U_3ehNgwPuIFln_3JxNqtpyIWd5YpWGPRtAqGYE8y2NyTMrJQcUCkfHIqOHVFk&s=LP0kSlI4ks9UXXhaWvSTLCiLpQlKKPp_dvNaR1FjDN7s54KEQGsAXP6els9Nekr8XWUYxu-ZqC8qHtk5FiZh74dAPSEpCrIr1pNPa7yZ3fhjKe0fpUigcRLvJkAFsT2db1u8HTBKULQhz3bt2QKtnx9356f_Wgu0a0H5Q6CLeXpKPnBytMQyZD7c8pnxRtabZrxAwalnTPdn48u3DQAvgAPggnHXf-Oet_-mC8bVSBkqkXyA1eyVwtaO7yMMOY_I8eiLTopcEsqPfyUwAof6hcTXkMc6itI-cB50WnwrjKn173vhwFCHm5Ewfunutyx2826CmWnqiR930BPOGpswfA&h=bcMiPQM-ZUGGuT4QNShj4ZUU7bqjKyj6s09FD8BJHIM
-  response:
-    body:
-      string: '{"name":"95988fff-11cc-4e06-8e82-76773f53af45","status":"InProgress","startTime":"2026-02-18T03:26:44.477Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '108'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Feb 2026 03:30:46 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-cache:
-      - CONFIG_NOCACHE
-      x-content-type-options:
-      - nosniff
-      x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f57d2932-2a78-450f-958a-e65997c3253b/eastus/f674bdff-9d74-45a9-8540-5a574fb8c84b
-      x-ms-ratelimit-remaining-subscription-global-reads:
-      - '16499'
-      x-msedge-ref:
-      - 'Ref A: 9086E673BCD142D4A9A4A380B6FB1D51 Ref B: BL2AA2011001062 Ref C: 2026-02-18T03:30:46Z'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - postgres flexible-server create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
-      User-Agent:
-      - AZURECLI/2.83.0 azsdk-python-core/1.38.0 Python/3.13.10 (Windows-11-10.0.26200-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/95988fff-11cc-4e06-8e82-76773f53af45?api-version=2026-01-01-preview&t=639069820045481199&c=MIIHhzCCBm-gAwIBAgITHgfeaAthBF252mKMUQAAB95oCzANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDYwHhcNMjYwMTE1MTIwMzEzWhcNMjYwNTI0MjI1NzAzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALF5UwB1TCaUQryWnLemNoR1STogfj5BkURewSVKqF6BNmNVe6OPy7h3BMUV8wQPDRcx564kcpxInHjnJ91C2HdWhYtJC9mQ-KfRTHGro-eDtjIDA_m8ZoQaG1t8ZDyGTw3sg-le416DRx--vNLJWTcJ5pPQrNGLHgukyEBEGqcperL--6vkuDR8piARKeWdPub4QGpdJgULAoKm577o9Yeour0AbDe48KV8DaKqEhZAqTR021tTIU5-OVtQTAIuOTVnkBLtraUBYl6qbV603_iHP0-lxSiAdoOKRc9hnw5EIzdh4P3k57bkUUGKXBcEaDzqiXI4zT2s2PpLMdlJGrECAwEAAaOCBHQwggRwMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFghfmRS4WsmTQCAWQCAQcwggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MB0GA1UdDgQWBBQpx7wy64aZi3bga5mYDPjiPc4VjDAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwIwDAYKKwYBBAGCN3sEAjAfBgNVHSMEGDAWgBTxRmjG8cPwKy19i2rhsvm-NfzRQTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAESi3AgZNii4-yX1M8j9s1tnNVejdi-hvwe3tGOyTBjO6vi2tuQDoyQ-t6WDcAY8Suwhm0D6N6beb9niA0Z4KG-xN1jzJx-JF23mcbREASBP-H_Sk80BObD4a0FrOXY0dcNg2oK5FAuM8bwFfqHTRPNqCqL20uzuAyXhTgbwYJ7v6R0YYYv67aIj096-6dGUEKCXLHUtQfPNpvGOCnyvW5-kJ2GJ6ImpJvVnBPvU6JNVR7QMnSEtf7vlMFKguYoC7kAalHyr4UMxGBU6PpqOlJca6U_3ehNgwPuIFln_3JxNqtpyIWd5YpWGPRtAqGYE8y2NyTMrJQcUCkfHIqOHVFk&s=LP0kSlI4ks9UXXhaWvSTLCiLpQlKKPp_dvNaR1FjDN7s54KEQGsAXP6els9Nekr8XWUYxu-ZqC8qHtk5FiZh74dAPSEpCrIr1pNPa7yZ3fhjKe0fpUigcRLvJkAFsT2db1u8HTBKULQhz3bt2QKtnx9356f_Wgu0a0H5Q6CLeXpKPnBytMQyZD7c8pnxRtabZrxAwalnTPdn48u3DQAvgAPggnHXf-Oet_-mC8bVSBkqkXyA1eyVwtaO7yMMOY_I8eiLTopcEsqPfyUwAof6hcTXkMc6itI-cB50WnwrjKn173vhwFCHm5Ewfunutyx2826CmWnqiR930BPOGpswfA&h=bcMiPQM-ZUGGuT4QNShj4ZUU7bqjKyj6s09FD8BJHIM
-  response:
-    body:
-      string: '{"name":"95988fff-11cc-4e06-8e82-76773f53af45","status":"Succeeded","startTime":"2026-02-18T03:26:44.477Z"}'
+      string: '{"name":"a9b6af9f-8c5f-411b-9087-11a46647c67f","status":"InProgress","startTime":"2026-03-30T14:12:18.98Z"}'
     headers:
       cache-control:
       - no-cache
@@ -525,7 +283,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Feb 2026 03:31:46 GMT
+      - Mon, 30 Mar 2026 14:12:19 GMT
       expires:
       - '-1'
       pragma:
@@ -537,11 +295,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f57d2932-2a78-450f-958a-e65997c3253b/eastus2/c591c0ec-7f28-4832-a274-f3cfce5f83c8
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/811bdabb-3cbb-488c-bbd7-37bfa9576ed4
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 1471C5273EB241E398DA599728CF043A Ref B: BL2AA2011006029 Ref C: 2026-02-18T03:31:46Z'
+      - 'Ref A: 834973342E134441A33B6BD9D88AC7ED Ref B: DUB601080510042 Ref C: 2026-03-30T14:12:19Z'
     status:
       code: 200
       message: OK
@@ -559,22 +317,262 @@ interactions:
       ParameterSetName:
       - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
       User-Agent:
-      - AZURECLI/2.83.0 azsdk-python-core/1.38.0 Python/3.13.10 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/a9b6af9f-8c5f-411b-9087-11a46647c67f?api-version=2026-01-01-preview&t=639104767394137249&c=MIIHlTCCBn2gAwIBAgIRAMrMZgep9-LTubYuD5c1bMgwDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgRVVTMiBDQSAwMTAeFw0yNjAyMjQxMzAxMjBaFw0yNjA4MTkxOTAxMjBaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtc9VqEvVV-f6_yUuDcAswQOf3pY-Y8bo2vLNVJr1CPCcGcMSxZtU9_kSwuHc77o3SYmOurgLtp6WdXT4o-p6NrDTkTl4KV4uY6pssTu-K6TasXs4zEWA4TN1ivwt0dt28Rl9RL-iTYepHyDjf7TsPethzhl3Yea9Bye2ACwkc4mI1PM1dSuDybmebI78BA3xYA6_LqSlF1-Pjk5qFuqHwPEIuiZCm7r8dtCGdMAyv075r86onD9M06bLHeKFbD0PsqtV9xwcaIM1wl6LdKNpYkkmcleFSWjil1F44HliNV85aG4ULUFhSxymugnZDV1k4dLp2b-NFd0ErNAMc8l2DQIDAQABo4IEkjCCBI4wgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQUAs4IkRNNSi2LOcksFd0_oJ9LnTwwHwYDVR0jBBgwFoAU_Ow-26p8H4IeBbihBvlD5wKzCrkwggGyBgNVHR8EggGpMIIBpTBpoGegZYZjaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzg5L2N1cnJlbnQuY3JsMGugaaBnhmVodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NybHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS84OS9jdXJyZW50LmNybDBaoFigVoZUaHR0cDovL2NybC5taWNyb3NvZnQuY29tL2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzg5L2N1cnJlbnQuY3JsMG-gbaBrhmlodHRwOi8vY2NtZWVhc3R1czJwa2kuZWFzdHVzMi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVlYXN0dXMyaWNhMDEvODkvY3VycmVudC5jcmwwggG3BggrBgEFBQcBAQSCAakwggGlMGwGCCsGAQUFBzAChmBodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwbgYIKwYBBQUHMAKGYmh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY2FjZXJ0cy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxL2NlcnQuY2VyMF0GCCsGAQUFBzAChlFodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwZgYIKwYBBQUHMAKGWmh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMTANBgkqhkiG9w0BAQsFAAOCAQEAEKc49KJHc6By0YpRr-FLth5Lupbcfj855fKMIxBRydPRMy2ML_NCOORdCclSMJOOS8fT_jyVfAgWbuOJjQqmoinjcf_Dn5apduFtwmTSWlJ00RLrD0f2x3veqrW9aqy0unjq5PVrwEgPAUXX4ng_iKGUKLjXcJHqB54M8_ZZwND8cZGmd0QuZ1lOsLua3ztb331S21nKgR84tkH51d2vGzWTRlnPbWwuXOJyAiVoPBJ5wQ9oxLFDAUtreJJDinMpHVPA6UOCg4x0k07b02_tycryA5zghFvFX-Vaw7F5Vm0bwz7vrYdS1dl478O8qtnRvMAvaIFNwkeB6HV29ubjUg&s=GYmyM_7hodJoMDy6Vcg3IV4vIMlpM4GMMT7TaH19mj9IyZQtPBvqv4HY4IGXP7KoiezGJ-e1ZnWF8kjBubhZyh4lSqnwxBaStpL8QIcaA92TY9ePxVJgZkF7IH6ZyYPE56ve0-u_6WJ16nG_SRPqFC5xJJdq40iX4Mc_J-AuhHuKyjV3SQgjiwwCqTbOBswn_kS60zzKdN82oEyJrKKePtiRawrpnl7XRvr2b9tkKRsJ0hxyHInHbVOqiLI8iQ8qBChxmTjmmpzzu5G2SrG30wfK2udgWz1ViMxaBtBGHflOj1lEIdwaEGDKTAQ32fqzLJhlekhmvCrxgyTTdT3YAw&h=Rd-91wJdq06ezIal_utYXgyD8ZbyZwDVBwmwnen9giM
+  response:
+    body:
+      string: '{"name":"a9b6af9f-8c5f-411b-9087-11a46647c67f","status":"InProgress","startTime":"2026-03-30T14:12:18.98Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Mar 2026 14:13:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/e09bdc15-288d-4567-8044-6235641a6b95
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 5A8E71C309AF44688246EDB51E556738 Ref B: DUB241062309023 Ref C: 2026-03-30T14:13:20Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - postgres flexible-server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
+      User-Agent:
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/a9b6af9f-8c5f-411b-9087-11a46647c67f?api-version=2026-01-01-preview&t=639104767394137249&c=MIIHlTCCBn2gAwIBAgIRAMrMZgep9-LTubYuD5c1bMgwDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgRVVTMiBDQSAwMTAeFw0yNjAyMjQxMzAxMjBaFw0yNjA4MTkxOTAxMjBaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtc9VqEvVV-f6_yUuDcAswQOf3pY-Y8bo2vLNVJr1CPCcGcMSxZtU9_kSwuHc77o3SYmOurgLtp6WdXT4o-p6NrDTkTl4KV4uY6pssTu-K6TasXs4zEWA4TN1ivwt0dt28Rl9RL-iTYepHyDjf7TsPethzhl3Yea9Bye2ACwkc4mI1PM1dSuDybmebI78BA3xYA6_LqSlF1-Pjk5qFuqHwPEIuiZCm7r8dtCGdMAyv075r86onD9M06bLHeKFbD0PsqtV9xwcaIM1wl6LdKNpYkkmcleFSWjil1F44HliNV85aG4ULUFhSxymugnZDV1k4dLp2b-NFd0ErNAMc8l2DQIDAQABo4IEkjCCBI4wgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQUAs4IkRNNSi2LOcksFd0_oJ9LnTwwHwYDVR0jBBgwFoAU_Ow-26p8H4IeBbihBvlD5wKzCrkwggGyBgNVHR8EggGpMIIBpTBpoGegZYZjaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzg5L2N1cnJlbnQuY3JsMGugaaBnhmVodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NybHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS84OS9jdXJyZW50LmNybDBaoFigVoZUaHR0cDovL2NybC5taWNyb3NvZnQuY29tL2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzg5L2N1cnJlbnQuY3JsMG-gbaBrhmlodHRwOi8vY2NtZWVhc3R1czJwa2kuZWFzdHVzMi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVlYXN0dXMyaWNhMDEvODkvY3VycmVudC5jcmwwggG3BggrBgEFBQcBAQSCAakwggGlMGwGCCsGAQUFBzAChmBodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwbgYIKwYBBQUHMAKGYmh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY2FjZXJ0cy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxL2NlcnQuY2VyMF0GCCsGAQUFBzAChlFodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwZgYIKwYBBQUHMAKGWmh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMTANBgkqhkiG9w0BAQsFAAOCAQEAEKc49KJHc6By0YpRr-FLth5Lupbcfj855fKMIxBRydPRMy2ML_NCOORdCclSMJOOS8fT_jyVfAgWbuOJjQqmoinjcf_Dn5apduFtwmTSWlJ00RLrD0f2x3veqrW9aqy0unjq5PVrwEgPAUXX4ng_iKGUKLjXcJHqB54M8_ZZwND8cZGmd0QuZ1lOsLua3ztb331S21nKgR84tkH51d2vGzWTRlnPbWwuXOJyAiVoPBJ5wQ9oxLFDAUtreJJDinMpHVPA6UOCg4x0k07b02_tycryA5zghFvFX-Vaw7F5Vm0bwz7vrYdS1dl478O8qtnRvMAvaIFNwkeB6HV29ubjUg&s=GYmyM_7hodJoMDy6Vcg3IV4vIMlpM4GMMT7TaH19mj9IyZQtPBvqv4HY4IGXP7KoiezGJ-e1ZnWF8kjBubhZyh4lSqnwxBaStpL8QIcaA92TY9ePxVJgZkF7IH6ZyYPE56ve0-u_6WJ16nG_SRPqFC5xJJdq40iX4Mc_J-AuhHuKyjV3SQgjiwwCqTbOBswn_kS60zzKdN82oEyJrKKePtiRawrpnl7XRvr2b9tkKRsJ0hxyHInHbVOqiLI8iQ8qBChxmTjmmpzzu5G2SrG30wfK2udgWz1ViMxaBtBGHflOj1lEIdwaEGDKTAQ32fqzLJhlekhmvCrxgyTTdT3YAw&h=Rd-91wJdq06ezIal_utYXgyD8ZbyZwDVBwmwnen9giM
+  response:
+    body:
+      string: '{"name":"a9b6af9f-8c5f-411b-9087-11a46647c67f","status":"InProgress","startTime":"2026-03-30T14:12:18.98Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Mar 2026 14:14:20 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/129672e6-ff19-4345-963a-fb9db47650d2
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: DC7821B8AAC64586927D51F70BD76753 Ref B: DUB601080513052 Ref C: 2026-03-30T14:14:20Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - postgres flexible-server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
+      User-Agent:
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/a9b6af9f-8c5f-411b-9087-11a46647c67f?api-version=2026-01-01-preview&t=639104767394137249&c=MIIHlTCCBn2gAwIBAgIRAMrMZgep9-LTubYuD5c1bMgwDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgRVVTMiBDQSAwMTAeFw0yNjAyMjQxMzAxMjBaFw0yNjA4MTkxOTAxMjBaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtc9VqEvVV-f6_yUuDcAswQOf3pY-Y8bo2vLNVJr1CPCcGcMSxZtU9_kSwuHc77o3SYmOurgLtp6WdXT4o-p6NrDTkTl4KV4uY6pssTu-K6TasXs4zEWA4TN1ivwt0dt28Rl9RL-iTYepHyDjf7TsPethzhl3Yea9Bye2ACwkc4mI1PM1dSuDybmebI78BA3xYA6_LqSlF1-Pjk5qFuqHwPEIuiZCm7r8dtCGdMAyv075r86onD9M06bLHeKFbD0PsqtV9xwcaIM1wl6LdKNpYkkmcleFSWjil1F44HliNV85aG4ULUFhSxymugnZDV1k4dLp2b-NFd0ErNAMc8l2DQIDAQABo4IEkjCCBI4wgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQUAs4IkRNNSi2LOcksFd0_oJ9LnTwwHwYDVR0jBBgwFoAU_Ow-26p8H4IeBbihBvlD5wKzCrkwggGyBgNVHR8EggGpMIIBpTBpoGegZYZjaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzg5L2N1cnJlbnQuY3JsMGugaaBnhmVodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NybHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS84OS9jdXJyZW50LmNybDBaoFigVoZUaHR0cDovL2NybC5taWNyb3NvZnQuY29tL2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzg5L2N1cnJlbnQuY3JsMG-gbaBrhmlodHRwOi8vY2NtZWVhc3R1czJwa2kuZWFzdHVzMi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVlYXN0dXMyaWNhMDEvODkvY3VycmVudC5jcmwwggG3BggrBgEFBQcBAQSCAakwggGlMGwGCCsGAQUFBzAChmBodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwbgYIKwYBBQUHMAKGYmh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY2FjZXJ0cy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxL2NlcnQuY2VyMF0GCCsGAQUFBzAChlFodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwZgYIKwYBBQUHMAKGWmh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMTANBgkqhkiG9w0BAQsFAAOCAQEAEKc49KJHc6By0YpRr-FLth5Lupbcfj855fKMIxBRydPRMy2ML_NCOORdCclSMJOOS8fT_jyVfAgWbuOJjQqmoinjcf_Dn5apduFtwmTSWlJ00RLrD0f2x3veqrW9aqy0unjq5PVrwEgPAUXX4ng_iKGUKLjXcJHqB54M8_ZZwND8cZGmd0QuZ1lOsLua3ztb331S21nKgR84tkH51d2vGzWTRlnPbWwuXOJyAiVoPBJ5wQ9oxLFDAUtreJJDinMpHVPA6UOCg4x0k07b02_tycryA5zghFvFX-Vaw7F5Vm0bwz7vrYdS1dl478O8qtnRvMAvaIFNwkeB6HV29ubjUg&s=GYmyM_7hodJoMDy6Vcg3IV4vIMlpM4GMMT7TaH19mj9IyZQtPBvqv4HY4IGXP7KoiezGJ-e1ZnWF8kjBubhZyh4lSqnwxBaStpL8QIcaA92TY9ePxVJgZkF7IH6ZyYPE56ve0-u_6WJ16nG_SRPqFC5xJJdq40iX4Mc_J-AuhHuKyjV3SQgjiwwCqTbOBswn_kS60zzKdN82oEyJrKKePtiRawrpnl7XRvr2b9tkKRsJ0hxyHInHbVOqiLI8iQ8qBChxmTjmmpzzu5G2SrG30wfK2udgWz1ViMxaBtBGHflOj1lEIdwaEGDKTAQ32fqzLJhlekhmvCrxgyTTdT3YAw&h=Rd-91wJdq06ezIal_utYXgyD8ZbyZwDVBwmwnen9giM
+  response:
+    body:
+      string: '{"name":"a9b6af9f-8c5f-411b-9087-11a46647c67f","status":"InProgress","startTime":"2026-03-30T14:12:18.98Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Mar 2026 14:15:21 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/ukwest/1043ad15-a47d-4b04-b3ca-eafc009a527f
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: FD4F07D9F5B34EF9B27E1FB4024EE2DB Ref B: DUB601080511029 Ref C: 2026-03-30T14:15:21Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - postgres flexible-server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
+      User-Agent:
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/a9b6af9f-8c5f-411b-9087-11a46647c67f?api-version=2026-01-01-preview&t=639104767394137249&c=MIIHlTCCBn2gAwIBAgIRAMrMZgep9-LTubYuD5c1bMgwDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgRVVTMiBDQSAwMTAeFw0yNjAyMjQxMzAxMjBaFw0yNjA4MTkxOTAxMjBaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtc9VqEvVV-f6_yUuDcAswQOf3pY-Y8bo2vLNVJr1CPCcGcMSxZtU9_kSwuHc77o3SYmOurgLtp6WdXT4o-p6NrDTkTl4KV4uY6pssTu-K6TasXs4zEWA4TN1ivwt0dt28Rl9RL-iTYepHyDjf7TsPethzhl3Yea9Bye2ACwkc4mI1PM1dSuDybmebI78BA3xYA6_LqSlF1-Pjk5qFuqHwPEIuiZCm7r8dtCGdMAyv075r86onD9M06bLHeKFbD0PsqtV9xwcaIM1wl6LdKNpYkkmcleFSWjil1F44HliNV85aG4ULUFhSxymugnZDV1k4dLp2b-NFd0ErNAMc8l2DQIDAQABo4IEkjCCBI4wgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQUAs4IkRNNSi2LOcksFd0_oJ9LnTwwHwYDVR0jBBgwFoAU_Ow-26p8H4IeBbihBvlD5wKzCrkwggGyBgNVHR8EggGpMIIBpTBpoGegZYZjaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzg5L2N1cnJlbnQuY3JsMGugaaBnhmVodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NybHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS84OS9jdXJyZW50LmNybDBaoFigVoZUaHR0cDovL2NybC5taWNyb3NvZnQuY29tL2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzg5L2N1cnJlbnQuY3JsMG-gbaBrhmlodHRwOi8vY2NtZWVhc3R1czJwa2kuZWFzdHVzMi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVlYXN0dXMyaWNhMDEvODkvY3VycmVudC5jcmwwggG3BggrBgEFBQcBAQSCAakwggGlMGwGCCsGAQUFBzAChmBodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwbgYIKwYBBQUHMAKGYmh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY2FjZXJ0cy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxL2NlcnQuY2VyMF0GCCsGAQUFBzAChlFodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwZgYIKwYBBQUHMAKGWmh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMTANBgkqhkiG9w0BAQsFAAOCAQEAEKc49KJHc6By0YpRr-FLth5Lupbcfj855fKMIxBRydPRMy2ML_NCOORdCclSMJOOS8fT_jyVfAgWbuOJjQqmoinjcf_Dn5apduFtwmTSWlJ00RLrD0f2x3veqrW9aqy0unjq5PVrwEgPAUXX4ng_iKGUKLjXcJHqB54M8_ZZwND8cZGmd0QuZ1lOsLua3ztb331S21nKgR84tkH51d2vGzWTRlnPbWwuXOJyAiVoPBJ5wQ9oxLFDAUtreJJDinMpHVPA6UOCg4x0k07b02_tycryA5zghFvFX-Vaw7F5Vm0bwz7vrYdS1dl478O8qtnRvMAvaIFNwkeB6HV29ubjUg&s=GYmyM_7hodJoMDy6Vcg3IV4vIMlpM4GMMT7TaH19mj9IyZQtPBvqv4HY4IGXP7KoiezGJ-e1ZnWF8kjBubhZyh4lSqnwxBaStpL8QIcaA92TY9ePxVJgZkF7IH6ZyYPE56ve0-u_6WJ16nG_SRPqFC5xJJdq40iX4Mc_J-AuhHuKyjV3SQgjiwwCqTbOBswn_kS60zzKdN82oEyJrKKePtiRawrpnl7XRvr2b9tkKRsJ0hxyHInHbVOqiLI8iQ8qBChxmTjmmpzzu5G2SrG30wfK2udgWz1ViMxaBtBGHflOj1lEIdwaEGDKTAQ32fqzLJhlekhmvCrxgyTTdT3YAw&h=Rd-91wJdq06ezIal_utYXgyD8ZbyZwDVBwmwnen9giM
+  response:
+    body:
+      string: '{"name":"a9b6af9f-8c5f-411b-9087-11a46647c67f","status":"InProgress","startTime":"2026-03-30T14:12:18.98Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Mar 2026 14:16:21 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/ac18b833-d921-4005-8648-b95b9d7580c1
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 79CE9AFD7AD7478F837E8117E4115351 Ref B: AMS231022012045 Ref C: 2026-03-30T14:16:22Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - postgres flexible-server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
+      User-Agent:
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/a9b6af9f-8c5f-411b-9087-11a46647c67f?api-version=2026-01-01-preview&t=639104767394137249&c=MIIHlTCCBn2gAwIBAgIRAMrMZgep9-LTubYuD5c1bMgwDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgRVVTMiBDQSAwMTAeFw0yNjAyMjQxMzAxMjBaFw0yNjA4MTkxOTAxMjBaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtc9VqEvVV-f6_yUuDcAswQOf3pY-Y8bo2vLNVJr1CPCcGcMSxZtU9_kSwuHc77o3SYmOurgLtp6WdXT4o-p6NrDTkTl4KV4uY6pssTu-K6TasXs4zEWA4TN1ivwt0dt28Rl9RL-iTYepHyDjf7TsPethzhl3Yea9Bye2ACwkc4mI1PM1dSuDybmebI78BA3xYA6_LqSlF1-Pjk5qFuqHwPEIuiZCm7r8dtCGdMAyv075r86onD9M06bLHeKFbD0PsqtV9xwcaIM1wl6LdKNpYkkmcleFSWjil1F44HliNV85aG4ULUFhSxymugnZDV1k4dLp2b-NFd0ErNAMc8l2DQIDAQABo4IEkjCCBI4wgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQUAs4IkRNNSi2LOcksFd0_oJ9LnTwwHwYDVR0jBBgwFoAU_Ow-26p8H4IeBbihBvlD5wKzCrkwggGyBgNVHR8EggGpMIIBpTBpoGegZYZjaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzg5L2N1cnJlbnQuY3JsMGugaaBnhmVodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NybHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS84OS9jdXJyZW50LmNybDBaoFigVoZUaHR0cDovL2NybC5taWNyb3NvZnQuY29tL2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzg5L2N1cnJlbnQuY3JsMG-gbaBrhmlodHRwOi8vY2NtZWVhc3R1czJwa2kuZWFzdHVzMi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVlYXN0dXMyaWNhMDEvODkvY3VycmVudC5jcmwwggG3BggrBgEFBQcBAQSCAakwggGlMGwGCCsGAQUFBzAChmBodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwbgYIKwYBBQUHMAKGYmh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY2FjZXJ0cy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxL2NlcnQuY2VyMF0GCCsGAQUFBzAChlFodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwZgYIKwYBBQUHMAKGWmh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMTANBgkqhkiG9w0BAQsFAAOCAQEAEKc49KJHc6By0YpRr-FLth5Lupbcfj855fKMIxBRydPRMy2ML_NCOORdCclSMJOOS8fT_jyVfAgWbuOJjQqmoinjcf_Dn5apduFtwmTSWlJ00RLrD0f2x3veqrW9aqy0unjq5PVrwEgPAUXX4ng_iKGUKLjXcJHqB54M8_ZZwND8cZGmd0QuZ1lOsLua3ztb331S21nKgR84tkH51d2vGzWTRlnPbWwuXOJyAiVoPBJ5wQ9oxLFDAUtreJJDinMpHVPA6UOCg4x0k07b02_tycryA5zghFvFX-Vaw7F5Vm0bwz7vrYdS1dl478O8qtnRvMAvaIFNwkeB6HV29ubjUg&s=GYmyM_7hodJoMDy6Vcg3IV4vIMlpM4GMMT7TaH19mj9IyZQtPBvqv4HY4IGXP7KoiezGJ-e1ZnWF8kjBubhZyh4lSqnwxBaStpL8QIcaA92TY9ePxVJgZkF7IH6ZyYPE56ve0-u_6WJ16nG_SRPqFC5xJJdq40iX4Mc_J-AuhHuKyjV3SQgjiwwCqTbOBswn_kS60zzKdN82oEyJrKKePtiRawrpnl7XRvr2b9tkKRsJ0hxyHInHbVOqiLI8iQ8qBChxmTjmmpzzu5G2SrG30wfK2udgWz1ViMxaBtBGHflOj1lEIdwaEGDKTAQ32fqzLJhlekhmvCrxgyTTdT3YAw&h=Rd-91wJdq06ezIal_utYXgyD8ZbyZwDVBwmwnen9giM
+  response:
+    body:
+      string: '{"name":"a9b6af9f-8c5f-411b-9087-11a46647c67f","status":"Succeeded","startTime":"2026-03-30T14:12:18.98Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '106'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Mar 2026 14:17:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/07e2baa9-249c-4118-837b-5120679d07c6
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: B3E383A695FC43F1BD38E0C6C91DE814 Ref B: AMS231020615025 Ref C: 2026-03-30T14:17:23Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - postgres flexible-server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --sku-name --tier --storage-size --version -l --public-access --yes
+      User-Agent:
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002?api-version=2026-01-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D4ds_v4","tier":"GeneralPurpose"},"systemData":{"createdAt":"2026-02-18T03:26:52.3053395Z"},"properties":{"replica":{"role":"Primary","capacity":5},"storage":{"type":"","iops":500,"tier":"P10","storageSizeGB":128,"autoGrow":"Disabled"},"network":{"publicNetworkAccess":"Disabled"},"privateEndpointConnections":[],"authConfig":{"activeDirectoryAuth":"Disabled","passwordAuth":"Enabled"},"fullyQualifiedDomainName":"azuredbclitest-000002.postgres.database.azure.com","version":"17","minorVersion":"7","administratorLogin":"wornoutlizard2","state":"Ready","availabilityZone":"1","backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"},"maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Primary","replicaCapacity":5},"location":"Canada
+      string: '{"sku":{"name":"Standard_D4ads_v5","tier":"GeneralPurpose"},"systemData":{"createdAt":"2026-03-30T14:12:31.5499334Z"},"properties":{"dataEncryption":{"type":"SystemManaged"},"replica":{"role":"Primary","capacity":6},"storage":{"type":"","iops":500,"tier":"P10","storageSizeGB":128,"autoGrow":"Disabled"},"network":{"publicNetworkAccess":"Disabled"},"privateEndpointConnections":[],"authConfig":{"activeDirectoryAuth":"Disabled","passwordAuth":"Enabled"},"fullyQualifiedDomainName":"azuredbclitest-000002.postgres.database.azure.com","version":"17","minorVersion":"9","administratorLogin":"unlinedparrot3","state":"Ready","availabilityZone":"2","backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"},"maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Primary","replicaCapacity":6},"location":"Canada
         Central","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforPostgreSQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1144'
+      - '1187'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Feb 2026 03:31:46 GMT
+      - Mon, 30 Mar 2026 14:17:23 GMT
       expires:
       - '-1'
       pragma:
@@ -588,7 +586,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 384A0D8E4F1A4C58865F7F8FEDA67F11 Ref B: MNZ221060610017 Ref C: 2026-02-18T03:31:47Z'
+      - 'Ref A: 633EE550A63C4756B829CF3DF9F72002 Ref B: DUB241062309031 Ref C: 2026-03-30T14:17:23Z'
     status:
       code: 200
       message: OK
@@ -606,7 +604,7 @@ interactions:
       ParameterSetName:
       - -g --server-name --name --value
       User-Agent:
-      - AZURECLI/2.83.0 azsdk-python-core/1.38.0 Python/3.13.10 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/configurations/logfiles.download_enable?api-version=2026-01-01-preview
   response:
@@ -621,7 +619,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Feb 2026 03:31:48 GMT
+      - Mon, 30 Mar 2026 14:17:24 GMT
       expires:
       - '-1'
       pragma:
@@ -633,16 +631,16 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f57d2932-2a78-450f-958a-e65997c3253b/canadacentral/8ed88ecf-dcc1-4c86-8f9f-ccdd47c41055
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/c5774dad-4296-417a-a66e-da201260f30a
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: CC67EA82B4DC4B7FB917ADA23666536A Ref B: MNZ221060608035 Ref C: 2026-02-18T03:31:47Z'
+      - 'Ref A: 2BEB3F3E69894248A5C6C1318F386B4B Ref B: AMS231020512033 Ref C: 2026-03-30T14:17:24Z'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"properties": {"source": "user-override", "value": "on"}}'
+    body: '{"properties": {"value": "on", "source": "user-override"}}'
     headers:
       Accept:
       - '*/*'
@@ -659,15 +657,15 @@ interactions:
       ParameterSetName:
       - -g --server-name --name --value
       User-Agent:
-      - AZURECLI/2.83.0 azsdk-python-core/1.38.0 Python/3.13.10 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/configurations/logfiles.download_enable?api-version=2026-01-01-preview
   response:
     body:
-      string: '{"operation":"UpdateOrcasServerParameterManagementOperation","startTime":"2026-02-18T03:31:48.7Z"}'
+      string: '{"operation":"UpdateOrcasServerParameterManagementOperation","startTime":"2026-03-30T14:17:25.1Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/cb4ff2c0-717c-4f7a-834f-f94498f18355?api-version=2026-01-01-preview&t=639069823087419832&c=MIIHhzCCBm-gAwIBAgITHgfeaAthBF252mKMUQAAB95oCzANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDYwHhcNMjYwMTE1MTIwMzEzWhcNMjYwNTI0MjI1NzAzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALF5UwB1TCaUQryWnLemNoR1STogfj5BkURewSVKqF6BNmNVe6OPy7h3BMUV8wQPDRcx564kcpxInHjnJ91C2HdWhYtJC9mQ-KfRTHGro-eDtjIDA_m8ZoQaG1t8ZDyGTw3sg-le416DRx--vNLJWTcJ5pPQrNGLHgukyEBEGqcperL--6vkuDR8piARKeWdPub4QGpdJgULAoKm577o9Yeour0AbDe48KV8DaKqEhZAqTR021tTIU5-OVtQTAIuOTVnkBLtraUBYl6qbV603_iHP0-lxSiAdoOKRc9hnw5EIzdh4P3k57bkUUGKXBcEaDzqiXI4zT2s2PpLMdlJGrECAwEAAaOCBHQwggRwMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFghfmRS4WsmTQCAWQCAQcwggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MB0GA1UdDgQWBBQpx7wy64aZi3bga5mYDPjiPc4VjDAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwIwDAYKKwYBBAGCN3sEAjAfBgNVHSMEGDAWgBTxRmjG8cPwKy19i2rhsvm-NfzRQTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAESi3AgZNii4-yX1M8j9s1tnNVejdi-hvwe3tGOyTBjO6vi2tuQDoyQ-t6WDcAY8Suwhm0D6N6beb9niA0Z4KG-xN1jzJx-JF23mcbREASBP-H_Sk80BObD4a0FrOXY0dcNg2oK5FAuM8bwFfqHTRPNqCqL20uzuAyXhTgbwYJ7v6R0YYYv67aIj096-6dGUEKCXLHUtQfPNpvGOCnyvW5-kJ2GJ6ImpJvVnBPvU6JNVR7QMnSEtf7vlMFKguYoC7kAalHyr4UMxGBU6PpqOlJca6U_3ehNgwPuIFln_3JxNqtpyIWd5YpWGPRtAqGYE8y2NyTMrJQcUCkfHIqOHVFk&s=cIsZ5WDTfacUK7Hk3Cfe8DVC_3B-u-IFeKelN_isyi5Xhh_hlrCL8uC1VqQIGnEFRWPMi425IvDVQ50HLxLBOEbGXLTTPTWEK_y_KC0GocggDHs_hxehMAdjIdGyWWDh1BOYj-EBPeE2yDBtafg5XsGxDfyeY9X9-R6udi0uNF0EcHjBR2hRWpZbdR-faPleDh930KF6Z4MFcSsz78rtDGSIHotNt6J7W85jaHPyXP3RbJlIiEUd90cL3kr_lJFlu-oSjAnoG3dYfI7cJRhTYTBJEfBjqvtcmPH0xfht2NV0JLy6nR-26MJUzRLQgRW9AeakvEt7hZWyA4jlZ_nRuQ&h=1WQhblYKRY9LGuRuSVi2G4cOqk-nJr_Rk-clw-CXhJg
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/e31d58b6-16bb-45a7-88ce-978f1878e88b?api-version=2026-01-01-preview&t=639104770451583147&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=PcTcBRqI22FSk2PXa8CXIU3vBBNIQ7hWUpHhv1kmdJT9-UsV8KLwtUAYkxxIc2_G1w_juXsjoWk9DbWMn5r94VKaxiRdKjtDfSw2CFc4zVCjKTPmmSMIqH9ExtNtHRuNA9squKPxe3b1-ZraoL3j2GU6Bg60qtYIXlfUoQkB4fmnRch-E4w2PBGXYoZTETxH4eu6nm4zyq0LpuiHajH68NZrGP5uyNBi55DaHDYOKUvGZKuKh0g9CzxTHvRyN3ffa8Tyye3fOF5Q3stolYnnhglcflAI_5EcYxIUI-sP8vxu_08PbK2rEP3aJzkraNjarEYtb2wGbmqOEeFd1faZHw&h=fq2lEMCPJCXyZwGeWxNvBny1zKWWZRUz8cCqTv89LZ8
       cache-control:
       - no-cache
       content-length:
@@ -675,11 +673,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Feb 2026 03:31:48 GMT
+      - Mon, 30 Mar 2026 14:17:24 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/operationResults/cb4ff2c0-717c-4f7a-834f-f94498f18355?api-version=2026-01-01-preview&t=639069823087419832&c=MIIHhzCCBm-gAwIBAgITHgfeaAthBF252mKMUQAAB95oCzANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDYwHhcNMjYwMTE1MTIwMzEzWhcNMjYwNTI0MjI1NzAzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALF5UwB1TCaUQryWnLemNoR1STogfj5BkURewSVKqF6BNmNVe6OPy7h3BMUV8wQPDRcx564kcpxInHjnJ91C2HdWhYtJC9mQ-KfRTHGro-eDtjIDA_m8ZoQaG1t8ZDyGTw3sg-le416DRx--vNLJWTcJ5pPQrNGLHgukyEBEGqcperL--6vkuDR8piARKeWdPub4QGpdJgULAoKm577o9Yeour0AbDe48KV8DaKqEhZAqTR021tTIU5-OVtQTAIuOTVnkBLtraUBYl6qbV603_iHP0-lxSiAdoOKRc9hnw5EIzdh4P3k57bkUUGKXBcEaDzqiXI4zT2s2PpLMdlJGrECAwEAAaOCBHQwggRwMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFghfmRS4WsmTQCAWQCAQcwggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MB0GA1UdDgQWBBQpx7wy64aZi3bga5mYDPjiPc4VjDAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwIwDAYKKwYBBAGCN3sEAjAfBgNVHSMEGDAWgBTxRmjG8cPwKy19i2rhsvm-NfzRQTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAESi3AgZNii4-yX1M8j9s1tnNVejdi-hvwe3tGOyTBjO6vi2tuQDoyQ-t6WDcAY8Suwhm0D6N6beb9niA0Z4KG-xN1jzJx-JF23mcbREASBP-H_Sk80BObD4a0FrOXY0dcNg2oK5FAuM8bwFfqHTRPNqCqL20uzuAyXhTgbwYJ7v6R0YYYv67aIj096-6dGUEKCXLHUtQfPNpvGOCnyvW5-kJ2GJ6ImpJvVnBPvU6JNVR7QMnSEtf7vlMFKguYoC7kAalHyr4UMxGBU6PpqOlJca6U_3ehNgwPuIFln_3JxNqtpyIWd5YpWGPRtAqGYE8y2NyTMrJQcUCkfHIqOHVFk&s=hJc1uDDyQnEkYmWzUSr0cfRJjSRFnFVXwnEmMK0LQSpQL1tpVrgk3gxKVmu5s0lYVtE_pcp3OuMVQcwThdyhRG0IK9VHwgnrBDKfiscxQA3pwfH_dghbVUopRbaS3rU8h9whL_NbRx_Xyz8kH1BMJwgbI0kpqZDHIUIHIthDDCBRWAHkMYSRQZVzQ5LGtSl0SkTDHMg7syv3XT5r7hF9dZfJ5O-CPYqXMMzGHEJE04BFAyTfd10VB5d1OqW8LV2Gp9M28KdaCpn76YmBiUO0z4tRRbCWP9KZq9uYSklMY1-NUpHDJ690Gs8nlzDIVEE-wuUMPbgtZYQ2H7v-mb5lpw&h=oF4EJNpnhdb2eLRSop0Dt3Legor55OoaQxNonfEzGwY
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/operationResults/e31d58b6-16bb-45a7-88ce-978f1878e88b?api-version=2026-01-01-preview&t=639104770451583147&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=UOo-4sxZDA9FRndpi-KoiSPXr3G1rp4lG-vGQDfLa_t4D0i_UsuvEQ2HoQiTNRb3dgd3bIjnnaxPzGwWBs8u2Xt6tjY2L4iEJdyW5D8pkQJnddSqVanRnFDQxme4yt2mdCQj5bqBhroBEIWYlrALOd3ofsn4xPlWbQrlq941hOgZUQIdMTNXPhaI0IKdxUnLoe5zgvddz66ZIaN2HbndMiUGK1TAHiJgfxG_MaAFRGZnrBDaaYxsJ4jESr-4JVFy5i49tzUSKDoqS9R0yo0OwaxHE_h9zZ42H8V6-hR5gj--Hcy5KzTaG7ONz17KT5gDHdWIUzgcxD9OPcCQ5segxg&h=Q2KxoYd7UPlYCaYn8uIZENS_Sdrb6_FutmQKMHjnzo0
       pragma:
       - no-cache
       strict-transport-security:
@@ -689,13 +687,13 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f57d2932-2a78-450f-958a-e65997c3253b/canadacentral/10a72db6-1728-405f-af56-1fc8c3dc9f78
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/956f6009-b377-4ff9-bfeb-a27decbc3ead
       x-ms-ratelimit-remaining-subscription-global-writes:
       - '11999'
       x-ms-ratelimit-remaining-subscription-writes:
       - '799'
       x-msedge-ref:
-      - 'Ref A: 67489A9C4873473EBEB4EFC3AFE330E6 Ref B: MNZ221060619031 Ref C: 2026-02-18T03:31:48Z'
+      - 'Ref A: CF5E45F4638340A78CE87F18F9527269 Ref B: AMS231032608031 Ref C: 2026-03-30T14:17:24Z'
     status:
       code: 202
       message: Accepted
@@ -713,12 +711,12 @@ interactions:
       ParameterSetName:
       - -g --server-name --name --value
       User-Agent:
-      - AZURECLI/2.83.0 azsdk-python-core/1.38.0 Python/3.13.10 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/cb4ff2c0-717c-4f7a-834f-f94498f18355?api-version=2026-01-01-preview&t=639069823087419832&c=MIIHhzCCBm-gAwIBAgITHgfeaAthBF252mKMUQAAB95oCzANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDYwHhcNMjYwMTE1MTIwMzEzWhcNMjYwNTI0MjI1NzAzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALF5UwB1TCaUQryWnLemNoR1STogfj5BkURewSVKqF6BNmNVe6OPy7h3BMUV8wQPDRcx564kcpxInHjnJ91C2HdWhYtJC9mQ-KfRTHGro-eDtjIDA_m8ZoQaG1t8ZDyGTw3sg-le416DRx--vNLJWTcJ5pPQrNGLHgukyEBEGqcperL--6vkuDR8piARKeWdPub4QGpdJgULAoKm577o9Yeour0AbDe48KV8DaKqEhZAqTR021tTIU5-OVtQTAIuOTVnkBLtraUBYl6qbV603_iHP0-lxSiAdoOKRc9hnw5EIzdh4P3k57bkUUGKXBcEaDzqiXI4zT2s2PpLMdlJGrECAwEAAaOCBHQwggRwMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFghfmRS4WsmTQCAWQCAQcwggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MB0GA1UdDgQWBBQpx7wy64aZi3bga5mYDPjiPc4VjDAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwIwDAYKKwYBBAGCN3sEAjAfBgNVHSMEGDAWgBTxRmjG8cPwKy19i2rhsvm-NfzRQTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAESi3AgZNii4-yX1M8j9s1tnNVejdi-hvwe3tGOyTBjO6vi2tuQDoyQ-t6WDcAY8Suwhm0D6N6beb9niA0Z4KG-xN1jzJx-JF23mcbREASBP-H_Sk80BObD4a0FrOXY0dcNg2oK5FAuM8bwFfqHTRPNqCqL20uzuAyXhTgbwYJ7v6R0YYYv67aIj096-6dGUEKCXLHUtQfPNpvGOCnyvW5-kJ2GJ6ImpJvVnBPvU6JNVR7QMnSEtf7vlMFKguYoC7kAalHyr4UMxGBU6PpqOlJca6U_3ehNgwPuIFln_3JxNqtpyIWd5YpWGPRtAqGYE8y2NyTMrJQcUCkfHIqOHVFk&s=cIsZ5WDTfacUK7Hk3Cfe8DVC_3B-u-IFeKelN_isyi5Xhh_hlrCL8uC1VqQIGnEFRWPMi425IvDVQ50HLxLBOEbGXLTTPTWEK_y_KC0GocggDHs_hxehMAdjIdGyWWDh1BOYj-EBPeE2yDBtafg5XsGxDfyeY9X9-R6udi0uNF0EcHjBR2hRWpZbdR-faPleDh930KF6Z4MFcSsz78rtDGSIHotNt6J7W85jaHPyXP3RbJlIiEUd90cL3kr_lJFlu-oSjAnoG3dYfI7cJRhTYTBJEfBjqvtcmPH0xfht2NV0JLy6nR-26MJUzRLQgRW9AeakvEt7hZWyA4jlZ_nRuQ&h=1WQhblYKRY9LGuRuSVi2G4cOqk-nJr_Rk-clw-CXhJg
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/e31d58b6-16bb-45a7-88ce-978f1878e88b?api-version=2026-01-01-preview&t=639104770451583147&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=PcTcBRqI22FSk2PXa8CXIU3vBBNIQ7hWUpHhv1kmdJT9-UsV8KLwtUAYkxxIc2_G1w_juXsjoWk9DbWMn5r94VKaxiRdKjtDfSw2CFc4zVCjKTPmmSMIqH9ExtNtHRuNA9squKPxe3b1-ZraoL3j2GU6Bg60qtYIXlfUoQkB4fmnRch-E4w2PBGXYoZTETxH4eu6nm4zyq0LpuiHajH68NZrGP5uyNBi55DaHDYOKUvGZKuKh0g9CzxTHvRyN3ffa8Tyye3fOF5Q3stolYnnhglcflAI_5EcYxIUI-sP8vxu_08PbK2rEP3aJzkraNjarEYtb2wGbmqOEeFd1faZHw&h=fq2lEMCPJCXyZwGeWxNvBny1zKWWZRUz8cCqTv89LZ8
   response:
     body:
-      string: '{"name":"cb4ff2c0-717c-4f7a-834f-f94498f18355","status":"InProgress","startTime":"2026-02-18T03:31:48.7Z"}'
+      string: '{"name":"e31d58b6-16bb-45a7-88ce-978f1878e88b","status":"InProgress","startTime":"2026-03-30T14:17:25.1Z"}'
     headers:
       cache-control:
       - no-cache
@@ -727,7 +725,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Feb 2026 03:31:48 GMT
+      - Mon, 30 Mar 2026 14:17:25 GMT
       expires:
       - '-1'
       pragma:
@@ -739,11 +737,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f57d2932-2a78-450f-958a-e65997c3253b/eastus2/5517e6c2-0d8d-4c2a-b8ca-e9ce307d4e48
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/ukwest/60a9ae8b-5dae-461a-b210-fee74e2493ec
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 4A84978920464CF1A603C941ABD048C4 Ref B: MNZ221060619035 Ref C: 2026-02-18T03:31:48Z'
+      - 'Ref A: 7D737CF9E29D41D78F738E0DE1583199 Ref B: AMS231032607009 Ref C: 2026-03-30T14:17:25Z'
     status:
       code: 200
       message: OK
@@ -761,108 +759,12 @@ interactions:
       ParameterSetName:
       - -g --server-name --name --value
       User-Agent:
-      - AZURECLI/2.83.0 azsdk-python-core/1.38.0 Python/3.13.10 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/cb4ff2c0-717c-4f7a-834f-f94498f18355?api-version=2026-01-01-preview&t=639069823087419832&c=MIIHhzCCBm-gAwIBAgITHgfeaAthBF252mKMUQAAB95oCzANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDYwHhcNMjYwMTE1MTIwMzEzWhcNMjYwNTI0MjI1NzAzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALF5UwB1TCaUQryWnLemNoR1STogfj5BkURewSVKqF6BNmNVe6OPy7h3BMUV8wQPDRcx564kcpxInHjnJ91C2HdWhYtJC9mQ-KfRTHGro-eDtjIDA_m8ZoQaG1t8ZDyGTw3sg-le416DRx--vNLJWTcJ5pPQrNGLHgukyEBEGqcperL--6vkuDR8piARKeWdPub4QGpdJgULAoKm577o9Yeour0AbDe48KV8DaKqEhZAqTR021tTIU5-OVtQTAIuOTVnkBLtraUBYl6qbV603_iHP0-lxSiAdoOKRc9hnw5EIzdh4P3k57bkUUGKXBcEaDzqiXI4zT2s2PpLMdlJGrECAwEAAaOCBHQwggRwMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFghfmRS4WsmTQCAWQCAQcwggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MB0GA1UdDgQWBBQpx7wy64aZi3bga5mYDPjiPc4VjDAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwIwDAYKKwYBBAGCN3sEAjAfBgNVHSMEGDAWgBTxRmjG8cPwKy19i2rhsvm-NfzRQTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAESi3AgZNii4-yX1M8j9s1tnNVejdi-hvwe3tGOyTBjO6vi2tuQDoyQ-t6WDcAY8Suwhm0D6N6beb9niA0Z4KG-xN1jzJx-JF23mcbREASBP-H_Sk80BObD4a0FrOXY0dcNg2oK5FAuM8bwFfqHTRPNqCqL20uzuAyXhTgbwYJ7v6R0YYYv67aIj096-6dGUEKCXLHUtQfPNpvGOCnyvW5-kJ2GJ6ImpJvVnBPvU6JNVR7QMnSEtf7vlMFKguYoC7kAalHyr4UMxGBU6PpqOlJca6U_3ehNgwPuIFln_3JxNqtpyIWd5YpWGPRtAqGYE8y2NyTMrJQcUCkfHIqOHVFk&s=cIsZ5WDTfacUK7Hk3Cfe8DVC_3B-u-IFeKelN_isyi5Xhh_hlrCL8uC1VqQIGnEFRWPMi425IvDVQ50HLxLBOEbGXLTTPTWEK_y_KC0GocggDHs_hxehMAdjIdGyWWDh1BOYj-EBPeE2yDBtafg5XsGxDfyeY9X9-R6udi0uNF0EcHjBR2hRWpZbdR-faPleDh930KF6Z4MFcSsz78rtDGSIHotNt6J7W85jaHPyXP3RbJlIiEUd90cL3kr_lJFlu-oSjAnoG3dYfI7cJRhTYTBJEfBjqvtcmPH0xfht2NV0JLy6nR-26MJUzRLQgRW9AeakvEt7hZWyA4jlZ_nRuQ&h=1WQhblYKRY9LGuRuSVi2G4cOqk-nJr_Rk-clw-CXhJg
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/e31d58b6-16bb-45a7-88ce-978f1878e88b?api-version=2026-01-01-preview&t=639104770451583147&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=PcTcBRqI22FSk2PXa8CXIU3vBBNIQ7hWUpHhv1kmdJT9-UsV8KLwtUAYkxxIc2_G1w_juXsjoWk9DbWMn5r94VKaxiRdKjtDfSw2CFc4zVCjKTPmmSMIqH9ExtNtHRuNA9squKPxe3b1-ZraoL3j2GU6Bg60qtYIXlfUoQkB4fmnRch-E4w2PBGXYoZTETxH4eu6nm4zyq0LpuiHajH68NZrGP5uyNBi55DaHDYOKUvGZKuKh0g9CzxTHvRyN3ffa8Tyye3fOF5Q3stolYnnhglcflAI_5EcYxIUI-sP8vxu_08PbK2rEP3aJzkraNjarEYtb2wGbmqOEeFd1faZHw&h=fq2lEMCPJCXyZwGeWxNvBny1zKWWZRUz8cCqTv89LZ8
   response:
     body:
-      string: '{"name":"cb4ff2c0-717c-4f7a-834f-f94498f18355","status":"InProgress","startTime":"2026-02-18T03:31:48.7Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '106'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Feb 2026 03:31:59 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-cache:
-      - CONFIG_NOCACHE
-      x-content-type-options:
-      - nosniff
-      x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f57d2932-2a78-450f-958a-e65997c3253b/eastus/e6a636b9-c85e-4a8c-8d77-6dcd377f4c2f
-      x-ms-ratelimit-remaining-subscription-global-reads:
-      - '16499'
-      x-msedge-ref:
-      - 'Ref A: B37C3074D37E48BA818C99E2AD249C44 Ref B: MNZ221060610029 Ref C: 2026-02-18T03:31:59Z'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - postgres flexible-server parameter set
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --server-name --name --value
-      User-Agent:
-      - AZURECLI/2.83.0 azsdk-python-core/1.38.0 Python/3.13.10 (Windows-11-10.0.26200-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/cb4ff2c0-717c-4f7a-834f-f94498f18355?api-version=2026-01-01-preview&t=639069823087419832&c=MIIHhzCCBm-gAwIBAgITHgfeaAthBF252mKMUQAAB95oCzANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDYwHhcNMjYwMTE1MTIwMzEzWhcNMjYwNTI0MjI1NzAzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALF5UwB1TCaUQryWnLemNoR1STogfj5BkURewSVKqF6BNmNVe6OPy7h3BMUV8wQPDRcx564kcpxInHjnJ91C2HdWhYtJC9mQ-KfRTHGro-eDtjIDA_m8ZoQaG1t8ZDyGTw3sg-le416DRx--vNLJWTcJ5pPQrNGLHgukyEBEGqcperL--6vkuDR8piARKeWdPub4QGpdJgULAoKm577o9Yeour0AbDe48KV8DaKqEhZAqTR021tTIU5-OVtQTAIuOTVnkBLtraUBYl6qbV603_iHP0-lxSiAdoOKRc9hnw5EIzdh4P3k57bkUUGKXBcEaDzqiXI4zT2s2PpLMdlJGrECAwEAAaOCBHQwggRwMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFghfmRS4WsmTQCAWQCAQcwggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MB0GA1UdDgQWBBQpx7wy64aZi3bga5mYDPjiPc4VjDAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwIwDAYKKwYBBAGCN3sEAjAfBgNVHSMEGDAWgBTxRmjG8cPwKy19i2rhsvm-NfzRQTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAESi3AgZNii4-yX1M8j9s1tnNVejdi-hvwe3tGOyTBjO6vi2tuQDoyQ-t6WDcAY8Suwhm0D6N6beb9niA0Z4KG-xN1jzJx-JF23mcbREASBP-H_Sk80BObD4a0FrOXY0dcNg2oK5FAuM8bwFfqHTRPNqCqL20uzuAyXhTgbwYJ7v6R0YYYv67aIj096-6dGUEKCXLHUtQfPNpvGOCnyvW5-kJ2GJ6ImpJvVnBPvU6JNVR7QMnSEtf7vlMFKguYoC7kAalHyr4UMxGBU6PpqOlJca6U_3ehNgwPuIFln_3JxNqtpyIWd5YpWGPRtAqGYE8y2NyTMrJQcUCkfHIqOHVFk&s=cIsZ5WDTfacUK7Hk3Cfe8DVC_3B-u-IFeKelN_isyi5Xhh_hlrCL8uC1VqQIGnEFRWPMi425IvDVQ50HLxLBOEbGXLTTPTWEK_y_KC0GocggDHs_hxehMAdjIdGyWWDh1BOYj-EBPeE2yDBtafg5XsGxDfyeY9X9-R6udi0uNF0EcHjBR2hRWpZbdR-faPleDh930KF6Z4MFcSsz78rtDGSIHotNt6J7W85jaHPyXP3RbJlIiEUd90cL3kr_lJFlu-oSjAnoG3dYfI7cJRhTYTBJEfBjqvtcmPH0xfht2NV0JLy6nR-26MJUzRLQgRW9AeakvEt7hZWyA4jlZ_nRuQ&h=1WQhblYKRY9LGuRuSVi2G4cOqk-nJr_Rk-clw-CXhJg
-  response:
-    body:
-      string: '{"name":"cb4ff2c0-717c-4f7a-834f-f94498f18355","status":"InProgress","startTime":"2026-02-18T03:31:48.7Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '106'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Feb 2026 03:32:09 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-cache:
-      - CONFIG_NOCACHE
-      x-content-type-options:
-      - nosniff
-      x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f57d2932-2a78-450f-958a-e65997c3253b/eastus/91916b20-7159-4fee-9d21-7f9fd75d9adb
-      x-ms-ratelimit-remaining-subscription-global-reads:
-      - '16499'
-      x-msedge-ref:
-      - 'Ref A: 44F2A9DBFB094856AD7CC7080607E622 Ref B: MNZ221060618053 Ref C: 2026-02-18T03:32:09Z'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - postgres flexible-server parameter set
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --server-name --name --value
-      User-Agent:
-      - AZURECLI/2.83.0 azsdk-python-core/1.38.0 Python/3.13.10 (Windows-11-10.0.26200-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/cb4ff2c0-717c-4f7a-834f-f94498f18355?api-version=2026-01-01-preview&t=639069823087419832&c=MIIHhzCCBm-gAwIBAgITHgfeaAthBF252mKMUQAAB95oCzANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDYwHhcNMjYwMTE1MTIwMzEzWhcNMjYwNTI0MjI1NzAzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALF5UwB1TCaUQryWnLemNoR1STogfj5BkURewSVKqF6BNmNVe6OPy7h3BMUV8wQPDRcx564kcpxInHjnJ91C2HdWhYtJC9mQ-KfRTHGro-eDtjIDA_m8ZoQaG1t8ZDyGTw3sg-le416DRx--vNLJWTcJ5pPQrNGLHgukyEBEGqcperL--6vkuDR8piARKeWdPub4QGpdJgULAoKm577o9Yeour0AbDe48KV8DaKqEhZAqTR021tTIU5-OVtQTAIuOTVnkBLtraUBYl6qbV603_iHP0-lxSiAdoOKRc9hnw5EIzdh4P3k57bkUUGKXBcEaDzqiXI4zT2s2PpLMdlJGrECAwEAAaOCBHQwggRwMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFghfmRS4WsmTQCAWQCAQcwggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MB0GA1UdDgQWBBQpx7wy64aZi3bga5mYDPjiPc4VjDAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwIwDAYKKwYBBAGCN3sEAjAfBgNVHSMEGDAWgBTxRmjG8cPwKy19i2rhsvm-NfzRQTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAESi3AgZNii4-yX1M8j9s1tnNVejdi-hvwe3tGOyTBjO6vi2tuQDoyQ-t6WDcAY8Suwhm0D6N6beb9niA0Z4KG-xN1jzJx-JF23mcbREASBP-H_Sk80BObD4a0FrOXY0dcNg2oK5FAuM8bwFfqHTRPNqCqL20uzuAyXhTgbwYJ7v6R0YYYv67aIj096-6dGUEKCXLHUtQfPNpvGOCnyvW5-kJ2GJ6ImpJvVnBPvU6JNVR7QMnSEtf7vlMFKguYoC7kAalHyr4UMxGBU6PpqOlJca6U_3ehNgwPuIFln_3JxNqtpyIWd5YpWGPRtAqGYE8y2NyTMrJQcUCkfHIqOHVFk&s=cIsZ5WDTfacUK7Hk3Cfe8DVC_3B-u-IFeKelN_isyi5Xhh_hlrCL8uC1VqQIGnEFRWPMi425IvDVQ50HLxLBOEbGXLTTPTWEK_y_KC0GocggDHs_hxehMAdjIdGyWWDh1BOYj-EBPeE2yDBtafg5XsGxDfyeY9X9-R6udi0uNF0EcHjBR2hRWpZbdR-faPleDh930KF6Z4MFcSsz78rtDGSIHotNt6J7W85jaHPyXP3RbJlIiEUd90cL3kr_lJFlu-oSjAnoG3dYfI7cJRhTYTBJEfBjqvtcmPH0xfht2NV0JLy6nR-26MJUzRLQgRW9AeakvEt7hZWyA4jlZ_nRuQ&h=1WQhblYKRY9LGuRuSVi2G4cOqk-nJr_Rk-clw-CXhJg
-  response:
-    body:
-      string: '{"name":"cb4ff2c0-717c-4f7a-834f-f94498f18355","status":"Succeeded","startTime":"2026-02-18T03:31:48.7Z"}'
+      string: '{"name":"e31d58b6-16bb-45a7-88ce-978f1878e88b","status":"Succeeded","startTime":"2026-03-30T14:17:25.1Z"}'
     headers:
       cache-control:
       - no-cache
@@ -871,7 +773,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Feb 2026 03:32:20 GMT
+      - Mon, 30 Mar 2026 14:17:35 GMT
       expires:
       - '-1'
       pragma:
@@ -883,11 +785,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f57d2932-2a78-450f-958a-e65997c3253b/eastus2/a72c6516-78e4-4c7a-aaef-d84582f828b3
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/4a6512f1-2fd1-4abb-98a9-243634b36603
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 3E5E05F87A3A44E3B97EB963366277A1 Ref B: MNZ221060619037 Ref C: 2026-02-18T03:32:20Z'
+      - 'Ref A: 853CF8B374A244278E19E7B7FD6A42E4 Ref B: AMS231022012023 Ref C: 2026-03-30T14:17:36Z'
     status:
       code: 200
       message: OK
@@ -905,7 +807,7 @@ interactions:
       ParameterSetName:
       - -g --server-name --name --value
       User-Agent:
-      - AZURECLI/2.83.0 azsdk-python-core/1.38.0 Python/3.13.10 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/configurations/logfiles.download_enable?api-version=2026-01-01-preview
   response:
@@ -920,7 +822,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Feb 2026 03:32:20 GMT
+      - Mon, 30 Mar 2026 14:17:37 GMT
       expires:
       - '-1'
       pragma:
@@ -932,11 +834,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f57d2932-2a78-450f-958a-e65997c3253b/canadacentral/059176ef-4d38-43af-984a-c783abb8dd16
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/ukwest/9faaf9a4-327c-49ef-9085-ea8bf593294b
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 78FC10D6C2EC4A23A0491AA66BB580C9 Ref B: MNZ221060618047 Ref C: 2026-02-18T03:32:20Z'
+      - 'Ref A: B0954060381A4638B7559EAF629827ED Ref B: AMS231022012053 Ref C: 2026-03-30T14:17:36Z'
     status:
       code: 200
       message: OK
@@ -954,7 +856,7 @@ interactions:
       ParameterSetName:
       - -g --server-name --name --value
       User-Agent:
-      - AZURECLI/2.83.0 azsdk-python-core/1.38.0 Python/3.13.10 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/configurations/logfiles.retention_days?api-version=2026-01-01-preview
   response:
@@ -969,7 +871,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Feb 2026 03:32:21 GMT
+      - Mon, 30 Mar 2026 14:17:37 GMT
       expires:
       - '-1'
       pragma:
@@ -981,16 +883,16 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f57d2932-2a78-450f-958a-e65997c3253b/canadacentral/a70c9de9-b2c4-4c6d-aa36-e0fe4e652672
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/80834962-0a1c-4da4-b9f9-e114c10a5e71
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: EBCACB05350C4F1CA9AB60B83699BDB8 Ref B: BL2AA2011005031 Ref C: 2026-02-18T03:32:21Z'
+      - 'Ref A: B4B624F4AB374C709D75CCA7E0B6EFF6 Ref B: DUB601080513036 Ref C: 2026-03-30T14:17:37Z'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"properties": {"source": "user-override", "value": "1"}}'
+    body: '{"properties": {"value": "1", "source": "user-override"}}'
     headers:
       Accept:
       - '*/*'
@@ -1007,15 +909,15 @@ interactions:
       ParameterSetName:
       - -g --server-name --name --value
       User-Agent:
-      - AZURECLI/2.83.0 azsdk-python-core/1.38.0 Python/3.13.10 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/configurations/logfiles.retention_days?api-version=2026-01-01-preview
   response:
     body:
-      string: '{"operation":"UpdateOrcasServerParameterManagementOperation","startTime":"2026-02-18T03:32:22.123Z"}'
+      string: '{"operation":"UpdateOrcasServerParameterManagementOperation","startTime":"2026-03-30T14:17:38.813Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/343a5907-da5b-4beb-8d11-f0f5dafd1c9e?api-version=2026-01-01-preview&t=639069823421642562&c=MIIHhzCCBm-gAwIBAgITHgfeaAthBF252mKMUQAAB95oCzANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDYwHhcNMjYwMTE1MTIwMzEzWhcNMjYwNTI0MjI1NzAzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALF5UwB1TCaUQryWnLemNoR1STogfj5BkURewSVKqF6BNmNVe6OPy7h3BMUV8wQPDRcx564kcpxInHjnJ91C2HdWhYtJC9mQ-KfRTHGro-eDtjIDA_m8ZoQaG1t8ZDyGTw3sg-le416DRx--vNLJWTcJ5pPQrNGLHgukyEBEGqcperL--6vkuDR8piARKeWdPub4QGpdJgULAoKm577o9Yeour0AbDe48KV8DaKqEhZAqTR021tTIU5-OVtQTAIuOTVnkBLtraUBYl6qbV603_iHP0-lxSiAdoOKRc9hnw5EIzdh4P3k57bkUUGKXBcEaDzqiXI4zT2s2PpLMdlJGrECAwEAAaOCBHQwggRwMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFghfmRS4WsmTQCAWQCAQcwggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MB0GA1UdDgQWBBQpx7wy64aZi3bga5mYDPjiPc4VjDAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwIwDAYKKwYBBAGCN3sEAjAfBgNVHSMEGDAWgBTxRmjG8cPwKy19i2rhsvm-NfzRQTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAESi3AgZNii4-yX1M8j9s1tnNVejdi-hvwe3tGOyTBjO6vi2tuQDoyQ-t6WDcAY8Suwhm0D6N6beb9niA0Z4KG-xN1jzJx-JF23mcbREASBP-H_Sk80BObD4a0FrOXY0dcNg2oK5FAuM8bwFfqHTRPNqCqL20uzuAyXhTgbwYJ7v6R0YYYv67aIj096-6dGUEKCXLHUtQfPNpvGOCnyvW5-kJ2GJ6ImpJvVnBPvU6JNVR7QMnSEtf7vlMFKguYoC7kAalHyr4UMxGBU6PpqOlJca6U_3ehNgwPuIFln_3JxNqtpyIWd5YpWGPRtAqGYE8y2NyTMrJQcUCkfHIqOHVFk&s=F9ZavMKcStm3ybFrJdIvfMq5AxCLDYXUkJ1MXKD1yy8QRSmPe1ZCBHFjEdowH-C_Bm_hKL1JENUT42s36kQDaU7uRCYi2lMz4mG8nXLyUPyAh-B1CxWJSfFbgrz6VdbGPd4r-Kd_dC83w0VRCX7w7ct58_WAj6QWGPxHp5yRQS_5c2Zjs_aashdEbwWicAG88oAlR35MGYnSHABHlbw8rX9zt7NY5sBi-1SvM5JmJSM3UibKmYFXBf4XFLO3xOWRliO9XWgQhfMO2qlqcMFh9ABBFio3v2DRtZWFD2TBVpdelChnCzoN8B7NWvX8gKE_90OmR7MlHtMFjm7aeQfnvw&h=mziZtLqkhWM8mKEXfns5ll-TwrQT9iQEm1q4mfz_MbI
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/01b8a738-bb8f-4598-bad3-6ccf23e110ba?api-version=2026-01-01-preview&t=639104770588437955&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=fE8CuxnP9NbZdLcTtPTjAOjsU3TVnM811Ss28BfGzVCQXHMVliRGUgUp9Wwwx_OVoZZ9IXMToVP-ycjH2e-P_K0l6JBXjTjNZCbjLw7dUElB2nLDFspc0O-Hm1Sga8K74sV1XsRB-5YURZ7nD_kc55bdKd-m9gZ68bHwqkwpsg7VoCxd5xudKHI8SnkmS_zrhR8nCeKaKCe4hLN3goqICsvaUw7okl4JaojNCj-RXIdjyYT3-tiAhRpqmI1k4jcM9r8DqBl76SIGmSjcaylU5R1Zt2O8V5a-C9Ojx7ipYmmpCTY5xDerE1wHLMx0oSVquN5ODxgSp9mgGMs5d67Fiw&h=A0ja3b_WJ4WaP6-M20aDszVVAfnx61vm1doAoNK0_gU
       cache-control:
       - no-cache
       content-length:
@@ -1023,11 +925,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Feb 2026 03:32:21 GMT
+      - Mon, 30 Mar 2026 14:17:38 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/operationResults/343a5907-da5b-4beb-8d11-f0f5dafd1c9e?api-version=2026-01-01-preview&t=639069823421642562&c=MIIHhzCCBm-gAwIBAgITHgfeaAthBF252mKMUQAAB95oCzANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDYwHhcNMjYwMTE1MTIwMzEzWhcNMjYwNTI0MjI1NzAzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALF5UwB1TCaUQryWnLemNoR1STogfj5BkURewSVKqF6BNmNVe6OPy7h3BMUV8wQPDRcx564kcpxInHjnJ91C2HdWhYtJC9mQ-KfRTHGro-eDtjIDA_m8ZoQaG1t8ZDyGTw3sg-le416DRx--vNLJWTcJ5pPQrNGLHgukyEBEGqcperL--6vkuDR8piARKeWdPub4QGpdJgULAoKm577o9Yeour0AbDe48KV8DaKqEhZAqTR021tTIU5-OVtQTAIuOTVnkBLtraUBYl6qbV603_iHP0-lxSiAdoOKRc9hnw5EIzdh4P3k57bkUUGKXBcEaDzqiXI4zT2s2PpLMdlJGrECAwEAAaOCBHQwggRwMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFghfmRS4WsmTQCAWQCAQcwggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MB0GA1UdDgQWBBQpx7wy64aZi3bga5mYDPjiPc4VjDAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwIwDAYKKwYBBAGCN3sEAjAfBgNVHSMEGDAWgBTxRmjG8cPwKy19i2rhsvm-NfzRQTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAESi3AgZNii4-yX1M8j9s1tnNVejdi-hvwe3tGOyTBjO6vi2tuQDoyQ-t6WDcAY8Suwhm0D6N6beb9niA0Z4KG-xN1jzJx-JF23mcbREASBP-H_Sk80BObD4a0FrOXY0dcNg2oK5FAuM8bwFfqHTRPNqCqL20uzuAyXhTgbwYJ7v6R0YYYv67aIj096-6dGUEKCXLHUtQfPNpvGOCnyvW5-kJ2GJ6ImpJvVnBPvU6JNVR7QMnSEtf7vlMFKguYoC7kAalHyr4UMxGBU6PpqOlJca6U_3ehNgwPuIFln_3JxNqtpyIWd5YpWGPRtAqGYE8y2NyTMrJQcUCkfHIqOHVFk&s=KjjpSvNZdv9E8LF3tRKqy5QOsSpE6XIKWxs2ZeuYtU3X_Hb4Yrxi70eWkhRkAnCvbGCPI8AttC8A0uFofUzWYvoJIRQGcZXFO1y-OldRZ_apsLwWvb9wAvWhfW_ql1zuRlMMt2mynYcXcfdTRg2i-8sGJb34J5Oglw-Rz0R6feplhgRQevAaVs__0-S2mVCi5QeAfUxQDq89qOBfD0_Kzs3levp-hNG9SN2-DEIgBs-Mk6jF0UWRJfDIvuFySZ9FQU41aAYbaE0F_fVDm-H2yWsBeShaAhsHkEag409q8NvcGVm31MpMpD_KEElHz2a_JimcfaPS8BV9n2aMogrjqw&h=WABH_BHdqBIhYURb2AJpcQ1mFeov125a1tyR-_O07a0
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/operationResults/01b8a738-bb8f-4598-bad3-6ccf23e110ba?api-version=2026-01-01-preview&t=639104770588594200&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=oS3CNKL8Dd1iNmJ1yffgCXnhIsHjf5RA6GD3uQFt8xhDYMiLiZfv301fHn4iqXmVocvHoRkIXBw9E6Sf-YID1j4sDNXr1oWhaP5qliIXMysvO9egpKas0R-Hd0Bbjxmc0WPS-s6C9UVKnBNn0VBldP6wNy2NmZFU37IVsnOGLnGjgQ77iZQGKlM7VaL5SFPLo7AHq0QYLpXSSu2F8kQ_aFze9fcf4J2ZA0sZ29ZUSgZbQhBpmKP3gzRNJ-lXeD-2DIfgaJekClkPzJBuO9GPsWy5fvWiT3EdCMaoDvdY3k20ROq3lwBIeVHk7uU5sRKSqvU8X7G2d50na25kOCjekg&h=B-vtp0_7MI4UdMRs6UUygjto-kwltGn-jvCpxnQZ8xQ
       pragma:
       - no-cache
       strict-transport-security:
@@ -1037,13 +939,13 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f57d2932-2a78-450f-958a-e65997c3253b/canadacentral/0cfe22ae-cc9a-4477-ab7a-bea20babe84b
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/3a1e2ece-849f-4688-97a6-086f3a0f41b6
       x-ms-ratelimit-remaining-subscription-global-writes:
       - '11999'
       x-ms-ratelimit-remaining-subscription-writes:
       - '799'
       x-msedge-ref:
-      - 'Ref A: AF394289FABA4A2195B08ED44DE4E0CE Ref B: BL2AA2011005054 Ref C: 2026-02-18T03:32:21Z'
+      - 'Ref A: 48D45DC5C2734F97940717ED85CE6BEA Ref B: DUB601080513023 Ref C: 2026-03-30T14:17:38Z'
     status:
       code: 202
       message: Accepted
@@ -1061,12 +963,12 @@ interactions:
       ParameterSetName:
       - -g --server-name --name --value
       User-Agent:
-      - AZURECLI/2.83.0 azsdk-python-core/1.38.0 Python/3.13.10 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/343a5907-da5b-4beb-8d11-f0f5dafd1c9e?api-version=2026-01-01-preview&t=639069823421642562&c=MIIHhzCCBm-gAwIBAgITHgfeaAthBF252mKMUQAAB95oCzANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDYwHhcNMjYwMTE1MTIwMzEzWhcNMjYwNTI0MjI1NzAzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALF5UwB1TCaUQryWnLemNoR1STogfj5BkURewSVKqF6BNmNVe6OPy7h3BMUV8wQPDRcx564kcpxInHjnJ91C2HdWhYtJC9mQ-KfRTHGro-eDtjIDA_m8ZoQaG1t8ZDyGTw3sg-le416DRx--vNLJWTcJ5pPQrNGLHgukyEBEGqcperL--6vkuDR8piARKeWdPub4QGpdJgULAoKm577o9Yeour0AbDe48KV8DaKqEhZAqTR021tTIU5-OVtQTAIuOTVnkBLtraUBYl6qbV603_iHP0-lxSiAdoOKRc9hnw5EIzdh4P3k57bkUUGKXBcEaDzqiXI4zT2s2PpLMdlJGrECAwEAAaOCBHQwggRwMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFghfmRS4WsmTQCAWQCAQcwggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MB0GA1UdDgQWBBQpx7wy64aZi3bga5mYDPjiPc4VjDAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwIwDAYKKwYBBAGCN3sEAjAfBgNVHSMEGDAWgBTxRmjG8cPwKy19i2rhsvm-NfzRQTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAESi3AgZNii4-yX1M8j9s1tnNVejdi-hvwe3tGOyTBjO6vi2tuQDoyQ-t6WDcAY8Suwhm0D6N6beb9niA0Z4KG-xN1jzJx-JF23mcbREASBP-H_Sk80BObD4a0FrOXY0dcNg2oK5FAuM8bwFfqHTRPNqCqL20uzuAyXhTgbwYJ7v6R0YYYv67aIj096-6dGUEKCXLHUtQfPNpvGOCnyvW5-kJ2GJ6ImpJvVnBPvU6JNVR7QMnSEtf7vlMFKguYoC7kAalHyr4UMxGBU6PpqOlJca6U_3ehNgwPuIFln_3JxNqtpyIWd5YpWGPRtAqGYE8y2NyTMrJQcUCkfHIqOHVFk&s=F9ZavMKcStm3ybFrJdIvfMq5AxCLDYXUkJ1MXKD1yy8QRSmPe1ZCBHFjEdowH-C_Bm_hKL1JENUT42s36kQDaU7uRCYi2lMz4mG8nXLyUPyAh-B1CxWJSfFbgrz6VdbGPd4r-Kd_dC83w0VRCX7w7ct58_WAj6QWGPxHp5yRQS_5c2Zjs_aashdEbwWicAG88oAlR35MGYnSHABHlbw8rX9zt7NY5sBi-1SvM5JmJSM3UibKmYFXBf4XFLO3xOWRliO9XWgQhfMO2qlqcMFh9ABBFio3v2DRtZWFD2TBVpdelChnCzoN8B7NWvX8gKE_90OmR7MlHtMFjm7aeQfnvw&h=mziZtLqkhWM8mKEXfns5ll-TwrQT9iQEm1q4mfz_MbI
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/01b8a738-bb8f-4598-bad3-6ccf23e110ba?api-version=2026-01-01-preview&t=639104770588437955&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=fE8CuxnP9NbZdLcTtPTjAOjsU3TVnM811Ss28BfGzVCQXHMVliRGUgUp9Wwwx_OVoZZ9IXMToVP-ycjH2e-P_K0l6JBXjTjNZCbjLw7dUElB2nLDFspc0O-Hm1Sga8K74sV1XsRB-5YURZ7nD_kc55bdKd-m9gZ68bHwqkwpsg7VoCxd5xudKHI8SnkmS_zrhR8nCeKaKCe4hLN3goqICsvaUw7okl4JaojNCj-RXIdjyYT3-tiAhRpqmI1k4jcM9r8DqBl76SIGmSjcaylU5R1Zt2O8V5a-C9Ojx7ipYmmpCTY5xDerE1wHLMx0oSVquN5ODxgSp9mgGMs5d67Fiw&h=A0ja3b_WJ4WaP6-M20aDszVVAfnx61vm1doAoNK0_gU
   response:
     body:
-      string: '{"name":"343a5907-da5b-4beb-8d11-f0f5dafd1c9e","status":"InProgress","startTime":"2026-02-18T03:32:22.123Z"}'
+      string: '{"name":"01b8a738-bb8f-4598-bad3-6ccf23e110ba","status":"InProgress","startTime":"2026-03-30T14:17:38.813Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1075,7 +977,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Feb 2026 03:32:21 GMT
+      - Mon, 30 Mar 2026 14:17:38 GMT
       expires:
       - '-1'
       pragma:
@@ -1087,11 +989,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f57d2932-2a78-450f-958a-e65997c3253b/eastus/67b2261c-5faa-4376-9a8d-1c429585d9fe
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/c309e041-8391-4e8b-b624-df88b8b81fd9
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 6B9C379FE8B0400FA9EB1788F51F3B4F Ref B: BL2AA2011006031 Ref C: 2026-02-18T03:32:22Z'
+      - 'Ref A: D01F197332674C7C8E8FF769CEC604CF Ref B: DUB241062309054 Ref C: 2026-03-30T14:17:39Z'
     status:
       code: 200
       message: OK
@@ -1109,108 +1011,12 @@ interactions:
       ParameterSetName:
       - -g --server-name --name --value
       User-Agent:
-      - AZURECLI/2.83.0 azsdk-python-core/1.38.0 Python/3.13.10 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/343a5907-da5b-4beb-8d11-f0f5dafd1c9e?api-version=2026-01-01-preview&t=639069823421642562&c=MIIHhzCCBm-gAwIBAgITHgfeaAthBF252mKMUQAAB95oCzANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDYwHhcNMjYwMTE1MTIwMzEzWhcNMjYwNTI0MjI1NzAzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALF5UwB1TCaUQryWnLemNoR1STogfj5BkURewSVKqF6BNmNVe6OPy7h3BMUV8wQPDRcx564kcpxInHjnJ91C2HdWhYtJC9mQ-KfRTHGro-eDtjIDA_m8ZoQaG1t8ZDyGTw3sg-le416DRx--vNLJWTcJ5pPQrNGLHgukyEBEGqcperL--6vkuDR8piARKeWdPub4QGpdJgULAoKm577o9Yeour0AbDe48KV8DaKqEhZAqTR021tTIU5-OVtQTAIuOTVnkBLtraUBYl6qbV603_iHP0-lxSiAdoOKRc9hnw5EIzdh4P3k57bkUUGKXBcEaDzqiXI4zT2s2PpLMdlJGrECAwEAAaOCBHQwggRwMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFghfmRS4WsmTQCAWQCAQcwggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MB0GA1UdDgQWBBQpx7wy64aZi3bga5mYDPjiPc4VjDAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwIwDAYKKwYBBAGCN3sEAjAfBgNVHSMEGDAWgBTxRmjG8cPwKy19i2rhsvm-NfzRQTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAESi3AgZNii4-yX1M8j9s1tnNVejdi-hvwe3tGOyTBjO6vi2tuQDoyQ-t6WDcAY8Suwhm0D6N6beb9niA0Z4KG-xN1jzJx-JF23mcbREASBP-H_Sk80BObD4a0FrOXY0dcNg2oK5FAuM8bwFfqHTRPNqCqL20uzuAyXhTgbwYJ7v6R0YYYv67aIj096-6dGUEKCXLHUtQfPNpvGOCnyvW5-kJ2GJ6ImpJvVnBPvU6JNVR7QMnSEtf7vlMFKguYoC7kAalHyr4UMxGBU6PpqOlJca6U_3ehNgwPuIFln_3JxNqtpyIWd5YpWGPRtAqGYE8y2NyTMrJQcUCkfHIqOHVFk&s=F9ZavMKcStm3ybFrJdIvfMq5AxCLDYXUkJ1MXKD1yy8QRSmPe1ZCBHFjEdowH-C_Bm_hKL1JENUT42s36kQDaU7uRCYi2lMz4mG8nXLyUPyAh-B1CxWJSfFbgrz6VdbGPd4r-Kd_dC83w0VRCX7w7ct58_WAj6QWGPxHp5yRQS_5c2Zjs_aashdEbwWicAG88oAlR35MGYnSHABHlbw8rX9zt7NY5sBi-1SvM5JmJSM3UibKmYFXBf4XFLO3xOWRliO9XWgQhfMO2qlqcMFh9ABBFio3v2DRtZWFD2TBVpdelChnCzoN8B7NWvX8gKE_90OmR7MlHtMFjm7aeQfnvw&h=mziZtLqkhWM8mKEXfns5ll-TwrQT9iQEm1q4mfz_MbI
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/01b8a738-bb8f-4598-bad3-6ccf23e110ba?api-version=2026-01-01-preview&t=639104770588437955&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=fE8CuxnP9NbZdLcTtPTjAOjsU3TVnM811Ss28BfGzVCQXHMVliRGUgUp9Wwwx_OVoZZ9IXMToVP-ycjH2e-P_K0l6JBXjTjNZCbjLw7dUElB2nLDFspc0O-Hm1Sga8K74sV1XsRB-5YURZ7nD_kc55bdKd-m9gZ68bHwqkwpsg7VoCxd5xudKHI8SnkmS_zrhR8nCeKaKCe4hLN3goqICsvaUw7okl4JaojNCj-RXIdjyYT3-tiAhRpqmI1k4jcM9r8DqBl76SIGmSjcaylU5R1Zt2O8V5a-C9Ojx7ipYmmpCTY5xDerE1wHLMx0oSVquN5ODxgSp9mgGMs5d67Fiw&h=A0ja3b_WJ4WaP6-M20aDszVVAfnx61vm1doAoNK0_gU
   response:
     body:
-      string: '{"name":"343a5907-da5b-4beb-8d11-f0f5dafd1c9e","status":"InProgress","startTime":"2026-02-18T03:32:22.123Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '108'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Feb 2026 03:32:32 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-cache:
-      - CONFIG_NOCACHE
-      x-content-type-options:
-      - nosniff
-      x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f57d2932-2a78-450f-958a-e65997c3253b/eastus/2812b7ff-879b-4618-8ad8-9d6f96491545
-      x-ms-ratelimit-remaining-subscription-global-reads:
-      - '16499'
-      x-msedge-ref:
-      - 'Ref A: 7E371B3B1F9C481BB1DDFC821348CC52 Ref B: MNZ221060608039 Ref C: 2026-02-18T03:32:32Z'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - postgres flexible-server parameter set
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --server-name --name --value
-      User-Agent:
-      - AZURECLI/2.83.0 azsdk-python-core/1.38.0 Python/3.13.10 (Windows-11-10.0.26200-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/343a5907-da5b-4beb-8d11-f0f5dafd1c9e?api-version=2026-01-01-preview&t=639069823421642562&c=MIIHhzCCBm-gAwIBAgITHgfeaAthBF252mKMUQAAB95oCzANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDYwHhcNMjYwMTE1MTIwMzEzWhcNMjYwNTI0MjI1NzAzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALF5UwB1TCaUQryWnLemNoR1STogfj5BkURewSVKqF6BNmNVe6OPy7h3BMUV8wQPDRcx564kcpxInHjnJ91C2HdWhYtJC9mQ-KfRTHGro-eDtjIDA_m8ZoQaG1t8ZDyGTw3sg-le416DRx--vNLJWTcJ5pPQrNGLHgukyEBEGqcperL--6vkuDR8piARKeWdPub4QGpdJgULAoKm577o9Yeour0AbDe48KV8DaKqEhZAqTR021tTIU5-OVtQTAIuOTVnkBLtraUBYl6qbV603_iHP0-lxSiAdoOKRc9hnw5EIzdh4P3k57bkUUGKXBcEaDzqiXI4zT2s2PpLMdlJGrECAwEAAaOCBHQwggRwMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFghfmRS4WsmTQCAWQCAQcwggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MB0GA1UdDgQWBBQpx7wy64aZi3bga5mYDPjiPc4VjDAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwIwDAYKKwYBBAGCN3sEAjAfBgNVHSMEGDAWgBTxRmjG8cPwKy19i2rhsvm-NfzRQTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAESi3AgZNii4-yX1M8j9s1tnNVejdi-hvwe3tGOyTBjO6vi2tuQDoyQ-t6WDcAY8Suwhm0D6N6beb9niA0Z4KG-xN1jzJx-JF23mcbREASBP-H_Sk80BObD4a0FrOXY0dcNg2oK5FAuM8bwFfqHTRPNqCqL20uzuAyXhTgbwYJ7v6R0YYYv67aIj096-6dGUEKCXLHUtQfPNpvGOCnyvW5-kJ2GJ6ImpJvVnBPvU6JNVR7QMnSEtf7vlMFKguYoC7kAalHyr4UMxGBU6PpqOlJca6U_3ehNgwPuIFln_3JxNqtpyIWd5YpWGPRtAqGYE8y2NyTMrJQcUCkfHIqOHVFk&s=F9ZavMKcStm3ybFrJdIvfMq5AxCLDYXUkJ1MXKD1yy8QRSmPe1ZCBHFjEdowH-C_Bm_hKL1JENUT42s36kQDaU7uRCYi2lMz4mG8nXLyUPyAh-B1CxWJSfFbgrz6VdbGPd4r-Kd_dC83w0VRCX7w7ct58_WAj6QWGPxHp5yRQS_5c2Zjs_aashdEbwWicAG88oAlR35MGYnSHABHlbw8rX9zt7NY5sBi-1SvM5JmJSM3UibKmYFXBf4XFLO3xOWRliO9XWgQhfMO2qlqcMFh9ABBFio3v2DRtZWFD2TBVpdelChnCzoN8B7NWvX8gKE_90OmR7MlHtMFjm7aeQfnvw&h=mziZtLqkhWM8mKEXfns5ll-TwrQT9iQEm1q4mfz_MbI
-  response:
-    body:
-      string: '{"name":"343a5907-da5b-4beb-8d11-f0f5dafd1c9e","status":"InProgress","startTime":"2026-02-18T03:32:22.123Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '108'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 18 Feb 2026 03:32:42 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-cache:
-      - CONFIG_NOCACHE
-      x-content-type-options:
-      - nosniff
-      x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f57d2932-2a78-450f-958a-e65997c3253b/eastus2/5da418da-bdc7-48f3-bbcf-b289310d4304
-      x-ms-ratelimit-remaining-subscription-global-reads:
-      - '16499'
-      x-msedge-ref:
-      - 'Ref A: 92BE89AC6DB84823B56930FE362AD398 Ref B: BL2AA2011003034 Ref C: 2026-02-18T03:32:43Z'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - postgres flexible-server parameter set
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --server-name --name --value
-      User-Agent:
-      - AZURECLI/2.83.0 azsdk-python-core/1.38.0 Python/3.13.10 (Windows-11-10.0.26200-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/343a5907-da5b-4beb-8d11-f0f5dafd1c9e?api-version=2026-01-01-preview&t=639069823421642562&c=MIIHhzCCBm-gAwIBAgITHgfeaAthBF252mKMUQAAB95oCzANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDYwHhcNMjYwMTE1MTIwMzEzWhcNMjYwNTI0MjI1NzAzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALF5UwB1TCaUQryWnLemNoR1STogfj5BkURewSVKqF6BNmNVe6OPy7h3BMUV8wQPDRcx564kcpxInHjnJ91C2HdWhYtJC9mQ-KfRTHGro-eDtjIDA_m8ZoQaG1t8ZDyGTw3sg-le416DRx--vNLJWTcJ5pPQrNGLHgukyEBEGqcperL--6vkuDR8piARKeWdPub4QGpdJgULAoKm577o9Yeour0AbDe48KV8DaKqEhZAqTR021tTIU5-OVtQTAIuOTVnkBLtraUBYl6qbV603_iHP0-lxSiAdoOKRc9hnw5EIzdh4P3k57bkUUGKXBcEaDzqiXI4zT2s2PpLMdlJGrECAwEAAaOCBHQwggRwMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFghfmRS4WsmTQCAWQCAQcwggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MB0GA1UdDgQWBBQpx7wy64aZi3bga5mYDPjiPc4VjDAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwIwDAYKKwYBBAGCN3sEAjAfBgNVHSMEGDAWgBTxRmjG8cPwKy19i2rhsvm-NfzRQTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAESi3AgZNii4-yX1M8j9s1tnNVejdi-hvwe3tGOyTBjO6vi2tuQDoyQ-t6WDcAY8Suwhm0D6N6beb9niA0Z4KG-xN1jzJx-JF23mcbREASBP-H_Sk80BObD4a0FrOXY0dcNg2oK5FAuM8bwFfqHTRPNqCqL20uzuAyXhTgbwYJ7v6R0YYYv67aIj096-6dGUEKCXLHUtQfPNpvGOCnyvW5-kJ2GJ6ImpJvVnBPvU6JNVR7QMnSEtf7vlMFKguYoC7kAalHyr4UMxGBU6PpqOlJca6U_3ehNgwPuIFln_3JxNqtpyIWd5YpWGPRtAqGYE8y2NyTMrJQcUCkfHIqOHVFk&s=F9ZavMKcStm3ybFrJdIvfMq5AxCLDYXUkJ1MXKD1yy8QRSmPe1ZCBHFjEdowH-C_Bm_hKL1JENUT42s36kQDaU7uRCYi2lMz4mG8nXLyUPyAh-B1CxWJSfFbgrz6VdbGPd4r-Kd_dC83w0VRCX7w7ct58_WAj6QWGPxHp5yRQS_5c2Zjs_aashdEbwWicAG88oAlR35MGYnSHABHlbw8rX9zt7NY5sBi-1SvM5JmJSM3UibKmYFXBf4XFLO3xOWRliO9XWgQhfMO2qlqcMFh9ABBFio3v2DRtZWFD2TBVpdelChnCzoN8B7NWvX8gKE_90OmR7MlHtMFjm7aeQfnvw&h=mziZtLqkhWM8mKEXfns5ll-TwrQT9iQEm1q4mfz_MbI
-  response:
-    body:
-      string: '{"name":"343a5907-da5b-4beb-8d11-f0f5dafd1c9e","status":"Succeeded","startTime":"2026-02-18T03:32:22.123Z"}'
+      string: '{"name":"01b8a738-bb8f-4598-bad3-6ccf23e110ba","status":"Succeeded","startTime":"2026-03-30T14:17:38.813Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1219,7 +1025,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Feb 2026 03:32:53 GMT
+      - Mon, 30 Mar 2026 14:17:49 GMT
       expires:
       - '-1'
       pragma:
@@ -1231,11 +1037,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f57d2932-2a78-450f-958a-e65997c3253b/eastus/cace4da8-1267-40e4-a51b-800fcee1c002
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/ba040e7b-93da-4397-a656-938a14c6ad82
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: DA0F3A34DD2C42E591D609C7B6788EBE Ref B: BL2AA2011001036 Ref C: 2026-02-18T03:32:53Z'
+      - 'Ref A: FB0BDA779CA148C6A6C57E4278F2FC15 Ref B: AMS231022012021 Ref C: 2026-03-30T14:17:49Z'
     status:
       code: 200
       message: OK
@@ -1253,7 +1059,7 @@ interactions:
       ParameterSetName:
       - -g --server-name --name --value
       User-Agent:
-      - AZURECLI/2.83.0 azsdk-python-core/1.38.0 Python/3.13.10 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/configurations/logfiles.retention_days?api-version=2026-01-01-preview
   response:
@@ -1268,7 +1074,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Feb 2026 03:32:53 GMT
+      - Mon, 30 Mar 2026 14:17:49 GMT
       expires:
       - '-1'
       pragma:
@@ -1280,11 +1086,4075 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f57d2932-2a78-450f-958a-e65997c3253b/canadacentral/fc85a824-effa-4e2a-95d6-ed2c04997143
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/80a28ff4-94a2-4ae7-896b-043ae00e9458
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: A2221E66A1F447DEA7A22FD0873F82E6 Ref B: MNZ221060609035 Ref C: 2026-02-18T03:32:53Z'
+      - 'Ref A: 74870E269CD7400EB0701EA76661D74C Ref B: AMS231032607029 Ref C: 2026-03-30T14:17:50Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - postgres flexible-server server-logs list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --server-name
+      User-Agent:
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/logFiles?api-version=2026-01-01-preview
+  response:
+    body:
+      string: '{"value":[{"properties":{"sizeInKb":168,"createdTime":"2026-03-30T14:36:36+00:00","lastModifiedTime":"2026-03-30T14:46:39+00:00","type":"ServerLogs","url":"https://e3091069db5dsa.blob.core.windows.net/d04ef2a694bb414da5336f0e5c112469bak/serverlogs/postgresql_2026_03_30_14_00_00.log?sv=2025-05-05&se=2026-03-30T14%3A52%3A51Z&sr=b&sp=rdl&sig=fF1DNdIUKx9v%2BeoHw4v762ysLRwXaPQfpp0C%2FzkDeg8%3D"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/logFiles","name":"postgresql_2026_03_30_14_00_00.log","type":"Microsoft.DBforPostgreSQL/flexibleServers/logFiles"}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '674'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Mar 2026 14:47:50 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/49fd8b11-fcae-4c19-b45e-288f75881c55
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 70CE7374CC7A4F23B74E88E4AA97B6FC Ref B: AMS231020615023 Ref C: 2026-03-30T14:47:51Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - postgres flexible-server server-logs download
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --server-name --name
+      User-Agent:
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/logFiles?api-version=2026-01-01-preview
+  response:
+    body:
+      string: '{"value":[{"properties":{"sizeInKb":168,"createdTime":"2026-03-30T14:36:36+00:00","lastModifiedTime":"2026-03-30T14:46:39+00:00","type":"ServerLogs","url":"https://e3091069db5dsa.blob.core.windows.net/d04ef2a694bb414da5336f0e5c112469bak/serverlogs/postgresql_2026_03_30_14_00_00.log?sv=2025-05-05&se=2026-03-30T14%3A52%3A51Z&sr=b&sp=rdl&sig=fF1DNdIUKx9v%2BeoHw4v762ysLRwXaPQfpp0C%2FzkDeg8%3D"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/logFiles","name":"postgresql_2026_03_30_14_00_00.log","type":"Microsoft.DBforPostgreSQL/flexibleServers/logFiles"}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '674'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Mar 2026 14:47:51 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/532b8d8a-c4a5-4c29-9caa-7983ca29b888
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 5FDD57AF55294DE2851F334743C87306 Ref B: DUB601080511029 Ref C: 2026-03-30T14:47:51Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - e3091069db5dsa.blob.core.windows.net
+      User-Agent:
+      - Python-urllib/3.13
+    method: GET
+    uri: https://e3091069db5dsa.blob.core.windows.net/d04ef2a694bb414da5336f0e5c112469bak/serverlogs/postgresql_2026_03_30_14_00_00.log?sv=2025-05-05&se=2026-03-30T14%3A52%3A51Z&sr=b&sp=rdl&sig=fF1DNdIUKx9v%2BeoHw4v762ysLRwXaPQfpp0C%2FzkDeg8%3D
+  response:
+    body:
+      string: '2026-03-30 14:26:35 UTC-69ca881b.590-LOG:  connection received: host=127.0.0.1
+        port=37508
+
+        2026-03-30 14:26:35 UTC-69ca881b.590-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:26:35 UTC-69ca881b.590-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:26:35 UTC-69ca881b.590-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:26:42 UTC-69ca880e.57f-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=azure_sys host=127.0.0.1 port=45082
+
+        2026-03-30 14:26:45 UTC-69ca8811.581-LOG:  disconnection: session time: 0:00:20.027
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=52854
+
+        2026-03-30 14:26:47 UTC-69ca8827.593-LOG:  connection received: host=127.0.0.1
+        port=51638
+
+        2026-03-30 14:26:47 UTC-69ca8827.593-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:26:47 UTC-69ca8827.593-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:26:47 UTC-69ca8827.593-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:26:47 UTC-69ca8813.58c-LOG:  disconnection: session time: 0:00:20.023
+        user=azuresu database=postgres host=127.0.0.1 port=52878
+
+        2026-03-30 14:26:47 UTC-69ca8827.594-LOG:  connection received: host=127.0.0.1
+        port=51650
+
+        2026-03-30 14:26:47 UTC-69ca8827.594-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:26:47 UTC-69ca8827.594-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:26:47 UTC-69ca8827.594-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:26:49 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
+        0/4000548, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-03-30 14:26:50 UTC-69ca882a.59f-LOG:  connection received: host=127.0.0.1
+        port=51660
+
+        2026-03-30 14:26:50 UTC-69ca882a.59f-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:26:50 UTC-69ca882a.59f-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:26:50 UTC-69ca882a.59f-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:26:50 UTC-69ca882a.59f-LOG:  disconnection: session time: 0:00:00.047
+        user=azuresu database=postgres host=127.0.0.1 port=51660
+
+        2026-03-30 14:26:53 UTC-69ca882d.5a1-LOG:  connection received: host=127.0.0.1
+        port=51674
+
+        2026-03-30 14:26:53 UTC-69ca882d.5a1-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:26:53 UTC-69ca882d.5a1-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:26:53 UTC-69ca882d.5a1-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:26:55 UTC-69ca881b.590-LOG:  disconnection: session time: 0:00:20.031
+        user=azuresu database=azure_sys host=127.0.0.1 port=37508
+
+        2026-03-30 14:27:07 UTC-69ca883b.5a5-LOG:  connection received: host=127.0.0.1
+        port=43408
+
+        2026-03-30 14:27:07 UTC-69ca8827.593-LOG:  disconnection: session time: 0:00:20.023
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=51638
+
+        2026-03-30 14:27:07 UTC-69ca883b.5a5-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:27:07 UTC-69ca883b.5a5-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:27:07 UTC-69ca883b.5a5-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:27:07 UTC-69ca8827.594-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=postgres host=127.0.0.1 port=51650
+
+        2026-03-30 14:27:09 UTC-69ca883d.5a7-LOG:  connection received: host=127.0.0.1
+        port=43412
+
+        2026-03-30 14:27:09 UTC-69ca883d.5a7-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:27:09 UTC-69ca883d.5a7-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:27:09 UTC-69ca883d.5a7-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:27:13 UTC-69ca882d.5a1-LOG:  disconnection: session time: 0:00:20.023
+        user=azuresu database=azure_sys host=127.0.0.1 port=51674
+
+        2026-03-30 14:27:15 UTC-69ca8843.5b3-LOG:  connection received: host=127.0.0.1
+        port=57650
+
+        2026-03-30 14:27:15 UTC-69ca8843.5b3-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:27:15 UTC-69ca8843.5b3-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:27:15 UTC-69ca8843.5b3-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:27:15 UTC-69ca8843.5b3-LOG:  disconnection: session time: 0:00:00.046
+        user=azuresu database=postgres host=127.0.0.1 port=57650
+
+        2026-03-30 14:27:24 UTC-69ca884c.5b6-LOG:  connection received: host=127.0.0.1
+        port=57660
+
+        2026-03-30 14:27:24 UTC-69ca884c.5b6-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:27:24 UTC-69ca884c.5b6-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:27:24 UTC-69ca884c.5b6-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:27:27 UTC-69ca883b.5a5-LOG:  disconnection: session time: 0:00:20.751
+        user=azuresu database=postgres host=127.0.0.1 port=43408
+
+        2026-03-30 14:27:27 UTC-69ca884f.5b7-LOG:  connection received: host=127.0.0.1
+        port=33676
+
+        2026-03-30 14:27:27 UTC-69ca884f.5b7-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:27:27 UTC-69ca884f.5b7-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:27:27 UTC-69ca884f.5b7-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:27:29 UTC-69ca883d.5a7-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=43412
+
+        2026-03-30 14:27:31 UTC-69ca8853.5b9-LOG:  connection received: host=127.0.0.1
+        port=33688
+
+        2026-03-30 14:27:31 UTC-69ca8853.5b9-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:27:31 UTC-69ca8853.5b9-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:27:31 UTC-69ca8853.5b9-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:27:40 UTC-69ca885c.5c6-LOG:  connection received: host=127.0.0.1
+        port=39226
+
+        2026-03-30 14:27:40 UTC-69ca885c.5c6-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:27:40 UTC-69ca885c.5c6-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:27:40 UTC-69ca885c.5c6-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:27:40 UTC-69ca885c.5c6-LOG:  disconnection: session time: 0:00:00.048
+        user=azuresu database=postgres host=127.0.0.1 port=39226
+
+        2026-03-30 14:27:44 UTC-69ca884c.5b6-LOG:  disconnection: session time: 0:00:20.033
+        user=azuresu database=azure_sys host=127.0.0.1 port=57660
+
+        2026-03-30 14:27:47 UTC-69ca884f.5b7-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=postgres host=127.0.0.1 port=33676
+
+        2026-03-30 14:27:48 UTC-69ca8864.5c9-LOG:  connection received: host=127.0.0.1
+        port=36184
+
+        2026-03-30 14:27:48 UTC-69ca8864.5c9-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:27:48 UTC-69ca8864.5c9-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:27:48 UTC-69ca8864.5c9-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:27:49 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
+        0/4000BE8, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-03-30 14:27:51 UTC-69ca8853.5b9-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=33688
+
+        2026-03-30 14:27:53 UTC-69ca8869.5cb-LOG:  connection received: host=127.0.0.1
+        port=36192
+
+        2026-03-30 14:27:53 UTC-69ca8869.5cb-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:27:53 UTC-69ca8869.5cb-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:27:53 UTC-69ca8869.5cb-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:27:55 UTC-69ca886b.5cd-LOG:  connection received: host=127.0.0.1
+        port=53856
+
+        2026-03-30 14:27:55 UTC-69ca886b.5cd-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:27:55 UTC-69ca886b.5cd-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:27:55 UTC-69ca886b.5cd-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:28:05 UTC-69ca8875.5d9-LOG:  connection received: host=127.0.0.1
+        port=42734
+
+        2026-03-30 14:28:05 UTC-69ca8875.5d9-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:28:05 UTC-69ca8875.5d9-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:28:05 UTC-69ca8875.5d9-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:28:05 UTC-69ca8875.5d9-LOG:  disconnection: session time: 0:00:00.047
+        user=azuresu database=postgres host=127.0.0.1 port=42734
+
+        2026-03-30 14:28:08 UTC-69ca8864.5c9-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=postgres host=127.0.0.1 port=36184
+
+        2026-03-30 14:28:08 UTC-69ca8878.5db-LOG:  connection received: host=127.0.0.1
+        port=42746
+
+        2026-03-30 14:28:08 UTC-69ca8878.5db-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:28:08 UTC-69ca8878.5db-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:28:08 UTC-69ca8878.5db-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:28:13 UTC-69ca8869.5cb-LOG:  disconnection: session time: 0:00:20.022
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=36192
+
+        2026-03-30 14:28:15 UTC-69ca887f.5de-LOG:  connection received: host=127.0.0.1
+        port=44900
+
+        2026-03-30 14:28:15 UTC-69ca886b.5cd-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=azure_sys host=127.0.0.1 port=53856
+
+        2026-03-30 14:28:15 UTC-69ca887f.5de-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:28:15 UTC-69ca887f.5de-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:28:15 UTC-69ca887f.5de-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:28:26 UTC-69ca888a.5e1-LOG:  connection received: host=127.0.0.1
+        port=52892
+
+        2026-03-30 14:28:26 UTC-69ca888a.5e1-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:28:26 UTC-69ca888a.5e1-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:28:26 UTC-69ca888a.5e1-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:28:28 UTC-69ca8878.5db-LOG:  disconnection: session time: 0:00:20.023
+        user=azuresu database=postgres host=127.0.0.1 port=42746
+
+        2026-03-30 14:28:28 UTC-69ca888c.5e3-LOG:  connection received: host=127.0.0.1
+        port=52894
+
+        2026-03-30 14:28:28 UTC-69ca888c.5e3-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:28:28 UTC-69ca888c.5e3-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:28:28 UTC-69ca888c.5e3-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:28:30 UTC-69ca888e.5ed-LOG:  connection received: host=127.0.0.1
+        port=52906
+
+        2026-03-30 14:28:30 UTC-69ca888e.5ed-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:28:30 UTC-69ca888e.5ed-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:28:30 UTC-69ca888e.5ed-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:28:30 UTC-69ca888e.5ed-LOG:  disconnection: session time: 0:00:00.046
+        user=azuresu database=postgres host=127.0.0.1 port=52906
+
+        2026-03-30 14:28:35 UTC-69ca887f.5de-LOG:  disconnection: session time: 0:00:20.028
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=44900
+
+        2026-03-30 14:28:37 UTC-69ca8895.5f0-LOG:  connection received: host=127.0.0.1
+        port=59294
+
+        2026-03-30 14:28:37 UTC-69ca8895.5f0-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:28:37 UTC-69ca8895.5f0-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:28:37 UTC-69ca8895.5f0-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:28:46 UTC-69ca888a.5e1-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=azure_sys host=127.0.0.1 port=52892
+
+        2026-03-30 14:28:48 UTC-69ca888c.5e3-LOG:  disconnection: session time: 0:00:20.022
+        user=azuresu database=postgres host=127.0.0.1 port=52894
+
+        2026-03-30 14:28:48 UTC-69ca88a0.5f4-LOG:  connection received: host=127.0.0.1
+        port=60218
+
+        2026-03-30 14:28:48 UTC-69ca88a0.5f4-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:28:48 UTC-69ca88a0.5f4-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:28:48 UTC-69ca88a0.5f4-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:28:49 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
+        0/4001288, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-03-30 14:28:55 UTC-69ca88a7.600-LOG:  connection received: host=127.0.0.1
+        port=34854
+
+        2026-03-30 14:28:55 UTC-69ca88a7.600-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:28:55 UTC-69ca88a7.600-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:28:55 UTC-69ca88a7.600-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:28:55 UTC-69ca88a7.600-LOG:  disconnection: session time: 0:00:00.046
+        user=azuresu database=postgres host=127.0.0.1 port=34854
+
+        2026-03-30 14:28:57 UTC-69ca88a9.601-LOG:  connection received: host=127.0.0.1
+        port=34864
+
+        2026-03-30 14:28:57 UTC-69ca8895.5f0-LOG:  disconnection: session time: 0:00:20.027
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=59294
+
+        2026-03-30 14:28:57 UTC-69ca88a9.601-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:28:57 UTC-69ca88a9.601-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:28:57 UTC-69ca88a9.601-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:28:59 UTC-69ca88ab.603-LOG:  connection received: host=127.0.0.1
+        port=34876
+
+        2026-03-30 14:28:59 UTC-69ca88ab.603-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:28:59 UTC-69ca88ab.603-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:28:59 UTC-69ca88ab.603-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:29:08 UTC-69ca88a0.5f4-LOG:  disconnection: session time: 0:00:20.022
+        user=azuresu database=postgres host=127.0.0.1 port=60218
+
+        2026-03-30 14:29:08 UTC-69ca88b4.606-LOG:  connection received: host=127.0.0.1
+        port=44922
+
+        2026-03-30 14:29:08 UTC-69ca88b4.606-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:29:08 UTC-69ca88b4.606-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:29:08 UTC-69ca88b4.606-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:29:17 UTC-69ca88a9.601-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=azure_sys host=127.0.0.1 port=34864
+
+        2026-03-30 14:29:19 UTC-69ca88ab.603-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=34876
+
+        2026-03-30 14:29:21 UTC-69ca88c1.613-LOG:  connection received: host=127.0.0.1
+        port=39840
+
+        2026-03-30 14:29:21 UTC-69ca88c1.614-LOG:  connection received: host=127.0.0.1
+        port=39842
+
+        2026-03-30 14:29:21 UTC-69ca88c1.614-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:29:21 UTC-69ca88c1.614-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:29:21 UTC-69ca88c1.614-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:29:21 UTC-69ca88c1.613-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:29:21 UTC-69ca88c1.613-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:29:21 UTC-69ca88c1.613-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:29:21 UTC-69ca88c1.613-LOG:  disconnection: session time: 0:00:00.051
+        user=azuresu database=postgres host=127.0.0.1 port=39840
+
+        2026-03-30 14:29:28 UTC-69ca88c8.616-LOG:  connection received: host=127.0.0.1
+        port=49968
+
+        2026-03-30 14:29:28 UTC-69ca88c8.616-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:29:28 UTC-69ca88c8.616-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:29:28 UTC-69ca88c8.616-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:29:28 UTC-69ca88b4.606-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=postgres host=127.0.0.1 port=44922
+
+        2026-03-30 14:29:28 UTC-69ca88c8.618-LOG:  connection received: host=127.0.0.1
+        port=49980
+
+        2026-03-30 14:29:28 UTC-69ca88c8.618-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:29:28 UTC-69ca88c8.618-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:29:28 UTC-69ca88c8.618-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:29:41 UTC-69ca88c1.614-LOG:  disconnection: session time: 0:00:20.027
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=39842
+
+        2026-03-30 14:29:43 UTC-69ca88d7.61c-LOG:  connection received: host=127.0.0.1
+        port=35190
+
+        2026-03-30 14:29:43 UTC-69ca88d7.61c-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:29:43 UTC-69ca88d7.61c-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:29:43 UTC-69ca88d7.61c-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:29:46 UTC-69ca88da.627-LOG:  connection received: host=127.0.0.1
+        port=44182
+
+        2026-03-30 14:29:46 UTC-69ca88da.627-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:29:46 UTC-69ca88da.627-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:29:46 UTC-69ca88da.627-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:29:46 UTC-69ca88da.627-LOG:  disconnection: session time: 0:00:00.047
+        user=azuresu database=postgres host=127.0.0.1 port=44182
+
+        2026-03-30 14:29:48 UTC-69ca88c8.616-LOG:  disconnection: session time: 0:00:20.025
+        user=azuresu database=azure_sys host=127.0.0.1 port=49968
+
+        2026-03-30 14:29:48 UTC-69ca88c8.618-LOG:  disconnection: session time: 0:00:20.025
+        user=azuresu database=postgres host=127.0.0.1 port=49980
+
+        2026-03-30 14:29:48 UTC-69ca88dc.629-LOG:  connection received: host=127.0.0.1
+        port=44190
+
+        2026-03-30 14:29:48 UTC-69ca88dc.629-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:29:48 UTC-69ca88dc.629-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:29:48 UTC-69ca88dc.629-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:29:49 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
+        0/4001928, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-03-30 14:29:59 UTC-69ca88e7.62d-LOG:  connection received: host=127.0.0.1
+        port=49612
+
+        2026-03-30 14:29:59 UTC-69ca88e7.62d-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:29:59 UTC-69ca88e7.62d-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:29:59 UTC-69ca88e7.62d-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:30:03 UTC-69ca88d7.61c-LOG:  disconnection: session time: 0:00:20.025
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=35190
+
+        2026-03-30 14:30:03 UTC-69ca85d0.2f7-LOG:  checkpoint starting: time
+
+        2026-03-30 14:30:05 UTC-69ca88ed.62f-LOG:  connection received: host=127.0.0.1
+        port=35500
+
+        2026-03-30 14:30:05 UTC-69ca88ed.62f-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:30:05 UTC-69ca88ed.62f-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:30:05 UTC-69ca88ed.62f-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:30:06 UTC-69ca85d0.2f7-LOG:  checkpoint complete: wrote 31 buffers
+        (0.0%); 0 WAL file(s) added, 0 removed, 0 recycled; write=3.015 s, sync=0.005
+        s, total=3.032 s; sync files=22, longest=0.004 s, average=0.001 s; distance=32774
+        kB, estimate=32774 kB; lsn=0/4002100, redo lsn=0/4001A98
+
+        2026-03-30 14:30:08 UTC-69ca88dc.629-LOG:  disconnection: session time: 0:00:20.029
+        user=azuresu database=postgres host=127.0.0.1 port=44190
+
+        2026-03-30 14:30:08 UTC-69ca88f0.631-LOG:  connection received: host=127.0.0.1
+        port=35510
+
+        2026-03-30 14:30:08 UTC-69ca88f0.631-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:30:08 UTC-69ca88f0.631-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:30:08 UTC-69ca88f0.631-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:30:11 UTC-69ca88f3.63b-LOG:  connection received: host=127.0.0.1
+        port=35518
+
+        2026-03-30 14:30:11 UTC-69ca88f3.63b-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:30:11 UTC-69ca88f3.63b-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:30:11 UTC-69ca88f3.63b-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:30:11 UTC-69ca88f3.63b-LOG:  disconnection: session time: 0:00:00.047
+        user=azuresu database=postgres host=127.0.0.1 port=35518
+
+        2026-03-30 14:30:19 UTC-69ca88e7.62d-LOG:  disconnection: session time: 0:00:20.023
+        user=azuresu database=azure_sys host=127.0.0.1 port=49612
+
+        2026-03-30 14:30:25 UTC-69ca88ed.62f-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=35500
+
+        2026-03-30 14:30:27 UTC-69ca8903.640-LOG:  connection received: host=127.0.0.1
+        port=44080
+
+        2026-03-30 14:30:27 UTC-69ca8903.640-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:30:27 UTC-69ca8903.640-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:30:27 UTC-69ca8903.640-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:30:28 UTC-69ca88f0.631-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=postgres host=127.0.0.1 port=35510
+
+        2026-03-30 14:30:28 UTC-69ca8904.642-LOG:  connection received: host=127.0.0.1
+        port=44092
+
+        2026-03-30 14:30:28 UTC-69ca8904.642-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:30:28 UTC-69ca8904.642-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:30:28 UTC-69ca8904.642-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:30:30 UTC-69ca8906.643-LOG:  connection received: host=127.0.0.1
+        port=44096
+
+        2026-03-30 14:30:30 UTC-69ca8906.643-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:30:30 UTC-69ca8906.643-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:30:30 UTC-69ca8906.643-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:30:36 UTC-69ca890c.64f-LOG:  connection received: host=127.0.0.1
+        port=43804
+
+        2026-03-30 14:30:36 UTC-69ca890c.64f-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:30:36 UTC-69ca890c.64f-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:30:36 UTC-69ca890c.64f-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:30:36 UTC-69ca890c.64f-LOG:  disconnection: session time: 0:00:00.046
+        user=azuresu database=postgres host=127.0.0.1 port=43804
+
+        2026-03-30 14:30:47 UTC-69ca8903.640-LOG:  disconnection: session time: 0:00:20.036
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=44080
+
+        2026-03-30 14:30:48 UTC-69ca8904.642-LOG:  disconnection: session time: 0:00:20.023
+        user=azuresu database=postgres host=127.0.0.1 port=44092
+
+        2026-03-30 14:30:49 UTC-69ca8919.653-LOG:  connection received: host=127.0.0.1
+        port=38378
+
+        2026-03-30 14:30:49 UTC-69ca8919.654-LOG:  connection received: host=127.0.0.1
+        port=38392
+
+        2026-03-30 14:30:49 UTC-69ca8919.653-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:30:49 UTC-69ca8919.653-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:30:49 UTC-69ca8919.653-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:30:49 UTC-69ca8919.654-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:30:49 UTC-69ca8919.654-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:30:49 UTC-69ca8919.654-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:30:49 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
+        0/4002670, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-03-30 14:30:50 UTC-69ca8906.643-LOG:  disconnection: session time: 0:00:20.030
+        user=azuresu database=azure_sys host=127.0.0.1 port=44096
+
+        2026-03-30 14:31:01 UTC-69ca8925.658-LOG:  connection received: host=127.0.0.1
+        port=34600
+
+        2026-03-30 14:31:01 UTC-69ca8925.658-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:31:01 UTC-69ca8925.658-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:31:01 UTC-69ca8925.658-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:31:01 UTC-69ca8925.662-LOG:  connection received: host=127.0.0.1
+        port=34616
+
+        2026-03-30 14:31:01 UTC-69ca8925.662-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:31:01 UTC-69ca8925.662-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:31:01 UTC-69ca8925.662-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:31:01 UTC-69ca8925.662-LOG:  disconnection: session time: 0:00:00.047
+        user=azuresu database=postgres host=127.0.0.1 port=34616
+
+        2026-03-30 14:31:09 UTC-69ca8919.653-LOG:  disconnection: session time: 0:00:20.041
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=38378
+
+        2026-03-30 14:31:09 UTC-69ca8919.654-LOG:  disconnection: session time: 0:00:20.038
+        user=azuresu database=postgres host=127.0.0.1 port=38392
+
+        2026-03-30 14:31:09 UTC-69ca892d.67e-LOG:  connection received: host=127.0.0.1
+        port=56154
+
+        2026-03-30 14:31:09 UTC-69ca892d.67e-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:31:09 UTC-69ca892d.67e-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:31:09 UTC-69ca892d.67e-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:31:11 UTC-69ca892f.681-LOG:  connection received: host=127.0.0.1
+        port=56156
+
+        2026-03-30 14:31:11 UTC-69ca892f.681-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:31:11 UTC-69ca892f.681-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:31:11 UTC-69ca892f.681-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:31:21 UTC-69ca8925.658-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=azure_sys host=127.0.0.1 port=34600
+
+        2026-03-30 14:31:26 UTC-69ca893e.691-LOG:  connection received: host=127.0.0.1
+        port=51438
+
+        2026-03-30 14:31:26 UTC-69ca893e.691-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:31:26 UTC-69ca893e.691-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:31:26 UTC-69ca893e.691-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:31:26 UTC-69ca893e.691-LOG:  disconnection: session time: 0:00:00.046
+        user=azuresu database=postgres host=127.0.0.1 port=51438
+
+        2026-03-30 14:31:29 UTC-69ca892d.67e-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=postgres host=127.0.0.1 port=56154
+
+        2026-03-30 14:31:29 UTC-69ca8941.693-LOG:  connection received: host=127.0.0.1
+        port=51452
+
+        2026-03-30 14:31:29 UTC-69ca8941.693-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:31:29 UTC-69ca8941.693-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:31:29 UTC-69ca8941.693-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:31:31 UTC-69ca892f.681-LOG:  disconnection: session time: 0:00:20.022
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=56156
+
+        2026-03-30 14:31:32 UTC-69ca8944.694-LOG:  connection received: host=127.0.0.1
+        port=51456
+
+        2026-03-30 14:31:32 UTC-69ca8944.694-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:31:32 UTC-69ca8944.694-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:31:32 UTC-69ca8944.694-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:31:33 UTC-69ca8945.695-LOG:  connection received: host=127.0.0.1
+        port=51468
+
+        2026-03-30 14:31:33 UTC-69ca8945.695-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:31:33 UTC-69ca8945.695-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:31:33 UTC-69ca8945.695-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:31:35 UTC-69ca8947.698-LOG:  connection received: host=127.0.0.1
+        port=36632
+
+        2026-03-30 14:31:35 UTC-69ca8947.698-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:31:35 UTC-69ca8947.698-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:31:35 UTC-69ca8947.698-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:31:49 UTC-69ca8941.693-LOG:  disconnection: session time: 0:00:20.023
+        user=azuresu database=postgres host=127.0.0.1 port=51452
+
+        2026-03-30 14:31:49 UTC-69ca8955.69c-LOG:  connection received: host=127.0.0.1
+        port=56600
+
+        2026-03-30 14:31:49 UTC-69ca8955.69c-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:31:49 UTC-69ca8955.69c-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:31:49 UTC-69ca8955.69c-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:31:49 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
+        0/5006F70, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-03-30 14:31:51 UTC-69ca8957.6a6-LOG:  connection received: host=127.0.0.1
+        port=56608
+
+        2026-03-30 14:31:51 UTC-69ca8957.6a6-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:31:51 UTC-69ca8957.6a6-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:31:51 UTC-69ca8957.6a6-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:31:51 UTC-69ca8957.6a6-LOG:  disconnection: session time: 0:00:00.047
+        user=azuresu database=postgres host=127.0.0.1 port=56608
+
+        2026-03-30 14:31:52 UTC-69ca8944.694-LOG:  disconnection: session time: 0:00:20.025
+        user=azuresu database=azure_sys host=127.0.0.1 port=51456
+
+        2026-03-30 14:31:53 UTC-69ca8945.695-LOG:  disconnection: session time: 0:00:20.025
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=51468
+
+        2026-03-30 14:31:55 UTC-69ca895b.6a9-LOG:  connection received: host=127.0.0.1
+        port=36514
+
+        2026-03-30 14:31:55 UTC-69ca8947.698-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=azure_sys host=127.0.0.1 port=36632
+
+        2026-03-30 14:31:55 UTC-69ca895b.6a9-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:31:55 UTC-69ca895b.6a9-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:31:55 UTC-69ca895b.6a9-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:31:59 UTC-69ca85db.373-LOG:  pg_qs: qs bgworker: worker woke
+        up and performed operations, with query data store as on
+
+        2026-03-30 14:31:59 UTC-69ca85db.373-LOG:  pg_qs: qs bgworker: instanceType=primary,
+        default_transaction_read_only=false
+
+        2026-03-30 14:31:59 UTC-69ca85db.373-LOG:  pg_qs: pg_qs_staging_data: Shall
+        collect the minimum of pg_qs.max_captured_queries (500) and pg_qs.max_queries
+        (1000).","context": "SQL statement \"SELECT *\n        FROM query_store.staging_data_1_4(showtext)\"\nPL/pgSQL
+        function query_store.staging_data(boolean) line 15 at RETURN QUERY\nSQL statement
+        \"WITH staging_data AS(\n\t\t\tSELECT * FROM query_store.staging_data(true)\n\t\t),\n\t\tdummyData
+        AS(\n\t\t\tINSERT INTO query_store.query_texts (query_text_id, query_sql_text,
+        query_type)\n\t\t\t\tSELECT query_id, CAST(query AS varchar(10000)) AS query,
+        query_type\n\t\t\t\tFROM staging_data\n\t\t\t\tON CONFLICT DO NOTHING\n\t\t\t\tRETURNING
+        query_text_id\n\t\t),\n\t\tdummyData2 AS(\n\t\t\tUPDATE query_store.query_texts
+        AS qt\n\t\t\t\tSET query_type = sd.query_type\n\t\t\t\tFROM staging_data AS
+        sd\n\t\t\t\tWHERE qt.query_text_id = sd.query_id\n\t\t\t\tRETURNING qt.query_text_id\n\t\t),
+        aux_interval_variables AS(\n            INSERT INTO query_store.runtime_stats_intervals
+        (start_time, end_time, comment) VALUES (current_timestamp - $1::INTERVAL,
+        current_timestamp, null) RETURNING runtime_stats_interval_id\n        ), aux_runtime_stats_variables
+        AS(\n            INSERT INTO query_store.runtime_stats_entries (user_id, db_id,
+        query_id, search_path, plan_id, runtime_stats_interval_id, query_parameters,
+        parameters_capture_status, search_path_capture_status)\n                SELECT
+        user_id, db_id, query_id, search_path, plan_id, aux_interval_variables.runtime_stats_interval_id,
+        query_parameters, parameters_capture_status, search_path_capture_status\n                FROM
+        aux_interval_variables, staging_data\n                RETURNING runtime_stats_entry_id,
+        user_id, db_id, query_id\n        ),\n\t\taux_runtime_stats_ws_entries AS(\n            INSERT
+        INTO query_store.runtime_stats_ws_entries (user_id, db_id, query_id, event_type,
+        event, runtime_stats_interval_id)\n                SELECT user_id, db_id,
+        query_id, event_type, event, aux_interval_variables.runtime_stats_interval_id\n                FROM
+        aux_interval_variables, query_store.staging_ws_data()\n                RETURNING
+        runtime_stats_ws_entry_id, user_id, db_id, query_id, event_type, event\n        ),\n\t\taux_runtime_stats_ws_values
+        AS\n\t\t(\n\t\t\tINSERT INTO query_store.runtime_stats_ws_values (runtime_stats_ws_entry_id,
+        calls)\n\t\t\t\tSELECT\n                aux_runtime_stats_ws_entries.runtime_stats_ws_entry_id,
+        calls\n\t\t\t\tFROM aux_runtime_stats_ws_entries JOIN query_store.staging_ws_data()
+        AS t1\n\t\t\t\tON\n\t\t\t\t\taux_runtime_stats_ws_entries.query_id = t1.query_id
+        AND\n\t\t\t\t\taux_runtime_stats_ws_entries.user_id = t1.user_id AND\n\t\t\t\t\taux_runtime_stats_ws_entries.db_id
+        = t1.db_id AND\n\t\t\t\t\taux_runtime_stats_ws_entries.event = t1.event AND\n\t\t\t\t\taux_runtime_stats_ws_entries.event_type
+        = t1.event_type\n\t\t),\n        plans AS\n\t\t(\n            INSERT INTO
+        query_store.query_plans (plan_id, db_id, query_id, plan_text)\n                SELECT
+        plan_id, db_id, query_id, CAST(plan_text AS varchar(10000)) AS plan_text\n                FROM
+        staging_data\n                WHERE plan_text IS NOT NULL AND query_id IS
+        NOT NULL AND plan_id IS NOT NULL\n                ON CONFLICT(plan_id, db_id,
+        query_id) DO NOTHING\n                returning plan_id, plan_text, query_id\n        )\n        INSERT
+        INTO query_store.runtime_stats (\n            runtime_stats_entry_id,\n            calls,\n            total_time,\n            min_time,\n            max_time,\n            mean_time,\n            stddev_time,\n            rows,\n            shared_blks_hit,\n            shared_blks_read,\n            shared_blks_dirtied,\n            shared_blks_written,\n            local_blks_hit,\n            local_blks_read,\n            local_blks_dirtied,\n            local_blks_written,\n            temp_blks_read,\n            temp_blks_written,\n            blk_read_time,\n            blk_write_time\n        )\n        SELECT\n            runtime_stats_entry_id,\n            calls,\n            total_time,\n            min_time,\n            max_time,\n            mean_time,\n            stddev_time,\n            rows,\n            shared_blks_hit,\n            shared_blks_read,\n            shared_blks_dirtied,\n            shared_blks_written,\n            local_blks_hit,\n            local_blks_read,\n            local_blks_dirtied,\n            local_blks_written,\n            temp_blks_read,\n            temp_blks_written,\n            blk_read_time,\n            blk_write_time\n        FROM\n            aux_runtime_stats_variables
+        JOIN staging_data AS t1 ON aux_runtime_stats_variables.user_id = t1.user_id
+        AND aux_runtime_stats_variables.db_id = t1.db_id AND aux_runtime_stats_variables.query_id
+        = t1.query_id\n\t\t\tLEFT OUTER JOIN plans p\n            ON aux_runtime_stats_variables.query_id
+        = p.query_id\"\nPL/pgSQL function query_store.collect_data(text,text) line
+        9 at SQL statement\nSQL statement \"SELECT query_store.collect_data(''15 minutes'',
+        ''7 days'')\"
+
+        2026-03-30 14:31:59 UTC-69ca85db.373-LOG:  pg_qs: pg_qs_staging_data: number
+        of hash entries (114) is within the limit (500), returning all","context":
+        "SQL statement \"SELECT *\n        FROM query_store.staging_data_1_4(showtext)\"\nPL/pgSQL
+        function query_store.staging_data(boolean) line 15 at RETURN QUERY\nSQL statement
+        \"WITH staging_data AS(\n\t\t\tSELECT * FROM query_store.staging_data(true)\n\t\t),\n\t\tdummyData
+        AS(\n\t\t\tINSERT INTO query_store.query_texts (query_text_id, query_sql_text,
+        query_type)\n\t\t\t\tSELECT query_id, CAST(query AS varchar(10000)) AS query,
+        query_type\n\t\t\t\tFROM staging_data\n\t\t\t\tON CONFLICT DO NOTHING\n\t\t\t\tRETURNING
+        query_text_id\n\t\t),\n\t\tdummyData2 AS(\n\t\t\tUPDATE query_store.query_texts
+        AS qt\n\t\t\t\tSET query_type = sd.query_type\n\t\t\t\tFROM staging_data AS
+        sd\n\t\t\t\tWHERE qt.query_text_id = sd.query_id\n\t\t\t\tRETURNING qt.query_text_id\n\t\t),
+        aux_interval_variables AS(\n            INSERT INTO query_store.runtime_stats_intervals
+        (start_time, end_time, comment) VALUES (current_timestamp - $1::INTERVAL,
+        current_timestamp, null) RETURNING runtime_stats_interval_id\n        ), aux_runtime_stats_variables
+        AS(\n            INSERT INTO query_store.runtime_stats_entries (user_id, db_id,
+        query_id, search_path, plan_id, runtime_stats_interval_id, query_parameters,
+        parameters_capture_status, search_path_capture_status)\n                SELECT
+        user_id, db_id, query_id, search_path, plan_id, aux_interval_variables.runtime_stats_interval_id,
+        query_parameters, parameters_capture_status, search_path_capture_status\n                FROM
+        aux_interval_variables, staging_data\n                RETURNING runtime_stats_entry_id,
+        user_id, db_id, query_id\n        ),\n\t\taux_runtime_stats_ws_entries AS(\n            INSERT
+        INTO query_store.runtime_stats_ws_entries (user_id, db_id, query_id, event_type,
+        event, runtime_stats_interval_id)\n                SELECT user_id, db_id,
+        query_id, event_type, event, aux_interval_variables.runtime_stats_interval_id\n                FROM
+        aux_interval_variables, query_store.staging_ws_data()\n                RETURNING
+        runtime_stats_ws_entry_id, user_id, db_id, query_id, event_type, event\n        ),\n\t\taux_runtime_stats_ws_values
+        AS\n\t\t(\n\t\t\tINSERT INTO query_store.runtime_stats_ws_values (runtime_stats_ws_entry_id,
+        calls)\n\t\t\t\tSELECT\n                aux_runtime_stats_ws_entries.runtime_stats_ws_entry_id,
+        calls\n\t\t\t\tFROM aux_runtime_stats_ws_entries JOIN query_store.staging_ws_data()
+        AS t1\n\t\t\t\tON\n\t\t\t\t\taux_runtime_stats_ws_entries.query_id = t1.query_id
+        AND\n\t\t\t\t\taux_runtime_stats_ws_entries.user_id = t1.user_id AND\n\t\t\t\t\taux_runtime_stats_ws_entries.db_id
+        = t1.db_id AND\n\t\t\t\t\taux_runtime_stats_ws_entries.event = t1.event AND\n\t\t\t\t\taux_runtime_stats_ws_entries.event_type
+        = t1.event_type\n\t\t),\n        plans AS\n\t\t(\n            INSERT INTO
+        query_store.query_plans (plan_id, db_id, query_id, plan_text)\n                SELECT
+        plan_id, db_id, query_id, CAST(plan_text AS varchar(10000)) AS plan_text\n                FROM
+        staging_data\n                WHERE plan_text IS NOT NULL AND query_id IS
+        NOT NULL AND plan_id IS NOT NULL\n                ON CONFLICT(plan_id, db_id,
+        query_id) DO NOTHING\n                returning plan_id, plan_text, query_id\n        )\n        INSERT
+        INTO query_store.runtime_stats (\n            runtime_stats_entry_id,\n            calls,\n            total_time,\n            min_time,\n            max_time,\n            mean_time,\n            stddev_time,\n            rows,\n            shared_blks_hit,\n            shared_blks_read,\n            shared_blks_dirtied,\n            shared_blks_written,\n            local_blks_hit,\n            local_blks_read,\n            local_blks_dirtied,\n            local_blks_written,\n            temp_blks_read,\n            temp_blks_written,\n            blk_read_time,\n            blk_write_time\n        )\n        SELECT\n            runtime_stats_entry_id,\n            calls,\n            total_time,\n            min_time,\n            max_time,\n            mean_time,\n            stddev_time,\n            rows,\n            shared_blks_hit,\n            shared_blks_read,\n            shared_blks_dirtied,\n            shared_blks_written,\n            local_blks_hit,\n            local_blks_read,\n            local_blks_dirtied,\n            local_blks_written,\n            temp_blks_read,\n            temp_blks_written,\n            blk_read_time,\n            blk_write_time\n        FROM\n            aux_runtime_stats_variables
+        JOIN staging_data AS t1 ON aux_runtime_stats_variables.user_id = t1.user_id
+        AND aux_runtime_stats_variables.db_id = t1.db_id AND aux_runtime_stats_variables.query_id
+        = t1.query_id\n\t\t\tLEFT OUTER JOIN plans p\n            ON aux_runtime_stats_variables.query_id
+        = p.query_id\"\nPL/pgSQL function query_store.collect_data(text,text) line
+        9 at SQL statement\nSQL statement \"SELECT query_store.collect_data(''15 minutes'',
+        ''7 days'')\"
+
+        2026-03-30 14:31:59 UTC-69ca85db.373-LOG:  pg_qs: pg_qs_staging_data: emitted
+        114 entries.","context": "SQL statement \"SELECT *\n        FROM query_store.staging_data_1_4(showtext)\"\nPL/pgSQL
+        function query_store.staging_data(boolean) line 15 at RETURN QUERY\nSQL statement
+        \"WITH staging_data AS(\n\t\t\tSELECT * FROM query_store.staging_data(true)\n\t\t),\n\t\tdummyData
+        AS(\n\t\t\tINSERT INTO query_store.query_texts (query_text_id, query_sql_text,
+        query_type)\n\t\t\t\tSELECT query_id, CAST(query AS varchar(10000)) AS query,
+        query_type\n\t\t\t\tFROM staging_data\n\t\t\t\tON CONFLICT DO NOTHING\n\t\t\t\tRETURNING
+        query_text_id\n\t\t),\n\t\tdummyData2 AS(\n\t\t\tUPDATE query_store.query_texts
+        AS qt\n\t\t\t\tSET query_type = sd.query_type\n\t\t\t\tFROM staging_data AS
+        sd\n\t\t\t\tWHERE qt.query_text_id = sd.query_id\n\t\t\t\tRETURNING qt.query_text_id\n\t\t),
+        aux_interval_variables AS(\n            INSERT INTO query_store.runtime_stats_intervals
+        (start_time, end_time, comment) VALUES (current_timestamp - $1::INTERVAL,
+        current_timestamp, null) RETURNING runtime_stats_interval_id\n        ), aux_runtime_stats_variables
+        AS(\n            INSERT INTO query_store.runtime_stats_entries (user_id, db_id,
+        query_id, search_path, plan_id, runtime_stats_interval_id, query_parameters,
+        parameters_capture_status, search_path_capture_status)\n                SELECT
+        user_id, db_id, query_id, search_path, plan_id, aux_interval_variables.runtime_stats_interval_id,
+        query_parameters, parameters_capture_status, search_path_capture_status\n                FROM
+        aux_interval_variables, staging_data\n                RETURNING runtime_stats_entry_id,
+        user_id, db_id, query_id\n        ),\n\t\taux_runtime_stats_ws_entries AS(\n            INSERT
+        INTO query_store.runtime_stats_ws_entries (user_id, db_id, query_id, event_type,
+        event, runtime_stats_interval_id)\n                SELECT user_id, db_id,
+        query_id, event_type, event, aux_interval_variables.runtime_stats_interval_id\n                FROM
+        aux_interval_variables, query_store.staging_ws_data()\n                RETURNING
+        runtime_stats_ws_entry_id, user_id, db_id, query_id, event_type, event\n        ),\n\t\taux_runtime_stats_ws_values
+        AS\n\t\t(\n\t\t\tINSERT INTO query_store.runtime_stats_ws_values (runtime_stats_ws_entry_id,
+        calls)\n\t\t\t\tSELECT\n                aux_runtime_stats_ws_entries.runtime_stats_ws_entry_id,
+        calls\n\t\t\t\tFROM aux_runtime_stats_ws_entries JOIN query_store.staging_ws_data()
+        AS t1\n\t\t\t\tON\n\t\t\t\t\taux_runtime_stats_ws_entries.query_id = t1.query_id
+        AND\n\t\t\t\t\taux_runtime_stats_ws_entries.user_id = t1.user_id AND\n\t\t\t\t\taux_runtime_stats_ws_entries.db_id
+        = t1.db_id AND\n\t\t\t\t\taux_runtime_stats_ws_entries.event = t1.event AND\n\t\t\t\t\taux_runtime_stats_ws_entries.event_type
+        = t1.event_type\n\t\t),\n        plans AS\n\t\t(\n            INSERT INTO
+        query_store.query_plans (plan_id, db_id, query_id, plan_text)\n                SELECT
+        plan_id, db_id, query_id, CAST(plan_text AS varchar(10000)) AS plan_text\n                FROM
+        staging_data\n                WHERE plan_text IS NOT NULL AND query_id IS
+        NOT NULL AND plan_id IS NOT NULL\n                ON CONFLICT(plan_id, db_id,
+        query_id) DO NOTHING\n                returning plan_id, plan_text, query_id\n        )\n        INSERT
+        INTO query_store.runtime_stats (\n            runtime_stats_entry_id,\n            calls,\n            total_time,\n            min_time,\n            max_time,\n            mean_time,\n            stddev_time,\n            rows,\n            shared_blks_hit,\n            shared_blks_read,\n            shared_blks_dirtied,\n            shared_blks_written,\n            local_blks_hit,\n            local_blks_read,\n            local_blks_dirtied,\n            local_blks_written,\n            temp_blks_read,\n            temp_blks_written,\n            blk_read_time,\n            blk_write_time\n        )\n        SELECT\n            runtime_stats_entry_id,\n            calls,\n            total_time,\n            min_time,\n            max_time,\n            mean_time,\n            stddev_time,\n            rows,\n            shared_blks_hit,\n            shared_blks_read,\n            shared_blks_dirtied,\n            shared_blks_written,\n            local_blks_hit,\n            local_blks_read,\n            local_blks_dirtied,\n            local_blks_written,\n            temp_blks_read,\n            temp_blks_written,\n            blk_read_time,\n            blk_write_time\n        FROM\n            aux_runtime_stats_variables
+        JOIN staging_data AS t1 ON aux_runtime_stats_variables.user_id = t1.user_id
+        AND aux_runtime_stats_variables.db_id = t1.db_id AND aux_runtime_stats_variables.query_id
+        = t1.query_id\n\t\t\tLEFT OUTER JOIN plans p\n            ON aux_runtime_stats_variables.query_id
+        = p.query_id\"\nPL/pgSQL function query_store.collect_data(text,text) line
+        9 at SQL statement\nSQL statement \"SELECT query_store.collect_data(''15 minutes'',
+        ''7 days'')\"
+
+        2026-03-30 14:31:59 UTC-69ca85db.373-LOG:  pgms_wait_sampling: num_entries
+        in table before calling collect_data: 22.","context": "SQL statement \"WITH
+        staging_data AS(\n\t\t\tSELECT * FROM query_store.staging_data(true)\n\t\t),\n\t\tdummyData
+        AS(\n\t\t\tINSERT INTO query_store.query_texts (query_text_id, query_sql_text,
+        query_type)\n\t\t\t\tSELECT query_id, CAST(query AS varchar(10000)) AS query,
+        query_type\n\t\t\t\tFROM staging_data\n\t\t\t\tON CONFLICT DO NOTHING\n\t\t\t\tRETURNING
+        query_text_id\n\t\t),\n\t\tdummyData2 AS(\n\t\t\tUPDATE query_store.query_texts
+        AS qt\n\t\t\t\tSET query_type = sd.query_type\n\t\t\t\tFROM staging_data AS
+        sd\n\t\t\t\tWHERE qt.query_text_id = sd.query_id\n\t\t\t\tRETURNING qt.query_text_id\n\t\t),
+        aux_interval_variables AS(\n            INSERT INTO query_store.runtime_stats_intervals
+        (start_time, end_time, comment) VALUES (current_timestamp - $1::INTERVAL,
+        current_timestamp, null) RETURNING runtime_stats_interval_id\n        ), aux_runtime_stats_variables
+        AS(\n            INSERT INTO query_store.runtime_stats_entries (user_id, db_id,
+        query_id, search_path, plan_id, runtime_stats_interval_id, query_parameters,
+        parameters_capture_status, search_path_capture_status)\n                SELECT
+        user_id, db_id, query_id, search_path, plan_id, aux_interval_variables.runtime_stats_interval_id,
+        query_parameters, parameters_capture_status, search_path_capture_status\n                FROM
+        aux_interval_variables, staging_data\n                RETURNING runtime_stats_entry_id,
+        user_id, db_id, query_id\n        ),\n\t\taux_runtime_stats_ws_entries AS(\n            INSERT
+        INTO query_store.runtime_stats_ws_entries (user_id, db_id, query_id, event_type,
+        event, runtime_stats_interval_id)\n                SELECT user_id, db_id,
+        query_id, event_type, event, aux_interval_variables.runtime_stats_interval_id\n                FROM
+        aux_interval_variables, query_store.staging_ws_data()\n                RETURNING
+        runtime_stats_ws_entry_id, user_id, db_id, query_id, event_type, event\n        ),\n\t\taux_runtime_stats_ws_values
+        AS\n\t\t(\n\t\t\tINSERT INTO query_store.runtime_stats_ws_values (runtime_stats_ws_entry_id,
+        calls)\n\t\t\t\tSELECT\n                aux_runtime_stats_ws_entries.runtime_stats_ws_entry_id,
+        calls\n\t\t\t\tFROM aux_runtime_stats_ws_entries JOIN query_store.staging_ws_data()
+        AS t1\n\t\t\t\tON\n\t\t\t\t\taux_runtime_stats_ws_entries.query_id = t1.query_id
+        AND\n\t\t\t\t\taux_runtime_stats_ws_entries.user_id = t1.user_id AND\n\t\t\t\t\taux_runtime_stats_ws_entries.db_id
+        = t1.db_id AND\n\t\t\t\t\taux_runtime_stats_ws_entries.event = t1.event AND\n\t\t\t\t\taux_runtime_stats_ws_entries.event_type
+        = t1.event_type\n\t\t),\n        plans AS\n\t\t(\n            INSERT INTO
+        query_store.query_plans (plan_id, db_id, query_id, plan_text)\n                SELECT
+        plan_id, db_id, query_id, CAST(plan_text AS varchar(10000)) AS plan_text\n                FROM
+        staging_data\n                WHERE plan_text IS NOT NULL AND query_id IS
+        NOT NULL AND plan_id IS NOT NULL\n                ON CONFLICT(plan_id, db_id,
+        query_id) DO NOTHING\n                returning plan_id, plan_text, query_id\n        )\n        INSERT
+        INTO query_store.runtime_stats (\n            runtime_stats_entry_id,\n            calls,\n            total_time,\n            min_time,\n            max_time,\n            mean_time,\n            stddev_time,\n            rows,\n            shared_blks_hit,\n            shared_blks_read,\n            shared_blks_dirtied,\n            shared_blks_written,\n            local_blks_hit,\n            local_blks_read,\n            local_blks_dirtied,\n            local_blks_written,\n            temp_blks_read,\n            temp_blks_written,\n            blk_read_time,\n            blk_write_time\n        )\n        SELECT\n            runtime_stats_entry_id,\n            calls,\n            total_time,\n            min_time,\n            max_time,\n            mean_time,\n            stddev_time,\n            rows,\n            shared_blks_hit,\n            shared_blks_read,\n            shared_blks_dirtied,\n            shared_blks_written,\n            local_blks_hit,\n            local_blks_read,\n            local_blks_dirtied,\n            local_blks_written,\n            temp_blks_read,\n            temp_blks_written,\n            blk_read_time,\n            blk_write_time\n        FROM\n            aux_runtime_stats_variables
+        JOIN staging_data AS t1 ON aux_runtime_stats_variables.user_id = t1.user_id
+        AND aux_runtime_stats_variables.db_id = t1.db_id AND aux_runtime_stats_variables.query_id
+        = t1.query_id\n\t\t\tLEFT OUTER JOIN plans p\n            ON aux_runtime_stats_variables.query_id
+        = p.query_id\"\nPL/pgSQL function query_store.collect_data(text,text) line
+        9 at SQL statement\nSQL statement \"SELECT query_store.collect_data(''15 minutes'',
+        ''7 days'')\"
+
+        2026-03-30 14:31:59 UTC-69ca85db.373-LOG:  pgms_wait_sampling: num_entries
+        in table before calling collect_data: 22.","context": "SQL statement \"WITH
+        staging_data AS(\n\t\t\tSELECT * FROM query_store.staging_data(true)\n\t\t),\n\t\tdummyData
+        AS(\n\t\t\tINSERT INTO query_store.query_texts (query_text_id, query_sql_text,
+        query_type)\n\t\t\t\tSELECT query_id, CAST(query AS varchar(10000)) AS query,
+        query_type\n\t\t\t\tFROM staging_data\n\t\t\t\tON CONFLICT DO NOTHING\n\t\t\t\tRETURNING
+        query_text_id\n\t\t),\n\t\tdummyData2 AS(\n\t\t\tUPDATE query_store.query_texts
+        AS qt\n\t\t\t\tSET query_type = sd.query_type\n\t\t\t\tFROM staging_data AS
+        sd\n\t\t\t\tWHERE qt.query_text_id = sd.query_id\n\t\t\t\tRETURNING qt.query_text_id\n\t\t),
+        aux_interval_variables AS(\n            INSERT INTO query_store.runtime_stats_intervals
+        (start_time, end_time, comment) VALUES (current_timestamp - $1::INTERVAL,
+        current_timestamp, null) RETURNING runtime_stats_interval_id\n        ), aux_runtime_stats_variables
+        AS(\n            INSERT INTO query_store.runtime_stats_entries (user_id, db_id,
+        query_id, search_path, plan_id, runtime_stats_interval_id, query_parameters,
+        parameters_capture_status, search_path_capture_status)\n                SELECT
+        user_id, db_id, query_id, search_path, plan_id, aux_interval_variables.runtime_stats_interval_id,
+        query_parameters, parameters_capture_status, search_path_capture_status\n                FROM
+        aux_interval_variables, staging_data\n                RETURNING runtime_stats_entry_id,
+        user_id, db_id, query_id\n        ),\n\t\taux_runtime_stats_ws_entries AS(\n            INSERT
+        INTO query_store.runtime_stats_ws_entries (user_id, db_id, query_id, event_type,
+        event, runtime_stats_interval_id)\n                SELECT user_id, db_id,
+        query_id, event_type, event, aux_interval_variables.runtime_stats_interval_id\n                FROM
+        aux_interval_variables, query_store.staging_ws_data()\n                RETURNING
+        runtime_stats_ws_entry_id, user_id, db_id, query_id, event_type, event\n        ),\n\t\taux_runtime_stats_ws_values
+        AS\n\t\t(\n\t\t\tINSERT INTO query_store.runtime_stats_ws_values (runtime_stats_ws_entry_id,
+        calls)\n\t\t\t\tSELECT\n                aux_runtime_stats_ws_entries.runtime_stats_ws_entry_id,
+        calls\n\t\t\t\tFROM aux_runtime_stats_ws_entries JOIN query_store.staging_ws_data()
+        AS t1\n\t\t\t\tON\n\t\t\t\t\taux_runtime_stats_ws_entries.query_id = t1.query_id
+        AND\n\t\t\t\t\taux_runtime_stats_ws_entries.user_id = t1.user_id AND\n\t\t\t\t\taux_runtime_stats_ws_entries.db_id
+        = t1.db_id AND\n\t\t\t\t\taux_runtime_stats_ws_entries.event = t1.event AND\n\t\t\t\t\taux_runtime_stats_ws_entries.event_type
+        = t1.event_type\n\t\t),\n        plans AS\n\t\t(\n            INSERT INTO
+        query_store.query_plans (plan_id, db_id, query_id, plan_text)\n                SELECT
+        plan_id, db_id, query_id, CAST(plan_text AS varchar(10000)) AS plan_text\n                FROM
+        staging_data\n                WHERE plan_text IS NOT NULL AND query_id IS
+        NOT NULL AND plan_id IS NOT NULL\n                ON CONFLICT(plan_id, db_id,
+        query_id) DO NOTHING\n                returning plan_id, plan_text, query_id\n        )\n        INSERT
+        INTO query_store.runtime_stats (\n            runtime_stats_entry_id,\n            calls,\n            total_time,\n            min_time,\n            max_time,\n            mean_time,\n            stddev_time,\n            rows,\n            shared_blks_hit,\n            shared_blks_read,\n            shared_blks_dirtied,\n            shared_blks_written,\n            local_blks_hit,\n            local_blks_read,\n            local_blks_dirtied,\n            local_blks_written,\n            temp_blks_read,\n            temp_blks_written,\n            blk_read_time,\n            blk_write_time\n        )\n        SELECT\n            runtime_stats_entry_id,\n            calls,\n            total_time,\n            min_time,\n            max_time,\n            mean_time,\n            stddev_time,\n            rows,\n            shared_blks_hit,\n            shared_blks_read,\n            shared_blks_dirtied,\n            shared_blks_written,\n            local_blks_hit,\n            local_blks_read,\n            local_blks_dirtied,\n            local_blks_written,\n            temp_blks_read,\n            temp_blks_written,\n            blk_read_time,\n            blk_write_time\n        FROM\n            aux_runtime_stats_variables
+        JOIN staging_data AS t1 ON aux_runtime_stats_variables.user_id = t1.user_id
+        AND aux_runtime_stats_variables.db_id = t1.db_id AND aux_runtime_stats_variables.query_id
+        = t1.query_id\n\t\t\tLEFT OUTER JOIN plans p\n            ON aux_runtime_stats_variables.query_id
+        = p.query_id\"\nPL/pgSQL function query_store.collect_data(text,text) line
+        9 at SQL statement\nSQL statement \"SELECT query_store.collect_data(''15 minutes'',
+        ''7 days'')\"
+
+        2026-03-30 14:31:59 UTC-69ca85db.373-LOG:  pg_qs: number of rows inserted
+        into runtime_stats: 114","context": "PL/pgSQL function query_store.collect_data(text,text)
+        line 110 at RAISE\nSQL statement \"SELECT query_store.collect_data(''15 minutes'',
+        ''7 days'')\"
+
+        2026-03-30 14:31:59 UTC-69ca85db.373-LOG:  pgms_wait_sampling: entry_reset
+        called","context": "SQL statement \"SELECT query_store.staging_ws_data_reset()\"\nPL/pgSQL
+        function query_store.collect_data(text,text) line 129 at PERFORM\nSQL statement
+        \"SELECT query_store.collect_data(''15 minutes'', ''7 days'')\"
+
+        2026-03-30 14:31:59 UTC-69ca85db.373-LOG:  pgms_wait_sampling: entry_reset
+        called","context": "SQL statement \"SELECT query_store.staging_ws_data_reset()\"
+
+        2026-03-30 14:31:59 UTC-69ca85db.373-LOG:  pg_qs: qs bgworker: worker finished
+        successfully in 13.288836 ms, with query store as on, is_writable_instance
+        as on and having_schema as true
+
+        2026-03-30 14:31:59 UTC-69ca85db.373-LOG:  pg_qs: qs bgworker: entry limit:
+        1000, tracked entries: 114, collected entries: 114, hash overflows: 0, entry
+        creation failures: 0, lock partitions: 32, spinlock buckets: on
+
+        2026-03-30 14:32:03 UTC-69ca8963.6ab-LOG:  connection received: host=127.0.0.1
+        port=36526
+
+        2026-03-30 14:32:03 UTC-69ca8963.6ab-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:32:03 UTC-69ca8963.6ab-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:32:03 UTC-69ca8963.6ab-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:32:09 UTC-69ca8955.69c-LOG:  disconnection: session time: 0:00:20.023
+        user=azuresu database=postgres host=127.0.0.1 port=56600
+
+        2026-03-30 14:32:09 UTC-69ca8969.6ae-LOG:  connection received: host=127.0.0.1
+        port=34570
+
+        2026-03-30 14:32:09 UTC-69ca8969.6ae-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:32:09 UTC-69ca8969.6ae-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:32:09 UTC-69ca8969.6ae-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:32:15 UTC-69ca895b.6a9-LOG:  disconnection: session time: 0:00:20.023
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=36514
+
+        2026-03-30 14:32:16 UTC-69ca8970.6ba-LOG:  connection received: host=127.0.0.1
+        port=60280
+
+        2026-03-30 14:32:16 UTC-69ca8970.6ba-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:32:16 UTC-69ca8970.6ba-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:32:16 UTC-69ca8970.6ba-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:32:16 UTC-69ca8970.6ba-LOG:  disconnection: session time: 0:00:00.047
+        user=azuresu database=postgres host=127.0.0.1 port=60280
+
+        2026-03-30 14:32:17 UTC-69ca8971.6bb-LOG:  connection received: host=127.0.0.1
+        port=60296
+
+        2026-03-30 14:32:17 UTC-69ca8971.6bb-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:32:17 UTC-69ca8971.6bb-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:32:17 UTC-69ca8971.6bb-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:32:23 UTC-69ca8963.6ab-LOG:  disconnection: session time: 0:00:20.036
+        user=azuresu database=azure_sys host=127.0.0.1 port=36526
+
+        2026-03-30 14:32:29 UTC-69ca8969.6ae-LOG:  disconnection: session time: 0:00:20.129
+        user=azuresu database=postgres host=127.0.0.1 port=34570
+
+        2026-03-30 14:32:34 UTC-69ca8982.6c1-LOG:  connection received: host=127.0.0.1
+        port=41882
+
+        2026-03-30 14:32:34 UTC-69ca8982.6c1-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:32:34 UTC-69ca8982.6c1-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:32:34 UTC-69ca8982.6c1-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:32:37 UTC-69ca8985.6c2-LOG:  connection received: host=127.0.0.1
+        port=45760
+
+        2026-03-30 14:32:37 UTC-69ca8971.6bb-LOG:  disconnection: session time: 0:00:20.028
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=60296
+
+        2026-03-30 14:32:37 UTC-69ca8985.6c2-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:32:37 UTC-69ca8985.6c2-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:32:37 UTC-69ca8985.6c2-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:32:39 UTC-69ca8987.6c4-LOG:  connection received: host=127.0.0.1
+        port=45768
+
+        2026-03-30 14:32:39 UTC-69ca8987.6c4-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:32:39 UTC-69ca8987.6c4-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:32:39 UTC-69ca8987.6c4-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:32:41 UTC-69ca8989.6ce-LOG:  connection received: host=127.0.0.1
+        port=45772
+
+        2026-03-30 14:32:42 UTC-69ca8989.6ce-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:32:42 UTC-69ca8989.6ce-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:32:42 UTC-69ca8989.6ce-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:32:42 UTC-69ca8989.6ce-LOG:  disconnection: session time: 0:00:00.046
+        user=azuresu database=postgres host=127.0.0.1 port=45772
+
+        2026-03-30 14:32:49 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
+        0/502F078, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-03-30 14:32:54 UTC-69ca8982.6c1-LOG:  disconnection: session time: 0:00:20.032
+        user=azuresu database=azure_sys host=127.0.0.1 port=41882
+
+        2026-03-30 14:32:57 UTC-69ca8985.6c2-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=postgres host=127.0.0.1 port=45760
+
+        2026-03-30 14:32:59 UTC-69ca8987.6c4-LOG:  disconnection: session time: 0:00:20.022
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=45768
+
+        2026-03-30 14:32:59 UTC-69ca899b.6d4-LOG:  connection received: host=127.0.0.1
+        port=42326
+
+        2026-03-30 14:32:59 UTC-69ca899b.6d4-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:32:59 UTC-69ca899b.6d4-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:32:59 UTC-69ca899b.6d4-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:33:01 UTC-69ca899d.6d5-LOG:  connection received: host=127.0.0.1
+        port=42342
+
+        2026-03-30 14:33:01 UTC-69ca899d.6d5-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:33:01 UTC-69ca899d.6d5-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:33:01 UTC-69ca899d.6d5-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:33:05 UTC-69ca89a1.6d7-LOG:  connection received: host=127.0.0.1
+        port=43248
+
+        2026-03-30 14:33:05 UTC-69ca89a1.6d7-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:33:05 UTC-69ca89a1.6d7-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:33:05 UTC-69ca89a1.6d7-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:33:07 UTC-69ca89a3.6e1-LOG:  connection received: host=127.0.0.1
+        port=43260
+
+        2026-03-30 14:33:07 UTC-69ca89a3.6e1-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:33:07 UTC-69ca89a3.6e1-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:33:07 UTC-69ca89a3.6e1-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:33:07 UTC-69ca89a3.6e1-LOG:  disconnection: session time: 0:00:00.048
+        user=azuresu database=postgres host=127.0.0.1 port=43260
+
+        2026-03-30 14:33:19 UTC-69ca899b.6d4-LOG:  disconnection: session time: 0:00:20.037
+        user=azuresu database=postgres host=127.0.0.1 port=42326
+
+        2026-03-30 14:33:19 UTC-69ca89af.6e6-LOG:  connection received: host=127.0.0.1
+        port=60822
+
+        2026-03-30 14:33:20 UTC-69ca89af.6e6-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:33:20 UTC-69ca89af.6e6-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:33:20 UTC-69ca89af.6e6-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:33:21 UTC-69ca899d.6d5-LOG:  disconnection: session time: 0:00:20.023
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=42342
+
+        2026-03-30 14:33:23 UTC-69ca89b3.6e7-LOG:  connection received: host=127.0.0.1
+        port=60826
+
+        2026-03-30 14:33:23 UTC-69ca89b3.6e7-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:33:23 UTC-69ca89b3.6e7-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:33:23 UTC-69ca89b3.6e7-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:33:25 UTC-69ca89a1.6d7-LOG:  disconnection: session time: 0:00:20.029
+        user=azuresu database=azure_sys host=127.0.0.1 port=43248
+
+        2026-03-30 14:33:32 UTC-69ca89bc.6f3-LOG:  connection received: host=127.0.0.1
+        port=35246
+
+        2026-03-30 14:33:32 UTC-69ca89bc.6f3-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:33:32 UTC-69ca89bc.6f3-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:33:32 UTC-69ca89bc.6f3-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:33:32 UTC-69ca89bc.6f3-LOG:  disconnection: session time: 0:00:00.046
+        user=azuresu database=postgres host=127.0.0.1 port=35246
+
+        2026-03-30 14:33:36 UTC-69ca89c0.6f6-LOG:  connection received: host=127.0.0.1
+        port=48462
+
+        2026-03-30 14:33:36 UTC-69ca89c0.6f6-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:33:36 UTC-69ca89c0.6f6-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:33:36 UTC-69ca89c0.6f6-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:33:40 UTC-69ca89af.6e6-LOG:  disconnection: session time: 0:00:20.022
+        user=azuresu database=postgres host=127.0.0.1 port=60822
+
+        2026-03-30 14:33:40 UTC-69ca89c4.6f8-LOG:  connection received: host=127.0.0.1
+        port=48464
+
+        2026-03-30 14:33:40 UTC-69ca89c4.6f8-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:33:40 UTC-69ca89c4.6f8-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:33:40 UTC-69ca89c4.6f8-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:33:43 UTC-69ca89b3.6e7-LOG:  disconnection: session time: 0:00:20.030
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=60826
+
+        2026-03-30 14:33:45 UTC-69ca89c9.6fa-LOG:  connection received: host=127.0.0.1
+        port=58190
+
+        2026-03-30 14:33:45 UTC-69ca89c9.6fa-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:33:45 UTC-69ca89c9.6fa-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:33:45 UTC-69ca89c9.6fa-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:33:49 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
+        0/502F718, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-03-30 14:33:56 UTC-69ca89c0.6f6-LOG:  disconnection: session time: 0:00:20.025
+        user=azuresu database=azure_sys host=127.0.0.1 port=48462
+
+        2026-03-30 14:33:57 UTC-69ca89d5.707-LOG:  connection received: host=127.0.0.1
+        port=55038
+
+        2026-03-30 14:33:57 UTC-69ca89d5.707-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:33:57 UTC-69ca89d5.707-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:33:57 UTC-69ca89d5.707-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:33:57 UTC-69ca89d5.707-LOG:  disconnection: session time: 0:00:00.046
+        user=azuresu database=postgres host=127.0.0.1 port=55038
+
+        2026-03-30 14:34:00 UTC-69ca89c4.6f8-LOG:  disconnection: session time: 0:00:20.027
+        user=azuresu database=postgres host=127.0.0.1 port=48464
+
+        2026-03-30 14:34:00 UTC-69ca89d8.709-LOG:  connection received: host=127.0.0.1
+        port=55052
+
+        2026-03-30 14:34:00 UTC-69ca89d8.709-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:34:00 UTC-69ca89d8.709-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:34:00 UTC-69ca89d8.709-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:34:05 UTC-69ca89c9.6fa-LOG:  disconnection: session time: 0:00:20.030
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=58190
+
+        2026-03-30 14:34:07 UTC-69ca89df.70b-LOG:  connection received: host=127.0.0.1
+        port=35722
+
+        2026-03-30 14:34:07 UTC-69ca89df.70c-LOG:  connection received: host=127.0.0.1
+        port=35728
+
+        2026-03-30 14:34:07 UTC-69ca89df.70b-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:34:07 UTC-69ca89df.70b-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:34:07 UTC-69ca89df.70b-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:34:07 UTC-69ca89df.70c-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:34:07 UTC-69ca89df.70c-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:34:07 UTC-69ca89df.70c-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:34:08 UTC-69ca89e0.70d-LOG:  connection received: host=127.0.0.1
+        port=35732
+
+        2026-03-30 14:34:08 UTC-69ca89e0.70d-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:34:08 UTC-69ca89e0.70d-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:34:08 UTC-69ca89e0.70d-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:34:20 UTC-69ca89e0.70d-LOG:  disconnection: session time: 0:00:12.052
+        user=azuresu database=postgres host=127.0.0.1 port=35732
+
+        2026-03-30 14:34:20 UTC-69ca89d8.709-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=postgres host=127.0.0.1 port=55052
+
+        2026-03-30 14:34:20 UTC-69ca89ec.712-LOG:  connection received: host=127.0.0.1
+        port=35656
+
+        2026-03-30 14:34:20 UTC-69ca89ec.712-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:34:20 UTC-69ca89ec.712-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:34:20 UTC-69ca89ec.712-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:34:22 UTC-69ca89ee.71c-LOG:  connection received: host=127.0.0.1
+        port=35660
+
+        2026-03-30 14:34:22 UTC-69ca89ee.71c-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:34:22 UTC-69ca89ee.71c-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:34:22 UTC-69ca89ee.71c-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:34:22 UTC-69ca89ee.71c-LOG:  disconnection: session time: 0:00:00.046
+        user=azuresu database=postgres host=127.0.0.1 port=35660
+
+        2026-03-30 14:34:27 UTC-69ca89df.70b-LOG:  disconnection: session time: 0:00:20.027
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=35722
+
+        2026-03-30 14:34:27 UTC-69ca89df.70c-LOG:  disconnection: session time: 0:00:20.030
+        user=azuresu database=azure_sys host=127.0.0.1 port=35728
+
+        2026-03-30 14:34:29 UTC-69ca89f5.71f-LOG:  connection received: host=127.0.0.1
+        port=39428
+
+        2026-03-30 14:34:29 UTC-69ca89f5.71f-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:34:29 UTC-69ca89f5.71f-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:34:29 UTC-69ca89f5.71f-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:34:38 UTC-69ca89fe.722-LOG:  connection received: host=127.0.0.1
+        port=39476
+
+        2026-03-30 14:34:38 UTC-69ca89fe.722-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:34:38 UTC-69ca89fe.722-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:34:38 UTC-69ca89fe.722-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:34:40 UTC-69ca89ec.712-LOG:  disconnection: session time: 0:00:20.027
+        user=azuresu database=postgres host=127.0.0.1 port=35656
+
+        2026-03-30 14:34:40 UTC-69ca8a00.724-LOG:  connection received: host=127.0.0.1
+        port=39486
+
+        2026-03-30 14:34:40 UTC-69ca8a00.724-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:34:40 UTC-69ca8a00.724-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:34:40 UTC-69ca8a00.724-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:34:47 UTC-69ca8a07.72f-LOG:  connection received: host=127.0.0.1
+        port=42134
+
+        2026-03-30 14:34:47 UTC-69ca8a07.72f-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:34:47 UTC-69ca8a07.72f-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:34:47 UTC-69ca8a07.72f-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:34:47 UTC-69ca8a07.72f-LOG:  disconnection: session time: 0:00:00.046
+        user=azuresu database=postgres host=127.0.0.1 port=42134
+
+        2026-03-30 14:34:49 UTC-69ca89f5.71f-LOG:  disconnection: session time: 0:00:20.025
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=39428
+
+        2026-03-30 14:34:49 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
+        0/502FDB8, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-03-30 14:34:51 UTC-69ca8a0b.731-LOG:  connection received: host=127.0.0.1
+        port=42136
+
+        2026-03-30 14:34:51 UTC-69ca8a0b.731-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:34:51 UTC-69ca8a0b.731-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:34:51 UTC-69ca8a0b.731-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:34:58 UTC-69ca89fe.722-LOG:  disconnection: session time: 0:00:20.023
+        user=azuresu database=azure_sys host=127.0.0.1 port=39476
+
+        2026-03-30 14:35:00 UTC-69ca8a00.724-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=postgres host=127.0.0.1 port=39486
+
+        2026-03-30 14:35:00 UTC-69ca8a14.735-LOG:  connection received: host=127.0.0.1
+        port=45000
+
+        2026-03-30 14:35:00 UTC-69ca8a14.735-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:35:00 UTC-69ca8a14.735-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:35:00 UTC-69ca8a14.735-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:35:09 UTC-69ca8a1d.738-LOG:  connection received: host=127.0.0.1
+        port=36916
+
+        2026-03-30 14:35:09 UTC-69ca8a1d.738-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:35:09 UTC-69ca8a1d.738-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:35:09 UTC-69ca8a1d.738-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:35:11 UTC-69ca8a0b.731-LOG:  disconnection: session time: 0:00:20.027
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=42136
+
+        2026-03-30 14:35:12 UTC-69ca8a20.742-LOG:  connection received: host=127.0.0.1
+        port=36930
+
+        2026-03-30 14:35:12 UTC-69ca8a20.742-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:35:12 UTC-69ca8a20.742-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:35:12 UTC-69ca8a20.742-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:35:12 UTC-69ca8a20.742-LOG:  disconnection: session time: 0:00:00.047
+        user=azuresu database=postgres host=127.0.0.1 port=36930
+
+        2026-03-30 14:35:13 UTC-69ca8a21.743-LOG:  connection received: host=127.0.0.1
+        port=36946
+
+        2026-03-30 14:35:13 UTC-69ca8a21.743-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:35:13 UTC-69ca8a21.743-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:35:13 UTC-69ca8a21.743-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:35:20 UTC-69ca8a14.735-LOG:  disconnection: session time: 0:00:20.022
+        user=azuresu database=postgres host=127.0.0.1 port=45000
+
+        2026-03-30 14:35:20 UTC-69ca8a28.747-LOG:  connection received: host=127.0.0.1
+        port=50564
+
+        2026-03-30 14:35:20 UTC-69ca8a28.747-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:35:20 UTC-69ca8a28.747-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:35:20 UTC-69ca8a28.747-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:35:29 UTC-69ca8a1d.738-LOG:  disconnection: session time: 0:00:20.025
+        user=azuresu database=azure_sys host=127.0.0.1 port=36916
+
+        2026-03-30 14:35:33 UTC-69ca8a21.743-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=36946
+
+        2026-03-30 14:35:35 UTC-69ca8a37.74c-LOG:  connection received: host=127.0.0.1
+        port=38640
+
+        2026-03-30 14:35:35 UTC-69ca8a37.74c-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:35:35 UTC-69ca8a37.74c-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:35:35 UTC-69ca8a37.74c-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:35:37 UTC-69ca8a39.756-LOG:  connection received: host=127.0.0.1
+        port=38642
+
+        2026-03-30 14:35:37 UTC-69ca8a39.756-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:35:37 UTC-69ca8a39.756-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:35:37 UTC-69ca8a39.756-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:35:37 UTC-69ca8a39.756-LOG:  disconnection: session time: 0:00:00.046
+        user=azuresu database=postgres host=127.0.0.1 port=38642
+
+        2026-03-30 14:35:40 UTC-69ca8a3c.758-LOG:  connection received: host=127.0.0.1
+        port=38650
+
+        2026-03-30 14:35:40 UTC-69ca8a3c.758-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:35:40 UTC-69ca8a3c.758-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:35:40 UTC-69ca8a3c.758-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:35:40 UTC-69ca8a28.747-LOG:  disconnection: session time: 0:00:20.023
+        user=azuresu database=postgres host=127.0.0.1 port=50564
+
+        2026-03-30 14:35:40 UTC-69ca8a3c.759-LOG:  connection received: host=127.0.0.1
+        port=38664
+
+        2026-03-30 14:35:40 UTC-69ca8a3c.759-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:35:40 UTC-69ca8a3c.759-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:35:40 UTC-69ca8a3c.759-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:35:49 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
+        0/5030470, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-03-30 14:35:55 UTC-69ca8a37.74c-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=38640
+
+        2026-03-30 14:35:57 UTC-69ca8a4d.75e-LOG:  connection received: host=127.0.0.1
+        port=37128
+
+        2026-03-30 14:35:57 UTC-69ca8a4d.75e-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:35:57 UTC-69ca8a4d.75e-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:35:57 UTC-69ca8a4d.75e-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:36:00 UTC-69ca8a3c.758-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=azure_sys host=127.0.0.1 port=38650
+
+        2026-03-30 14:36:00 UTC-69ca8a3c.759-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=postgres host=127.0.0.1 port=38664
+
+        2026-03-30 14:36:00 UTC-69ca8a50.760-LOG:  connection received: host=127.0.0.1
+        port=37138
+
+        2026-03-30 14:36:00 UTC-69ca8a50.760-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:36:00 UTC-69ca8a50.760-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:36:00 UTC-69ca8a50.760-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:36:02 UTC-69ca8a52.76a-LOG:  connection received: host=127.0.0.1
+        port=37146
+
+        2026-03-30 14:36:02 UTC-69ca8a52.76a-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:36:02 UTC-69ca8a52.76a-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:36:02 UTC-69ca8a52.76a-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:36:02 UTC-69ca8a52.76a-LOG:  disconnection: session time: 0:00:00.046
+        user=azuresu database=postgres host=127.0.0.1 port=37146
+
+        2026-03-30 14:36:11 UTC-69ca8a5b.788-LOG:  connection received: host=127.0.0.1
+        port=35126
+
+        2026-03-30 14:36:11 UTC-69ca8a5b.788-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:36:11 UTC-69ca8a5b.788-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:36:11 UTC-69ca8a5b.788-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:36:17 UTC-69ca8a4d.75e-LOG:  disconnection: session time: 0:00:20.033
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=37128
+
+        2026-03-30 14:36:19 UTC-69ca8a63.78f-LOG:  connection received: host=127.0.0.1
+        port=52336
+
+        2026-03-30 14:36:19 UTC-69ca8a63.78f-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:36:19 UTC-69ca8a63.78f-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:36:19 UTC-69ca8a63.78f-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:36:20 UTC-69ca8a50.760-LOG:  disconnection: session time: 0:00:20.021
+        user=azuresu database=postgres host=127.0.0.1 port=37138
+
+        2026-03-30 14:36:21 UTC-69ca8a65.790-LOG:  connection received: host=127.0.0.1
+        port=52352
+
+        2026-03-30 14:36:21 UTC-69ca8a65.790-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:36:21 UTC-69ca8a65.790-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:36:21 UTC-69ca8a65.790-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:36:28 UTC-69ca8a6c.79b-LOG:  connection received: host=127.0.0.1
+        port=38176
+
+        2026-03-30 14:36:28 UTC-69ca8a6c.79b-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:36:28 UTC-69ca8a6c.79b-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:36:28 UTC-69ca8a6c.79b-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:36:28 UTC-69ca8a6c.79b-LOG:  disconnection: session time: 0:00:00.047
+        user=azuresu database=postgres host=127.0.0.1 port=38176
+
+        2026-03-30 14:36:31 UTC-69ca8a5b.788-LOG:  disconnection: session time: 0:00:20.025
+        user=azuresu database=azure_sys host=127.0.0.1 port=35126
+
+        2026-03-30 14:36:35 UTC-69ca8a73.79f-LOG:  connection received: host=127.0.0.1
+        port=36346
+
+        2026-03-30 14:36:35 UTC-69ca8a73.79f-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:36:35 UTC-69ca8a73.79f-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:36:35 UTC-69ca8a73.79f-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:36:39 UTC-69ca8a77.7a1-LOG:  connection received: host=127.0.0.1
+        port=36356
+
+        2026-03-30 14:36:39 UTC-69ca8a63.78f-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=52336
+
+        2026-03-30 14:36:39 UTC-69ca8a77.7a1-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:36:39 UTC-69ca8a77.7a1-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:36:39 UTC-69ca8a77.7a1-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:36:41 UTC-69ca8a65.790-LOG:  disconnection: session time: 0:00:20.028
+        user=azuresu database=postgres host=127.0.0.1 port=52352
+
+        2026-03-30 14:36:41 UTC-69ca8a79.7a2-LOG:  connection received: host=127.0.0.1
+        port=36362
+
+        2026-03-30 14:36:41 UTC-69ca8a79.7a2-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:36:41 UTC-69ca8a79.7a2-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:36:41 UTC-69ca8a79.7a2-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:36:42 UTC-69ca8a7a.7a3-LOG:  connection received: host=127.0.0.1
+        port=36376
+
+        2026-03-30 14:36:42 UTC-69ca8a7a.7a3-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:36:42 UTC-69ca8a7a.7a3-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:36:42 UTC-69ca8a7a.7a3-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:36:50 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
+        0/6000600, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-03-30 14:36:53 UTC-69ca8a85.7af-LOG:  connection received: host=127.0.0.1
+        port=44106
+
+        2026-03-30 14:36:53 UTC-69ca8a85.7af-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:36:53 UTC-69ca8a85.7af-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:36:53 UTC-69ca8a85.7af-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:36:53 UTC-69ca8a85.7af-LOG:  disconnection: session time: 0:00:00.050
+        user=azuresu database=postgres host=127.0.0.1 port=44106
+
+        2026-03-30 14:36:55 UTC-69ca8a73.79f-LOG:  disconnection: session time: 0:00:20.028
+        user=azuresu database=azure_sys host=127.0.0.1 port=36346
+
+        2026-03-30 14:37:01 UTC-69ca8a77.7a1-LOG:  disconnection: session time: 0:00:21.904
+        user=azuresu database=postgres host=127.0.0.1 port=36356
+
+        2026-03-30 14:37:01 UTC-69ca8a79.7a2-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=36362
+
+        2026-03-30 14:37:01 UTC-69ca8a8d.7b3-LOG:  connection received: host=127.0.0.1
+        port=49392
+
+        2026-03-30 14:37:01 UTC-69ca8a8d.7b3-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:37:01 UTC-69ca8a8d.7b3-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:37:01 UTC-69ca8a8d.7b3-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:37:02 UTC-69ca8a7a.7a3-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=azure_sys host=127.0.0.1 port=36376
+
+        2026-03-30 14:37:03 UTC-69ca8a8f.7b4-LOG:  connection received: host=127.0.0.1
+        port=49404
+
+        2026-03-30 14:37:03 UTC-69ca8a8f.7b4-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:37:03 UTC-69ca8a8f.7b4-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:37:03 UTC-69ca8a8f.7b4-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:37:13 UTC-69ca8a99.7b7-LOG:  connection received: host=127.0.0.1
+        port=39602
+
+        2026-03-30 14:37:13 UTC-69ca8a99.7b7-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:37:13 UTC-69ca8a99.7b7-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:37:13 UTC-69ca8a99.7b7-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:37:18 UTC-69ca8a9e.7c4-LOG:  connection received: host=127.0.0.1
+        port=39248
+
+        2026-03-30 14:37:18 UTC-69ca8a9e.7c4-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:37:18 UTC-69ca8a9e.7c4-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:37:18 UTC-69ca8a9e.7c4-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:37:18 UTC-69ca8a9e.7c4-LOG:  disconnection: session time: 0:00:00.046
+        user=azuresu database=postgres host=127.0.0.1 port=39248
+
+        2026-03-30 14:37:21 UTC-69ca8a8d.7b3-LOG:  disconnection: session time: 0:00:20.035
+        user=azuresu database=postgres host=127.0.0.1 port=49392
+
+        2026-03-30 14:37:21 UTC-69ca8aa1.7c5-LOG:  connection received: host=127.0.0.1
+        port=39252
+
+        2026-03-30 14:37:21 UTC-69ca8aa1.7c5-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:37:21 UTC-69ca8aa1.7c5-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:37:21 UTC-69ca8aa1.7c5-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:37:23 UTC-69ca8a8f.7b4-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=49404
+
+        2026-03-30 14:37:25 UTC-69ca8aa5.7c7-LOG:  connection received: host=127.0.0.1
+        port=44814
+
+        2026-03-30 14:37:25 UTC-69ca8aa5.7c7-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:37:25 UTC-69ca8aa5.7c7-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:37:25 UTC-69ca8aa5.7c7-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:37:33 UTC-69ca8a99.7b7-LOG:  disconnection: session time: 0:00:20.130
+        user=azuresu database=azure_sys host=127.0.0.1 port=39602
+
+        2026-03-30 14:37:39 UTC-69ca8ab3.7cc-LOG:  connection received: host=127.0.0.1
+        port=46614
+
+        2026-03-30 14:37:39 UTC-69ca8ab3.7cc-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:37:39 UTC-69ca8ab3.7cc-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:37:39 UTC-69ca8ab3.7cc-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:37:41 UTC-69ca8aa1.7c5-LOG:  disconnection: session time: 0:00:20.023
+        user=azuresu database=postgres host=127.0.0.1 port=39252
+
+        2026-03-30 14:37:43 UTC-69ca8ab7.7d7-LOG:  connection received: host=127.0.0.1
+        port=46626
+
+        2026-03-30 14:37:43 UTC-69ca8ab7.7d7-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:37:43 UTC-69ca8ab7.7d7-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:37:43 UTC-69ca8ab7.7d7-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:37:43 UTC-69ca8ab7.7d7-LOG:  disconnection: session time: 0:00:00.046
+        user=azuresu database=postgres host=127.0.0.1 port=46626
+
+        2026-03-30 14:37:44 UTC-69ca8ab8.7d8-LOG:  connection received: host=127.0.0.1
+        port=46634
+
+        2026-03-30 14:37:44 UTC-69ca8ab8.7d8-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:37:44 UTC-69ca8ab8.7d8-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:37:44 UTC-69ca8ab8.7d8-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:37:45 UTC-69ca8aa5.7c7-LOG:  disconnection: session time: 0:00:20.025
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=44814
+
+        2026-03-30 14:37:47 UTC-69ca8abb.7d9-LOG:  connection received: host=127.0.0.1
+        port=54946
+
+        2026-03-30 14:37:47 UTC-69ca8abb.7d9-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:37:47 UTC-69ca8abb.7d9-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:37:47 UTC-69ca8abb.7d9-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:37:50 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
+        0/6000CA0, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-03-30 14:38:01 UTC-69ca8ab3.7cc-LOG:  disconnection: session time: 0:00:22.238
+        user=azuresu database=postgres host=127.0.0.1 port=46614
+
+        2026-03-30 14:38:01 UTC-69ca8ac9.7de-LOG:  connection received: host=127.0.0.1
+        port=34026
+
+        2026-03-30 14:38:01 UTC-69ca8ac9.7de-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:38:01 UTC-69ca8ac9.7de-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:38:01 UTC-69ca8ac9.7de-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:38:04 UTC-69ca8ab8.7d8-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=azure_sys host=127.0.0.1 port=46634
+
+        2026-03-30 14:38:07 UTC-69ca8abb.7d9-LOG:  disconnection: session time: 0:00:20.025
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=54946
+
+        2026-03-30 14:38:08 UTC-69ca8ad0.7ea-LOG:  connection received: host=127.0.0.1
+        port=36640
+
+        2026-03-30 14:38:08 UTC-69ca8ad0.7ea-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:38:08 UTC-69ca8ad0.7ea-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:38:08 UTC-69ca8ad0.7ea-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:38:08 UTC-69ca8ad0.7ea-LOG:  disconnection: session time: 0:00:00.047
+        user=azuresu database=postgres host=127.0.0.1 port=36640
+
+        2026-03-30 14:38:09 UTC-69ca8ad1.7eb-LOG:  connection received: host=127.0.0.1
+        port=36652
+
+        2026-03-30 14:38:09 UTC-69ca8ad1.7eb-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:38:09 UTC-69ca8ad1.7eb-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:38:09 UTC-69ca8ad1.7eb-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:38:15 UTC-69ca8ad7.7ee-LOG:  connection received: host=127.0.0.1
+        port=53394
+
+        2026-03-30 14:38:15 UTC-69ca8ad7.7ee-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:38:15 UTC-69ca8ad7.7ee-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:38:15 UTC-69ca8ad7.7ee-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:38:21 UTC-69ca8ac9.7de-LOG:  disconnection: session time: 0:00:20.033
+        user=azuresu database=postgres host=127.0.0.1 port=34026
+
+        2026-03-30 14:38:21 UTC-69ca8add.7f0-LOG:  connection received: host=127.0.0.1
+        port=53398
+
+        2026-03-30 14:38:21 UTC-69ca8add.7f0-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:38:21 UTC-69ca8add.7f0-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:38:21 UTC-69ca8add.7f0-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:38:29 UTC-69ca8ad1.7eb-LOG:  disconnection: session time: 0:00:20.025
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=36652
+
+        2026-03-30 14:38:31 UTC-69ca8ae7.7f3-LOG:  connection received: host=127.0.0.1
+        port=34180
+
+        2026-03-30 14:38:31 UTC-69ca8ae7.7f3-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:38:31 UTC-69ca8ae7.7f3-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:38:31 UTC-69ca8ae7.7f3-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:38:33 UTC-69ca8ae9.7fe-LOG:  connection received: host=127.0.0.1
+        port=34190
+
+        2026-03-30 14:38:33 UTC-69ca8ae9.7fe-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:38:33 UTC-69ca8ae9.7fe-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:38:33 UTC-69ca8ae9.7fe-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:38:33 UTC-69ca8ae9.7fe-LOG:  disconnection: session time: 0:00:00.046
+        user=azuresu database=postgres host=127.0.0.1 port=34190
+
+        2026-03-30 14:38:35 UTC-69ca8ad7.7ee-LOG:  disconnection: session time: 0:00:20.022
+        user=azuresu database=azure_sys host=127.0.0.1 port=53394
+
+        2026-03-30 14:38:41 UTC-69ca8add.7f0-LOG:  disconnection: session time: 0:00:20.027
+        user=azuresu database=postgres host=127.0.0.1 port=53398
+
+        2026-03-30 14:38:42 UTC-69ca8af2.801-LOG:  connection received: host=127.0.0.1
+        port=59018
+
+        2026-03-30 14:38:42 UTC-69ca8af2.801-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:38:42 UTC-69ca8af2.801-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:38:42 UTC-69ca8af2.801-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:38:46 UTC-69ca8af6.803-LOG:  connection received: host=127.0.0.1
+        port=51010
+
+        2026-03-30 14:38:46 UTC-69ca8af6.803-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:38:46 UTC-69ca8af6.803-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:38:46 UTC-69ca8af6.803-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:38:50 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
+        0/6002960, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-03-30 14:38:51 UTC-69ca8ae7.7f3-LOG:  disconnection: session time: 0:00:20.023
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=34180
+
+        2026-03-30 14:38:53 UTC-69ca8afd.805-LOG:  connection received: host=127.0.0.1
+        port=51024
+
+        2026-03-30 14:38:53 UTC-69ca8afd.805-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:38:53 UTC-69ca8afd.805-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:38:53 UTC-69ca8afd.805-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:38:58 UTC-69ca8b02.812-LOG:  connection received: host=127.0.0.1
+        port=47968
+
+        2026-03-30 14:38:58 UTC-69ca8b02.812-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:38:58 UTC-69ca8b02.812-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:38:58 UTC-69ca8b02.812-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:38:58 UTC-69ca8b02.812-LOG:  disconnection: session time: 0:00:00.047
+        user=azuresu database=postgres host=127.0.0.1 port=47968
+
+        2026-03-30 14:39:02 UTC-69ca8af2.801-LOG:  disconnection: session time: 0:00:20.025
+        user=azuresu database=postgres host=127.0.0.1 port=59018
+
+        2026-03-30 14:39:03 UTC-69ca8b07.813-LOG:  connection received: host=127.0.0.1
+        port=47980
+
+        2026-03-30 14:39:03 UTC-69ca8b07.813-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:39:03 UTC-69ca8b07.813-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:39:03 UTC-69ca8b07.813-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:39:06 UTC-69ca8af6.803-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=azure_sys host=127.0.0.1 port=51010
+
+        2026-03-30 14:39:13 UTC-69ca8afd.805-LOG:  disconnection: session time: 0:00:20.031
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=51024
+
+        2026-03-30 14:39:15 UTC-69ca8b13.818-LOG:  connection received: host=127.0.0.1
+        port=53640
+
+        2026-03-30 14:39:15 UTC-69ca8b13.818-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:39:15 UTC-69ca8b13.818-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:39:15 UTC-69ca8b13.818-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:39:17 UTC-69ca8b15.819-LOG:  connection received: host=127.0.0.1
+        port=53650
+
+        2026-03-30 14:39:17 UTC-69ca8b15.819-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:39:17 UTC-69ca8b15.819-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:39:17 UTC-69ca8b15.819-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:39:23 UTC-69ca8b07.813-LOG:  disconnection: session time: 0:00:20.027
+        user=azuresu database=postgres host=127.0.0.1 port=47980
+
+        2026-03-30 14:39:23 UTC-69ca8b1b.825-LOG:  connection received: host=127.0.0.1
+        port=53652
+
+        2026-03-30 14:39:23 UTC-69ca8b1b.825-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:39:23 UTC-69ca8b1b.825-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:39:23 UTC-69ca8b1b.825-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:39:23 UTC-69ca8b1b.825-LOG:  disconnection: session time: 0:00:00.046
+        user=azuresu database=postgres host=127.0.0.1 port=53652
+
+        2026-03-30 14:39:24 UTC-69ca8b1c.826-LOG:  connection received: host=127.0.0.1
+        port=53662
+
+        2026-03-30 14:39:24 UTC-69ca8b1c.826-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:39:24 UTC-69ca8b1c.826-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:39:24 UTC-69ca8b1c.826-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:39:35 UTC-69ca8b13.818-LOG:  disconnection: session time: 0:00:20.023
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=53640
+
+        2026-03-30 14:39:37 UTC-69ca8b29.82a-LOG:  connection received: host=127.0.0.1
+        port=46658
+
+        2026-03-30 14:39:37 UTC-69ca8b15.819-LOG:  disconnection: session time: 0:00:20.023
+        user=azuresu database=azure_sys host=127.0.0.1 port=53650
+
+        2026-03-30 14:39:37 UTC-69ca8b29.82a-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:39:37 UTC-69ca8b29.82a-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:39:37 UTC-69ca8b29.82a-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:39:44 UTC-69ca8b1c.826-LOG:  disconnection: session time: 0:00:20.025
+        user=azuresu database=postgres host=127.0.0.1 port=53662
+
+        2026-03-30 14:39:45 UTC-69ca8b31.82d-LOG:  connection received: host=127.0.0.1
+        port=36918
+
+        2026-03-30 14:39:45 UTC-69ca8b31.82d-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:39:45 UTC-69ca8b31.82d-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:39:45 UTC-69ca8b31.82d-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:39:48 UTC-69ca8b34.82e-LOG:  connection received: host=127.0.0.1
+        port=36932
+
+        2026-03-30 14:39:48 UTC-69ca8b34.82e-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:39:48 UTC-69ca8b34.82e-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:39:48 UTC-69ca8b34.82e-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:39:48 UTC-69ca8b34.839-LOG:  connection received: host=127.0.0.1
+        port=36936
+
+        2026-03-30 14:39:48 UTC-69ca8b34.839-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:39:48 UTC-69ca8b34.839-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:39:48 UTC-69ca8b34.839-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:39:48 UTC-69ca8b34.839-LOG:  disconnection: session time: 0:00:00.047
+        user=azuresu database=postgres host=127.0.0.1 port=36936
+
+        2026-03-30 14:39:50 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
+        0/6003000, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-03-30 14:39:57 UTC-69ca8b29.82a-LOG:  disconnection: session time: 0:00:20.025
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=46658
+
+        2026-03-30 14:39:59 UTC-69ca8b3f.83d-LOG:  connection received: host=127.0.0.1
+        port=52944
+
+        2026-03-30 14:39:59 UTC-69ca8b3f.83d-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:39:59 UTC-69ca8b3f.83d-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:39:59 UTC-69ca8b3f.83d-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:40:03 UTC-69ca85d0.2f7-LOG:  checkpoint starting: time
+
+        2026-03-30 14:40:05 UTC-69ca8b31.82d-LOG:  disconnection: session time: 0:00:20.022
+        user=azuresu database=postgres host=127.0.0.1 port=36918
+
+        2026-03-30 14:40:06 UTC-69ca8b46.846-LOG:  connection received: host=127.0.0.1
+        port=58694
+
+        2026-03-30 14:40:06 UTC-69ca8b46.846-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:40:06 UTC-69ca8b46.846-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:40:06 UTC-69ca8b46.846-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:40:08 UTC-69ca8b34.82e-LOG:  disconnection: session time: 0:00:20.027
+        user=azuresu database=azure_sys host=127.0.0.1 port=36932
+
+        2026-03-30 14:40:12 UTC-69ca85d0.2f7-LOG:  checkpoint complete: wrote 88 buffers
+        (0.0%); 0 WAL file(s) added, 0 removed, 0 recycled; write=8.747 s, sync=0.003
+        s, total=8.779 s; sync files=49, longest=0.003 s, average=0.001 s; distance=32773
+        kB, estimate=32774 kB; lsn=0/60034C8, redo lsn=0/60031A8
+
+        2026-03-30 14:40:14 UTC-69ca8b4e.852-LOG:  connection received: host=127.0.0.1
+        port=58696
+
+        2026-03-30 14:40:14 UTC-69ca8b4e.852-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:40:14 UTC-69ca8b4e.852-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:40:14 UTC-69ca8b4e.852-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:40:14 UTC-69ca8b4e.852-LOG:  disconnection: session time: 0:00:00.047
+        user=azuresu database=postgres host=127.0.0.1 port=58696
+
+        2026-03-30 14:40:19 UTC-69ca8b53.855-LOG:  connection received: host=127.0.0.1
+        port=42404
+
+        2026-03-30 14:40:19 UTC-69ca8b3f.83d-LOG:  disconnection: session time: 0:00:20.022
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=52944
+
+        2026-03-30 14:40:19 UTC-69ca8b53.855-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:40:19 UTC-69ca8b53.855-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:40:19 UTC-69ca8b53.855-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:40:21 UTC-69ca8b55.856-LOG:  connection received: host=127.0.0.1
+        port=42418
+
+        2026-03-30 14:40:21 UTC-69ca8b55.856-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:40:21 UTC-69ca8b55.856-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:40:21 UTC-69ca8b55.856-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:40:26 UTC-69ca8b46.846-LOG:  disconnection: session time: 0:00:20.029
+        user=azuresu database=postgres host=127.0.0.1 port=58694
+
+        2026-03-30 14:40:28 UTC-69ca8b5c.858-LOG:  connection received: host=127.0.0.1
+        port=32916
+
+        2026-03-30 14:40:28 UTC-69ca8b5c.858-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:40:28 UTC-69ca8b5c.858-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:40:28 UTC-69ca8b5c.858-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:40:39 UTC-69ca8b67.866-LOG:  connection received: host=127.0.0.1
+        port=52136
+
+        2026-03-30 14:40:39 UTC-69ca8b67.866-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:40:39 UTC-69ca8b67.866-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:40:39 UTC-69ca8b67.866-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:40:39 UTC-69ca8b67.866-LOG:  disconnection: session time: 0:00:00.046
+        user=azuresu database=postgres host=127.0.0.1 port=52136
+
+        2026-03-30 14:40:39 UTC-69ca8b53.855-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=azure_sys host=127.0.0.1 port=42404
+
+        2026-03-30 14:40:41 UTC-69ca8b55.856-LOG:  disconnection: session time: 0:00:20.025
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=42418
+
+        2026-03-30 14:40:43 UTC-69ca8b6b.867-LOG:  connection received: host=127.0.0.1
+        port=52142
+
+        2026-03-30 14:40:43 UTC-69ca8b6b.867-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:40:43 UTC-69ca8b6b.867-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:40:43 UTC-69ca8b6b.867-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:40:48 UTC-69ca8b5c.858-LOG:  disconnection: session time: 0:00:20.023
+        user=azuresu database=postgres host=127.0.0.1 port=32916
+
+        2026-03-30 14:40:50 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
+        0/6003980, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-03-30 14:40:50 UTC-69ca8b72.86a-LOG:  connection received: host=127.0.0.1
+        port=40852
+
+        2026-03-30 14:40:50 UTC-69ca8b72.86b-LOG:  connection received: host=127.0.0.1
+        port=40858
+
+        2026-03-30 14:40:50 UTC-69ca8b72.86a-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:40:50 UTC-69ca8b72.86a-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:40:50 UTC-69ca8b72.86a-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:40:50 UTC-69ca8b72.86b-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:40:50 UTC-69ca8b72.86b-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:40:50 UTC-69ca8b72.86b-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:41:03 UTC-69ca8b6b.867-LOG:  disconnection: session time: 0:00:20.022
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=52142
+
+        2026-03-30 14:41:04 UTC-69ca8b80.879-LOG:  connection received: host=127.0.0.1
+        port=48234
+
+        2026-03-30 14:41:04 UTC-69ca8b80.879-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:41:04 UTC-69ca8b80.879-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:41:04 UTC-69ca8b80.879-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:41:04 UTC-69ca8b80.879-LOG:  disconnection: session time: 0:00:00.047
+        user=azuresu database=postgres host=127.0.0.1 port=48234
+
+        2026-03-30 14:41:05 UTC-69ca8b81.88f-LOG:  connection received: host=127.0.0.1
+        port=55844
+
+        2026-03-30 14:41:05 UTC-69ca8b81.88f-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:41:05 UTC-69ca8b81.88f-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:41:05 UTC-69ca8b81.88f-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:41:10 UTC-69ca8b72.86a-LOG:  disconnection: session time: 0:00:20.025
+        user=azuresu database=azure_sys host=127.0.0.1 port=40852
+
+        2026-03-30 14:41:10 UTC-69ca8b72.86b-LOG:  disconnection: session time: 0:00:20.029
+        user=azuresu database=postgres host=127.0.0.1 port=40858
+
+        2026-03-30 14:41:11 UTC-69ca8b87.891-LOG:  connection received: host=127.0.0.1
+        port=55852
+
+        2026-03-30 14:41:11 UTC-69ca8b87.891-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:41:11 UTC-69ca8b87.891-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:41:11 UTC-69ca8b87.891-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:41:21 UTC-69ca8b91.895-LOG:  connection received: host=127.0.0.1
+        port=45320
+
+        2026-03-30 14:41:21 UTC-69ca8b91.895-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:41:21 UTC-69ca8b91.895-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:41:21 UTC-69ca8b91.895-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:41:25 UTC-69ca8b81.88f-LOG:  disconnection: session time: 0:00:20.181
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=55844
+
+        2026-03-30 14:41:27 UTC-69ca8b97.897-LOG:  connection received: host=127.0.0.1
+        port=35850
+
+        2026-03-30 14:41:27 UTC-69ca8b97.897-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:41:27 UTC-69ca8b97.897-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:41:27 UTC-69ca8b97.897-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:41:29 UTC-69ca8b99.8a2-LOG:  connection received: host=127.0.0.1
+        port=35860
+
+        2026-03-30 14:41:29 UTC-69ca8b99.8a2-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:41:29 UTC-69ca8b99.8a2-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:41:29 UTC-69ca8b99.8a2-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:41:29 UTC-69ca8b99.8a2-LOG:  disconnection: session time: 0:00:00.046
+        user=azuresu database=postgres host=127.0.0.1 port=35860
+
+        2026-03-30 14:41:31 UTC-69ca8b87.891-LOG:  disconnection: session time: 0:00:20.028
+        user=azuresu database=postgres host=127.0.0.1 port=55852
+
+        2026-03-30 14:41:32 UTC-69ca8b9c.8a3-LOG:  connection received: host=127.0.0.1
+        port=35864
+
+        2026-03-30 14:41:32 UTC-69ca8b9c.8a3-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:41:32 UTC-69ca8b9c.8a3-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:41:32 UTC-69ca8b9c.8a3-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:41:35 UTC-69ca8b9f.8a6-LOG:  connection received: host=127.0.0.1
+        port=53388
+
+        2026-03-30 14:41:35 UTC-69ca8b9f.8a6-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:41:35 UTC-69ca8b9f.8a6-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:41:35 UTC-69ca8b9f.8a6-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:41:39 UTC-69ca8ba3.8a8-LOG:  connection received: host=127.0.0.1
+        port=53400
+
+        2026-03-30 14:41:39 UTC-69ca8ba3.8a8-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:41:39 UTC-69ca8ba3.8a8-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:41:39 UTC-69ca8ba3.8a8-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:41:41 UTC-69ca8b91.895-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=azure_sys host=127.0.0.1 port=45320
+
+        2026-03-30 14:41:47 UTC-69ca8b97.897-LOG:  disconnection: session time: 0:00:20.025
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=35850
+
+        2026-03-30 14:41:49 UTC-69ca8bad.8ab-LOG:  connection received: host=127.0.0.1
+        port=33994
+
+        2026-03-30 14:41:49 UTC-69ca8bad.8ab-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:41:49 UTC-69ca8bad.8ab-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:41:49 UTC-69ca8bad.8ab-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:41:50 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
+        0/7000600, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-03-30 14:41:52 UTC-69ca8bb0.8ac-LOG:  connection received: host=127.0.0.1
+        port=34006
+
+        2026-03-30 14:41:52 UTC-69ca8ba3.8a8-LOG:  disconnection: session time: 0:00:13.019
+        user=azuresu database=postgres host=127.0.0.1 port=53400
+
+        2026-03-30 14:41:52 UTC-69ca8b9c.8a3-LOG:  disconnection: session time: 0:00:20.023
+        user=azuresu database=postgres host=127.0.0.1 port=35864
+
+        2026-03-30 14:41:52 UTC-69ca8bb0.8ac-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:41:52 UTC-69ca8bb0.8ac-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:41:52 UTC-69ca8bb0.8ac-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:41:53 UTC-69ca8bb1.8ad-LOG:  connection received: host=127.0.0.1
+        port=34016
+
+        2026-03-30 14:41:53 UTC-69ca8bb1.8ad-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:41:53 UTC-69ca8bb1.8ad-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:41:53 UTC-69ca8bb1.8ad-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:41:54 UTC-69ca8bb2.8b9-LOG:  connection received: host=127.0.0.1
+        port=57350
+
+        2026-03-30 14:41:54 UTC-69ca8bb2.8b9-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:41:54 UTC-69ca8bb2.8b9-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:41:54 UTC-69ca8bb2.8b9-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:41:54 UTC-69ca8bb2.8b9-LOG:  disconnection: session time: 0:00:00.047
+        user=azuresu database=postgres host=127.0.0.1 port=57350
+
+        2026-03-30 14:41:55 UTC-69ca8b9f.8a6-LOG:  disconnection: session time: 0:00:20.025
+        user=azuresu database=azure_sys host=127.0.0.1 port=53388
+
+        2026-03-30 14:42:09 UTC-69ca8bad.8ab-LOG:  disconnection: session time: 0:00:20.025
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=33994
+
+        2026-03-30 14:42:11 UTC-69ca8bc3.8bd-LOG:  connection received: host=127.0.0.1
+        port=42630
+
+        2026-03-30 14:42:11 UTC-69ca8bc3.8bd-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:42:11 UTC-69ca8bc3.8bd-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:42:11 UTC-69ca8bc3.8bd-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:42:12 UTC-69ca8bb0.8ac-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=azure_sys host=127.0.0.1 port=34006
+
+        2026-03-30 14:42:13 UTC-69ca8bb1.8ad-LOG:  disconnection: session time: 0:00:20.023
+        user=azuresu database=postgres host=127.0.0.1 port=34016
+
+        2026-03-30 14:42:13 UTC-69ca8bc5.8be-LOG:  connection received: host=127.0.0.1
+        port=42646
+
+        2026-03-30 14:42:13 UTC-69ca8bc5.8be-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:42:13 UTC-69ca8bc5.8be-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:42:13 UTC-69ca8bc5.8be-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:42:19 UTC-69ca8bcb.8cb-LOG:  connection received: host=127.0.0.1
+        port=42306
+
+        2026-03-30 14:42:19 UTC-69ca8bcb.8cb-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:42:19 UTC-69ca8bcb.8cb-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:42:19 UTC-69ca8bcb.8cb-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:42:19 UTC-69ca8bcb.8cb-LOG:  disconnection: session time: 0:00:00.048
+        user=azuresu database=postgres host=127.0.0.1 port=42306
+
+        2026-03-30 14:42:23 UTC-69ca8bcf.8cc-LOG:  connection received: host=127.0.0.1
+        port=42308
+
+        2026-03-30 14:42:23 UTC-69ca8bcf.8cc-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:42:23 UTC-69ca8bcf.8cc-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:42:23 UTC-69ca8bcf.8cc-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:42:31 UTC-69ca8bc3.8bd-LOG:  disconnection: session time: 0:00:20.025
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=42630
+
+        2026-03-30 14:42:33 UTC-69ca8bc5.8be-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=postgres host=127.0.0.1 port=42646
+
+        2026-03-30 14:42:33 UTC-69ca8bd9.8cf-LOG:  connection received: host=127.0.0.1
+        port=35882
+
+        2026-03-30 14:42:33 UTC-69ca8bd9.8cf-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:42:33 UTC-69ca8bd9.8cf-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:42:33 UTC-69ca8bd9.8cf-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:42:33 UTC-69ca8bd9.8d0-LOG:  connection received: host=127.0.0.1
+        port=35894
+
+        2026-03-30 14:42:33 UTC-69ca8bd9.8d0-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:42:33 UTC-69ca8bd9.8d0-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:42:33 UTC-69ca8bd9.8d0-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:42:43 UTC-69ca8bcf.8cc-LOG:  disconnection: session time: 0:00:20.125
+        user=azuresu database=azure_sys host=127.0.0.1 port=42308
+
+        2026-03-30 14:42:44 UTC-69ca8be4.8de-LOG:  connection received: host=127.0.0.1
+        port=47488
+
+        2026-03-30 14:42:44 UTC-69ca8be4.8de-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:42:44 UTC-69ca8be4.8de-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:42:44 UTC-69ca8be4.8de-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:42:44 UTC-69ca8be4.8de-LOG:  disconnection: session time: 0:00:00.046
+        user=azuresu database=postgres host=127.0.0.1 port=47488
+
+        2026-03-30 14:42:50 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
+        0/7000C68, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-03-30 14:42:53 UTC-69ca8bd9.8cf-LOG:  disconnection: session time: 0:00:20.023
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=35882
+
+        2026-03-30 14:42:53 UTC-69ca8bd9.8d0-LOG:  disconnection: session time: 0:00:20.023
+        user=azuresu database=postgres host=127.0.0.1 port=35894
+
+        2026-03-30 14:42:53 UTC-69ca8bed.8e1-LOG:  connection received: host=127.0.0.1
+        port=47496
+
+        2026-03-30 14:42:53 UTC-69ca8bed.8e1-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:42:53 UTC-69ca8bed.8e1-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:42:53 UTC-69ca8bed.8e1-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:42:54 UTC-69ca8bee.8e2-LOG:  connection received: host=127.0.0.1
+        port=47502
+
+        2026-03-30 14:42:54 UTC-69ca8bee.8e2-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:42:54 UTC-69ca8bee.8e2-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:42:54 UTC-69ca8bee.8e2-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:42:55 UTC-69ca8bef.8e4-LOG:  connection received: host=127.0.0.1
+        port=48062
+
+        2026-03-30 14:42:55 UTC-69ca8bef.8e4-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:42:55 UTC-69ca8bef.8e4-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:42:55 UTC-69ca8bef.8e4-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:43:09 UTC-69ca8bfd.8f1-LOG:  connection received: host=127.0.0.1
+        port=46370
+
+        2026-03-30 14:43:09 UTC-69ca8bfd.8f1-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:43:09 UTC-69ca8bfd.8f1-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:43:09 UTC-69ca8bfd.8f1-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:43:09 UTC-69ca8bfd.8f1-LOG:  disconnection: session time: 0:00:00.046
+        user=azuresu database=postgres host=127.0.0.1 port=46370
+
+        2026-03-30 14:43:13 UTC-69ca8bed.8e1-LOG:  disconnection: session time: 0:00:20.034
+        user=azuresu database=postgres host=127.0.0.1 port=47496
+
+        2026-03-30 14:43:13 UTC-69ca8c01.8f3-LOG:  connection received: host=127.0.0.1
+        port=46380
+
+        2026-03-30 14:43:13 UTC-69ca8c01.8f3-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:43:13 UTC-69ca8c01.8f3-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:43:13 UTC-69ca8c01.8f3-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:43:14 UTC-69ca8bee.8e2-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=azure_sys host=127.0.0.1 port=47502
+
+        2026-03-30 14:43:15 UTC-69ca8bef.8e4-LOG:  disconnection: session time: 0:00:20.028
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=48062
+
+        2026-03-30 14:43:17 UTC-69ca8c05.8f5-LOG:  connection received: host=127.0.0.1
+        port=57190
+
+        2026-03-30 14:43:17 UTC-69ca8c05.8f5-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:43:17 UTC-69ca8c05.8f5-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:43:17 UTC-69ca8c05.8f5-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:43:25 UTC-69ca8c0d.8f8-LOG:  connection received: host=127.0.0.1
+        port=34478
+
+        2026-03-30 14:43:25 UTC-69ca8c0d.8f8-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:43:25 UTC-69ca8c0d.8f8-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:43:25 UTC-69ca8c0d.8f8-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:43:33 UTC-69ca8c01.8f3-LOG:  disconnection: session time: 0:00:20.032
+        user=azuresu database=postgres host=127.0.0.1 port=46380
+
+        2026-03-30 14:43:33 UTC-69ca8c15.8fb-LOG:  connection received: host=127.0.0.1
+        port=34494
+
+        2026-03-30 14:43:33 UTC-69ca8c15.8fb-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:43:33 UTC-69ca8c15.8fb-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:43:33 UTC-69ca8c15.8fb-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:43:34 UTC-69ca8c16.906-LOG:  connection received: host=127.0.0.1
+        port=50214
+
+        2026-03-30 14:43:35 UTC-69ca8c16.906-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:43:35 UTC-69ca8c16.906-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:43:35 UTC-69ca8c16.906-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:43:35 UTC-69ca8c16.906-LOG:  disconnection: session time: 0:00:00.046
+        user=azuresu database=postgres host=127.0.0.1 port=50214
+
+        2026-03-30 14:43:37 UTC-69ca8c05.8f5-LOG:  disconnection: session time: 0:00:20.022
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=57190
+
+        2026-03-30 14:43:39 UTC-69ca8c1b.908-LOG:  connection received: host=127.0.0.1
+        port=50222
+
+        2026-03-30 14:43:39 UTC-69ca8c1b.908-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:43:39 UTC-69ca8c1b.908-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:43:39 UTC-69ca8c1b.908-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:43:45 UTC-69ca8c0d.8f8-LOG:  disconnection: session time: 0:00:20.025
+        user=azuresu database=azure_sys host=127.0.0.1 port=34478
+
+        2026-03-30 14:43:50 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
+        0/7001308, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-03-30 14:43:53 UTC-69ca8c15.8fb-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=postgres host=127.0.0.1 port=34494
+
+        2026-03-30 14:43:53 UTC-69ca8c29.90c-LOG:  connection received: host=127.0.0.1
+        port=53104
+
+        2026-03-30 14:43:53 UTC-69ca8c29.90c-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:43:53 UTC-69ca8c29.90c-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:43:53 UTC-69ca8c29.90c-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:43:56 UTC-69ca8c2c.90e-LOG:  connection received: host=127.0.0.1
+        port=53956
+
+        2026-03-30 14:43:56 UTC-69ca8c2c.90e-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:43:56 UTC-69ca8c2c.90e-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:43:56 UTC-69ca8c2c.90e-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:43:59 UTC-69ca8c1b.908-LOG:  disconnection: session time: 0:00:20.023
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=50222
+
+        2026-03-30 14:44:00 UTC-69ca8c30.919-LOG:  connection received: host=127.0.0.1
+        port=53964
+
+        2026-03-30 14:44:00 UTC-69ca8c30.919-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:44:00 UTC-69ca8c30.919-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:44:00 UTC-69ca8c30.919-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:44:00 UTC-69ca8c30.919-LOG:  disconnection: session time: 0:00:00.046
+        user=azuresu database=postgres host=127.0.0.1 port=53964
+
+        2026-03-30 14:44:01 UTC-69ca8c31.91a-LOG:  connection received: host=127.0.0.1
+        port=53976
+
+        2026-03-30 14:44:01 UTC-69ca8c31.91a-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:44:01 UTC-69ca8c31.91a-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:44:01 UTC-69ca8c31.91a-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:44:13 UTC-69ca8c29.90c-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=postgres host=127.0.0.1 port=53104
+
+        2026-03-30 14:44:13 UTC-69ca8c3d.91e-LOG:  connection received: host=127.0.0.1
+        port=35026
+
+        2026-03-30 14:44:13 UTC-69ca8c3d.91e-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:44:13 UTC-69ca8c3d.91e-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:44:13 UTC-69ca8c3d.91e-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:44:16 UTC-69ca8c2c.90e-LOG:  disconnection: session time: 0:00:20.025
+        user=azuresu database=azure_sys host=127.0.0.1 port=53956
+
+        2026-03-30 14:44:21 UTC-69ca8c31.91a-LOG:  disconnection: session time: 0:00:20.027
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=53976
+
+        2026-03-30 14:44:23 UTC-69ca8c47.921-LOG:  connection received: host=127.0.0.1
+        port=34658
+
+        2026-03-30 14:44:23 UTC-69ca8c47.921-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:44:23 UTC-69ca8c47.921-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:44:23 UTC-69ca8c47.921-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:44:25 UTC-69ca8c49.92c-LOG:  connection received: host=127.0.0.1
+        port=53382
+
+        2026-03-30 14:44:25 UTC-69ca8c49.92c-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:44:25 UTC-69ca8c49.92c-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:44:25 UTC-69ca8c49.92c-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:44:25 UTC-69ca8c49.92c-LOG:  disconnection: session time: 0:00:00.049
+        user=azuresu database=postgres host=127.0.0.1 port=53382
+
+        2026-03-30 14:44:27 UTC-69ca8c4b.92d-LOG:  connection received: host=127.0.0.1
+        port=53394
+
+        2026-03-30 14:44:27 UTC-69ca8c4b.92d-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:44:27 UTC-69ca8c4b.92d-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:44:27 UTC-69ca8c4b.92d-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:44:33 UTC-69ca8c3d.91e-LOG:  disconnection: session time: 0:00:20.023
+        user=azuresu database=postgres host=127.0.0.1 port=35026
+
+        2026-03-30 14:44:34 UTC-69ca8c52.930-LOG:  connection received: host=127.0.0.1
+        port=53400
+
+        2026-03-30 14:44:34 UTC-69ca8c52.930-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:44:34 UTC-69ca8c52.930-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:44:34 UTC-69ca8c52.930-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:44:43 UTC-69ca8c47.921-LOG:  disconnection: session time: 0:00:20.023
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=34658
+
+        2026-03-30 14:44:45 UTC-69ca8c5d.934-LOG:  connection received: host=127.0.0.1
+        port=43406
+
+        2026-03-30 14:44:45 UTC-69ca8c5d.934-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:44:45 UTC-69ca8c5d.934-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:44:45 UTC-69ca8c5d.934-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:44:47 UTC-69ca8c4b.92d-LOG:  disconnection: session time: 0:00:20.023
+        user=azuresu database=azure_sys host=127.0.0.1 port=53394
+
+        2026-03-30 14:44:50 UTC-69ca8c62.93f-LOG:  connection received: host=127.0.0.1
+        port=43422
+
+        2026-03-30 14:44:50 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
+        0/70019A8, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-03-30 14:44:50 UTC-69ca8c62.93f-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:44:50 UTC-69ca8c62.93f-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:44:50 UTC-69ca8c62.93f-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:44:50 UTC-69ca8c62.93f-LOG:  disconnection: session time: 0:00:00.047
+        user=azuresu database=postgres host=127.0.0.1 port=43422
+
+        2026-03-30 14:44:54 UTC-69ca8c52.930-LOG:  disconnection: session time: 0:00:20.023
+        user=azuresu database=postgres host=127.0.0.1 port=53400
+
+        2026-03-30 14:44:54 UTC-69ca8c66.941-LOG:  connection received: host=127.0.0.1
+        port=43434
+
+        2026-03-30 14:44:54 UTC-69ca8c66.941-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:44:54 UTC-69ca8c66.941-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:44:54 UTC-69ca8c66.941-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:44:58 UTC-69ca8c6a.943-LOG:  connection received: host=127.0.0.1
+        port=47446
+
+        2026-03-30 14:44:58 UTC-69ca8c6a.943-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:44:58 UTC-69ca8c6a.943-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:44:58 UTC-69ca8c6a.943-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:45:05 UTC-69ca8c5d.934-LOG:  disconnection: session time: 0:00:20.027
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=43406
+
+        2026-03-30 14:45:07 UTC-69ca8c73.946-LOG:  connection received: host=127.0.0.1
+        port=35420
+
+        2026-03-30 14:45:07 UTC-69ca8c73.946-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:45:07 UTC-69ca8c73.946-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:45:07 UTC-69ca8c73.946-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:45:14 UTC-69ca8c66.941-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=postgres host=127.0.0.1 port=43434
+
+        2026-03-30 14:45:14 UTC-69ca8c7a.94a-LOG:  connection received: host=127.0.0.1
+        port=35430
+
+        2026-03-30 14:45:14 UTC-69ca8c7a.94a-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:45:14 UTC-69ca8c7a.94a-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:45:14 UTC-69ca8c7a.94a-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:45:15 UTC-69ca8c7b.954-LOG:  connection received: host=127.0.0.1
+        port=50924
+
+        2026-03-30 14:45:15 UTC-69ca8c7b.954-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:45:15 UTC-69ca8c7b.954-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:45:15 UTC-69ca8c7b.954-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:45:15 UTC-69ca8c7b.954-LOG:  disconnection: session time: 0:00:00.047
+        user=azuresu database=postgres host=127.0.0.1 port=50924
+
+        2026-03-30 14:45:18 UTC-69ca8c6a.943-LOG:  disconnection: session time: 0:00:20.023
+        user=azuresu database=azure_sys host=127.0.0.1 port=47446
+
+        2026-03-30 14:45:27 UTC-69ca8c73.946-LOG:  disconnection: session time: 0:00:20.031
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=35420
+
+        2026-03-30 14:45:29 UTC-69ca8c89.958-LOG:  connection received: host=127.0.0.1
+        port=34750
+
+        2026-03-30 14:45:29 UTC-69ca8c89.959-LOG:  connection received: host=127.0.0.1
+        port=34764
+
+        2026-03-30 14:45:29 UTC-69ca8c89.958-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:45:29 UTC-69ca8c89.958-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:45:29 UTC-69ca8c89.958-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:45:29 UTC-69ca8c89.959-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:45:29 UTC-69ca8c89.959-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:45:29 UTC-69ca8c89.959-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:45:34 UTC-69ca8c7a.94a-LOG:  disconnection: session time: 0:00:20.024
+        user=azuresu database=postgres host=127.0.0.1 port=35430
+
+        2026-03-30 14:45:34 UTC-69ca8c8e.95c-LOG:  connection received: host=127.0.0.1
+        port=34778
+
+        2026-03-30 14:45:34 UTC-69ca8c8e.95c-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:45:34 UTC-69ca8c8e.95c-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:45:34 UTC-69ca8c8e.95c-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:45:40 UTC-69ca8c94.967-LOG:  connection received: host=127.0.0.1
+        port=35452
+
+        2026-03-30 14:45:40 UTC-69ca8c94.967-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:45:40 UTC-69ca8c94.967-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:45:40 UTC-69ca8c94.967-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:45:40 UTC-69ca8c94.967-LOG:  disconnection: session time: 0:00:00.047
+        user=azuresu database=postgres host=127.0.0.1 port=35452
+
+        2026-03-30 14:45:49 UTC-69ca8c89.958-LOG:  disconnection: session time: 0:00:20.034
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=34750
+
+        2026-03-30 14:45:49 UTC-69ca8c89.959-LOG:  disconnection: session time: 0:00:20.036
+        user=azuresu database=azure_sys host=127.0.0.1 port=34764
+
+        2026-03-30 14:45:50 UTC-69ca85d1.2fe-LOG:  [pg-availability]: current_lsn:
+        0/7007A80, current_lsn_counter: 6, spi_return_msg: SPI_OK_UPDATE
+
+        2026-03-30 14:45:51 UTC-69ca8c9f.96a-LOG:  connection received: host=127.0.0.1
+        port=43398
+
+        2026-03-30 14:45:51 UTC-69ca8c9f.96a-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:45:51 UTC-69ca8c9f.96a-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:45:51 UTC-69ca8c9f.96a-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:45:54 UTC-69ca8c8e.95c-LOG:  disconnection: session time: 0:00:20.028
+        user=azuresu database=postgres host=127.0.0.1 port=34778
+
+        2026-03-30 14:45:54 UTC-69ca8ca2.96d-LOG:  connection received: host=127.0.0.1
+        port=55202
+
+        2026-03-30 14:45:54 UTC-69ca8ca2.96d-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:45:54 UTC-69ca8ca2.96d-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:45:54 UTC-69ca8ca2.96d-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:46:00 UTC-69ca8ca8.96f-LOG:  connection received: host=127.0.0.1
+        port=55204
+
+        2026-03-30 14:46:00 UTC-69ca8ca8.96f-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:46:00 UTC-69ca8ca8.96f-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:46:00 UTC-69ca8ca8.96f-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:46:05 UTC-69ca8cad.990-LOG:  connection received: host=127.0.0.1
+        port=54820
+
+        2026-03-30 14:46:05 UTC-69ca8cad.990-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:46:05 UTC-69ca8cad.990-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:46:05 UTC-69ca8cad.990-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:46:05 UTC-69ca8cad.990-LOG:  disconnection: session time: 0:00:00.046
+        user=azuresu database=postgres host=127.0.0.1 port=54820
+
+        2026-03-30 14:46:11 UTC-69ca8c9f.96a-LOG:  disconnection: session time: 0:00:20.030
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=43398
+
+        2026-03-30 14:46:13 UTC-69ca8cb5.992-LOG:  connection received: host=127.0.0.1
+        port=54834
+
+        2026-03-30 14:46:13 UTC-69ca8cb5.992-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:46:13 UTC-69ca8cb5.992-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:46:13 UTC-69ca8cb5.992-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:46:14 UTC-69ca8ca2.96d-LOG:  disconnection: session time: 0:00:20.023
+        user=azuresu database=postgres host=127.0.0.1 port=55202
+
+        2026-03-30 14:46:14 UTC-69ca8cb6.995-LOG:  connection received: host=127.0.0.1
+        port=52630
+
+        2026-03-30 14:46:14 UTC-69ca8cb6.995-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:46:14 UTC-69ca8cb6.995-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:46:14 UTC-69ca8cb6.995-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:46:20 UTC-69ca8ca8.96f-LOG:  disconnection: session time: 0:00:20.025
+        user=azuresu database=azure_sys host=127.0.0.1 port=55204
+
+        2026-03-30 14:46:30 UTC-69ca8cc6.9a2-LOG:  connection received: host=127.0.0.1
+        port=37678
+
+        2026-03-30 14:46:30 UTC-69ca8cc6.9a2-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:46:30 UTC-69ca8cc6.9a2-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:46:30 UTC-69ca8cc6.9a2-LOG:  connection authorized: user=azuresu
+        database=postgres application_name=psql SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:46:30 UTC-69ca8cc6.9a2-LOG:  disconnection: session time: 0:00:00.046
+        user=azuresu database=postgres host=127.0.0.1 port=37678
+
+        2026-03-30 14:46:31 UTC-69ca8cc7.9a3-LOG:  connection received: host=127.0.0.1
+        port=37686
+
+        2026-03-30 14:46:31 UTC-69ca8cc7.9a3-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:46:31 UTC-69ca8cc7.9a3-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:46:31 UTC-69ca8cc7.9a3-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:46:33 UTC-69ca8cb5.992-LOG:  disconnection: session time: 0:00:20.045
+        user=azuresu database=azure_maintenance host=127.0.0.1 port=54834
+
+        2026-03-30 14:46:34 UTC-69ca8cb6.995-LOG:  disconnection: session time: 0:00:20.026
+        user=azuresu database=postgres host=127.0.0.1 port=52630
+
+        2026-03-30 14:46:34 UTC-69ca8cca.9a6-LOG:  connection received: host=127.0.0.1
+        port=41578
+
+        2026-03-30 14:46:34 UTC-69ca8cca.9a6-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:46:34 UTC-69ca8cca.9a6-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:46:34 UTC-69ca8cca.9a6-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:46:35 UTC-69ca8ccb.9a8-LOG:  connection received: host=127.0.0.1
+        port=41604
+
+        2026-03-30 14:46:35 UTC-69ca8ccb.9a7-LOG:  connection received: host=127.0.0.1
+        port=41594
+
+        2026-03-30 14:46:35 UTC-69ca8ccb.9a9-LOG:  connection received: host=127.0.0.1
+        port=41608
+
+        2026-03-30 14:46:35 UTC-69ca8ccb.9a9-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:46:35 UTC-69ca8ccb.9a9-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:46:35 UTC-69ca8ccb.9a9-LOG:  connection authorized: user=azuresu
+        database=postgres SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:46:35 UTC-69ca8ccb.9a8-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:46:35 UTC-69ca8ccb.9a8-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:46:35 UTC-69ca8ccb.9a8-LOG:  connection authorized: user=azuresu
+        database=azure_sys SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        2026-03-30 14:46:35 UTC-69ca8ccb.9a7-LOG:  [Microsoft Entra] aad_tenant_id
+        is NULL
+
+        2026-03-30 14:46:35 UTC-69ca8ccb.9a7-LOG:  connection authenticated: identity=\"CN=azuresu.e3091069db5d.database.azure.com\"
+        method=cert (/datadrive/pg/data/pg_hba.conf:12)
+
+        2026-03-30 14:46:35 UTC-69ca8ccb.9a7-LOG:  connection authorized: user=azuresu
+        database=azure_maintenance SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384,
+        bits=256)
+
+        '
+    headers:
+      accept-ranges:
+      - bytes
+      connection:
+      - close
+      content-length:
+      - '168656'
+      content-md5:
+      - eoUwP0hGnLn+x5kEWNSHWQ==
+      content-type:
+      - text/plain
+      date:
+      - Mon, 30 Mar 2026 14:47:51 GMT
+      etag:
+      - '"0x8DE8E6B26BD597F"'
+      last-modified:
+      - Mon, 30 Mar 2026 14:46:39 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-access-tier:
+      - Cool
+      x-ms-access-tier-inferred:
+      - 'true'
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-creation-time:
+      - Mon, 30 Mar 2026 14:36:36 GMT
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2025-05-05'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - postgres flexible-server parameter set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --server-name --name --value
+      User-Agent:
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/configurations/logfiles.download_enable?api-version=2026-01-01-preview
+  response:
+    body:
+      string: '{"properties":{"value":"on","description":"Enables or disables server
+        logs functionality.","defaultValue":"off","dataType":"Boolean","allowedValues":"on,off","source":"user-override","isDynamicConfig":true,"isReadOnly":false,"isConfigPendingRestart":false,"documentationLink":"https://go.microsoft.com/fwlink/?linkid=2274270"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/configurations/logfiles.download_enable","name":"logfiles.download_enable","type":"Microsoft.DBforPostgreSQL/flexibleServers/configurations"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '632'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Mar 2026 14:47:52 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/475f7932-1e06-43a1-9264-f81d3cb106c2
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: D7EF7F9963394D8CB1732ECD0064D4FB Ref B: DUB241062310023 Ref C: 2026-03-30T14:47:52Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"value": "off", "source": "user-override"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - postgres flexible-server parameter set
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '59'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g --server-name --name --value
+      User-Agent:
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+    method: PATCH
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/configurations/logfiles.download_enable?api-version=2026-01-01-preview
+  response:
+    body:
+      string: '{"operation":"UpdateOrcasServerParameterManagementOperation","startTime":"2026-03-30T14:47:53.44Z"}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/5248ac38-9aea-4674-8705-35ece5319c3f?api-version=2026-01-01-preview&t=639104788734800213&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=J-hOLX3h0NJ7ufo5EEDGfTjG2zRIkaJVBDDxEO0Vuo-6veFIi5xv80PYXs_PABCQVfnWjxBVBkLUZyXgA0pDTVnXGCIyzQtuSWVVCdkIPeW5O8B2LAd7a4CB9FnUtj5kCN-5XdQA-niM_nhqf7a_XO-aeC4Y5FuK_ZVzp1TG8pnpExd4JbyJ0vRqwRa3cihMyexPhalPGU-gMU3V-HwqdMqtaMhLzSPJMbDRP0F_VuBhXlsaexqPIcxLb1Zs9b-DeUk1d6u_SXOMYnUPceS1i1tOUiqLXEFwRJfBALK1nHlvIl2pn2XVIMI9LYuDFtuESALQaut-qwAnGogNowzpwQ&h=dppahVLn1YK-y0z693IzV2bd4ISdHVvoow_qcOfaDNs
+      cache-control:
+      - no-cache
+      content-length:
+      - '99'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Mar 2026 14:47:52 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/operationResults/5248ac38-9aea-4674-8705-35ece5319c3f?api-version=2026-01-01-preview&t=639104788734800213&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=KialwA7xCLuUjcMrgGLZr5wujBlQV4aeH8C1ps-3qoxG0WIM1go7Qe5ndujUJqGlBy7Rq1oXPxc6x0-vLm_xDQAPkpzlPJP01acTya-dEP-KPsQTmO7KDm_6yEarhiLRP5KP1TwWfJFrphre53DZ56s16OE3wNpDJt8jKp2Lb99CWddqkilkqCEaC6YM0FWzouswxL7TrfSDiponW1yLp1IPRjOUoE42PqseZJvhVk8NbQfC3KjMH4NZ75RIrw58xzJ5kjqfY4tXscyci7PqYJQe5Ur6G-_RB1ExGFDCsFQSC6iCQ4GbESpMicHioVMm60mHdg4NzTu628JX7UBvWQ&h=QMwSR4QZtQNwrnpglqyJTZjkuSBdP2aJ6zX5h5ffPgc
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/08e205bd-9f79-4d5c-b650-33d54d54b530
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '11999'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: FE19DF17F78947EC9229DA9A5308BC39 Ref B: AMS231032609037 Ref C: 2026-03-30T14:47:53Z'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - postgres flexible-server parameter set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --server-name --name --value
+      User-Agent:
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/5248ac38-9aea-4674-8705-35ece5319c3f?api-version=2026-01-01-preview&t=639104788734800213&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=J-hOLX3h0NJ7ufo5EEDGfTjG2zRIkaJVBDDxEO0Vuo-6veFIi5xv80PYXs_PABCQVfnWjxBVBkLUZyXgA0pDTVnXGCIyzQtuSWVVCdkIPeW5O8B2LAd7a4CB9FnUtj5kCN-5XdQA-niM_nhqf7a_XO-aeC4Y5FuK_ZVzp1TG8pnpExd4JbyJ0vRqwRa3cihMyexPhalPGU-gMU3V-HwqdMqtaMhLzSPJMbDRP0F_VuBhXlsaexqPIcxLb1Zs9b-DeUk1d6u_SXOMYnUPceS1i1tOUiqLXEFwRJfBALK1nHlvIl2pn2XVIMI9LYuDFtuESALQaut-qwAnGogNowzpwQ&h=dppahVLn1YK-y0z693IzV2bd4ISdHVvoow_qcOfaDNs
+  response:
+    body:
+      string: '{"name":"5248ac38-9aea-4674-8705-35ece5319c3f","status":"InProgress","startTime":"2026-03-30T14:47:53.44Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Mar 2026 14:47:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/bee00500-9bd0-42f1-9262-807ae7a6996e
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: BA094F2B59B740848CD078DBAF0516B6 Ref B: AMS231020512009 Ref C: 2026-03-30T14:47:53Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - postgres flexible-server parameter set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --server-name --name --value
+      User-Agent:
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/canadacentral/azureAsyncOperation/5248ac38-9aea-4674-8705-35ece5319c3f?api-version=2026-01-01-preview&t=639104788734800213&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=J-hOLX3h0NJ7ufo5EEDGfTjG2zRIkaJVBDDxEO0Vuo-6veFIi5xv80PYXs_PABCQVfnWjxBVBkLUZyXgA0pDTVnXGCIyzQtuSWVVCdkIPeW5O8B2LAd7a4CB9FnUtj5kCN-5XdQA-niM_nhqf7a_XO-aeC4Y5FuK_ZVzp1TG8pnpExd4JbyJ0vRqwRa3cihMyexPhalPGU-gMU3V-HwqdMqtaMhLzSPJMbDRP0F_VuBhXlsaexqPIcxLb1Zs9b-DeUk1d6u_SXOMYnUPceS1i1tOUiqLXEFwRJfBALK1nHlvIl2pn2XVIMI9LYuDFtuESALQaut-qwAnGogNowzpwQ&h=dppahVLn1YK-y0z693IzV2bd4ISdHVvoow_qcOfaDNs
+  response:
+    body:
+      string: '{"name":"5248ac38-9aea-4674-8705-35ece5319c3f","status":"Succeeded","startTime":"2026-03-30T14:47:53.44Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '106'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Mar 2026 14:48:04 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/dc91c65a-b51a-40cc-a107-665cbd072c32
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 9F33D77384904E9C86E3AFF33797FC97 Ref B: DUB601080513062 Ref C: 2026-03-30T14:48:04Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - postgres flexible-server parameter set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --server-name --name --value
+      User-Agent:
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/configurations/logfiles.download_enable?api-version=2026-01-01-preview
+  response:
+    body:
+      string: '{"properties":{"value":"off","description":"Enables or disables server
+        logs functionality.","defaultValue":"off","dataType":"Boolean","allowedValues":"on,off","source":"user-override","isDynamicConfig":true,"isReadOnly":false,"isConfigPendingRestart":false,"documentationLink":"https://go.microsoft.com/fwlink/?linkid=2274270"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002/configurations/logfiles.download_enable","name":"logfiles.download_enable","type":"Microsoft.DBforPostgreSQL/flexibleServers/configurations"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '633'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 30 Mar 2026 14:48:05 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/0207c5a0-1009-41d6-9ea1-37e7106cff18
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 578F039F86AC436AB3AEF1C997E7EA86 Ref B: AMS231020512045 Ref C: 2026-03-30T14:48:04Z'
     status:
       code: 200
       message: OK
@@ -1304,27 +5174,27 @@ interactions:
       ParameterSetName:
       - -g -n --yes
       User-Agent:
-      - AZURECLI/2.83.0 azsdk-python-core/1.38.0 Python/3.13.10 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/flexibleServers/azuredbclitest-000002?api-version=2026-01-01-preview
   response:
     body:
-      string: '{"operation":"DropServerManagementOperation","startTime":"2026-02-18T03:32:55.1Z"}'
+      string: '{"operation":"DropServerManagementOperation","startTime":"2026-03-30T14:48:06.19Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/azureAsyncOperation/6072a2d7-62b4-46fc-8b16-30ed1dcebba6?api-version=2026-01-01-preview&t=639069823751424430&c=MIIHhzCCBm-gAwIBAgITHgfeaAthBF252mKMUQAAB95oCzANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDYwHhcNMjYwMTE1MTIwMzEzWhcNMjYwNTI0MjI1NzAzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALF5UwB1TCaUQryWnLemNoR1STogfj5BkURewSVKqF6BNmNVe6OPy7h3BMUV8wQPDRcx564kcpxInHjnJ91C2HdWhYtJC9mQ-KfRTHGro-eDtjIDA_m8ZoQaG1t8ZDyGTw3sg-le416DRx--vNLJWTcJ5pPQrNGLHgukyEBEGqcperL--6vkuDR8piARKeWdPub4QGpdJgULAoKm577o9Yeour0AbDe48KV8DaKqEhZAqTR021tTIU5-OVtQTAIuOTVnkBLtraUBYl6qbV603_iHP0-lxSiAdoOKRc9hnw5EIzdh4P3k57bkUUGKXBcEaDzqiXI4zT2s2PpLMdlJGrECAwEAAaOCBHQwggRwMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFghfmRS4WsmTQCAWQCAQcwggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MB0GA1UdDgQWBBQpx7wy64aZi3bga5mYDPjiPc4VjDAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwIwDAYKKwYBBAGCN3sEAjAfBgNVHSMEGDAWgBTxRmjG8cPwKy19i2rhsvm-NfzRQTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAESi3AgZNii4-yX1M8j9s1tnNVejdi-hvwe3tGOyTBjO6vi2tuQDoyQ-t6WDcAY8Suwhm0D6N6beb9niA0Z4KG-xN1jzJx-JF23mcbREASBP-H_Sk80BObD4a0FrOXY0dcNg2oK5FAuM8bwFfqHTRPNqCqL20uzuAyXhTgbwYJ7v6R0YYYv67aIj096-6dGUEKCXLHUtQfPNpvGOCnyvW5-kJ2GJ6ImpJvVnBPvU6JNVR7QMnSEtf7vlMFKguYoC7kAalHyr4UMxGBU6PpqOlJca6U_3ehNgwPuIFln_3JxNqtpyIWd5YpWGPRtAqGYE8y2NyTMrJQcUCkfHIqOHVFk&s=bVm7gksgtz6uC4JmrzrJl3feK3Zx8KHF816x-CWgldiwpROSuckxu6kGOC3yZvBM_tU2BMcqCq7e1yFEIilkpl58b0l_jVdE6LJiRv78JnUteeZ1ulyZg3okMilnlRg8AqfWUOe7a3VaiIrb2Zmtz_753qKBInbMj-P_eI2Lo4UcZGCdDpWrRkjxEweQnMci6TpnNw1ogViuxNhvOCMF1rjb_Yhz-3zXITnI8YzVORDLL9obDFQYLoxJ824JtAwcXYhtbe1vLjKLopkk2krDu0PH_OC-5EeYG_buvrBta9Q0-OwSBDDkDLvJVtkU5QoVXRO-GHy-KrbDMBqyCxxb9A&h=fuvsOMObj1NzerVUv5kiwBc3pySY9-66eL57z6LCtFM
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/azureAsyncOperation/c825ff55-99c7-4b1b-b634-3d2b751d5505?api-version=2026-01-01-preview&t=639104788862499093&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=COe2rq3ZYXHoDkxmpL6Apmvjp-VM-7kEqXYFbqPrs39QxI51EzIDjgb8Vdf1NwkqbNP4eaetnSVBV37WIqDyqOmaajPAngH_nBaBXjJPPhoKmQ5zCT5mmPDabzGXSV2uUM-VBGJ7aA1Vra75ydDkkakuDaD0Sh4BtWcg56gDUUWCYONtLiTLv1jWia9SUT5CCbUVBg91fmxGkq3B9v8Wk0eY8qzqbDXdq0CDEcp2eQgp2MQVH92l9aGo41I3Qwadl-gxH0Fq_F1qJjlOuf6wNztgbshpvkWDQqx6JKBY1QH5TsvolEiqgjRXzfNNnHiHT59_jpa3ieTgZbfL2lFfIQ&h=3eKwChnyOr-P3umYYwZVmeZ2Csy9eKbm9kZBY7RA1zQ
       cache-control:
       - no-cache
       content-length:
-      - '82'
+      - '83'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Feb 2026 03:32:55 GMT
+      - Mon, 30 Mar 2026 14:48:06 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/operationResults/6072a2d7-62b4-46fc-8b16-30ed1dcebba6?api-version=2026-01-01-preview&t=639069823751581131&c=MIIHhzCCBm-gAwIBAgITHgfeaAthBF252mKMUQAAB95oCzANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDYwHhcNMjYwMTE1MTIwMzEzWhcNMjYwNTI0MjI1NzAzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALF5UwB1TCaUQryWnLemNoR1STogfj5BkURewSVKqF6BNmNVe6OPy7h3BMUV8wQPDRcx564kcpxInHjnJ91C2HdWhYtJC9mQ-KfRTHGro-eDtjIDA_m8ZoQaG1t8ZDyGTw3sg-le416DRx--vNLJWTcJ5pPQrNGLHgukyEBEGqcperL--6vkuDR8piARKeWdPub4QGpdJgULAoKm577o9Yeour0AbDe48KV8DaKqEhZAqTR021tTIU5-OVtQTAIuOTVnkBLtraUBYl6qbV603_iHP0-lxSiAdoOKRc9hnw5EIzdh4P3k57bkUUGKXBcEaDzqiXI4zT2s2PpLMdlJGrECAwEAAaOCBHQwggRwMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFghfmRS4WsmTQCAWQCAQcwggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MB0GA1UdDgQWBBQpx7wy64aZi3bga5mYDPjiPc4VjDAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwIwDAYKKwYBBAGCN3sEAjAfBgNVHSMEGDAWgBTxRmjG8cPwKy19i2rhsvm-NfzRQTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAESi3AgZNii4-yX1M8j9s1tnNVejdi-hvwe3tGOyTBjO6vi2tuQDoyQ-t6WDcAY8Suwhm0D6N6beb9niA0Z4KG-xN1jzJx-JF23mcbREASBP-H_Sk80BObD4a0FrOXY0dcNg2oK5FAuM8bwFfqHTRPNqCqL20uzuAyXhTgbwYJ7v6R0YYYv67aIj096-6dGUEKCXLHUtQfPNpvGOCnyvW5-kJ2GJ6ImpJvVnBPvU6JNVR7QMnSEtf7vlMFKguYoC7kAalHyr4UMxGBU6PpqOlJca6U_3ehNgwPuIFln_3JxNqtpyIWd5YpWGPRtAqGYE8y2NyTMrJQcUCkfHIqOHVFk&s=GGNU2_Cy75y3UgW4L8qa9p9YQ4TI7v8HGw86PIVk-Mji-Gm33dnvoB-hwFHjlZ8rLf9H-XC97oPGbCt0s1msQWtXgQBHw5CZ2EPOjBc8hYb3-cAzDxEJjPTa8TjFt5vRPo1uDif4xI0zfgid8ne4DdleNZECOqeKqHW0nc_44lWl7Wux3VJLlXfZjuHqbXgEJqsR2_ETr8snkTNkG28D9Zu1j2y98cb2XeAJu99jC7OrpnrKtLstz5IFv--9NJPP9EU7eaxa0Z65wZX5iqSSOBPEZa3IlKQbds3Lg7ZR15NfRU8cUeTfMR0ZhO6o1-BE4uVJUSlpgIDIn4iB_4NzUw&h=dNZRIsLxnFutwQVug_lAXN3qWjoczNoaspjU61O0ywA
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/operationResults/c825ff55-99c7-4b1b-b634-3d2b751d5505?api-version=2026-01-01-preview&t=639104788862655348&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=RafzRCpJ4eIXPp7DPK6NEOugZXiVktXETzNYAzwQmtZ_2AlP0j6SVnEor9U7IRuVQA0qIeXIKxPH2evgzPVZXZ-ogz0H6SrlsSbjt2WLG85QjC_TXddcyyC4bSMva0OkrMXN8oPNYbx1vtmAqxswzO4dYmnDQK9MXz5-Xs6XBHuHRstA20vI1TiM2UKjHtpDrn_dhxsF1I65JB7-lC-dfUTpCDMFfsA75zkgvxnCP1UXOdFDbEFGBjdtSc5TrFlUZQMmBNBjNn8h6bqIEZu2K62IVT6oWBPOJfeM1JQwTttxnSxnNnVCYDv4dlXrfKZ6ROsOKXKWfrP16s1l6cwhNw&h=JNbukbKjZfixDyfwzCG0YJyib9N1lNDRO962x8VHrZw
       pragma:
       - no-cache
       strict-transport-security:
@@ -1334,13 +5204,13 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f57d2932-2a78-450f-958a-e65997c3253b/canadacentral/6b90edeb-5daa-4666-9d11-6536e192ca5b
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/canadacentral/32793c29-340e-4008-b387-a0d263584344
       x-ms-ratelimit-remaining-subscription-deletes:
       - '799'
       x-ms-ratelimit-remaining-subscription-global-deletes:
       - '11999'
       x-msedge-ref:
-      - 'Ref A: A9993F822B244418B2E194E4970D29CE Ref B: MNZ221060619037 Ref C: 2026-02-18T03:32:54Z'
+      - 'Ref A: AF237432F371467F8D1C480623E82A5E Ref B: AMS231022012027 Ref C: 2026-03-30T14:48:05Z'
     status:
       code: 202
       message: Accepted
@@ -1358,21 +5228,21 @@ interactions:
       ParameterSetName:
       - -g -n --yes
       User-Agent:
-      - AZURECLI/2.83.0 azsdk-python-core/1.38.0 Python/3.13.10 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/azureAsyncOperation/6072a2d7-62b4-46fc-8b16-30ed1dcebba6?api-version=2026-01-01-preview&t=639069823751424430&c=MIIHhzCCBm-gAwIBAgITHgfeaAthBF252mKMUQAAB95oCzANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDYwHhcNMjYwMTE1MTIwMzEzWhcNMjYwNTI0MjI1NzAzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALF5UwB1TCaUQryWnLemNoR1STogfj5BkURewSVKqF6BNmNVe6OPy7h3BMUV8wQPDRcx564kcpxInHjnJ91C2HdWhYtJC9mQ-KfRTHGro-eDtjIDA_m8ZoQaG1t8ZDyGTw3sg-le416DRx--vNLJWTcJ5pPQrNGLHgukyEBEGqcperL--6vkuDR8piARKeWdPub4QGpdJgULAoKm577o9Yeour0AbDe48KV8DaKqEhZAqTR021tTIU5-OVtQTAIuOTVnkBLtraUBYl6qbV603_iHP0-lxSiAdoOKRc9hnw5EIzdh4P3k57bkUUGKXBcEaDzqiXI4zT2s2PpLMdlJGrECAwEAAaOCBHQwggRwMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFghfmRS4WsmTQCAWQCAQcwggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MB0GA1UdDgQWBBQpx7wy64aZi3bga5mYDPjiPc4VjDAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwIwDAYKKwYBBAGCN3sEAjAfBgNVHSMEGDAWgBTxRmjG8cPwKy19i2rhsvm-NfzRQTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAESi3AgZNii4-yX1M8j9s1tnNVejdi-hvwe3tGOyTBjO6vi2tuQDoyQ-t6WDcAY8Suwhm0D6N6beb9niA0Z4KG-xN1jzJx-JF23mcbREASBP-H_Sk80BObD4a0FrOXY0dcNg2oK5FAuM8bwFfqHTRPNqCqL20uzuAyXhTgbwYJ7v6R0YYYv67aIj096-6dGUEKCXLHUtQfPNpvGOCnyvW5-kJ2GJ6ImpJvVnBPvU6JNVR7QMnSEtf7vlMFKguYoC7kAalHyr4UMxGBU6PpqOlJca6U_3ehNgwPuIFln_3JxNqtpyIWd5YpWGPRtAqGYE8y2NyTMrJQcUCkfHIqOHVFk&s=bVm7gksgtz6uC4JmrzrJl3feK3Zx8KHF816x-CWgldiwpROSuckxu6kGOC3yZvBM_tU2BMcqCq7e1yFEIilkpl58b0l_jVdE6LJiRv78JnUteeZ1ulyZg3okMilnlRg8AqfWUOe7a3VaiIrb2Zmtz_753qKBInbMj-P_eI2Lo4UcZGCdDpWrRkjxEweQnMci6TpnNw1ogViuxNhvOCMF1rjb_Yhz-3zXITnI8YzVORDLL9obDFQYLoxJ824JtAwcXYhtbe1vLjKLopkk2krDu0PH_OC-5EeYG_buvrBta9Q0-OwSBDDkDLvJVtkU5QoVXRO-GHy-KrbDMBqyCxxb9A&h=fuvsOMObj1NzerVUv5kiwBc3pySY9-66eL57z6LCtFM
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/azureAsyncOperation/c825ff55-99c7-4b1b-b634-3d2b751d5505?api-version=2026-01-01-preview&t=639104788862499093&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=COe2rq3ZYXHoDkxmpL6Apmvjp-VM-7kEqXYFbqPrs39QxI51EzIDjgb8Vdf1NwkqbNP4eaetnSVBV37WIqDyqOmaajPAngH_nBaBXjJPPhoKmQ5zCT5mmPDabzGXSV2uUM-VBGJ7aA1Vra75ydDkkakuDaD0Sh4BtWcg56gDUUWCYONtLiTLv1jWia9SUT5CCbUVBg91fmxGkq3B9v8Wk0eY8qzqbDXdq0CDEcp2eQgp2MQVH92l9aGo41I3Qwadl-gxH0Fq_F1qJjlOuf6wNztgbshpvkWDQqx6JKBY1QH5TsvolEiqgjRXzfNNnHiHT59_jpa3ieTgZbfL2lFfIQ&h=3eKwChnyOr-P3umYYwZVmeZ2Csy9eKbm9kZBY7RA1zQ
   response:
     body:
-      string: '{"name":"6072a2d7-62b4-46fc-8b16-30ed1dcebba6","status":"InProgress","startTime":"2026-02-18T03:32:55.1Z"}'
+      string: '{"name":"c825ff55-99c7-4b1b-b634-3d2b751d5505","status":"InProgress","startTime":"2026-03-30T14:48:06.19Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '106'
+      - '107'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Feb 2026 03:32:55 GMT
+      - Mon, 30 Mar 2026 14:48:06 GMT
       expires:
       - '-1'
       pragma:
@@ -1384,11 +5254,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f57d2932-2a78-450f-958a-e65997c3253b/eastus2/480b379b-00df-407d-9dc8-de2f5e0ec637
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/1ca82d95-ffe2-4ca4-b4a1-fd509fe242ce
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 76D91D9BF38E4965B24BA643A80D45C6 Ref B: MNZ221060619033 Ref C: 2026-02-18T03:32:55Z'
+      - 'Ref A: E661AB62F45D42778C9721FAF72E719D Ref B: AMS231020512035 Ref C: 2026-03-30T14:48:06Z'
     status:
       code: 200
       message: OK
@@ -1406,21 +5276,21 @@ interactions:
       ParameterSetName:
       - -g -n --yes
       User-Agent:
-      - AZURECLI/2.83.0 azsdk-python-core/1.38.0 Python/3.13.10 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/azureAsyncOperation/6072a2d7-62b4-46fc-8b16-30ed1dcebba6?api-version=2026-01-01-preview&t=639069823751424430&c=MIIHhzCCBm-gAwIBAgITHgfeaAthBF252mKMUQAAB95oCzANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDYwHhcNMjYwMTE1MTIwMzEzWhcNMjYwNTI0MjI1NzAzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALF5UwB1TCaUQryWnLemNoR1STogfj5BkURewSVKqF6BNmNVe6OPy7h3BMUV8wQPDRcx564kcpxInHjnJ91C2HdWhYtJC9mQ-KfRTHGro-eDtjIDA_m8ZoQaG1t8ZDyGTw3sg-le416DRx--vNLJWTcJ5pPQrNGLHgukyEBEGqcperL--6vkuDR8piARKeWdPub4QGpdJgULAoKm577o9Yeour0AbDe48KV8DaKqEhZAqTR021tTIU5-OVtQTAIuOTVnkBLtraUBYl6qbV603_iHP0-lxSiAdoOKRc9hnw5EIzdh4P3k57bkUUGKXBcEaDzqiXI4zT2s2PpLMdlJGrECAwEAAaOCBHQwggRwMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFghfmRS4WsmTQCAWQCAQcwggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MB0GA1UdDgQWBBQpx7wy64aZi3bga5mYDPjiPc4VjDAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwIwDAYKKwYBBAGCN3sEAjAfBgNVHSMEGDAWgBTxRmjG8cPwKy19i2rhsvm-NfzRQTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAESi3AgZNii4-yX1M8j9s1tnNVejdi-hvwe3tGOyTBjO6vi2tuQDoyQ-t6WDcAY8Suwhm0D6N6beb9niA0Z4KG-xN1jzJx-JF23mcbREASBP-H_Sk80BObD4a0FrOXY0dcNg2oK5FAuM8bwFfqHTRPNqCqL20uzuAyXhTgbwYJ7v6R0YYYv67aIj096-6dGUEKCXLHUtQfPNpvGOCnyvW5-kJ2GJ6ImpJvVnBPvU6JNVR7QMnSEtf7vlMFKguYoC7kAalHyr4UMxGBU6PpqOlJca6U_3ehNgwPuIFln_3JxNqtpyIWd5YpWGPRtAqGYE8y2NyTMrJQcUCkfHIqOHVFk&s=bVm7gksgtz6uC4JmrzrJl3feK3Zx8KHF816x-CWgldiwpROSuckxu6kGOC3yZvBM_tU2BMcqCq7e1yFEIilkpl58b0l_jVdE6LJiRv78JnUteeZ1ulyZg3okMilnlRg8AqfWUOe7a3VaiIrb2Zmtz_753qKBInbMj-P_eI2Lo4UcZGCdDpWrRkjxEweQnMci6TpnNw1ogViuxNhvOCMF1rjb_Yhz-3zXITnI8YzVORDLL9obDFQYLoxJ824JtAwcXYhtbe1vLjKLopkk2krDu0PH_OC-5EeYG_buvrBta9Q0-OwSBDDkDLvJVtkU5QoVXRO-GHy-KrbDMBqyCxxb9A&h=fuvsOMObj1NzerVUv5kiwBc3pySY9-66eL57z6LCtFM
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/azureAsyncOperation/c825ff55-99c7-4b1b-b634-3d2b751d5505?api-version=2026-01-01-preview&t=639104788862499093&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=COe2rq3ZYXHoDkxmpL6Apmvjp-VM-7kEqXYFbqPrs39QxI51EzIDjgb8Vdf1NwkqbNP4eaetnSVBV37WIqDyqOmaajPAngH_nBaBXjJPPhoKmQ5zCT5mmPDabzGXSV2uUM-VBGJ7aA1Vra75ydDkkakuDaD0Sh4BtWcg56gDUUWCYONtLiTLv1jWia9SUT5CCbUVBg91fmxGkq3B9v8Wk0eY8qzqbDXdq0CDEcp2eQgp2MQVH92l9aGo41I3Qwadl-gxH0Fq_F1qJjlOuf6wNztgbshpvkWDQqx6JKBY1QH5TsvolEiqgjRXzfNNnHiHT59_jpa3ieTgZbfL2lFfIQ&h=3eKwChnyOr-P3umYYwZVmeZ2Csy9eKbm9kZBY7RA1zQ
   response:
     body:
-      string: '{"name":"6072a2d7-62b4-46fc-8b16-30ed1dcebba6","status":"InProgress","startTime":"2026-02-18T03:32:55.1Z"}'
+      string: '{"name":"c825ff55-99c7-4b1b-b634-3d2b751d5505","status":"InProgress","startTime":"2026-03-30T14:48:06.19Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '106'
+      - '107'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Feb 2026 03:33:10 GMT
+      - Mon, 30 Mar 2026 14:48:21 GMT
       expires:
       - '-1'
       pragma:
@@ -1432,11 +5302,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f57d2932-2a78-450f-958a-e65997c3253b/eastus2/91327500-5e06-47c3-868e-c96eb1bfb24a
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/86e0bd8a-e3ec-408b-aba0-a44729d61609
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 28BE0BC7D02B47D3AA1D4BA026A8D48B Ref B: BL2AA2011006036 Ref C: 2026-02-18T03:33:10Z'
+      - 'Ref A: 16B37198A1AF43B29FD4019855B988BD Ref B: AMS231020614035 Ref C: 2026-03-30T14:48:22Z'
     status:
       code: 200
       message: OK
@@ -1454,21 +5324,21 @@ interactions:
       ParameterSetName:
       - -g -n --yes
       User-Agent:
-      - AZURECLI/2.83.0 azsdk-python-core/1.38.0 Python/3.13.10 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/azureAsyncOperation/6072a2d7-62b4-46fc-8b16-30ed1dcebba6?api-version=2026-01-01-preview&t=639069823751424430&c=MIIHhzCCBm-gAwIBAgITHgfeaAthBF252mKMUQAAB95oCzANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDYwHhcNMjYwMTE1MTIwMzEzWhcNMjYwNTI0MjI1NzAzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALF5UwB1TCaUQryWnLemNoR1STogfj5BkURewSVKqF6BNmNVe6OPy7h3BMUV8wQPDRcx564kcpxInHjnJ91C2HdWhYtJC9mQ-KfRTHGro-eDtjIDA_m8ZoQaG1t8ZDyGTw3sg-le416DRx--vNLJWTcJ5pPQrNGLHgukyEBEGqcperL--6vkuDR8piARKeWdPub4QGpdJgULAoKm577o9Yeour0AbDe48KV8DaKqEhZAqTR021tTIU5-OVtQTAIuOTVnkBLtraUBYl6qbV603_iHP0-lxSiAdoOKRc9hnw5EIzdh4P3k57bkUUGKXBcEaDzqiXI4zT2s2PpLMdlJGrECAwEAAaOCBHQwggRwMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFghfmRS4WsmTQCAWQCAQcwggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MB0GA1UdDgQWBBQpx7wy64aZi3bga5mYDPjiPc4VjDAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwIwDAYKKwYBBAGCN3sEAjAfBgNVHSMEGDAWgBTxRmjG8cPwKy19i2rhsvm-NfzRQTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAESi3AgZNii4-yX1M8j9s1tnNVejdi-hvwe3tGOyTBjO6vi2tuQDoyQ-t6WDcAY8Suwhm0D6N6beb9niA0Z4KG-xN1jzJx-JF23mcbREASBP-H_Sk80BObD4a0FrOXY0dcNg2oK5FAuM8bwFfqHTRPNqCqL20uzuAyXhTgbwYJ7v6R0YYYv67aIj096-6dGUEKCXLHUtQfPNpvGOCnyvW5-kJ2GJ6ImpJvVnBPvU6JNVR7QMnSEtf7vlMFKguYoC7kAalHyr4UMxGBU6PpqOlJca6U_3ehNgwPuIFln_3JxNqtpyIWd5YpWGPRtAqGYE8y2NyTMrJQcUCkfHIqOHVFk&s=bVm7gksgtz6uC4JmrzrJl3feK3Zx8KHF816x-CWgldiwpROSuckxu6kGOC3yZvBM_tU2BMcqCq7e1yFEIilkpl58b0l_jVdE6LJiRv78JnUteeZ1ulyZg3okMilnlRg8AqfWUOe7a3VaiIrb2Zmtz_753qKBInbMj-P_eI2Lo4UcZGCdDpWrRkjxEweQnMci6TpnNw1ogViuxNhvOCMF1rjb_Yhz-3zXITnI8YzVORDLL9obDFQYLoxJ824JtAwcXYhtbe1vLjKLopkk2krDu0PH_OC-5EeYG_buvrBta9Q0-OwSBDDkDLvJVtkU5QoVXRO-GHy-KrbDMBqyCxxb9A&h=fuvsOMObj1NzerVUv5kiwBc3pySY9-66eL57z6LCtFM
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/azureAsyncOperation/c825ff55-99c7-4b1b-b634-3d2b751d5505?api-version=2026-01-01-preview&t=639104788862499093&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=COe2rq3ZYXHoDkxmpL6Apmvjp-VM-7kEqXYFbqPrs39QxI51EzIDjgb8Vdf1NwkqbNP4eaetnSVBV37WIqDyqOmaajPAngH_nBaBXjJPPhoKmQ5zCT5mmPDabzGXSV2uUM-VBGJ7aA1Vra75ydDkkakuDaD0Sh4BtWcg56gDUUWCYONtLiTLv1jWia9SUT5CCbUVBg91fmxGkq3B9v8Wk0eY8qzqbDXdq0CDEcp2eQgp2MQVH92l9aGo41I3Qwadl-gxH0Fq_F1qJjlOuf6wNztgbshpvkWDQqx6JKBY1QH5TsvolEiqgjRXzfNNnHiHT59_jpa3ieTgZbfL2lFfIQ&h=3eKwChnyOr-P3umYYwZVmeZ2Csy9eKbm9kZBY7RA1zQ
   response:
     body:
-      string: '{"name":"6072a2d7-62b4-46fc-8b16-30ed1dcebba6","status":"InProgress","startTime":"2026-02-18T03:32:55.1Z"}'
+      string: '{"name":"c825ff55-99c7-4b1b-b634-3d2b751d5505","status":"InProgress","startTime":"2026-03-30T14:48:06.19Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '106'
+      - '107'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Feb 2026 03:33:26 GMT
+      - Mon, 30 Mar 2026 14:48:37 GMT
       expires:
       - '-1'
       pragma:
@@ -1480,11 +5350,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f57d2932-2a78-450f-958a-e65997c3253b/eastus2/674a2bc8-9c7a-496f-9be1-c82a972a297a
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/6ea37fee-8a34-4253-80cb-f12529433109
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 2B7FDD034E5442D6A75FCD634E8BDACC Ref B: BL2AA2011001040 Ref C: 2026-02-18T03:33:26Z'
+      - 'Ref A: 31DC7EDD4BFB43EAA87D01E404010AD9 Ref B: AMS231022012039 Ref C: 2026-03-30T14:48:37Z'
     status:
       code: 200
       message: OK
@@ -1502,21 +5372,21 @@ interactions:
       ParameterSetName:
       - -g -n --yes
       User-Agent:
-      - AZURECLI/2.83.0 azsdk-python-core/1.38.0 Python/3.13.10 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/azureAsyncOperation/6072a2d7-62b4-46fc-8b16-30ed1dcebba6?api-version=2026-01-01-preview&t=639069823751424430&c=MIIHhzCCBm-gAwIBAgITHgfeaAthBF252mKMUQAAB95oCzANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDYwHhcNMjYwMTE1MTIwMzEzWhcNMjYwNTI0MjI1NzAzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALF5UwB1TCaUQryWnLemNoR1STogfj5BkURewSVKqF6BNmNVe6OPy7h3BMUV8wQPDRcx564kcpxInHjnJ91C2HdWhYtJC9mQ-KfRTHGro-eDtjIDA_m8ZoQaG1t8ZDyGTw3sg-le416DRx--vNLJWTcJ5pPQrNGLHgukyEBEGqcperL--6vkuDR8piARKeWdPub4QGpdJgULAoKm577o9Yeour0AbDe48KV8DaKqEhZAqTR021tTIU5-OVtQTAIuOTVnkBLtraUBYl6qbV603_iHP0-lxSiAdoOKRc9hnw5EIzdh4P3k57bkUUGKXBcEaDzqiXI4zT2s2PpLMdlJGrECAwEAAaOCBHQwggRwMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFghfmRS4WsmTQCAWQCAQcwggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MB0GA1UdDgQWBBQpx7wy64aZi3bga5mYDPjiPc4VjDAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwIwDAYKKwYBBAGCN3sEAjAfBgNVHSMEGDAWgBTxRmjG8cPwKy19i2rhsvm-NfzRQTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAESi3AgZNii4-yX1M8j9s1tnNVejdi-hvwe3tGOyTBjO6vi2tuQDoyQ-t6WDcAY8Suwhm0D6N6beb9niA0Z4KG-xN1jzJx-JF23mcbREASBP-H_Sk80BObD4a0FrOXY0dcNg2oK5FAuM8bwFfqHTRPNqCqL20uzuAyXhTgbwYJ7v6R0YYYv67aIj096-6dGUEKCXLHUtQfPNpvGOCnyvW5-kJ2GJ6ImpJvVnBPvU6JNVR7QMnSEtf7vlMFKguYoC7kAalHyr4UMxGBU6PpqOlJca6U_3ehNgwPuIFln_3JxNqtpyIWd5YpWGPRtAqGYE8y2NyTMrJQcUCkfHIqOHVFk&s=bVm7gksgtz6uC4JmrzrJl3feK3Zx8KHF816x-CWgldiwpROSuckxu6kGOC3yZvBM_tU2BMcqCq7e1yFEIilkpl58b0l_jVdE6LJiRv78JnUteeZ1ulyZg3okMilnlRg8AqfWUOe7a3VaiIrb2Zmtz_753qKBInbMj-P_eI2Lo4UcZGCdDpWrRkjxEweQnMci6TpnNw1ogViuxNhvOCMF1rjb_Yhz-3zXITnI8YzVORDLL9obDFQYLoxJ824JtAwcXYhtbe1vLjKLopkk2krDu0PH_OC-5EeYG_buvrBta9Q0-OwSBDDkDLvJVtkU5QoVXRO-GHy-KrbDMBqyCxxb9A&h=fuvsOMObj1NzerVUv5kiwBc3pySY9-66eL57z6LCtFM
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/azureAsyncOperation/c825ff55-99c7-4b1b-b634-3d2b751d5505?api-version=2026-01-01-preview&t=639104788862499093&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=COe2rq3ZYXHoDkxmpL6Apmvjp-VM-7kEqXYFbqPrs39QxI51EzIDjgb8Vdf1NwkqbNP4eaetnSVBV37WIqDyqOmaajPAngH_nBaBXjJPPhoKmQ5zCT5mmPDabzGXSV2uUM-VBGJ7aA1Vra75ydDkkakuDaD0Sh4BtWcg56gDUUWCYONtLiTLv1jWia9SUT5CCbUVBg91fmxGkq3B9v8Wk0eY8qzqbDXdq0CDEcp2eQgp2MQVH92l9aGo41I3Qwadl-gxH0Fq_F1qJjlOuf6wNztgbshpvkWDQqx6JKBY1QH5TsvolEiqgjRXzfNNnHiHT59_jpa3ieTgZbfL2lFfIQ&h=3eKwChnyOr-P3umYYwZVmeZ2Csy9eKbm9kZBY7RA1zQ
   response:
     body:
-      string: '{"name":"6072a2d7-62b4-46fc-8b16-30ed1dcebba6","status":"InProgress","startTime":"2026-02-18T03:32:55.1Z"}'
+      string: '{"name":"c825ff55-99c7-4b1b-b634-3d2b751d5505","status":"InProgress","startTime":"2026-03-30T14:48:06.19Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '106'
+      - '107'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Feb 2026 03:33:42 GMT
+      - Mon, 30 Mar 2026 14:48:53 GMT
       expires:
       - '-1'
       pragma:
@@ -1528,11 +5398,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f57d2932-2a78-450f-958a-e65997c3253b/eastus/acebbf6b-819f-41c7-95fa-6067116af57b
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/aa296567-4ed4-4ec4-9cc1-50539566e130
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: B09FB2B8A37A454E9FAD26F0F6175981 Ref B: MNZ221060619017 Ref C: 2026-02-18T03:33:42Z'
+      - 'Ref A: A8BFDE237F934C248DDF28EC9F004215 Ref B: AMS231022012053 Ref C: 2026-03-30T14:48:53Z'
     status:
       code: 200
       message: OK
@@ -1550,21 +5420,21 @@ interactions:
       ParameterSetName:
       - -g -n --yes
       User-Agent:
-      - AZURECLI/2.83.0 azsdk-python-core/1.38.0 Python/3.13.10 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.84.0 azsdk-python-core/1.38.0 Python/3.13.12 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/azureAsyncOperation/6072a2d7-62b4-46fc-8b16-30ed1dcebba6?api-version=2026-01-01-preview&t=639069823751424430&c=MIIHhzCCBm-gAwIBAgITHgfeaAthBF252mKMUQAAB95oCzANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDYwHhcNMjYwMTE1MTIwMzEzWhcNMjYwNTI0MjI1NzAzWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALF5UwB1TCaUQryWnLemNoR1STogfj5BkURewSVKqF6BNmNVe6OPy7h3BMUV8wQPDRcx564kcpxInHjnJ91C2HdWhYtJC9mQ-KfRTHGro-eDtjIDA_m8ZoQaG1t8ZDyGTw3sg-le416DRx--vNLJWTcJ5pPQrNGLHgukyEBEGqcperL--6vkuDR8piARKeWdPub4QGpdJgULAoKm577o9Yeour0AbDe48KV8DaKqEhZAqTR021tTIU5-OVtQTAIuOTVnkBLtraUBYl6qbV603_iHP0-lxSiAdoOKRc9hnw5EIzdh4P3k57bkUUGKXBcEaDzqiXI4zT2s2PpLMdlJGrECAwEAAaOCBHQwggRwMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFghfmRS4WsmTQCAWQCAQcwggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAyLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA2LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMi5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNi5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDIuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3J0MB0GA1UdDgQWBBQpx7wy64aZi3bga5mYDPjiPc4VjDAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDYuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwIwDAYKKwYBBAGCN3sEAjAfBgNVHSMEGDAWgBTxRmjG8cPwKy19i2rhsvm-NfzRQTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAESi3AgZNii4-yX1M8j9s1tnNVejdi-hvwe3tGOyTBjO6vi2tuQDoyQ-t6WDcAY8Suwhm0D6N6beb9niA0Z4KG-xN1jzJx-JF23mcbREASBP-H_Sk80BObD4a0FrOXY0dcNg2oK5FAuM8bwFfqHTRPNqCqL20uzuAyXhTgbwYJ7v6R0YYYv67aIj096-6dGUEKCXLHUtQfPNpvGOCnyvW5-kJ2GJ6ImpJvVnBPvU6JNVR7QMnSEtf7vlMFKguYoC7kAalHyr4UMxGBU6PpqOlJca6U_3ehNgwPuIFln_3JxNqtpyIWd5YpWGPRtAqGYE8y2NyTMrJQcUCkfHIqOHVFk&s=bVm7gksgtz6uC4JmrzrJl3feK3Zx8KHF816x-CWgldiwpROSuckxu6kGOC3yZvBM_tU2BMcqCq7e1yFEIilkpl58b0l_jVdE6LJiRv78JnUteeZ1ulyZg3okMilnlRg8AqfWUOe7a3VaiIrb2Zmtz_753qKBInbMj-P_eI2Lo4UcZGCdDpWrRkjxEweQnMci6TpnNw1ogViuxNhvOCMF1rjb_Yhz-3zXITnI8YzVORDLL9obDFQYLoxJ824JtAwcXYhtbe1vLjKLopkk2krDu0PH_OC-5EeYG_buvrBta9Q0-OwSBDDkDLvJVtkU5QoVXRO-GHy-KrbDMBqyCxxb9A&h=fuvsOMObj1NzerVUv5kiwBc3pySY9-66eL57z6LCtFM
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/Canada%20Central/azureAsyncOperation/c825ff55-99c7-4b1b-b634-3d2b751d5505?api-version=2026-01-01-preview&t=639104788862499093&c=MIIHlDCCBnygAwIBAgIQKKjplgwMQSaep8IFYd6aujANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIxODE5NTczOVoXDTI2MDgxNDAxNTczOVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDH3lHezd1jN-Q7GiBIuEvyrCXT3IkQ0gXovFQxd7raGgyusLyVDUAAVKJUURO5aA5pG8Ly7skeqTwiIk12VITfV-CL3Ti4jcifOmCc9lTpJMT84TgR_e3SSwbH6ugYXNA94tY5TSiHd8N6iUv277xSiUUUEqmz9oltk32GfYgwXZ7TXQ_CtHthYrYiFNBE8b56xsYnEHUAQ4ARd0vVIfF6uYBKRlxSWw7r3k-FeBf3w_oVo5dlksrMW1dW9ifsUhOl7k_zOibz8NMTOmtOKCUcDkf-QCQWMvdKZANqf2mehdkIJzq9jXXn0Fdxks35B53hrRd6uDOuTc-8J55WvShNAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRYlNrT1QX5I5zS3xvtBhE5TOeISzAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAF9HWFfM18c_8F6HsZljPAIucL-GTRHyZ99Aszi1Oj0linApfv0rtur0YoiCU5RkyeTwHYpMEblSzqxZRxdHVlP32L2Vh0F5w6qnTqAzmvb5qhhYzk5JxZlUHd-cJIyPMLdVJpMra8pYcokTtPTj_uQYIkvtHqUq-gyBLMwCfHbndSKFRTUrXbP6yYKeI4gzhksZkd1psp9ts6TBXxPG-f4TmDJy6k8Z2RGZYAaTfbPAYdjX96IdxJAHCaFFSV9D3W8rFQOdnx9IwHaWngdV3l4Yra0Th1RmzCLQmsnhgv3oLxVxFsVOarjtCtNnDLc8kyeh7tVeEm2omgAOfUFnFP&s=COe2rq3ZYXHoDkxmpL6Apmvjp-VM-7kEqXYFbqPrs39QxI51EzIDjgb8Vdf1NwkqbNP4eaetnSVBV37WIqDyqOmaajPAngH_nBaBXjJPPhoKmQ5zCT5mmPDabzGXSV2uUM-VBGJ7aA1Vra75ydDkkakuDaD0Sh4BtWcg56gDUUWCYONtLiTLv1jWia9SUT5CCbUVBg91fmxGkq3B9v8Wk0eY8qzqbDXdq0CDEcp2eQgp2MQVH92l9aGo41I3Qwadl-gxH0Fq_F1qJjlOuf6wNztgbshpvkWDQqx6JKBY1QH5TsvolEiqgjRXzfNNnHiHT59_jpa3ieTgZbfL2lFfIQ&h=3eKwChnyOr-P3umYYwZVmeZ2Csy9eKbm9kZBY7RA1zQ
   response:
     body:
-      string: '{"name":"6072a2d7-62b4-46fc-8b16-30ed1dcebba6","status":"Succeeded","startTime":"2026-02-18T03:32:55.1Z"}'
+      string: '{"name":"c825ff55-99c7-4b1b-b634-3d2b751d5505","status":"Succeeded","startTime":"2026-03-30T14:48:06.19Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '105'
+      - '106'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 18 Feb 2026 03:33:57 GMT
+      - Mon, 30 Mar 2026 14:49:08 GMT
       expires:
       - '-1'
       pragma:
@@ -1576,11 +5446,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f57d2932-2a78-450f-958a-e65997c3253b/eastus/9f9aa9ad-4b59-4f7a-8b56-359ec3f2f0fd
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=15659232-7461-4854-b909-7dff9a1e844c/uksouth/5761c01e-3627-495a-abd1-cccdef4e8d36
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: C60B5EC604494E55800FF7CD6CA57472 Ref B: BL2AA2011004036 Ref C: 2026-02-18T03:33:57Z'
+      - 'Ref A: 65DEA2C59844405A9F41BB9B9993E215 Ref B: AMS231032609023 Ref C: 2026-03-30T14:49:08Z'
     status:
       code: 200
       message: OK

--- a/src/azure-cli/azure/cli/command_modules/postgresql/tests/latest/test_postgres_flexible_commands_server_logs.py
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/tests/latest/test_postgres_flexible_commands_server_logs.py
@@ -38,11 +38,7 @@ class FlexibleServerLogsMgmtScenarioTest(ScenarioTest):
                     checks=[JMESPathCheck('value', "1"),
                             JMESPathCheck('name', "logfiles.retention_days")]).get_output_in_json()
 
-        if os.environ.get(ENV_LIVE_TEST, True):
-            return
-
-        # wait for around 30 min to allow log files to be generated
-        sleep(30*60)
+        os.environ.get(ENV_LIVE_TEST, False) and sleep(30*60)  # wait for around 30 min to allow log files to be generated
 
         # list server log files
         server_log_files = self.cmd('postgres flexible-server server-logs list -g {} --server-name {} '


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
`az postgres flexible-server server-logs list` crashes with an AttributeError when listing log files.

```
File ".../azure/cli/command_modules/postgresql/flexible_server_custom_postgres.py", line 1317, in flexible_server_list_log_files_with_filter
    del f.created_time
        ^^^^^^^^^^^^^^
AttributeError: 'CapturedLog' object has no attribute 'created_time'
```

Here are the significant differences between LogFile (old) and CapturedLog (new):

**Field changes**

| Aspect | LogFile (old) | CapturedLog (new) |
| -- | -- | -- |
| Class name | LogFile | CapturedLog |
| type field name | type_properties_type (renamed to avoid collision with ARM's type) | type (inside CapturedLogProperties) |
| type values | Undocumented free string | Documented: 'ServerLogs' or 'UpgradeLogs' |
| system_data | Absent | Present (ARM createdBy/modifiedBy metadata) |
| Properties nesting | Flat on the model | Nested in CapturedLogProperties, flattened via __flattened_items |

**Read-only enforcement**
In the old SDK, created_time and last_modified_time were declared readonly: True in _validation — i.e., server-side only. In the new SDK, both are declared with full CRUD visibility (["read", "create", "update", "delete", "query"]), removing the hard read-only constraint at the SDK layer.

**SDK generation style**
The old SDK was AutoRest-generated (_serialization.Model, _validation, _attribute_map dicts). The new SDK uses the Python Code Generator (_Model, rest_field, @overload constructors). This changes how serialization and validation are expressed, though the wire format is the same.

For now, let's fix it like this. My proposal is to also add a deprecation note to inform that shape of returned object will change in the future to, at least, surface createdTime. We could also consider renaming typePropertiestype to something like logType.

**Testing Guide**
I noticed that the existing tests weren't running the `server-logs list' command when live test was run. That would have caught the error before we would have merged the PR that introduced the offending SDK. So, I've enable it and refreshed the recordings.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[PostgreSQL] Fix #33090: `az postgres flexible-server server-logs list`: Command crashes with an AttributeError when listing log files

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
