### PR TITLE
[POSTGRESQL] `az postgres flexible-server update`: Restart is no longer required for scaling storage size of Premium SSDv2 server

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/postgresql/commands/custom_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/commands/custom_commands.py
@@ -501,10 +501,6 @@ def flexible_server_update_custom_func(cmd, client, instance,
     if instance.storage.type == "PremiumV2_LRS":
         instance.storage.tier = None
 
-        if sku_name or storage_gb:
-            logger.warning("You are changing the compute and/or storage size of the server. "
-                           "The server will be restarted for this operation and you will see a short downtime.")
-
         if iops:
             instance.storage.iops = iops
 
@@ -633,8 +629,8 @@ def _confirm_restart_server(instance, sku_name, storage_gb, yes):
         show_confirmation = True
 
     if not yes and show_confirmation:
-        user_confirmation("You are trying to change the compute or the size of storage assigned to your server in a way that \
-            requires a server restart. During the restart, you'll experience some downtime of the server. Do you want to proceed?", yes=yes)
+        user_confirmation('You are trying to update the compute or storage size assigned to your server in a way that '
+                          'requires a server restart. During the restart, you\'ll experience some downtime of the server. Do you want to proceed?', yes=yes)
 
 
 def flexible_server_delete(cmd, client, resource_group_name, server_name, yes=False):

--- a/src/azure-cli/azure/cli/command_modules/postgresql/commands/custom_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/commands/custom_commands.py
@@ -624,18 +624,17 @@ def _update_login(server_name, resource_group_name, auth_config, password_auth, 
 def _confirm_restart_server(instance, sku_name, storage_gb, yes):
     show_confirmation = False
 
-    if instance.storage.type != "PremiumV2_LRS":
-        # check if sku_name is changed
-        if sku_name and sku_name != instance.sku.name:
-            show_confirmation = True
+    # check if sku_name is changed
+    if sku_name and sku_name != instance.sku.name:
+        show_confirmation = True
 
-        # check if requested storage growth is crossing the 4096 threshold
-        if storage_gb and storage_gb > 4096 and instance.storage.storage_size_gb <= 4096:
-            show_confirmation = True
+    # check if requested storage growth is crossing the 4096 threshold
+    if storage_gb and storage_gb > 4096 and instance.storage.storage_size_gb <= 4096 and instance.storage.type != "PremiumV2_LRS":
+        show_confirmation = True
 
-        if not yes and show_confirmation:
-            user_confirmation("You are trying to change the compute or the size of storage assigned to your server in a way that \
-                requires a server restart. During the restart, you'll experience some downtime of the server. Do you want to proceed?", yes=yes)
+    if not yes and show_confirmation:
+        user_confirmation("You are trying to change the compute or the size of storage assigned to your server in a way that \
+            requires a server restart. During the restart, you'll experience some downtime of the server. Do you want to proceed?", yes=yes)
 
 
 def flexible_server_delete(cmd, client, resource_group_name, server_name, yes=False):

--- a/src/azure-cli/azure/cli/command_modules/postgresql/commands/custom_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/commands/custom_commands.py
@@ -624,21 +624,18 @@ def _update_login(server_name, resource_group_name, auth_config, password_auth, 
 def _confirm_restart_server(instance, sku_name, storage_gb, yes):
     show_confirmation = False
 
-    # check if sku_name is changed
-    if sku_name and sku_name != instance.sku.name:
-        show_confirmation = True
+    if instance.storage.type != "PremiumV2_LRS":
+        # check if sku_name is changed
+        if sku_name and sku_name != instance.sku.name:
+            show_confirmation = True
 
-    # check if requested storage growth is crossing the 4096 threshold
-    if storage_gb and storage_gb > 4096 and instance.storage.storage_size_gb <= 4096 and instance.storage.type == "":
-        show_confirmation = True
+        # check if requested storage growth is crossing the 4096 threshold
+        if storage_gb and storage_gb > 4096 and instance.storage.storage_size_gb <= 4096:
+            show_confirmation = True
 
-    # check if storage_gb changed for PremiumV2_LRS
-    if storage_gb and instance.storage.type == "PremiumV2_LRS" and instance.storage.storage_size_gb != storage_gb:
-        show_confirmation = True
-
-    if not yes and show_confirmation:
-        user_confirmation("You are trying to change the compute or the size of storage assigned to your server in a way that \
-            requires a server restart. During the restart, you'll experience some downtime of the server. Do you want to proceed?", yes=yes)
+        if not yes and show_confirmation:
+            user_confirmation("You are trying to change the compute or the size of storage assigned to your server in a way that \
+                requires a server restart. During the restart, you'll experience some downtime of the server. Do you want to proceed?", yes=yes)
 
 
 def flexible_server_delete(cmd, client, resource_group_name, server_name, yes=False):

--- a/src/azure-cli/azure/cli/command_modules/postgresql/utils/_flexible_server_location_capabilities_util.py
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/utils/_flexible_server_location_capabilities_util.py
@@ -54,6 +54,7 @@ def _postgres_parse_list_capability(result, is_offer_restriction_check_required=
     zone_redundant = [feature for feature in supported_features if feature.name == "ZoneRedundantHa"]
     geo_backup = [feature for feature in supported_features if feature.name == "GeoBackup"]
     autonomous_tuning = [feature for feature in supported_features if feature.name == "IndexTuning"]
+    online_resize = [feature for feature in supported_features if feature.name == "OnlineResize"]
 
     # Update once capability calls are corrected for each command
     if restricted == "Enabled" and not is_offer_restriction_check_required:
@@ -65,7 +66,7 @@ def _postgres_parse_list_capability(result, is_offer_restriction_check_required=
     single_az = zone_redundant[0].status != "Enabled" if zone_redundant else True
     geo_backup_supported = geo_backup[0].status == "Enabled" if geo_backup else False
     autonomous_tuning_supported = autonomous_tuning[0].status == "Enabled" if autonomous_tuning else False
-
+    online_resize_supported = online_resize[0].status == "Enabled" if online_resize else False
     tiers = result[0].supported_server_editions
     tiers_dict = {}
     for tier_info in tiers:
@@ -113,7 +114,8 @@ def _postgres_parse_list_capability(result, is_offer_restriction_check_required=
         'zones': zones,
         'server_versions': versions,
         'supported_server_versions': supported_server_versions,
-        'autonomous_tuning_supported': autonomous_tuning_supported
+        'autonomous_tuning_supported': autonomous_tuning_supported,
+        'online_resize_supported': online_resize_supported
     }
 
 


### PR DESCRIPTION
**Related command**
`az postgres flexible-server update`

**Description**<!--Mandatory-->
Restart is no longer required for scaling storage size of Premium SSDv2 server. Online resizing is always enabled.

**Testing Guide**
Manual

`az postgres flexible-server update --ids /nasc-jan2 --sku-name Standard_D2ads_v5
You are trying to update the compute or storage size assigned to your server in a way that requires a server restart. During the restart, you'll experience some downtime of the server. Do you want to proceed? (y/n): `

``

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[POSTGRESQL] `az postgres flexible-server update`: Restart is no longer required for scaling storage size of Premium SSDv2 server

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
