### PR TITLE
[ACR] `az acr login`: Support Podman for `--name` parameter

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/check_health.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/check_health.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import re
+import json
 from knack.util import CLIError
 from knack.log import get_logger
 from .custom import get_docker_command
@@ -73,11 +74,11 @@ def _subprocess_communicate(command_parts, shell=False):
 
 
 # Checks for the environment
-# Checks docker command, docker daemon, docker version and docker pull
+# Checks container command, daemon, version and image pull
 def _get_docker_status_and_version(ignore_errors, yes):
     from ._errors import DOCKER_DAEMON_ERROR, DOCKER_PULL_ERROR, DOCKER_VERSION_ERROR
 
-    # Docker command and docker daemon check
+    # Container command and daemon check
     docker_command, error = get_docker_command(is_diagnostics_context=True)
     docker_daemon_available = True
 
@@ -88,18 +89,31 @@ def _get_docker_status_and_version(ignore_errors, yes):
         docker_daemon_available = False
 
     if docker_daemon_available:
-        logger.warning("Docker daemon status: available")
+        logger.warning("%s daemon status: available", docker_command.title())
 
     # Docker version check
-    output, warning, stderr, succeeded = _subprocess_communicate(
-        [docker_command, "version", "--format", "'Docker version {{.Server.Version}}, "
-         "build {{.Server.GitCommit}}, platform {{.Server.Os}}/{{.Server.Arch}}'"])
+    output, warning, stderr, succeeded = _subprocess_communicate([docker_command, "version", "--format", "json"])
     if not succeeded:
         _handle_error(DOCKER_VERSION_ERROR.append_error_message(stderr), ignore_errors)
     else:
         if warning:
             logger.warning(warning)
-        logger.warning("Docker version: %s", output)
+        try:
+            json_output = json.loads(output).get("Client")
+        except json.decoder.JSONDecodeError:
+            json_output = {}
+        version = json_output.get("Version", "unknown")
+        commit = json_output.get("GitCommit", "unknown")[:7]
+        if docker_command == "docker":
+            os = json_output.get("Os", "unknown")
+            arch = json_output.get("Arch", "unknown")
+        else:
+            try:
+                os, arch = json_output.get("OsArch", "unknown").split("/")
+            except ValueError:
+                os = "unknown"
+                arch = "unknown"
+        logger.warning("%s version: %s, build %s, platform %s/%s", docker_command.title(), version, commit, os, arch)
 
     # Docker pull check - only if docker daemon is available
     if docker_daemon_available:
@@ -114,14 +128,14 @@ def _get_docker_status_and_version(ignore_errors, yes):
 
         if not succeeded:
             if stderr and DOCKER_PULL_WRONG_PLATFORM in stderr:
-                print_pass("Docker pull of '{}'".format(IMAGE))
+                print_pass(f"{docker_command.title()} pull of '{IMAGE}'")
                 logger.warning("Image '%s' can be pulled but cannot be used on this platform", IMAGE)
                 return
             _handle_error(DOCKER_PULL_ERROR.append_error_message(stderr), ignore_errors)
         else:
             if warning:
                 logger.warning(warning)
-            print_pass("Docker pull of '{}'".format(IMAGE))
+            print_pass(f"{docker_command.title()} pull of '{IMAGE}'")
 
 
 # Get current CLI version

--- a/src/azure-cli/azure/cli/command_modules/acr/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/custom.py
@@ -7,6 +7,7 @@
 
 import os
 import re
+import shutil
 from knack.util import CLIError
 from knack.log import get_logger
 from azure.cli.core.azclierror import InvalidArgumentValueError, RequiredArgumentMissingError
@@ -396,6 +397,8 @@ def get_docker_command(is_diagnostics_context=False):
         docker_command = os.getenv('DOCKER_COMMAND')
     else:
         docker_command = 'docker'
+        if not shutil.which('docker') and shutil.which('podman'):
+            docker_command = 'podman'
 
     from subprocess import PIPE, Popen, CalledProcessError
     try:
@@ -405,7 +408,7 @@ def get_docker_command(is_diagnostics_context=False):
         logger.debug("Could not run '%s' command. Exception: %s", docker_command, str(e))
         # The executable may not be discoverable in WSL so retry *.exe once
         try:
-            docker_command = 'docker.exe'
+            docker_command = f'{docker_command}.exe'
             p = Popen([docker_command, "ps"], stdout=PIPE, stderr=PIPE)
             _, stderr = p.communicate()
         except OSError as inner:


### PR DESCRIPTION
This is a follow-up PR based on https://github.com/Azure/azure-cli/pull/31850. All credit for the initial work goes to the original author cpressland

**Related command**
`az acr login`

**Description**
Adds a simple check for `podman` being in `PATH` and sets that as the `docker_command` if found. This enables users to run `az acr login` without Docker being installed or setting the DOCKER_COMMAND environment variable.

Since `get_docker_command` function is also used by Azure CLI extensions, renaming it now would cause those extension commands to break and error out. We'll defer the name update for now.

**Testing Guide**
Execute `az acr login` + arguments to a valid ACR instance when you have podman installed, instead of getting an error, it should pass:
```
$ az acr login -n example
Login Succeeded!
```

**History Notes**
[ACR] `az acr login`: Support Podman for `--name` parameter

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
