### PR TITLE
[POSTGRESQL] BREAKING CHANGE: `az postgres flexible-server upgrade`: Remove the enum for `--version`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/postgresql/_breaking_change.py
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/_breaking_change.py
@@ -22,12 +22,6 @@ register_command_group_deprecate(command_group='postgres flexible-server long-te
                                  message='Long term retention command group will be removed. '
                                  'For more information, open a support incident.')
 
-# Upgrade command argument changes
-register_other_breaking_change('postgres flexible-server upgrade',
-                               message='The allowed values will be changed from set list to '
-                               'supported versions for upgrade based on capabilities.',
-                               arg='--version')
-
 # Name of new backup no longer required in backup create command
 register_other_breaking_change('postgres flexible-server backup create',
                                message='The argument for backup name will no longer be required '

--- a/src/azure-cli/azure/cli/command_modules/postgresql/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/_params.py
@@ -272,7 +272,6 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
         )
 
         pg_version_upgrade_arg_type = CLIArgumentType(
-            arg_type=get_enum_type(['13', '14', '15', '16', '17', '18']),
             options_list=['--version', '-v'],
             help='Server major version.'
         )


### PR DESCRIPTION
**Related command**
az postgres flexible-server upgrade

**Description**<!--Mandatory-->
Remove the enum for `--version`

**Testing Guide**
<!--Example commands with explanations.-->
Manual testing

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[POSTGRESQL] BREAKING CHANGE: `az postgres flexible-server upgrade`: Remove the enum for `--version`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
