### PR TITLE
{ACR} az acr check-health: fix check-health command by removing outdated API version gate for CMK check

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/check_health.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/check_health.py
@@ -321,7 +321,6 @@ def _get_endpoint_and_token_status(cmd, login_server, registry_abac_enabled, rep
 
 
 def _check_registry_health(cmd, registry_name, repository, ignore_errors):
-    from azure.cli.core.profiles import ResourceType
     if registry_name is None:
         logger.warning("Registry name must be provided to check connectivity.")
         return
@@ -349,25 +348,24 @@ def _check_registry_health(cmd, registry_name, repository, ignore_errors):
             registry and registry.role_assignment_mode == RoleAssignmentMode.ABAC_REPOSITORY_PERMISSIONS
         _get_endpoint_and_token_status(cmd, login_server, registry_abac_enabled, repository, ignore_errors)
 
-    if cmd.supported_api_version(min_api='2020-11-01-preview', resource_type=ResourceType.MGMT_CONTAINERREGISTRY):  # pylint: disable=too-many-nested-blocks
-        # CMK settings
-        if registry and registry.encryption and registry.encryption.key_vault_properties:  # pylint: disable=too-many-nested-blocks
-            client_id = registry.encryption.key_vault_properties.identity
-            valid_identity = False
-            if registry.identity:
-                valid_identity = ((client_id == 'system') and
-                                  bool(registry.identity.principal_id))  # use system identity?
-                if not valid_identity and registry.identity.user_assigned_identities:
-                    for k, v in registry.identity.user_assigned_identities.items():
-                        if v.client_id == client_id:
-                            from azure.core.exceptions import HttpResponseError
-                            try:
-                                valid_identity = resolve_identity_client_id(cmd.cli_ctx, k) == client_id
-                            except HttpResponseError:
-                                pass
-            if not valid_identity:
-                from ._errors import CMK_MANAGED_IDENTITY_ERROR
-                _handle_error(CMK_MANAGED_IDENTITY_ERROR.format_error_message(registry_name), ignore_errors)
+    # CMK settings
+    if registry and registry.encryption and registry.encryption.key_vault_properties:  # pylint: disable=too-many-nested-blocks
+        client_id = registry.encryption.key_vault_properties.identity
+        valid_identity = False
+        if registry.identity:
+            valid_identity = ((client_id == 'system') and
+                              bool(registry.identity.principal_id))  # use system identity?
+            if not valid_identity and registry.identity.user_assigned_identities:
+                for k, v in registry.identity.user_assigned_identities.items():
+                    if v.client_id == client_id:
+                        from azure.core.exceptions import HttpResponseError
+                        try:
+                            valid_identity = resolve_identity_client_id(cmd.cli_ctx, k) == client_id
+                        except HttpResponseError:
+                            pass
+        if not valid_identity:
+            from ._errors import CMK_MANAGED_IDENTITY_ERROR
+            _handle_error(CMK_MANAGED_IDENTITY_ERROR.format_error_message(registry_name), ignore_errors)
 
 
 def _check_private_endpoint(cmd, registry_name, vnet_of_private_endpoint):  # pylint: disable=too-many-locals, too-many-statements


### PR DESCRIPTION
**Related command**
`az acr check-health`

**Description**
[PR #33017](https://github.com/Azure/azure-cli/pull/33017/changes#diff-817dfb662b344e1666b95ab3ad0b614a2f042217b02a20e572738e824d35b32b) set MGMT_CONTAINERREGISTRY's API version to None in the profile, but check_health.py still calls `cmd.supported_api_version(min_api='2020-11-01-preview', resource_type=ResourceType.MGMT_CONTAINERREGISTRY)` which tries to compare None against a version string, causing the 'NoneType' object has no attribute 'split' crash.

This PR removed the `cmd.supported_api_version(min_api='2020-11-01-preview', ...)` check — the 2020-11-01-preview feature (CMK) has been GA for years, so no need to guard it

**Testing Guide**
Before:
```
az acr check-health -n example -y
Remove Notary client version validation in next breaking change release(2.86.0) scheduled for May 2026. The Notary client version check will no longer be performed as part of the check-health command due to Docker Content Trust deprecation. To know more about the Breaking Change, please visit https://aka.ms/acr/dctdeprecation.
Docker daemon status: available
Docker version: 'Docker version 29.2.1, build 6bc6209, platform linux/amd64'
Docker pull of 'mcr.microsoft.com/mcr/hello-world:latest' : OK
Azure CLI version: 2.85.0
DNS lookup to example.azurecr.io at IP 20.62.128.0 : OK
Challenge endpoint https://example.azurecr.io/v2/ : OK
Fetch refresh token for registry 'example.azurecr.io' : OK
Fetch access token for registry 'example.azurecr.io' : OK
The command failed with an unexpected error. Here is the traceback:
'NoneType' object has no attribute 'split'
Traceback (most recent call last):
  File "c:\users\zoeyli\acr\azure-cli\src\azure-cli-core\azure\cli\core\profiles\_shared.py", line 335, in __init__
    if 'preview' in api_version_str:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "c:\users\zoeyli\acr\azure-cli\src\azure-cli-core\azure\cli\core\profiles\_shared.py", line 375, in _parse_api_version
    return _DateAPIFormat(api_version)
  File "c:\users\zoeyli\acr\azure-cli\src\azure-cli-core\azure\cli\core\profiles\_shared.py", line 342, in __init__
    raise ValueError('The API version {} is not in a '
                     'supported format'.format(api_version_str))
ValueError: The API version None is not in a supported format

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users\zoeyli\ACR\azure-cli\.venv\Lib\site-packages\knack\cli.py", line 233, in invoke
    cmd_result = self.invocation.execute(args)
  File "c:\users\zoeyli\acr\azure-cli\src\azure-cli-core\azure\cli\core\commands\__init__.py", line 677, in execute
    raise ex
  File "c:\users\zoeyli\acr\azure-cli\src\azure-cli-core\azure\cli\core\commands\__init__.py", line 820, in _run_jobs_serially
    results.append(self._run_job(expanded_arg, cmd_copy))
                   ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\users\zoeyli\acr\azure-cli\src\azure-cli-core\azure\cli\core\commands\__init__.py", line 789, in _run_job
    result = cmd_copy(params)
  File "c:\users\zoeyli\acr\azure-cli\src\azure-cli-core\azure\cli\core\commands\__init__.py", line 335, in __call__
    return self.handler(*args, **kwargs)
           ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "c:\users\zoeyli\acr\azure-cli\src\azure-cli-core\azure\cli\core\commands\command_operation.py", line 120, in handler
    return op(**command_args)
  File "c:\users\zoeyli\acr\azure-cli\src\azure-cli\azure\cli\command_modules\acr\check_health.py", line 465, in acr_check_health
    _check_registry_health(cmd, registry_name, repository, ignore_errors)
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\users\zoeyli\acr\azure-cli\src\azure-cli\azure\cli\command_modules\acr\check_health.py", line 352, in _check_registry_health
    if cmd.supported_api_version(min_api='2020-11-01-preview', resource_type=ResourceType.MGMT_CONTAINERREGISTRY):  # pylint: disable=too-many-nested-blocks    
       ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\users\zoeyli\acr\azure-cli\src\azure-cli-core\azure\cli\core\commands\__init__.py", line 352, in supported_api_version
    return self.loader.supported_api_version(resource_type=resource_type, min_api=min_api, max_api=max_api,
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                             operation_group=operation_group)
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\users\zoeyli\acr\azure-cli\src\azure-cli-core\azure\cli\core\__init__.py", line 1401, in supported_api_version
    api_support = supported_api_version(
        cli_ctx=self.cli_ctx,
    ...<2 lines>...
        max_api=max_api,
        operation_group=operation_group)
  File "c:\users\zoeyli\acr\azure-cli\src\azure-cli-core\azure\cli\core\profiles\__init__.py", line 41, in supported_api_version
    return _sdk_supported_api_version(cli_ctx.cloud.profile,
                                      resource_type=resource_type,
                                      min_api=min_api,
                                      max_api=max_api,
                                      operation_group=operation_group)
  File "c:\users\zoeyli\acr\azure-cli\src\azure-cli-core\azure\cli\core\profiles\_shared.py", line 420, in supported_api_version
    return _validate_api_version(api_version_obj, min_api, max_api)
  File "c:\users\zoeyli\acr\azure-cli\src\azure-cli-core\azure\cli\core\profiles\_shared.py", line 397, in _validate_api_version
    if min_api and _cross_api_format_less_than(api_version_str, min_api):
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\users\zoeyli\acr\azure-cli\src\azure-cli-core\azure\cli\core\profiles\_shared.py", line 386, in _cross_api_format_less_than
    api_version = _parse_api_version(api_version)
  File "c:\users\zoeyli\acr\azure-cli\src\azure-cli-core\azure\cli\core\profiles\_shared.py", line 377, in _parse_api_version
    return _SemVerAPIFormat(api_version)
  File "c:\users\zoeyli\acr\azure-cli\src\azure-cli-core\azure\cli\core\profiles\_shared.py", line 305, in __init__
    parts = api_version_str.split('.')
            ^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'split'
To check existing issues, please visit: https://github.com/Azure/azure-cli/issues
```

After:
```
az acr check-health -n example -y
Remove Notary client version validation in next breaking change release(2.86.0) scheduled for May 2026. The Notary client version check will no longer be performed as part of the check-health command due to Docker Content Trust deprecation. To know more about the Breaking Change, please visit https://aka.ms/acr/dctdeprecation.
Docker daemon status: available
Docker version: 'Docker version 29.2.1, build 6bc6209, platform linux/amd64'
Docker pull of 'mcr.microsoft.com/mcr/hello-world:latest' : OK
Azure CLI version: 2.85.0
DNS lookup to example.azurecr.io at IP 20.62.128.0 : OK
Challenge endpoint https://example.azurecr.io/v2/ : OK
Fetch refresh token for registry 'example.azurecr.io' : OK
Fetch access token for registry 'example.azurecr.io' : OK
```

**History Notes**

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
