### PR TITLE
{AKS} Add provisioningState retry logic to AKS test base class

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
@@ -106,10 +106,14 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
                 last_seen_etag = initial_etag
                 max_retries = max(1, int(os.environ.get('AZURE_CLI_TEST_PROVISIONING_MAX_RETRIES', '10')))
                 base_delay = float(os.environ.get('AZURE_CLI_TEST_PROVISIONING_BASE_DELAY', '2.0'))
+                # Cap per-attempt sleep so unbounded exponential growth can't
+                # stall a runner. Default 60s keeps worst-case total under
+                # max_retries * max_delay (e.g. 10 * 60s = 10 min).
+                max_delay = float(os.environ.get('AZURE_CLI_TEST_PROVISIONING_MAX_DELAY', '60.0'))
 
                 # Poll with exponential backoff + jitter until terminal state
                 for attempt in range(max_retries):
-                    delay = base_delay * (2 ** attempt) + random.uniform(0, 1)
+                    delay = min(base_delay * (2 ** attempt), max_delay) + random.uniform(0, 1)
                     time.sleep(delay)
                     poll_result = execute(self.cli_ctx, f'resource show --ids {resource_id}', expect_failure=False)
                     poll_data = poll_result.get_output_in_json()

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
@@ -54,7 +54,8 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
     def cmd(self, command, checks=None, expect_failure=False):
         if (checks and self.is_live and
             os.environ.get('AZURE_CLI_TEST_RETRY_PROVISIONING_CHECK') == 'true'):
-            return self._cmd_with_retry(command, checks, expect_failure)
+            normalized_checks = checks if isinstance(checks, (list, tuple)) else [checks]
+            return self._cmd_with_retry(command, normalized_checks, expect_failure)
         return super().cmd(command, checks=checks, expect_failure=expect_failure)
 
     def _is_provisioning_state_check(self, check):
@@ -72,8 +73,9 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         provisioning_state = data.get('provisioningState')
         if not provisioning_state:
             return False, None
-        terminal_states = {'Succeeded', 'Failed', 'Canceled'}
-        if provisioning_state in terminal_states:
+        if provisioning_state in {'Failed', 'Canceled'}:
+            raise AssertionError(f"provisioningState is {provisioning_state}")
+        if provisioning_state == 'Succeeded':
             return False, None
         return True, data['id']
 
@@ -96,7 +98,7 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
                 initial_data = result.get_output_in_json()
                 initial_etag = initial_data.get('etag')
                 last_seen_etag = initial_etag
-                max_retries = int(os.environ.get('AZURE_CLI_TEST_PROVISIONING_MAX_RETRIES', '10'))
+                max_retries = max(1, int(os.environ.get('AZURE_CLI_TEST_PROVISIONING_MAX_RETRIES', '10')))
                 base_delay = float(os.environ.get('AZURE_CLI_TEST_PROVISIONING_BASE_DELAY', '2.0'))
 
                 # Poll with exponential backoff + jitter until terminal state
@@ -132,8 +134,8 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             # Provisioning checks already verified via polling, skip re-checking stale result
 
         # Run all non-provisioning checks against the original result
-        for check in other_checks:
-            check(result)
+        if other_checks:
+            result.assert_with_checks(other_checks)
 
         return result
 

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
@@ -52,7 +52,7 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         )
 
     def cmd(self, command, checks=None, expect_failure=False):
-        if (checks and self.is_live and
+        if (checks and
             os.environ.get('AZURE_CLI_TEST_RETRY_PROVISIONING_CHECK') == 'true'):
             normalized_checks = checks if isinstance(checks, (list, tuple)) else [checks]
             return self._cmd_with_retry(command, normalized_checks, expect_failure)
@@ -104,7 +104,10 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
                 # Poll with exponential backoff + jitter until terminal state
                 for attempt in range(max_retries):
                     delay = base_delay * (2 ** attempt) + random.uniform(0, 1)
-                    time.sleep(delay)
+                    # Skip the sleep in replay; cassette entries are served
+                    # instantly and the backoff is meaningless.
+                    if self.is_live:
+                        time.sleep(delay)
                     poll_result = execute(self.cli_ctx, f'resource show --ids {resource_id}', expect_failure=False)
                     poll_data = poll_result.get_output_in_json()
                     current_provisioning_state = poll_data.get('provisioningState')

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
@@ -52,7 +52,13 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         )
 
     def cmd(self, command, checks=None, expect_failure=False):
-        if (checks and
+        # Live-only retry adapter: when AZURE_CLI_TEST_RETRY_PROVISIONING_CHECK
+        # is set during a live run, poll provisioningState until terminal so an
+        # Azure Policy race can't fail the test on a stale 'Updating' body.
+        # Recordings made with the flag enabled must NOT be committed; the
+        # replay pipeline runs with the flag off and would assert against the
+        # initial pre-poll response.
+        if (checks and self.is_live and
             os.environ.get('AZURE_CLI_TEST_RETRY_PROVISIONING_CHECK') == 'true'):
             normalized_checks = checks if isinstance(checks, (list, tuple)) else [checks]
             return self._cmd_with_retry(command, normalized_checks, expect_failure)
@@ -104,10 +110,7 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
                 # Poll with exponential backoff + jitter until terminal state
                 for attempt in range(max_retries):
                     delay = base_delay * (2 ** attempt) + random.uniform(0, 1)
-                    # Skip the sleep in replay; cassette entries are served
-                    # instantly and the backoff is meaningless.
-                    if self.is_live:
-                        time.sleep(delay)
+                    time.sleep(delay)
                     poll_result = execute(self.cli_ctx, f'resource show --ids {resource_id}', expect_failure=False)
                     poll_data = poll_result.get_output_in_json()
                     current_provisioning_state = poll_data.get('provisioningState')

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
@@ -130,8 +130,11 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
                         f"provisioningState did not reach 'Succeeded' after {max_retries} retries. "
                         f"Final state: {current_provisioning_state}{final_etag_msg}"
                     )
-
-            # Provisioning checks already verified via polling, skip re-checking stale result
+                # Polled to 'Succeeded'; don't re-check `result` (stale body).
+            else:
+                # Did not poll (already Succeeded, or missing id/state).
+                # Run the assertion anyway so it can't be silently dropped.
+                result.assert_with_checks(provisioning_checks)
 
         # Run all non-provisioning checks against the original result
         if other_checks:

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
@@ -5,6 +5,7 @@
 
 import json
 import os
+import random
 import subprocess
 import tempfile
 import time
@@ -49,6 +50,92 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         super(AzureKubernetesServiceScenarioTest, self).__init__(
             method_name, recording_processors=[KeyReplacer()]
         )
+
+    def cmd(self, command, checks=None, expect_failure=False):
+        if (checks and self.is_live and
+            os.environ.get('AZURE_CLI_TEST_RETRY_PROVISIONING_CHECK') == 'true'):
+            return self._cmd_with_retry(command, checks, expect_failure)
+        return super().cmd(command, checks=checks, expect_failure=expect_failure)
+
+    def _is_provisioning_state_check(self, check):
+        from azure.cli.testsdk.checkers import JMESPathCheck
+        if not isinstance(check, JMESPathCheck):
+            return False
+        return check._query == 'provisioningState' and check._expected_result == 'Succeeded'
+
+    def _should_retry_for_provisioning_state(self, result):
+        if not hasattr(result, 'get_output_in_json'):
+            return False, None
+        data = result.get_output_in_json()
+        if not isinstance(data, dict) or 'id' not in data:
+            return False, None
+        provisioning_state = data.get('provisioningState')
+        if not provisioning_state:
+            return False, None
+        terminal_states = {'Succeeded', 'Failed', 'Canceled'}
+        if provisioning_state in terminal_states:
+            return False, None
+        return True, data['id']
+
+    def _cmd_with_retry(self, command, checks, expect_failure):
+        from azure.cli.testsdk.base import execute
+        import logging
+
+        # Apply kwargs substitution (e.g. {resource_group}) before executing,
+        # matching what ScenarioTest.cmd() does internally.
+        command = self._apply_kwargs(command)
+        result = execute(self.cli_ctx, command, expect_failure=expect_failure)
+
+        # Split checks into provisioning vs everything else
+        provisioning_checks = [c for c in (checks or []) if self._is_provisioning_state_check(c)]
+        other_checks = [c for c in (checks or []) if not self._is_provisioning_state_check(c)]
+
+        if provisioning_checks:
+            should_retry, resource_id = self._should_retry_for_provisioning_state(result)
+            if should_retry:
+                initial_data = result.get_output_in_json()
+                initial_etag = initial_data.get('etag')
+                last_seen_etag = initial_etag
+                max_retries = int(os.environ.get('AZURE_CLI_TEST_PROVISIONING_MAX_RETRIES', '10'))
+                base_delay = float(os.environ.get('AZURE_CLI_TEST_PROVISIONING_BASE_DELAY', '2.0'))
+
+                # Poll with exponential backoff + jitter until terminal state
+                for attempt in range(max_retries):
+                    delay = base_delay * (2 ** attempt) + random.uniform(0, 1)
+                    time.sleep(delay)
+                    poll_result = execute(self.cli_ctx, f'resource show --ids {resource_id}', expect_failure=False)
+                    poll_data = poll_result.get_output_in_json()
+                    current_provisioning_state = poll_data.get('provisioningState')
+                    current_etag = poll_data.get('etag')
+
+                    # Track etag changes to detect external modifications during polling
+                    if current_etag and last_seen_etag and current_etag != last_seen_etag:
+                        logging.warning(f"ETag changed during polling (external modification detected)")
+                    last_seen_etag = current_etag
+
+                    if current_provisioning_state == 'Succeeded':
+                        break
+                    elif current_provisioning_state in {'Failed', 'Canceled'}:
+                        raise AssertionError(
+                            f"provisioningState reached terminal failure: {current_provisioning_state}"
+                        )
+                else:
+                    # for/else: ran all retries without breaking
+                    final_etag_msg = ""
+                    if initial_etag and last_seen_etag:
+                        final_etag_msg = f" (initial etag: {initial_etag}, final: {last_seen_etag})"
+                    raise TimeoutError(
+                        f"provisioningState did not reach 'Succeeded' after {max_retries} retries. "
+                        f"Final state: {current_provisioning_state}{final_etag_msg}"
+                    )
+
+            # Provisioning checks already verified via polling, skip re-checking stale result
+
+        # Run all non-provisioning checks against the original result
+        for check in other_checks:
+            check(result)
+
+        return result
 
     @classmethod
     def generate_ssh_keys(cls):

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_provisioning_retry.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_provisioning_retry.py
@@ -164,5 +164,41 @@ class TestCmdWithRetry(unittest.TestCase):
         name_check.assert_called_once()
 
 
+    @patch.dict(os.environ, {'AZURE_CLI_TEST_PROVISIONING_MAX_RETRIES': '3', 'AZURE_CLI_TEST_PROVISIONING_BASE_DELAY': '0.01'})
+    @patch('time.sleep', return_value=None)
+    @patch('random.uniform', return_value=0)
+    @patch('azure.cli.testsdk.base.execute')
+    def test_missing_provisioning_state_fails_loudly(self, mock_execute, _mock_random, _mock_sleep):
+        # Regression: when the response body has no 'provisioningState',
+        # _should_retry_for_provisioning_state returns (False, None) and the
+        # adapter MUST still run the provisioning check against the result
+        # so the assertion fails loudly rather than being silently dropped.
+        from azure.cli.testsdk.exceptions import JMESPathCheckAssertionError
+        mock_execute.return_value = self._result({'id': '/rg/mc', 'name': 'mc'})
+        with self.assertRaises(JMESPathCheckAssertionError):
+            self._make_instance()._cmd_with_retry(
+                'aks show',
+                [JMESPathCheck('provisioningState', 'Succeeded')],
+                False,
+            )
+
+    @patch.dict(os.environ, {'AZURE_CLI_TEST_PROVISIONING_MAX_RETRIES': '3', 'AZURE_CLI_TEST_PROVISIONING_BASE_DELAY': '0.01'})
+    @patch('time.sleep', return_value=None)
+    @patch('random.uniform', return_value=0)
+    @patch('azure.cli.testsdk.base.execute')
+    def test_missing_id_fails_loudly(self, mock_execute, _mock_random, _mock_sleep):
+        # Regression: when the response body has no 'id', polling cannot
+        # proceed; the provisioning check MUST still run against the result
+        # rather than be silently dropped.
+        from azure.cli.testsdk.exceptions import JMESPathCheckAssertionError
+        mock_execute.return_value = self._result({'provisioningState': 'Updating'})
+        with self.assertRaises(JMESPathCheckAssertionError):
+            self._make_instance()._cmd_with_retry(
+                'aks show',
+                [JMESPathCheck('provisioningState', 'Succeeded')],
+                False,
+            )
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_provisioning_retry.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_provisioning_retry.py
@@ -85,7 +85,7 @@ class TestShouldRetryForProvisioningState(unittest.TestCase):
 
 class TestCmdWithRetry(unittest.TestCase):
 
-    def _make_instance(self):
+    def _make_instance(self, is_live=True):
         from azure.cli.command_modules.acs.tests.latest.test_aks_commands import (
             AzureKubernetesServiceScenarioTest,
         )
@@ -93,6 +93,9 @@ class TestCmdWithRetry(unittest.TestCase):
         instance.kwargs = {}
         instance._apply_kwargs = lambda cmd: cmd
         instance.cli_ctx = MagicMock()
+        # is_live drives whether time.sleep runs during polling. Default True
+        # so existing tests behave as before; replay-mode tests pass False.
+        instance.is_live = is_live
         return instance
 
     def _result(self, data):
@@ -198,6 +201,32 @@ class TestCmdWithRetry(unittest.TestCase):
                 [JMESPathCheck('provisioningState', 'Succeeded')],
                 False,
             )
+
+    @patch.dict(os.environ, {'AZURE_CLI_TEST_PROVISIONING_MAX_RETRIES': '3', 'AZURE_CLI_TEST_PROVISIONING_BASE_DELAY': '0.01'})
+    @patch('time.sleep')
+    @patch('random.uniform', return_value=0)
+    @patch('azure.cli.testsdk.base.execute')
+    def test_replay_with_race_polls_captured_entries(self, mock_execute, _mock_random, mock_sleep):
+        # Reproduces the replay-mode race scenario: a cassette was recorded
+        # where the initial response showed 'Updating' and the subsequent
+        # poll responses were captured. In replay mode (is_live=False) the
+        # adapter must still poll, consuming the captured entries, so the
+        # assertion succeeds against the polled body. Without this, the
+        # check would fail against the stale initial 'Updating' response.
+        resource_id = '/subscriptions/xxx/resourceGroups/rg/providers/Microsoft.ContainerService/managedClusters/mc'
+        mock_execute.side_effect = [
+            self._result({'id': resource_id, 'provisioningState': 'Updating'}),
+            self._result({'provisioningState': 'Updating'}),
+            self._result({'provisioningState': 'Succeeded'}),
+        ]
+        self._make_instance(is_live=False)._cmd_with_retry(
+            'aks show',
+            [JMESPathCheck('provisioningState', 'Succeeded')],
+            False,
+        )
+        self.assertEqual(mock_execute.call_count, 3)
+        # No sleep in replay; the cassette serves polls instantly.
+        mock_sleep.assert_not_called()
 
 
 if __name__ == '__main__':

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_provisioning_retry.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_provisioning_retry.py
@@ -1,0 +1,123 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import json
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from azure.cli.testsdk.checkers import JMESPathCheck
+
+
+class MockExecutionResult:
+    def __init__(self, output_json):
+        self._json = output_json
+        self.output = json.dumps(output_json)
+        self.json_value = None
+
+    def get_output_in_json(self):
+        return self._json
+
+
+class TestShouldRetryForProvisioningState(unittest.TestCase):
+
+    def _make_instance(self):
+        from azure.cli.command_modules.acs.tests.latest.test_aks_commands import (
+            AzureKubernetesServiceScenarioTest,
+        )
+        return object.__new__(AzureKubernetesServiceScenarioTest)
+
+    def test_non_terminal_state_returns_true(self):
+        inst = self._make_instance()
+        result = MockExecutionResult({
+            'id': '/subscriptions/xxx/resourceGroups/rg/providers/Microsoft.ContainerService/managedClusters/mc',
+            'provisioningState': 'Updating',
+        })
+        should_retry, resource_id = inst._should_retry_for_provisioning_state(result)
+        self.assertTrue(should_retry)
+        self.assertIn('managedClusters/mc', resource_id)
+
+    def test_succeeded_returns_false(self):
+        inst = self._make_instance()
+        result = MockExecutionResult({'id': '/subscriptions/xxx/rg/mc', 'provisioningState': 'Succeeded'})
+        should_retry, _ = inst._should_retry_for_provisioning_state(result)
+        self.assertFalse(should_retry)
+
+    def test_no_id_returns_false(self):
+        inst = self._make_instance()
+        result = MockExecutionResult({'provisioningState': 'Updating'})
+        should_retry, _ = inst._should_retry_for_provisioning_state(result)
+        self.assertFalse(should_retry)
+
+    def test_list_response_returns_false(self):
+        inst = self._make_instance()
+        result = MockExecutionResult([{'id': '/some/id', 'provisioningState': 'Updating'}])
+        should_retry, _ = inst._should_retry_for_provisioning_state(result)
+        self.assertFalse(should_retry)
+
+
+class TestCmdWithRetry(unittest.TestCase):
+
+    def _make_instance(self):
+        from azure.cli.command_modules.acs.tests.latest.test_aks_commands import (
+            AzureKubernetesServiceScenarioTest,
+        )
+        instance = object.__new__(AzureKubernetesServiceScenarioTest)
+        instance.kwargs = {}
+        instance._apply_kwargs = lambda cmd: cmd
+        instance.cli_ctx = MagicMock()
+        return instance
+
+    def _result(self, data):
+        return MockExecutionResult(data)
+
+    @patch.dict(os.environ, {'AZURE_CLI_TEST_PROVISIONING_MAX_RETRIES': '3', 'AZURE_CLI_TEST_PROVISIONING_BASE_DELAY': '0.01'})
+    @patch('azure.cli.testsdk.base.execute')
+    def test_no_retry_when_already_succeeded(self, mock_execute):
+        mock_execute.return_value = self._result({'id': '/rg/mc', 'provisioningState': 'Succeeded'})
+        self._make_instance()._cmd_with_retry('aks show', [JMESPathCheck('provisioningState', 'Succeeded')], False)
+        mock_execute.assert_called_once()
+
+    @patch.dict(os.environ, {'AZURE_CLI_TEST_PROVISIONING_MAX_RETRIES': '3', 'AZURE_CLI_TEST_PROVISIONING_BASE_DELAY': '0.01'})
+    @patch('azure.cli.testsdk.base.execute')
+    def test_retries_until_succeeded(self, mock_execute):
+        resource_id = '/subscriptions/xxx/resourceGroups/rg/providers/Microsoft.ContainerService/managedClusters/mc'
+        mock_execute.side_effect = [
+            self._result({'id': resource_id, 'provisioningState': 'Updating'}),
+            self._result({'provisioningState': 'Updating'}),
+            self._result({'provisioningState': 'Succeeded'}),
+        ]
+        self._make_instance()._cmd_with_retry('aks show', [JMESPathCheck('provisioningState', 'Succeeded')], False)
+        self.assertEqual(mock_execute.call_count, 3)
+
+    @patch.dict(os.environ, {'AZURE_CLI_TEST_PROVISIONING_MAX_RETRIES': '2', 'AZURE_CLI_TEST_PROVISIONING_BASE_DELAY': '0.01'})
+    @patch('azure.cli.testsdk.base.execute')
+    def test_raises_on_failed_state(self, mock_execute):
+        mock_execute.side_effect = [
+            self._result({'id': '/rg/mc', 'provisioningState': 'Updating'}),
+            self._result({'provisioningState': 'Failed'}),
+        ]
+        with self.assertRaises(AssertionError):
+            self._make_instance()._cmd_with_retry('aks show', [JMESPathCheck('provisioningState', 'Succeeded')], False)
+
+    @patch.dict(os.environ, {'AZURE_CLI_TEST_PROVISIONING_MAX_RETRIES': '2', 'AZURE_CLI_TEST_PROVISIONING_BASE_DELAY': '0.01'})
+    @patch('azure.cli.testsdk.base.execute')
+    def test_raises_timeout_after_max_retries(self, mock_execute):
+        poll = self._result({'provisioningState': 'Updating'})
+        mock_execute.side_effect = [self._result({'id': '/rg/mc', 'provisioningState': 'Updating'}), poll, poll]
+        with self.assertRaises(TimeoutError):
+            self._make_instance()._cmd_with_retry('aks show', [JMESPathCheck('provisioningState', 'Succeeded')], False)
+
+    @patch.dict(os.environ, {'AZURE_CLI_TEST_PROVISIONING_MAX_RETRIES': '3', 'AZURE_CLI_TEST_PROVISIONING_BASE_DELAY': '0.01'})
+    @patch('azure.cli.testsdk.base.execute')
+    def test_non_provisioning_checks_still_run(self, mock_execute):
+        mock_execute.return_value = self._result({'id': '/rg/mc', 'name': 'mc', 'provisioningState': 'Succeeded'})
+        name_check = MagicMock()
+        self._make_instance()._cmd_with_retry('aks show', [JMESPathCheck('provisioningState', 'Succeeded'), name_check], False)
+        name_check.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_provisioning_retry.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_provisioning_retry.py
@@ -163,7 +163,6 @@ class TestCmdWithRetry(unittest.TestCase):
         self._make_instance()._cmd_with_retry('aks show', [JMESPathCheck('provisioningState', 'Succeeded'), name_check], False)
         name_check.assert_called_once()
 
-
     @patch.dict(os.environ, {'AZURE_CLI_TEST_PROVISIONING_MAX_RETRIES': '3', 'AZURE_CLI_TEST_PROVISIONING_BASE_DELAY': '0.01'})
     @patch('time.sleep', return_value=None)
     @patch('random.uniform', return_value=0)
@@ -198,6 +197,33 @@ class TestCmdWithRetry(unittest.TestCase):
                 [JMESPathCheck('provisioningState', 'Succeeded')],
                 False,
             )
+
+    @patch.dict(os.environ, {
+        'AZURE_CLI_TEST_PROVISIONING_MAX_RETRIES': '5',
+        'AZURE_CLI_TEST_PROVISIONING_BASE_DELAY': '2.0',
+        'AZURE_CLI_TEST_PROVISIONING_MAX_DELAY': '10.0',
+    })
+    @patch('time.sleep', return_value=None)
+    @patch('random.uniform', return_value=0)
+    @patch('azure.cli.testsdk.base.execute')
+    def test_delay_is_clamped_to_max_delay(self, mock_execute, _mock_random, mock_sleep):
+        # Regression: exponential backoff must be capped by
+        # AZURE_CLI_TEST_PROVISIONING_MAX_DELAY so a single sleep can't grow
+        # unbounded (e.g. base 2.0 * 2^9 = 1024s on attempt 9).
+        resource_id = '/subscriptions/xxx/resourceGroups/rg/providers/Microsoft.ContainerService/managedClusters/mc'
+        mock_execute.side_effect = [
+            self._result({'id': resource_id, 'provisioningState': 'Updating'}),
+            self._result({'provisioningState': 'Updating'}),
+            self._result({'provisioningState': 'Updating'}),
+            self._result({'provisioningState': 'Updating'}),
+            self._result({'provisioningState': 'Updating'}),
+            self._result({'provisioningState': 'Succeeded'}),
+        ]
+        self._make_instance()._cmd_with_retry('aks show', [JMESPathCheck('provisioningState', 'Succeeded')], False)
+        # Without the cap, attempts 3 and 4 would sleep 16s and 32s.
+        # With max_delay=10.0 and jitter pinned to 0, every sleep must be <= 10.0.
+        for call in mock_sleep.call_args_list:
+            self.assertLessEqual(call.args[0], 10.0)
 
 
 if __name__ == '__main__':

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_provisioning_retry.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_provisioning_retry.py
@@ -16,9 +16,22 @@ class MockExecutionResult:
         self._json = output_json
         self.output = json.dumps(output_json)
         self.json_value = None
+        self.skip_assert = False
 
     def get_output_in_json(self):
         return self._json
+
+    def assert_with_checks(self, *args):
+        checks = []
+        for each in args:
+            if isinstance(each, list):
+                checks.extend(each)
+            elif callable(each):
+                checks.append(each)
+        if not self.skip_assert:
+            for c in checks:
+                c(self)
+        return self
 
 
 class TestShouldRetryForProvisioningState(unittest.TestCase):
@@ -44,6 +57,18 @@ class TestShouldRetryForProvisioningState(unittest.TestCase):
         result = MockExecutionResult({'id': '/subscriptions/xxx/rg/mc', 'provisioningState': 'Succeeded'})
         should_retry, _ = inst._should_retry_for_provisioning_state(result)
         self.assertFalse(should_retry)
+
+    def test_failed_raises_assertion(self):
+        inst = self._make_instance()
+        result = MockExecutionResult({'id': '/subscriptions/xxx/rg/mc', 'provisioningState': 'Failed'})
+        with self.assertRaises(AssertionError):
+            inst._should_retry_for_provisioning_state(result)
+
+    def test_canceled_raises_assertion(self):
+        inst = self._make_instance()
+        result = MockExecutionResult({'id': '/subscriptions/xxx/rg/mc', 'provisioningState': 'Canceled'})
+        with self.assertRaises(AssertionError):
+            inst._should_retry_for_provisioning_state(result)
 
     def test_no_id_returns_false(self):
         inst = self._make_instance()
@@ -74,15 +99,19 @@ class TestCmdWithRetry(unittest.TestCase):
         return MockExecutionResult(data)
 
     @patch.dict(os.environ, {'AZURE_CLI_TEST_PROVISIONING_MAX_RETRIES': '3', 'AZURE_CLI_TEST_PROVISIONING_BASE_DELAY': '0.01'})
+    @patch('time.sleep', return_value=None)
+    @patch('random.uniform', return_value=0)
     @patch('azure.cli.testsdk.base.execute')
-    def test_no_retry_when_already_succeeded(self, mock_execute):
+    def test_no_retry_when_already_succeeded(self, mock_execute, _mock_random, _mock_sleep):
         mock_execute.return_value = self._result({'id': '/rg/mc', 'provisioningState': 'Succeeded'})
         self._make_instance()._cmd_with_retry('aks show', [JMESPathCheck('provisioningState', 'Succeeded')], False)
         mock_execute.assert_called_once()
 
     @patch.dict(os.environ, {'AZURE_CLI_TEST_PROVISIONING_MAX_RETRIES': '3', 'AZURE_CLI_TEST_PROVISIONING_BASE_DELAY': '0.01'})
+    @patch('time.sleep', return_value=None)
+    @patch('random.uniform', return_value=0)
     @patch('azure.cli.testsdk.base.execute')
-    def test_retries_until_succeeded(self, mock_execute):
+    def test_retries_until_succeeded(self, mock_execute, _mock_random, _mock_sleep):
         resource_id = '/subscriptions/xxx/resourceGroups/rg/providers/Microsoft.ContainerService/managedClusters/mc'
         mock_execute.side_effect = [
             self._result({'id': resource_id, 'provisioningState': 'Updating'}),
@@ -93,8 +122,10 @@ class TestCmdWithRetry(unittest.TestCase):
         self.assertEqual(mock_execute.call_count, 3)
 
     @patch.dict(os.environ, {'AZURE_CLI_TEST_PROVISIONING_MAX_RETRIES': '2', 'AZURE_CLI_TEST_PROVISIONING_BASE_DELAY': '0.01'})
+    @patch('time.sleep', return_value=None)
+    @patch('random.uniform', return_value=0)
     @patch('azure.cli.testsdk.base.execute')
-    def test_raises_on_failed_state(self, mock_execute):
+    def test_raises_on_failed_state(self, mock_execute, _mock_random, _mock_sleep):
         mock_execute.side_effect = [
             self._result({'id': '/rg/mc', 'provisioningState': 'Updating'}),
             self._result({'provisioningState': 'Failed'}),
@@ -103,16 +134,30 @@ class TestCmdWithRetry(unittest.TestCase):
             self._make_instance()._cmd_with_retry('aks show', [JMESPathCheck('provisioningState', 'Succeeded')], False)
 
     @patch.dict(os.environ, {'AZURE_CLI_TEST_PROVISIONING_MAX_RETRIES': '2', 'AZURE_CLI_TEST_PROVISIONING_BASE_DELAY': '0.01'})
+    @patch('time.sleep', return_value=None)
+    @patch('random.uniform', return_value=0)
     @patch('azure.cli.testsdk.base.execute')
-    def test_raises_timeout_after_max_retries(self, mock_execute):
+    def test_raises_immediately_on_initial_failed_state(self, mock_execute, _mock_random, _mock_sleep):
+        mock_execute.return_value = self._result({'id': '/rg/mc', 'provisioningState': 'Failed'})
+        with self.assertRaises(AssertionError):
+            self._make_instance()._cmd_with_retry('aks show', [JMESPathCheck('provisioningState', 'Succeeded')], False)
+        mock_execute.assert_called_once()
+
+    @patch.dict(os.environ, {'AZURE_CLI_TEST_PROVISIONING_MAX_RETRIES': '2', 'AZURE_CLI_TEST_PROVISIONING_BASE_DELAY': '0.01'})
+    @patch('time.sleep', return_value=None)
+    @patch('random.uniform', return_value=0)
+    @patch('azure.cli.testsdk.base.execute')
+    def test_raises_timeout_after_max_retries(self, mock_execute, _mock_random, _mock_sleep):
         poll = self._result({'provisioningState': 'Updating'})
         mock_execute.side_effect = [self._result({'id': '/rg/mc', 'provisioningState': 'Updating'}), poll, poll]
         with self.assertRaises(TimeoutError):
             self._make_instance()._cmd_with_retry('aks show', [JMESPathCheck('provisioningState', 'Succeeded')], False)
 
     @patch.dict(os.environ, {'AZURE_CLI_TEST_PROVISIONING_MAX_RETRIES': '3', 'AZURE_CLI_TEST_PROVISIONING_BASE_DELAY': '0.01'})
+    @patch('time.sleep', return_value=None)
+    @patch('random.uniform', return_value=0)
     @patch('azure.cli.testsdk.base.execute')
-    def test_non_provisioning_checks_still_run(self, mock_execute):
+    def test_non_provisioning_checks_still_run(self, mock_execute, _mock_random, _mock_sleep):
         mock_execute.return_value = self._result({'id': '/rg/mc', 'name': 'mc', 'provisioningState': 'Succeeded'})
         name_check = MagicMock()
         self._make_instance()._cmd_with_retry('aks show', [JMESPathCheck('provisioningState', 'Succeeded'), name_check], False)

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_provisioning_retry.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_provisioning_retry.py
@@ -85,7 +85,7 @@ class TestShouldRetryForProvisioningState(unittest.TestCase):
 
 class TestCmdWithRetry(unittest.TestCase):
 
-    def _make_instance(self, is_live=True):
+    def _make_instance(self):
         from azure.cli.command_modules.acs.tests.latest.test_aks_commands import (
             AzureKubernetesServiceScenarioTest,
         )
@@ -93,9 +93,6 @@ class TestCmdWithRetry(unittest.TestCase):
         instance.kwargs = {}
         instance._apply_kwargs = lambda cmd: cmd
         instance.cli_ctx = MagicMock()
-        # is_live drives whether time.sleep runs during polling. Default True
-        # so existing tests behave as before; replay-mode tests pass False.
-        instance.is_live = is_live
         return instance
 
     def _result(self, data):
@@ -201,32 +198,6 @@ class TestCmdWithRetry(unittest.TestCase):
                 [JMESPathCheck('provisioningState', 'Succeeded')],
                 False,
             )
-
-    @patch.dict(os.environ, {'AZURE_CLI_TEST_PROVISIONING_MAX_RETRIES': '3', 'AZURE_CLI_TEST_PROVISIONING_BASE_DELAY': '0.01'})
-    @patch('time.sleep')
-    @patch('random.uniform', return_value=0)
-    @patch('azure.cli.testsdk.base.execute')
-    def test_replay_with_race_polls_captured_entries(self, mock_execute, _mock_random, mock_sleep):
-        # Reproduces the replay-mode race scenario: a cassette was recorded
-        # where the initial response showed 'Updating' and the subsequent
-        # poll responses were captured. In replay mode (is_live=False) the
-        # adapter must still poll, consuming the captured entries, so the
-        # assertion succeeds against the polled body. Without this, the
-        # check would fail against the stale initial 'Updating' response.
-        resource_id = '/subscriptions/xxx/resourceGroups/rg/providers/Microsoft.ContainerService/managedClusters/mc'
-        mock_execute.side_effect = [
-            self._result({'id': resource_id, 'provisioningState': 'Updating'}),
-            self._result({'provisioningState': 'Updating'}),
-            self._result({'provisioningState': 'Succeeded'}),
-        ]
-        self._make_instance(is_live=False)._cmd_with_retry(
-            'aks show',
-            [JMESPathCheck('provisioningState', 'Succeeded')],
-            False,
-        )
-        self.assertEqual(mock_execute.call_count, 3)
-        # No sleep in replay; the cassette serves polls instantly.
-        mock_sleep.assert_not_called()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add opt-in retry logic to the AKS CLI tests for handling provisioningState race conditions caused by external modifications (e.g., Azure Policy) during live tests.

**Related command**
`az aks update`

**Description**<!--Mandatory-->
### Problem:
provisioningState race condition caused by Azure Policy seen in AKS CLI Runners that use azure cli test sdk. Live tests in Microsoft-managed subscriptions intermittently fail with:

`Query 'provisioningState' doesn't yield expected value 'Succeeded', instead the actual value is 'Updating'`

| Time | Actor | Action | provisioningState |
|------|-------|--------|-------------------|
| 20:46:01 | Azure CLI | PUT managed cluster (cli test) | - |
| 20:56:52 | AKS | PUT completes successfully | Succeeded |
| 20:57:08 | Azure Policy | PUT managed cluster (azure policy compliance) | Updating |
| 20:57:14 | Azure CLI SDK | GET managed cluster (test assertion) | Updating (cli test failure) |

### Proposed Fix in the PR:
Overrides `cmd()` in `AzureKubernetesServiceScenarioTest` to poll via `az resource show --ids <id>` with exponential backoff when provisioningState is non-terminal. Scoped entirely within the ACS module.

Opt-in via `AZURE_CLI_TEST_RETRY_PROVISIONING_CHECK=true`. The retry path is gated on `self.is_live` and the env var, so it never runs in replay. Recordings produced with the flag on must not be committed — the live runners already discard them, but flagging it here so the rule is on paper.

**Testing Guide**
Unit tests in `test_aks_provisioning_retry.py`. To enable retry path:
```
AZURE_CLI_TEST_RETRY_PROVISIONING_CHECK=true \
azdev test test_aks_create_default_service_with_monitoring_addon_msi --live
```
This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
