### PR TITLE
{Packaging} Fix cask template and `az upgrade` for preview and homebrew-cask migration

### DIFF
--- a/scripts/release/macos/templates/azure-cli.rb.in
+++ b/scripts/release/macos/templates/azure-cli.rb.in
@@ -1,12 +1,12 @@
 cask "azure-cli" do
   arch arm: "arm64", intel: "x86_64"
-  os macos: "macos"
 
   version "{{ version }}"
   sha256 arm:   "{{ arm64_sha }}",
          intel: "{{ x86_64_sha }}"
 
-  url "https://github.com/{{ github_repo }}/releases/download/azure-cli-#{version}/azure-cli-#{version}-#{os}-#{arch}.tar.gz"
+  url "https://github.com/{{ github_repo }}/releases/download/azure-cli-#{version}/azure-cli-#{version}-macos-#{arch}.tar.gz",
+      verified: "github.com/{{ github_repo }}/"
   name "Azure CLI"
   desc "Microsoft Azure CLI 2.0"
   homepage "https://docs.microsoft.com/cli/azure/overview"
@@ -19,9 +19,9 @@ cask "azure-cli" do
   depends_on formula: "python@{{ python_version }}"
 
   binary "bin/az"
-  zsh_completion "completions/zsh/_az"
   bash_completion "completions/bash/az"
   fish_completion "completions/fish/az.fish"
+  zsh_completion "completions/zsh/_az"
 
   zap trash: "~/.azure"
 end

--- a/src/azure-cli/azure/cli/command_modules/util/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/util/custom.py
@@ -132,9 +132,17 @@ def upgrade_version(cmd, update_all=None, yes=None, allow_preview=None):  # pyli
                 exit_code = subprocess.call(update_cmd)
         elif installer == 'HOMEBREW_CASK':
             logger.debug("Update homebrew cask")
+            # Determine cask token: 'azure-cli-preview' (custom tap) or 'azure-cli' (homebrew-cask)
+            cask_token = 'azure-cli'
+            try:
+                if subprocess.call(['brew', 'list', '--cask', 'azure-cli-preview'],
+                                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL) == 0:
+                    cask_token = 'azure-cli-preview'
+            except Exception:  # pylint: disable=broad-except
+                pass
             exit_code = subprocess.call(['brew', 'update'])
             if exit_code == 0:
-                update_cmd = ['brew', 'upgrade', '--cask', 'azure-cli']
+                update_cmd = ['brew', 'upgrade', '--cask', cask_token]
                 logger.debug("Update azure cli with '%s'", " ".join(update_cmd))
                 exit_code = subprocess.call(update_cmd)
         elif installer == 'PIP':

--- a/src/azure-cli/azure/cli/command_modules/util/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/util/custom.py
@@ -133,13 +133,20 @@ def upgrade_version(cmd, update_all=None, yes=None, allow_preview=None):  # pyli
         elif installer == 'HOMEBREW_CASK':
             logger.debug("Update homebrew cask")
             # Determine cask token: 'azure-cli-preview' (custom tap) or 'azure-cli' (homebrew-cask)
-            cask_token = 'azure-cli'
             try:
-                if subprocess.call(['brew', 'list', '--cask', 'azure-cli-preview'],
-                                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL) == 0:
+                preview_installed = subprocess.call(['brew', 'list', '--cask', 'azure-cli-preview'],
+                                                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL) == 0
+                cli_installed = subprocess.call(['brew', 'list', '--cask', 'azure-cli'],
+                                                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL) == 0
+                if preview_installed:
                     cask_token = 'azure-cli-preview'
-            except Exception:  # pylint: disable=broad-except
-                pass
+                elif cli_installed:
+                    cask_token = 'azure-cli'
+                else:
+                    raise CLIError(UPGRADE_MSG)
+            except OSError as ex:
+                logger.debug("Failed to detect Homebrew cask token: %s", ex)
+                cask_token = 'azure-cli'
             exit_code = subprocess.call(['brew', 'update'])
             if exit_code == 0:
                 update_cmd = ['brew', 'upgrade', '--cask', cask_token]


### PR DESCRIPTION
## Summary

Two packaging fixes for the upcoming homebrew-cask migration (Plan B):

### 1. `az upgrade`: Detect correct cask token for preview vs production

The current `az upgrade` hardcodes `brew upgrade --cask azure-cli`. Under Plan B, preview users install via the `azure-cli-preview` cask token (from custom tap `Azure/homebrew-azure-cli`). This fix adds runtime detection so `az upgrade` uses the correct token.

**Change:** `src/azure-cli/azure/cli/command_modules/util/custom.py`
- Check if `azure-cli-preview` cask is installed via `brew list --cask azure-cli-preview`
- If found, use `azure-cli-preview` as the cask token; otherwise default to `azure-cli`

### 2. Fix cask definition template (`azure-cli.rb.in`)

Fixes discovered during Homebrew PR [#257931](https://github.com/Homebrew/homebrew-cask/pull/257931):

**Change:** `scripts/release/macos/templates/azure-cli.rb.in`
1. **Removed `os macos: "macos"` stanza** — caused Homebrew CI to simulate Linux tags, resulting in `sha256: nil` audit failure
2. **Hardcoded `macos` in URL** — replaced `#{os}` interpolation since `os` stanza is removed
3. **Added `verified:` parameter** to URL — required by Homebrew when URL domain differs from homepage domain
4. **Fixed completion stanza ordering** — bash → fish → zsh (alphabetical, per Homebrew style guide)

The updated template now matches the working cask in the custom tap [`Azure/homebrew-azure-cli`](https://github.com/Azure/homebrew-azure-cli).

## Testing

- Verified generated cask output matches the working `azure-cli-preview` cask in `Azure/homebrew-azure-cli`
- `az upgrade` logic tested with both `azure-cli` and `azure-cli-preview` cask tokens
