### PR TITLE
[Profile] `az login`: Add `--subscription` and `--skip-subscription-discovery` to filter subscriptions during login

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -856,6 +856,23 @@ class SubscriptionFinder:
         self.tenants.append(tenant)
         return all_subscriptions
 
+    def find_specific_subscriptions(self, tenant, credential, subscription_ids):
+        """Fetch specific subscriptions by ID using GET /subscriptions/{id}
+        instead of listing all subscriptions.
+        https://learn.microsoft.com/en-us/rest/api/resources/subscriptions/get
+        """
+        client = self._create_subscription_client(credential)
+        all_subscriptions = []
+        for sub_id in subscription_ids:
+            try:
+                s = client.subscriptions.get(sub_id)
+                _attach_token_tenant(s, tenant)
+                all_subscriptions.append(s)
+            except Exception as ex:  # pylint: disable=broad-except
+                logger.warning("Failed to retrieve subscription %s: %s", sub_id, ex)
+        self.tenants.append(tenant)
+        return all_subscriptions
+
     def _create_subscription_client(self, credential):
         from azure.cli.core.profiles import ResourceType, get_api_version
         from azure.cli.core.profiles._shared import get_client_class

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -152,7 +152,9 @@ class Profile:
               allow_no_subscriptions=False,
               use_cert_sn_issuer=None,
               show_progress=False,
-              claims_challenge=None):
+              claims_challenge=None,
+              skip_subscription_discovery=False,
+              subscription=None):
         """
         For service principal, `password` is a dict returned by ServicePrincipalAuth.build_credential
         """
@@ -198,15 +200,31 @@ class Profile:
         else:
             credential = identity.get_service_principal_credential(username)
 
-        if tenant:
+        is_bare_mode = skip_subscription_discovery and not subscription
+
+        if skip_subscription_discovery and subscription:
+            # Fast path: fetch only the specified subscription (1 API call)
+            subscriptions = subscription_finder.find_specific_subscriptions(
+                tenant, credential, [subscription])
+        elif is_bare_mode:
+            # Bare mode: no ARM subscription calls. Tenant-level account will be created below
+            subscriptions = []
+            subscription_finder.tenants.append(tenant)
+        elif tenant:
             subscriptions = subscription_finder.find_using_specific_tenant(tenant, credential)
         else:
             subscriptions = subscription_finder.find_using_common_tenant(username, credential)
 
         if not subscriptions and not allow_no_subscriptions:
-            raise CLIError("No subscriptions found for {}.".format(username))
+            if skip_subscription_discovery and subscription:
+                raise CLIError(
+                    "The subscription '{}' could not be retrieved for '{}'. "
+                    "Ensure the subscription exists and that you have access to it.".format(
+                        subscription, username))
+            if not is_bare_mode:
+                raise CLIError("No subscriptions found for {}.".format(username))
 
-        if allow_no_subscriptions:
+        if allow_no_subscriptions or is_bare_mode:
             t_list = [s.tenant_id for s in subscriptions]
             bare_tenants = [t for t in subscription_finder.tenants if t not in t_list]
             tenant_accounts = self._build_tenant_level_accounts(bare_tenants)
@@ -216,8 +234,24 @@ class Profile:
 
         consolidated = self._normalize_properties(username, subscriptions,
                                                   is_service_principal, bool(use_cert_sn_issuer))
+        self._set_subscriptions(consolidated, preferred_subscription=subscription)
 
-        self._set_subscriptions(consolidated)
+        if subscription:
+            matches = [s for s in consolidated
+                       if s[_SUBSCRIPTION_ID].lower() == subscription.lower() or
+                       s.get(_SUBSCRIPTION_NAME, '').lower() == subscription.lower()]
+            if matches:
+                return deepcopy(matches)
+            if skip_subscription_discovery:
+                # --skip-subscription-discovery + --subscription S, but S is inaccessible.
+                # without --allow-no-subscriptions → already errored above
+                # with --allow-no-subscriptions → tenant-level account only (we reach here)
+                logger.warning("Subscription '%s' not found. Profile has tenant-level account only.",
+                               subscription)
+            else:
+                raise CLIError("Subscription '{}' not found. Check the ID or name and try again."
+                               .format(subscription))
+
         return deepcopy(consolidated)
 
     def login_with_managed_identity(self, client_id=None, object_id=None, resource_id=None,
@@ -463,7 +497,8 @@ class Profile:
         s.state = 'Enabled'
         return s
 
-    def _set_subscriptions(self, new_subscriptions, merge=True, secondary_key_name=None):
+    def _set_subscriptions(self, new_subscriptions, merge=True, secondary_key_name=None,
+                           preferred_subscription=None):
 
         def _get_key_name(account, secondary_key_name):
             return (account[_SUBSCRIPTION_ID] if secondary_key_name is None
@@ -489,17 +524,26 @@ class Profile:
         dic.update((_get_key_name(x, secondary_key_name), x) for x in new_subscriptions)
         subscriptions = list(dic.values())
         if subscriptions:
-            if active_one:
+            new_active_one = None
+
+            # If a preferred subscription is specified, try to use it as default
+            if preferred_subscription:
+                preferred_lower = preferred_subscription.lower()
+                new_active_one = next(
+                    (x for x in new_subscriptions
+                     if x[_SUBSCRIPTION_ID].lower() == preferred_lower or
+                     x.get(_SUBSCRIPTION_NAME, '').lower() == preferred_lower), None)
+
+            # Fall back to previously active subscription if still present
+            if not new_active_one and active_one:
                 new_active_one = next(
                     (x for x in new_subscriptions if _match_account(x, active_subscription_id, secondary_key_name,
                                                                     active_secondary_key_val)), None)
 
-                for s in subscriptions:
-                    s[_IS_DEFAULT_SUBSCRIPTION] = False
+            for s in subscriptions:
+                s[_IS_DEFAULT_SUBSCRIPTION] = False
 
-                if not new_active_one:
-                    new_active_one = Profile._pick_working_subscription(new_subscriptions)
-            else:
+            if not new_active_one:
                 new_active_one = Profile._pick_working_subscription(new_subscriptions)
 
             new_active_one[_IS_DEFAULT_SUBSCRIPTION] = True
@@ -507,6 +551,7 @@ class Profile:
 
             set_cloud_subscription(self.cli_ctx, active_cloud.name, default_sub_id)
         self._storage[_SUBSCRIPTIONS] = subscriptions
+        return subscriptions
 
     @staticmethod
     def _pick_working_subscription(subscriptions):

--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -1638,5 +1638,134 @@ class TestUtils(unittest.TestCase):
         assert d == {'managedByTenants': [{"tenantId": tenant_id}]}
 
 
+class TestSubscriptionFinderFindSpecific(unittest.TestCase):
+    """Tests for SubscriptionFinder.find_specific_subscriptions()"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tenant_id = 'test.onmicrosoft.com'
+        cls.sub_id_1 = '00000000-0000-0000-0000-000000000001'
+        cls.sub_id_2 = '00000000-0000-0000-0000-000000000002'
+
+        cls.subscription1_raw = SubscriptionStub(
+            'subscriptions/{}'.format(cls.sub_id_1),
+            'sub1', 'Enabled', tenant_id=cls.tenant_id)
+        cls.subscription2_raw = SubscriptionStub(
+            'subscriptions/{}'.format(cls.sub_id_2),
+            'sub2', 'Enabled', tenant_id=cls.tenant_id)
+
+    @mock.patch('azure.cli.core._profile.SubscriptionFinder._create_subscription_client', autospec=True)
+    def test_find_specific_subscriptions_single(self, create_subscription_client_mock):
+        """Single subscription ID is fetched via GET, not LIST."""
+        cli = DummyCli()
+        mock_client = mock.MagicMock()
+        mock_client.subscriptions.get.return_value = deepcopy(self.subscription1_raw)
+        create_subscription_client_mock.return_value = mock_client
+
+        finder = SubscriptionFinder(cli)
+        credential = mock.MagicMock()
+        result = finder.find_specific_subscriptions(self.tenant_id, credential, [self.sub_id_1])
+
+        # Assert GET was called, LIST was not
+        mock_client.subscriptions.get.assert_called_once_with(self.sub_id_1)
+        mock_client.subscriptions.list.assert_not_called()
+
+        # Assert result
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].subscription_id, self.sub_id_1)
+        # Assert tenant_id is attached (by _attach_token_tenant)
+        self.assertEqual(result[0].tenant_id, self.tenant_id)
+        # Assert tenant is tracked
+        self.assertIn(self.tenant_id, finder.tenants)
+
+    @mock.patch('azure.cli.core._profile.SubscriptionFinder._create_subscription_client', autospec=True)
+    def test_find_specific_subscriptions_multiple(self, create_subscription_client_mock):
+        """Multiple subscription IDs are each fetched individually via GET."""
+        cli = DummyCli()
+        mock_client = mock.MagicMock()
+        mock_client.subscriptions.get.side_effect = [
+            deepcopy(self.subscription1_raw),
+            deepcopy(self.subscription2_raw)
+        ]
+        create_subscription_client_mock.return_value = mock_client
+
+        finder = SubscriptionFinder(cli)
+        credential = mock.MagicMock()
+        result = finder.find_specific_subscriptions(
+            self.tenant_id, credential, [self.sub_id_1, self.sub_id_2])
+
+        # Assert GET was called for each sub
+        self.assertEqual(mock_client.subscriptions.get.call_count, 2)
+        mock_client.subscriptions.get.assert_any_call(self.sub_id_1)
+        mock_client.subscriptions.get.assert_any_call(self.sub_id_2)
+        mock_client.subscriptions.list.assert_not_called()
+
+        # Assert both results returned
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].subscription_id, self.sub_id_1)
+        self.assertEqual(result[1].subscription_id, self.sub_id_2)
+
+    @mock.patch('azure.cli.core._profile.SubscriptionFinder._create_subscription_client', autospec=True)
+    def test_find_specific_subscriptions_inaccessible_warns_and_continues(self, create_subscription_client_mock):
+        """If a subscription is inaccessible, log warning and continue with others."""
+        cli = DummyCli()
+        mock_client = mock.MagicMock()
+        mock_client.subscriptions.get.side_effect = [
+            Exception("Subscription not found or not accessible"),
+            deepcopy(self.subscription2_raw)
+        ]
+        create_subscription_client_mock.return_value = mock_client
+
+        finder = SubscriptionFinder(cli)
+        credential = mock.MagicMock()
+
+        with mock.patch('azure.cli.core._profile.logger') as mock_logger:
+            result = finder.find_specific_subscriptions(
+                self.tenant_id, credential, [self.sub_id_1, self.sub_id_2])
+
+            # Assert warning was logged for the failed sub
+            mock_logger.warning.assert_called_once()
+            self.assertIn(self.sub_id_1, mock_logger.warning.call_args[0][1])
+
+        # Assert only the accessible sub is returned
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].subscription_id, self.sub_id_2)
+        # Assert tenant is still tracked
+        self.assertIn(self.tenant_id, finder.tenants)
+
+    @mock.patch('azure.cli.core._profile.SubscriptionFinder._create_subscription_client', autospec=True)
+    def test_find_specific_subscriptions_all_inaccessible(self, create_subscription_client_mock):
+        """If all subscriptions are inaccessible, return empty list."""
+        cli = DummyCli()
+        mock_client = mock.MagicMock()
+        mock_client.subscriptions.get.side_effect = Exception("Not found")
+        create_subscription_client_mock.return_value = mock_client
+
+        finder = SubscriptionFinder(cli)
+        credential = mock.MagicMock()
+        result = finder.find_specific_subscriptions(
+            self.tenant_id, credential, [self.sub_id_1])
+
+        self.assertEqual(len(result), 0)
+        # Tenant is still tracked even with no results
+        self.assertIn(self.tenant_id, finder.tenants)
+
+    @mock.patch('azure.cli.core._profile.SubscriptionFinder._create_subscription_client', autospec=True)
+    def test_find_specific_subscriptions_empty_list(self, create_subscription_client_mock):
+        """Empty subscription_ids list returns empty result."""
+        cli = DummyCli()
+        mock_client = mock.MagicMock()
+        create_subscription_client_mock.return_value = mock_client
+
+        finder = SubscriptionFinder(cli)
+        credential = mock.MagicMock()
+        result = finder.find_specific_subscriptions(self.tenant_id, credential, [])
+
+        mock_client.subscriptions.get.assert_not_called()
+        mock_client.subscriptions.list.assert_not_called()
+        self.assertEqual(len(result), 0)
+        self.assertIn(self.tenant_id, finder.tenants)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -12,7 +12,8 @@ from copy import deepcopy
 from unittest import mock
 
 from azure.cli.core._profile import (Profile, SubscriptionFinder, _attach_token_tenant,
-                                     _transform_subscription_for_multiapi)
+                                     _transform_subscription_for_multiapi,
+                                     _TENANT_LEVEL_ACCOUNT_NAME)
 from azure.cli.core.auth.util import AccessToken
 from azure.cli.core.mock import DummyCli
 from azure.mgmt.resource.subscriptions.models import \
@@ -551,7 +552,7 @@ class TestProfile(unittest.TestCase):
         self.assertEqual(len(subscriptions), 1)
         s = subscriptions[0]
 
-        self.assertEqual(s['name'], 'N/A(tenant level account)')
+        self.assertEqual(s['name'], _TENANT_LEVEL_ACCOUNT_NAME)
         self.assertEqual(s['id'], self.test_mi_tenant)
         self.assertEqual(s['tenantId'], self.test_mi_tenant)
 
@@ -656,8 +657,31 @@ class TestProfile(unittest.TestCase):
         self.assertEqual(subs[0]['id'], self.tenant_id)
         self.assertEqual(subs[0]['state'], 'Enabled')
         self.assertEqual(subs[0]['tenantId'], self.tenant_id)
-        self.assertEqual(subs[0]['name'], 'N/A(tenant level account)')
+        self.assertEqual(subs[0]['name'], _TENANT_LEVEL_ACCOUNT_NAME)
         self.assertTrue(profile.is_tenant_level_account())
+
+    @mock.patch('azure.cli.core._profile.SubscriptionFinder._create_subscription_client', autospec=True)
+    @mock.patch('azure.cli.core.auth.identity.Identity.get_user_credential', autospec=True)
+    @mock.patch('azure.cli.core.auth.identity.Identity.login_with_auth_code', autospec=True)
+    @mock.patch('azure.cli.core._profile.can_launch_browser', autospec=True, return_value=True)
+    def test_login_no_subscription_raises_error(self, can_launch_browser_mock,
+                                                login_with_auth_code_mock, get_user_credential_mock,
+                                                create_subscription_client_mock):
+        """No subscriptions found without --allow-no-subscriptions raises CLIError."""
+        login_with_auth_code_mock.return_value = self.user_identity_mock
+
+        cli = DummyCli()
+        mock_subscription_client = mock.MagicMock()
+        mock_subscription_client.tenants.list.return_value = [TenantStub(self.tenant_id)]
+        mock_subscription_client.subscriptions.list.return_value = []
+        create_subscription_client_mock.return_value = mock_subscription_client
+
+        storage_mock = {'subscriptions': None}
+        profile = Profile(cli_ctx=cli, storage=storage_mock)
+
+        with self.assertRaisesRegex(CLIError, "No subscriptions found"):
+            profile.login(True, None, None, False, None, use_device_code=False,
+                          allow_no_subscriptions=False)
 
     @mock.patch('azure.cli.core._profile.SubscriptionFinder._create_subscription_client', autospec=True)
     @mock.patch('azure.cli.core.auth.identity.Identity.get_user_credential', autospec=True)
@@ -1636,6 +1660,397 @@ class TestUtils(unittest.TestCase):
         d = {}
         _transform_subscription_for_multiapi(s, d)
         assert d == {'managedByTenants': [{"tenantId": tenant_id}]}
+
+
+class TestLoginSubscriptionFilter(unittest.TestCase):
+    """Tests for Profile.login() with --skip-subscription-discovery and --subscription parameters."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tenant_id = 'test.onmicrosoft.com'
+        cls.user1 = 'foo@foo.com'
+        cls.user_identity_mock = {
+            'username': cls.user1,
+            'tenantId': cls.tenant_id
+        }
+
+        cls.sub_id = '00000000-0000-0000-0000-000000000001'
+        cls.subscription_raw = SubscriptionStub(
+            'subscriptions/{}'.format(cls.sub_id),
+            'test sub', 'Enabled', tenant_id=cls.tenant_id,
+            home_tenant_id=cls.tenant_id)
+
+    @mock.patch('azure.cli.core._profile.SubscriptionFinder._create_subscription_client', autospec=True)
+    @mock.patch('azure.cli.core.auth.identity.Identity.get_user_credential', autospec=True)
+    @mock.patch('azure.cli.core.auth.identity.Identity.login_with_auth_code', autospec=True)
+    @mock.patch('azure.cli.core._profile.can_launch_browser', autospec=True, return_value=True)
+    def test_skip_discovery_with_subscription(self, can_launch_browser_mock, login_with_auth_code_mock,
+                                              get_user_credential_mock, create_subscription_client_mock):
+        """--skip-subscription-discovery --subscription S: calls GET /subscriptions/S (1 API call), S is default."""
+        login_with_auth_code_mock.return_value = self.user_identity_mock
+
+        cli = DummyCli()
+        mock_subscription_client = mock.MagicMock()
+        mock_subscription_client.subscriptions.get.return_value = deepcopy(self.subscription_raw)
+        create_subscription_client_mock.return_value = mock_subscription_client
+
+        storage_mock = {'subscriptions': None}
+        profile = Profile(cli_ctx=cli, storage=storage_mock)
+        subs = profile.login(True, None, None, False, self.tenant_id,
+                             allow_no_subscriptions=False,
+                             skip_subscription_discovery=True, subscription=self.sub_id)
+
+        # Assert GET was called, not LIST
+        mock_subscription_client.subscriptions.get.assert_called_once_with(self.sub_id)
+        mock_subscription_client.subscriptions.list.assert_not_called()
+
+        # Assert subscription returned and is default
+        self.assertEqual(len(subs), 1)
+        self.assertEqual(subs[0]['id'], self.sub_id)
+        self.assertEqual(subs[0]['name'], 'test sub')
+        self.assertTrue(subs[0]['isDefault'])
+
+    @mock.patch('azure.cli.core._profile.SubscriptionFinder._create_subscription_client', autospec=True)
+    @mock.patch('azure.cli.core.auth.identity.Identity.get_user_credential', autospec=True)
+    @mock.patch('azure.cli.core.auth.identity.Identity.login_with_auth_code', autospec=True)
+    @mock.patch('azure.cli.core._profile.can_launch_browser', autospec=True, return_value=True)
+    def test_skip_discovery_bare_mode(self, can_launch_browser_mock, login_with_auth_code_mock,
+                                      get_user_credential_mock, create_subscription_client_mock):
+        """--skip-subscription-discovery (no --subscription): 0 ARM calls, tenant-level account created."""
+        login_with_auth_code_mock.return_value = self.user_identity_mock
+
+        cli = DummyCli()
+        mock_subscription_client = mock.MagicMock()
+        create_subscription_client_mock.return_value = mock_subscription_client
+
+        storage_mock = {'subscriptions': None}
+        profile = Profile(cli_ctx=cli, storage=storage_mock)
+        subs = profile.login(True, None, None, False, self.tenant_id,
+                             allow_no_subscriptions=False,
+                             skip_subscription_discovery=True)
+
+        # Assert no ARM subscription calls were made
+        mock_subscription_client.subscriptions.get.assert_not_called()
+        mock_subscription_client.subscriptions.list.assert_not_called()
+
+        # Assert tenant-level account created
+        self.assertEqual(len(subs), 1)
+        self.assertEqual(subs[0]['id'], self.tenant_id)
+        self.assertEqual(subs[0]['name'], _TENANT_LEVEL_ACCOUNT_NAME)
+        self.assertEqual(subs[0]['tenantId'], self.tenant_id)
+        self.assertTrue(profile.is_tenant_level_account())
+
+    @mock.patch('azure.cli.core._profile.SubscriptionFinder._create_subscription_client', autospec=True)
+    @mock.patch('azure.cli.core.auth.identity.Identity.get_user_credential', autospec=True)
+    @mock.patch('azure.cli.core.auth.identity.Identity.login_with_auth_code', autospec=True)
+    @mock.patch('azure.cli.core._profile.can_launch_browser', autospec=True, return_value=True)
+    def test_skip_discovery_with_subscription_inaccessible(self, can_launch_browser_mock,
+                                                           login_with_auth_code_mock,
+                                                           get_user_credential_mock,
+                                                           create_subscription_client_mock):
+        """--skip-subscription-discovery --subscription S where S is inaccessible: raises CLIError."""
+        login_with_auth_code_mock.return_value = self.user_identity_mock
+
+        cli = DummyCli()
+        mock_subscription_client = mock.MagicMock()
+        mock_subscription_client.subscriptions.get.side_effect = Exception("Not found")
+        create_subscription_client_mock.return_value = mock_subscription_client
+
+        storage_mock = {'subscriptions': None}
+        profile = Profile(cli_ctx=cli, storage=storage_mock)
+
+        with self.assertRaisesRegex(CLIError, "could not be retrieved"):
+            profile.login(True, None, None, False, self.tenant_id,
+                          allow_no_subscriptions=False,
+                          skip_subscription_discovery=True, subscription=self.sub_id)
+
+    @mock.patch('azure.cli.core._profile.logger', autospec=True)
+    @mock.patch('azure.cli.core._profile.SubscriptionFinder._create_subscription_client', autospec=True)
+    @mock.patch('azure.cli.core.auth.identity.Identity.get_user_credential', autospec=True)
+    @mock.patch('azure.cli.core.auth.identity.Identity.login_with_auth_code', autospec=True)
+    @mock.patch('azure.cli.core._profile.can_launch_browser', autospec=True, return_value=True)
+    def test_skip_discovery_with_subscription_inaccessible_allow_no_subs(self, can_launch_browser_mock,
+                                                                         login_with_auth_code_mock,
+                                                                         get_user_credential_mock,
+                                                                         create_subscription_client_mock,
+                                                                         logger_mock):
+        """--skip-subscription-discovery --subscription S (inaccessible) --allow-no-subscriptions:
+        tenant-level account created, warning logged."""
+        login_with_auth_code_mock.return_value = self.user_identity_mock
+
+        cli = DummyCli()
+        mock_subscription_client = mock.MagicMock()
+        mock_subscription_client.subscriptions.get.side_effect = Exception("Not found")
+        create_subscription_client_mock.return_value = mock_subscription_client
+
+        storage_mock = {'subscriptions': None}
+        profile = Profile(cli_ctx=cli, storage=storage_mock)
+        subs = profile.login(True, None, None, False, self.tenant_id,
+                             allow_no_subscriptions=True,
+                             skip_subscription_discovery=True, subscription=self.sub_id)
+
+        # Tenant-level account created since subscription was inaccessible
+        self.assertEqual(len(subs), 1)
+        self.assertEqual(subs[0]['name'], _TENANT_LEVEL_ACCOUNT_NAME)
+
+        # Warning logged about inaccessible subscription
+        logger_mock.warning.assert_any_call(
+            "Subscription '%s' not found. Profile has tenant-level account only.",
+            self.sub_id)
+
+    @mock.patch('azure.cli.core._profile.SubscriptionFinder._create_subscription_client', autospec=True)
+    @mock.patch('azure.cli.core.auth.identity.Identity.get_user_credential', autospec=True)
+    @mock.patch('azure.cli.core.auth.identity.Identity.login_with_auth_code', autospec=True)
+    @mock.patch('azure.cli.core._profile.can_launch_browser', autospec=True, return_value=True)
+    def test_no_skip_with_subscription_sets_default(self, can_launch_browser_mock, login_with_auth_code_mock,
+                                                     get_user_credential_mock,
+                                                     create_subscription_client_mock):
+        """--subscription S (without skip): full discovery unchanged, S set as default."""
+        login_with_auth_code_mock.return_value = self.user_identity_mock
+
+        cli = DummyCli()
+        mock_subscription_client = mock.MagicMock()
+        mock_subscription_client.tenants.list.return_value = [TenantStub(self.tenant_id)]
+        mock_subscription_client.subscriptions.list.return_value = [deepcopy(self.subscription_raw)]
+        create_subscription_client_mock.return_value = mock_subscription_client
+
+        storage_mock = {'subscriptions': None}
+        profile = Profile(cli_ctx=cli, storage=storage_mock)
+        subs = profile.login(True, None, None, False, self.tenant_id,
+                             allow_no_subscriptions=False,
+                             subscription=self.sub_id)
+
+        # Assert LIST was called (full discovery), not just GET
+        mock_subscription_client.subscriptions.list.assert_called()
+        mock_subscription_client.subscriptions.get.assert_not_called()
+
+        # Assert subscription returned and is default
+        self.assertEqual(len(subs), 1)
+        self.assertEqual(subs[0]['id'], self.sub_id)
+        self.assertTrue(subs[0]['isDefault'])
+
+    @mock.patch('azure.cli.core._profile.SubscriptionFinder._create_subscription_client', autospec=True)
+    @mock.patch('azure.cli.core.auth.identity.Identity.get_user_credential', autospec=True)
+    @mock.patch('azure.cli.core.auth.identity.Identity.login_with_auth_code', autospec=True)
+    @mock.patch('azure.cli.core._profile.can_launch_browser', autospec=True, return_value=True)
+    def test_no_skip_with_subscription_not_found_raises_error(self, can_launch_browser_mock,
+                                                               login_with_auth_code_mock,
+                                                               get_user_credential_mock,
+                                                               create_subscription_client_mock):
+        """--subscription S (no skip), S not in discovered list: raises CLIError."""
+        login_with_auth_code_mock.return_value = self.user_identity_mock
+
+        cli = DummyCli()
+        mock_subscription_client = mock.MagicMock()
+        mock_subscription_client.tenants.list.return_value = [TenantStub(self.tenant_id)]
+        mock_subscription_client.subscriptions.list.return_value = [deepcopy(self.subscription_raw)]
+        create_subscription_client_mock.return_value = mock_subscription_client
+
+        storage_mock = {'subscriptions': None}
+        profile = Profile(cli_ctx=cli, storage=storage_mock)
+
+        with self.assertRaisesRegex(CLIError, "Subscription 'non-existent' not found"):
+            profile.login(True, None, None, False, self.tenant_id,
+                          allow_no_subscriptions=False,
+                          subscription='non-existent')
+
+    @mock.patch('azure.cli.core._profile.SubscriptionFinder._create_subscription_client', autospec=True)
+    @mock.patch('azure.cli.core.auth.identity.Identity.get_user_credential', autospec=True)
+    @mock.patch('azure.cli.core.auth.identity.Identity.login_with_auth_code', autospec=True)
+    @mock.patch('azure.cli.core._profile.can_launch_browser', autospec=True, return_value=True)
+    def test_skip_discovery_preserves_prior_subscriptions(self, can_launch_browser_mock,
+                                                          login_with_auth_code_mock,
+                                                          get_user_credential_mock,
+                                                          create_subscription_client_mock):
+        """Profile merge: prior subscriptions in azureProfile.json are preserved."""
+        login_with_auth_code_mock.return_value = self.user_identity_mock
+
+        cli = DummyCli()
+        mock_subscription_client = mock.MagicMock()
+        mock_subscription_client.subscriptions.get.return_value = deepcopy(self.subscription_raw)
+        create_subscription_client_mock.return_value = mock_subscription_client
+
+        # Pre-existing subscription in profile
+        existing_sub_id = '00000000-0000-0000-0000-000000000099'
+        existing_sub = {
+            'id': existing_sub_id,
+            'name': 'existing sub',
+            'state': 'Enabled',
+            'user': {'name': self.user1, 'type': 'user'},
+            'isDefault': True,
+            'tenantId': self.tenant_id,
+            'environmentName': 'AzureCloud'
+        }
+        storage_mock = {'subscriptions': [existing_sub]}
+        profile = Profile(cli_ctx=cli, storage=storage_mock)
+        subs = profile.login(True, None, None, False, self.tenant_id,
+                             allow_no_subscriptions=False,
+                             skip_subscription_discovery=True, subscription=self.sub_id)
+
+        # Both the new and existing subscriptions should be in storage (merge)
+        stored = storage_mock['subscriptions']
+        stored_ids = {s['id'] for s in stored}
+        self.assertIn(self.sub_id, stored_ids)
+        self.assertIn(existing_sub_id, stored_ids)
+
+    @mock.patch('azure.cli.core._profile.SubscriptionFinder._create_subscription_client', autospec=True)
+    @mock.patch('azure.cli.core.auth.identity.Identity.get_user_credential', autospec=True)
+    @mock.patch('azure.cli.core.auth.identity.Identity.login_with_auth_code', autospec=True)
+    @mock.patch('azure.cli.core._profile.can_launch_browser', autospec=True, return_value=True)
+    def test_skip_discovery_bare_preserves_prior_subscriptions(self, can_launch_browser_mock,
+                                                               login_with_auth_code_mock,
+                                                               get_user_credential_mock,
+                                                               create_subscription_client_mock):
+        """Bare --skip-subscription-discovery preserves prior subscriptions in azureProfile.json."""
+        login_with_auth_code_mock.return_value = self.user_identity_mock
+
+        cli = DummyCli()
+        mock_subscription_client = mock.MagicMock()
+        create_subscription_client_mock.return_value = mock_subscription_client
+
+        # Pre-existing subscription in profile
+        existing_sub_id = '00000000-0000-0000-0000-000000000099'
+        existing_sub = {
+            'id': existing_sub_id,
+            'name': 'existing sub',
+            'state': 'Enabled',
+            'user': {'name': self.user1, 'type': 'user'},
+            'isDefault': True,
+            'tenantId': self.tenant_id,
+            'environmentName': 'AzureCloud'
+        }
+        storage_mock = {'subscriptions': [existing_sub]}
+        profile = Profile(cli_ctx=cli, storage=storage_mock)
+        subs = profile.login(True, None, None, False, self.tenant_id,
+                             allow_no_subscriptions=False,
+                             skip_subscription_discovery=True)
+
+        # No ARM calls in bare mode
+        mock_subscription_client.subscriptions.get.assert_not_called()
+        mock_subscription_client.subscriptions.list.assert_not_called()
+
+        # Tenant-level account created
+        self.assertEqual(len(subs), 1)
+        self.assertEqual(subs[0]['name'], _TENANT_LEVEL_ACCOUNT_NAME)
+
+        # Prior subscription preserved in storage
+        stored = storage_mock['subscriptions']
+        stored_ids = {s['id'] for s in stored}
+        self.assertIn(existing_sub_id, stored_ids)
+        self.assertIn(self.tenant_id, stored_ids)
+
+    def test_set_subscriptions_preferred_subscription(self):
+        """preferred_subscription overrides the active subscription in _set_subscriptions."""
+        cli = DummyCli()
+        storage_mock = {'subscriptions': []}
+        profile = Profile(cli_ctx=cli, storage=storage_mock)
+
+        # sub1 is Enabled (would be picked by _pick_working_subscription)
+        sub1 = SubscriptionStub('subscriptions/sub1-id', 'sub1', 'Enabled',
+                                tenant_id=self.tenant_id, home_tenant_id=self.tenant_id)
+        sub2 = SubscriptionStub('subscriptions/sub2-id', 'sub2', 'Enabled',
+                                tenant_id=self.tenant_id, home_tenant_id=self.tenant_id)
+        consolidated = profile._normalize_properties(self.user1, [sub1, sub2], False)
+
+        # First call: sub1 becomes default (first Enabled)
+        profile._set_subscriptions(consolidated)
+        self.assertTrue(storage_mock['subscriptions'][0]['isDefault'])  # sub1
+        self.assertFalse(storage_mock['subscriptions'][1]['isDefault'])  # sub2
+
+        # Second call with preferred_subscription=sub2: sub2 becomes default
+        profile._set_subscriptions(consolidated, preferred_subscription='sub2-id')
+        sub1_stored = next(s for s in storage_mock['subscriptions'] if s['id'] == 'sub1-id')
+        sub2_stored = next(s for s in storage_mock['subscriptions'] if s['id'] == 'sub2-id')
+        self.assertFalse(sub1_stored['isDefault'])
+        self.assertTrue(sub2_stored['isDefault'])
+
+    def test_set_subscriptions_preferred_subscription_by_name(self):
+        """preferred_subscription can match by name (case-insensitive)."""
+        cli = DummyCli()
+        storage_mock = {'subscriptions': []}
+        profile = Profile(cli_ctx=cli, storage=storage_mock)
+
+        sub1 = SubscriptionStub('subscriptions/sub1-id', 'Alpha Sub', 'Enabled',
+                                tenant_id=self.tenant_id, home_tenant_id=self.tenant_id)
+        sub2 = SubscriptionStub('subscriptions/sub2-id', 'Beta Sub', 'Enabled',
+                                tenant_id=self.tenant_id, home_tenant_id=self.tenant_id)
+        consolidated = profile._normalize_properties(self.user1, [sub1, sub2], False)
+
+        profile._set_subscriptions(consolidated, preferred_subscription='beta sub')
+        sub1_stored = next(s for s in storage_mock['subscriptions'] if s['id'] == 'sub1-id')
+        sub2_stored = next(s for s in storage_mock['subscriptions'] if s['id'] == 'sub2-id')
+        self.assertFalse(sub1_stored['isDefault'])
+        self.assertTrue(sub2_stored['isDefault'])
+
+    def test_set_subscriptions_preferred_subscription_not_found_falls_back(self):
+        """preferred_subscription not found falls back to previously active subscription."""
+        cli = DummyCli()
+        storage_mock = {'subscriptions': []}
+        profile = Profile(cli_ctx=cli, storage=storage_mock)
+
+        sub1 = SubscriptionStub('subscriptions/sub1-id', 'sub1', 'Enabled',
+                                tenant_id=self.tenant_id, home_tenant_id=self.tenant_id)
+        sub2 = SubscriptionStub('subscriptions/sub2-id', 'sub2', 'Enabled',
+                                tenant_id=self.tenant_id, home_tenant_id=self.tenant_id)
+        consolidated = profile._normalize_properties(self.user1, [sub1, sub2], False)
+
+        # First call: set sub2 as active
+        profile._set_subscriptions(consolidated, preferred_subscription='sub2-id')
+        sub2_stored = next(s for s in storage_mock['subscriptions'] if s['id'] == 'sub2-id')
+        self.assertTrue(sub2_stored['isDefault'])
+
+        # Second call: preferred not found → should fall back to previously active (sub2)
+        profile._set_subscriptions(consolidated, preferred_subscription='nonexistent')
+        sub1_stored = next(s for s in storage_mock['subscriptions'] if s['id'] == 'sub1-id')
+        sub2_stored = next(s for s in storage_mock['subscriptions'] if s['id'] == 'sub2-id')
+        self.assertFalse(sub1_stored['isDefault'])
+        self.assertTrue(sub2_stored['isDefault'])
+
+    @mock.patch('azure.cli.core._profile.SubscriptionFinder._create_subscription_client', autospec=True)
+    @mock.patch('azure.cli.core.auth.identity.Identity.get_user_credential', autospec=True)
+    @mock.patch('azure.cli.core.auth.identity.Identity.login_with_auth_code', autospec=True)
+    @mock.patch('azure.cli.core._profile.can_launch_browser', autospec=True, return_value=True)
+    def test_login_with_subscription_in_two_tenants_returns_filtered(self, can_launch_browser_mock,
+                                                                     login_with_auth_code_mock,
+                                                                     get_user_credential_mock,
+                                                                     create_subscription_client_mock):
+        """--subscription matching 2 tenants returns only the 2 filtered subs, first one is default."""
+        login_with_auth_code_mock.return_value = self.user_identity_mock
+
+        cli = DummyCli()
+        mock_subscription_client = mock.MagicMock()
+
+        home_tenant = 'home-tenant-id'
+        delegated_tenant = 'delegated-tenant-id'
+        # Same sub name and ID, but in different tenants
+        sub_in_home = SubscriptionStub(
+            'subscriptions/{}'.format(self.sub_id), 'test sub', 'Enabled',
+            tenant_id=home_tenant, home_tenant_id=home_tenant)
+        sub_in_delegated = SubscriptionStub(
+            'subscriptions/{}'.format(self.sub_id), 'test sub', 'Enabled',
+            tenant_id=delegated_tenant, home_tenant_id=home_tenant)
+        # Also a different sub that should be filtered out
+        other_sub = SubscriptionStub(
+            'subscriptions/other-sub-id', 'other sub', 'Enabled',
+            tenant_id=home_tenant, home_tenant_id=home_tenant)
+
+        mock_subscription_client.tenants.list.return_value = [
+            TenantStub(home_tenant), TenantStub(delegated_tenant)]
+        mock_subscription_client.subscriptions.list.return_value = [
+            deepcopy(sub_in_home), deepcopy(sub_in_delegated), deepcopy(other_sub)]
+        create_subscription_client_mock.return_value = mock_subscription_client
+
+        storage_mock = {'subscriptions': []}
+        profile = Profile(cli_ctx=cli, storage=storage_mock)
+        subs = profile.login(True, None, None, False, home_tenant,
+                             allow_no_subscriptions=False,
+                             subscription=self.sub_id)
+
+        # Only the 2 matching subs are returned, not 'other sub'
+        self.assertEqual(len(subs), 2)
+        self.assertTrue(all(s['id'] == self.sub_id for s in subs))
+        # First match is set as default by preferred_subscription
+        self.assertTrue(subs[0]['isDefault'])
 
 
 class TestSubscriptionFinderFindSpecific(unittest.TestCase):

--- a/src/azure-cli/azure/cli/command_modules/profile/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/__init__.py
@@ -60,6 +60,18 @@ class ProfileCommandsLoader(AzCommandsLoader):
                             "WWW-Authenticate header.")
             c.ignore('_subscription')  # hide the global subscription parameter
 
+            # Skip subscription discovery
+            c.argument('skip_subscription_discovery', options_list=['--skip-subscription-discovery', '--skip-sub'],
+                       action='store_true',
+                       help='Skip the subscription discovery process during login. '
+                            'Requires --tenant. Use with --subscription to '
+                            'fetch a single subscription without listing all.')
+            c.argument('subscription', options_list=['--subscription', '-s'],
+                       help='Subscription ID or name to set as the default. '
+                            'When combined with --skip-subscription-discovery, '
+                            'only this subscription is retrieved via a direct API call '
+                            '(must be a subscription ID, not a name).')
+
             # Device code flow
             c.argument('use_device_code', action='store_true',
                        help="Use device code flow. Azure CLI will also use this if it can't launch a browser, "

--- a/src/azure-cli/azure/cli/command_modules/profile/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/_help.py
@@ -47,6 +47,12 @@ examples:
       text: az login --identity --client-id 00000000-0000-0000-0000-000000000000
     - name: Log in with a user-assigned managed identity's resource ID.
       text: az login --identity --resource-id /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MyResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/MyIdentity
+    - name: Log in and skip subscription discovery, fetching only a single subscription (fastest for tenants with many subscriptions).
+      text: az login --tenant TENANT_ID --skip-subscription-discovery --subscription SUBSCRIPTION_ID
+    - name: Log in and skip subscription discovery entirely for tenant-level operations only (e.g., 'az ad').
+      text: az login --tenant TENANT_ID --skip-subscription-discovery
+    - name: Log in with full discovery but set a specific subscription as the default.
+      text: az login --subscription SUBSCRIPTION_ID
 """
 
 helps['account'] = """

--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -120,6 +120,18 @@ def account_clear(cmd):
     profile.logout_all()
 
 
+def _select_and_set_active(profile, subscriptions):
+    """Launch interactive subscription selector and set the chosen subscription as active."""
+    from ._subscription_selector import SubscriptionSelector
+    from azure.cli.core._profile import _SUBSCRIPTION_ID
+
+    selected = SubscriptionSelector(subscriptions)()
+    profile.set_active_subscription(selected[_SUBSCRIPTION_ID])
+
+    print(LOGIN_ANNOUNCEMENT)
+    logger.warning(LOGIN_OUTPUT_WARNING)
+
+
 # pylint: disable=too-many-branches, too-many-locals
 def login(cmd, username=None, password=None, tenant=None, scopes=None, allow_no_subscriptions=False,
           claims_challenge=None,
@@ -128,7 +140,9 @@ def login(cmd, username=None, password=None, tenant=None, scopes=None, allow_no_
           # Service principal
           service_principal=None, certificate=None, use_cert_sn_issuer=None, client_assertion=None,
           # Managed identity
-          identity=False, client_id=None, object_id=None, resource_id=None):
+          identity=False, client_id=None, object_id=None, resource_id=None,
+          # Subscription discovery and default subscription selection control
+          skip_subscription_discovery=False, subscription=None):
     """Log in to access Azure subscriptions"""
 
     # quick argument usage check
@@ -143,6 +157,13 @@ def login(cmd, username=None, password=None, tenant=None, scopes=None, allow_no_
         raise CLIError("usage error: '--use-sn-issuer' is only applicable with a service principal")
     if service_principal and not username:
         raise CLIError('usage error: --service-principal --username NAME --password SECRET --tenant TENANT')
+    if skip_subscription_discovery and not tenant:
+        raise CLIError("usage error: '--skip-subscription-discovery' requires '--tenant'")
+    if skip_subscription_discovery and subscription:
+        from azure.cli.core.util import is_guid
+        if not is_guid(subscription):
+            raise CLIError("usage error: '--subscription' must be a subscription ID (GUID), not a name, "
+                           "when combined with '--skip-subscription-discovery'.")
     if username and not service_principal and not identity:
         if cmd.cli_ctx.cloud.endpoints.active_directory.startswith('https://login.microsoftonline.com'):
             logger.warning(USERNAME_PASSWORD_DEPRECATION_WARNING_AZURE_CLOUD)
@@ -187,7 +208,9 @@ def login(cmd, username=None, password=None, tenant=None, scopes=None, allow_no_
     from azure.cli.core.telemetry import set_login_experience_v2
     set_login_experience_v2(login_experience_v2)
 
-    select_subscription = interactive and sys.stdin.isatty() and sys.stdout.isatty() and login_experience_v2
+    can_show_selector = (interactive and sys.stdin.isatty() and sys.stdout.isatty() and
+                         login_experience_v2)
+    is_subscription_filter = bool(subscription or skip_subscription_discovery)
 
     subscriptions = profile.login(
         interactive,
@@ -199,20 +222,20 @@ def login(cmd, username=None, password=None, tenant=None, scopes=None, allow_no_
         use_device_code=use_device_code,
         allow_no_subscriptions=allow_no_subscriptions,
         use_cert_sn_issuer=use_cert_sn_issuer,
-        show_progress=select_subscription,
-        claims_challenge=claims_challenge
+        show_progress=can_show_selector and not skip_subscription_discovery,
+        claims_challenge=claims_challenge,
+        skip_subscription_discovery=skip_subscription_discovery,
+        subscription=subscription
     )
 
-    # Launch interactive account selection. No JSON output.
-    if select_subscription:
-        from ._subscription_selector import SubscriptionSelector
-        from azure.cli.core._profile import _SUBSCRIPTION_ID
+    # Filtered path (--subscription or --skip): show selector only when multiple matches
+    if can_show_selector and is_subscription_filter and len(subscriptions) > 1:
+        _select_and_set_active(profile, subscriptions)
+        return
 
-        selected = SubscriptionSelector(subscriptions)()
-        profile.set_active_subscription(selected[_SUBSCRIPTION_ID])
-
-        print(LOGIN_ANNOUNCEMENT)
-        logger.warning(LOGIN_OUTPUT_WARNING)
+    # Original no-filter path: always show selector (even 1 item) for backward compatibility
+    if can_show_selector and not is_subscription_filter:
+        _select_and_set_active(profile, subscriptions)
         return
 
     all_subscriptions = list(subscriptions)

--- a/src/azure-cli/azure/cli/command_modules/profile/tests/latest/test_profile_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/tests/latest/test_profile_custom.py
@@ -9,6 +9,7 @@ from unittest import mock
 from azure.cli.command_modules.profile.custom import (
     list_subscriptions, get_access_token, login, logout, account_clear, _remove_adal_token_cache)
 
+from azure.cli.core._profile import _TENANT_LEVEL_ACCOUNT_NAME
 from azure.cli.core.mock import DummyCli
 from knack.util import CLIError
 
@@ -194,3 +195,187 @@ class ProfileCommandTest(unittest.TestCase):
             f.write("test_token_cache")
         assert _remove_adal_token_cache()
         assert not os.path.exists(adal_token_cache)
+
+
+class TestLoginSubscriptionFilter(unittest.TestCase):
+    """Tests for custom.login() with --skip-subscription-discovery and --subscription parameters."""
+
+    def test_skip_subscription_discovery_requires_tenant(self):
+        """--skip-subscription-discovery without --tenant raises CLIError."""
+        cmd = mock.MagicMock()
+        cmd.cli_ctx = DummyCli()
+        with self.assertRaisesRegex(CLIError, "'--skip-subscription-discovery' requires '--tenant'"):
+            login(cmd, skip_subscription_discovery=True)
+
+    def test_skip_subscription_discovery_without_tenant_with_subscription(self):
+        """--skip-subscription-discovery --subscription S without --tenant raises CLIError."""
+        cmd = mock.MagicMock()
+        cmd.cli_ctx = DummyCli()
+        with self.assertRaisesRegex(CLIError, "'--skip-subscription-discovery' requires '--tenant'"):
+            login(cmd, skip_subscription_discovery=True, subscription='sub-id')
+
+    def test_skip_subscription_discovery_with_name_rejects_non_guid(self):
+        """--skip-subscription-discovery --subscription 'My Sub' (a name, not GUID) raises CLIError."""
+        cmd = mock.MagicMock()
+        cmd.cli_ctx = DummyCli()
+        with self.assertRaisesRegex(CLIError, "must be a subscription ID"):
+            login(cmd, tenant='tenant1', skip_subscription_discovery=True, subscription='My Subscription')
+
+    @mock.patch('azure.cli.command_modules.profile.custom.sys')
+    @mock.patch('azure.cli.command_modules.profile._subscription_selector.SubscriptionSelector', autospec=True)
+    @mock.patch('azure.cli.command_modules.profile.custom.Profile', autospec=True)
+    def test_skip_subscription_discovery_bypasses_selector(self, profile_mock, selector_mock, sys_mock):
+        """--skip-subscription-discovery should bypass the interactive selector."""
+        tenant_id = 'test-tenant'
+        profile_instance = mock.MagicMock()
+        profile_instance.login.return_value = [
+            {'id': tenant_id, 'name': _TENANT_LEVEL_ACCOUNT_NAME, 'isDefault': True,
+             'environmentName': 'AzureCloud', 'tenantId': tenant_id}
+        ]
+        profile_mock.return_value = profile_instance
+
+        # Simulate interactive TTY so selector would normally run
+        sys_mock.stdin.isatty.return_value = True
+        sys_mock.stdout.isatty.return_value = True
+
+        cmd = mock.MagicMock()
+        cmd.cli_ctx = DummyCli()
+        cmd.cli_ctx.config = mock.MagicMock()
+        cmd.cli_ctx.config.getboolean.return_value = True  # login_experience_v2 = True
+
+        result = login(cmd, tenant=tenant_id, skip_subscription_discovery=True)
+
+        # Assert selector was never instantiated because --skip-subscription-discovery bypasses it
+        selector_mock.assert_not_called()
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['name'], _TENANT_LEVEL_ACCOUNT_NAME)
+
+    @mock.patch('azure.cli.command_modules.profile.custom.sys')
+    @mock.patch('azure.cli.command_modules.profile._subscription_selector.SubscriptionSelector', autospec=True)
+    @mock.patch('azure.cli.command_modules.profile.custom.Profile', autospec=True)
+    def test_default_subscription_bypasses_selector(self, profile_mock, selector_mock, sys_mock):
+        """--subscription should bypass the interactive selector even without --skip-subscription-discovery."""
+        sub_id = 'target-sub-id'
+        profile_instance = mock.MagicMock()
+        profile_instance.login.return_value = [
+            {'id': sub_id, 'name': 'Target Sub', 'isDefault': True,
+             'environmentName': 'AzureCloud', 'tenantId': 'tenant1'}
+        ]
+        profile_mock.return_value = profile_instance
+
+        # Simulate interactive TTY so selector would normally run
+        sys_mock.stdin.isatty.return_value = True
+        sys_mock.stdout.isatty.return_value = True
+
+        cmd = mock.MagicMock()
+        cmd.cli_ctx = DummyCli()
+        cmd.cli_ctx.config = mock.MagicMock()
+        cmd.cli_ctx.config.getboolean.return_value = True  # login_experience_v2=True
+
+        # Interactive login (no username) with --subscription
+        result = login(cmd, tenant='tenant1', subscription=sub_id)
+
+        # Assert selector was never instantiated because --subscription bypasses it
+        selector_mock.assert_not_called()
+        assert result is not None
+        self.assertEqual(len(result), 1)
+
+    @mock.patch('azure.cli.command_modules.profile.custom.sys')
+    @mock.patch('azure.cli.command_modules.profile._subscription_selector.SubscriptionSelector', autospec=True)
+    @mock.patch('azure.cli.command_modules.profile.custom.Profile', autospec=True)
+    def test_subscription_in_two_tenants_triggers_interactive_selector(self, profile_mock, selector_mock, sys_mock):
+        """--subscription matching 2 tenants triggers the interactive selector."""
+        sub_id = 'target-sub-id'
+        sub_home = {'id': sub_id, 'name': 'Shared Sub', 'isDefault': True,
+                    'environmentName': 'AzureCloud', 'tenantId': 'home-tenant'}
+        sub_delegated = {'id': sub_id, 'name': 'Shared Sub', 'isDefault': False,
+                         'environmentName': 'AzureCloud', 'tenantId': 'delegated-tenant'}
+
+        profile_instance = mock.MagicMock()
+        profile_instance.login.return_value = [sub_home, sub_delegated]
+        profile_mock.return_value = profile_instance
+
+        # Simulate interactive TTY
+        sys_mock.stdin.isatty.return_value = True
+        sys_mock.stdout.isatty.return_value = True
+
+        # SubscriptionSelector returns the selected sub
+        selector_instance = mock.MagicMock()
+        selector_instance.return_value = sub_delegated
+        selector_mock.return_value = selector_instance
+
+        cmd = mock.MagicMock()
+        cmd.cli_ctx = DummyCli()
+        cmd.cli_ctx.config = mock.MagicMock()
+        cmd.cli_ctx.config.getboolean.return_value = True  # login_experience_v2=True
+
+        # Interactive login (no username) with --subscription that matches 2 tenants
+        result = login(cmd, tenant='home-tenant', subscription=sub_id)
+
+        # Assert selector was called with the 2 matching subs
+        selector_mock.assert_called_once_with([sub_home, sub_delegated])
+        # Assert set_active_subscription was called with the selected sub
+        profile_instance.set_active_subscription.assert_called_once_with(sub_id)
+        # Interactive selector returns None (prints announcement instead)
+        self.assertIsNone(result)
+
+    @mock.patch('azure.cli.command_modules.profile.custom.sys')
+    @mock.patch('azure.cli.command_modules.profile._subscription_selector.SubscriptionSelector', autospec=True)
+    @mock.patch('azure.cli.command_modules.profile.custom.Profile', autospec=True)
+    def test_single_filtered_subscription_bypasses_selector(self, profile_mock, selector_mock, sys_mock):
+        """--subscription with 1 match should not show interactive selector."""
+        sub_id = 'target-sub-id'
+        profile_instance = mock.MagicMock()
+        profile_instance.login.return_value = [
+            {'id': sub_id, 'name': 'Target Sub', 'isDefault': True,
+             'environmentName': 'AzureCloud', 'tenantId': 'tenant1'}
+        ]
+        profile_mock.return_value = profile_instance
+
+        sys_mock.stdin.isatty.return_value = True
+        sys_mock.stdout.isatty.return_value = True
+
+        cmd = mock.MagicMock()
+        cmd.cli_ctx = DummyCli()
+        cmd.cli_ctx.config = mock.MagicMock()
+        cmd.cli_ctx.config.getboolean.return_value = True  # login_experience_v2=True
+
+        result = login(cmd, tenant='tenant1', subscription=sub_id)
+
+        # Selector should not be shown for single filtered match
+        selector_mock.assert_not_called()
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result), 1)
+
+    @mock.patch('azure.cli.command_modules.profile.custom.sys')
+    @mock.patch('azure.cli.command_modules.profile._subscription_selector.SubscriptionSelector', autospec=True)
+    @mock.patch('azure.cli.command_modules.profile.custom.Profile', autospec=True)
+    def test_single_unfiltered_subscription_shows_selector(self, profile_mock, selector_mock, sys_mock):
+        """No --subscription with 1 sub should still show selector for backward compatibility."""
+        sub = {'id': 'sub-1', 'name': 'Only Sub', 'isDefault': True,
+               'environmentName': 'AzureCloud', 'tenantId': 'tenant1'}
+
+        profile_instance = mock.MagicMock()
+        profile_instance.login.return_value = [sub]
+        profile_mock.return_value = profile_instance
+
+        sys_mock.stdin.isatty.return_value = True
+        sys_mock.stdout.isatty.return_value = True
+
+        selector_instance = mock.MagicMock()
+        selector_instance.return_value = sub
+        selector_mock.return_value = selector_instance
+
+        cmd = mock.MagicMock()
+        cmd.cli_ctx = DummyCli()
+        cmd.cli_ctx.config = mock.MagicMock()
+        cmd.cli_ctx.config.getboolean.return_value = True  # login_experience_v2=True
+
+        # Interactive login, no --subscription
+        result = login(cmd)
+
+        # Selector should be shown even with 1 sub (backward compat)
+        selector_mock.assert_called_once_with([sub])
+        self.assertIsNone(result)

--- a/src/azure-cli/azure/cli/command_modules/profile/tests/latest/test_subscription_filter_e2e.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/tests/latest/test_subscription_filter_e2e.py
@@ -1,0 +1,352 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from azure.cli.core.auth.util import decode_access_token
+from azure.cli.core._profile import _TENANT_LEVEL_ACCOUNT_NAME
+from azure.cli.testsdk import LiveScenarioTest
+
+
+class SubscriptionFilterScenarioTest(LiveScenarioTest):
+    """Live scenario tests for --skip-subscription-discovery and --subscription on az login.
+
+    Prerequisites:
+      - Run with a user account that has access to at least two subscriptions.
+      - Each test performs an initial interactive login to discover tenant/subscription info,
+        then re-logins with the feature flags under test.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.cmd('az account clear')
+
+    def tearDown(self):
+        self.cmd('az account clear')
+
+    def _login_and_get_account_info(self):
+        """Login interactively and return (tenant_id, subscription_id, subscription_name) of a real subscription.
+
+        Skips tenant-level accounts to avoid passing a tenant ID where a subscription ID is expected.
+        The test account must have access to at least one real subscription.
+        """
+        self.cmd('az login')
+        accounts = self.cmd('az account list').get_output_in_json()
+        real_sub = next(a for a in accounts if a.get('name') != _TENANT_LEVEL_ACCOUNT_NAME)
+        return real_sub['tenantId'], real_sub['id'], real_sub['name']
+
+    def test_skip_discovery_fast_path(self):
+        """
+        az login --tenant T --skip-subscription-discovery --subscription S
+
+        Fast path: only the specified subscription is fetched via a direct API call.
+        It should be set as the default subscription.
+        """
+        tenant_id, sub_id, _ = self._login_and_get_account_info()
+        self.cmd('az account clear')
+
+        self.kwargs.update({'tenant': tenant_id, 'sub_id': sub_id})
+
+        # Re-login with skip-discovery + specific subscription
+        self.cmd('az login --tenant {tenant} --skip-subscription-discovery --subscription {sub_id}')
+
+        # The specified subscription should be the default
+        account = self.cmd('az account show').get_output_in_json()
+        self.assertEqual(account['id'], sub_id)
+        self.assertEqual(account['tenantId'], tenant_id)
+        self.assertTrue(account['isDefault'])
+
+        # Only the specified subscription should be present (no full discovery)
+        accounts = self.cmd('az account list').get_output_in_json()
+        self.assertEqual(len(accounts), 1)
+        self.assertEqual(accounts[0]['id'], sub_id)
+
+    def test_skip_discovery_bare_mode(self):
+        """
+        az login --tenant T --skip-subscription-discovery
+
+        Bare mode: no ARM subscription discovery at all. Only a tenant-level account
+        should exist, suitable for tenant-level operations like 'az ad'.
+        """
+        tenant_id, _, _ = self._login_and_get_account_info()
+        self.cmd('az account clear')
+
+        self.kwargs['tenant'] = tenant_id
+
+        # Re-login in bare mode (no subscription discovery)
+        self.cmd('az login --tenant {tenant} --skip-subscription-discovery')
+
+        # Should have only a tenant-level account
+        accounts = self.cmd('az account list').get_output_in_json()
+        self.assertEqual(len(accounts), 1)
+        self.assertEqual(accounts[0]['id'], tenant_id)
+        self.assertEqual(accounts[0]['name'], _TENANT_LEVEL_ACCOUNT_NAME)
+
+    def test_login_with_default_subscription(self):
+        """
+        az login --subscription S
+
+        Full subscription discovery, but the specified subscription is set as the default.
+        """
+        _, sub_id, _ = self._login_and_get_account_info()
+        self.cmd('az account clear')
+
+        self.kwargs['sub_id'] = sub_id
+
+        # Re-login with full discovery + explicit default subscription
+        self.cmd('az login --subscription {sub_id}')
+
+        # Full discovery should return more than one subscription
+        accounts = self.cmd('az account list').get_output_in_json()
+        self.assertGreater(len(accounts), 1, "Test requires access to more than one subscription")
+
+        # The specified subscription should be the default
+        account = self.cmd('az account show').get_output_in_json()
+        self.assertEqual(account['id'], sub_id)
+        self.assertTrue(account['isDefault'])
+
+    def test_skip_discovery_inaccessible_subscription(self):
+        """
+        az login --tenant T --skip-subscription-discovery --subscription BAD --allow-no-subscriptions
+
+        When the requested subscription is inaccessible, --allow-no-subscriptions should
+        fall back to a tenant-level account with a warning instead of erroring.
+        """
+        tenant_id, _, _ = self._login_and_get_account_info()
+        self.cmd('az account clear')
+
+        self.kwargs.update({
+            'tenant': tenant_id,
+            'bad_sub': '00000000-0000-0000-0000-000000000000'
+        })
+
+        # Inaccessible subscription with --allow-no-subscriptions: warn and fall back
+        self.cmd('az login --tenant {tenant} --skip-subscription-discovery '
+                 '--subscription {bad_sub} --allow-no-subscriptions')
+
+        # Should fall back to tenant-level account
+        accounts = self.cmd('az account list').get_output_in_json()
+        self.assertEqual(len(accounts), 1)
+        self.assertEqual(accounts[0]['name'], _TENANT_LEVEL_ACCOUNT_NAME)
+
+    def test_skip_discovery_inaccessible_subscription_no_allow(self):
+        """
+        az login --tenant T --skip-subscription-discovery --subscription BAD
+
+        When the requested subscription is inaccessible and --allow-no-subscriptions
+        is NOT set, should raise an error.
+        """
+        tenant_id, _, _ = self._login_and_get_account_info()
+        self.cmd('az account clear')
+
+        self.kwargs.update({
+            'tenant': tenant_id,
+            'bad_sub': '00000000-0000-0000-0000-000000000000'
+        })
+
+        with self.assertRaises(Exception):
+            self.cmd('az login --tenant {tenant} --skip-subscription-discovery '
+                     '--subscription {bad_sub}')
+
+    def test_skip_discovery_preserves_prior_subscriptions(self):
+        """
+        Login normally first (full discovery), then re-login with --skip-subscription-discovery
+        --subscription S. Prior subscriptions from the first login should be preserved
+        in azureProfile.json (merged, not replaced).
+        """
+        tenant_id, sub_id, _ = self._login_and_get_account_info()
+
+        # Full discovery should have returned more than one subscription
+        subs_before = self.cmd('az account list').get_output_in_json()
+        self.assertGreater(len(subs_before), 1, "Test requires access to more than one subscription")
+
+        self.kwargs.update({'tenant': tenant_id, 'sub_id': sub_id})
+
+        # Re-login with skip-discovery + specific subscription (should merge, not replace)
+        self.cmd('az login --tenant {tenant} --skip-subscription-discovery --subscription {sub_id}')
+
+        # The specified subscription should be the default
+        account = self.cmd('az account show').get_output_in_json()
+        self.assertEqual(account['id'], sub_id)
+
+        # Prior subscriptions should still be in the profile (merged)
+        subs_after = self.cmd('az account list').get_output_in_json()
+        before_ids = {s['id'] for s in subs_before}
+        after_ids = {s['id'] for s in subs_after}
+        self.assertTrue(before_ids.issubset(after_ids),
+                        "Prior subscriptions should be preserved after skip-discovery re-login")
+
+    def test_login_subscription_by_name(self):
+        """
+        az login --subscription "Sub Name"
+
+        Full discovery with --subscription matching by display name (case-insensitive).
+        """
+        _, _, sub_name = self._login_and_get_account_info()
+        self.cmd('az account clear')
+
+        self.kwargs['sub_name'] = sub_name
+
+        # Re-login using subscription name
+        self.cmd('az login --subscription "{sub_name}"')
+
+        # Full discovery should return more than one subscription
+        accounts = self.cmd('az account list').get_output_in_json()
+        self.assertGreater(len(accounts), 1, "Test requires access to more than one subscription")
+
+        # The named subscription should be the default
+        account = self.cmd('az account show').get_output_in_json()
+        self.assertEqual(account['name'], sub_name)
+        self.assertTrue(account['isDefault'])
+
+    def test_login_nonexistent_subscription_raises_error(self):
+        """
+        az login --subscription "nonexistent"
+
+        Full discovery where --subscription doesn't match any discovered subscription
+        should raise an error.
+        """
+        with self.assertRaises(Exception):
+            self.cmd('az login --subscription "nonexistent-sub-00000000"')
+
+    def test_skip_discovery_bare_mode_allows_ad_operations(self):
+        """
+        az login --tenant T --skip-subscription-discovery
+
+        Bare mode should still allow tenant-level operations like 'az ad' to work,
+        even without any subscription.
+        """
+        tenant_id, _, _ = self._login_and_get_account_info()
+        self.cmd('az account clear')
+
+        self.kwargs['tenant'] = tenant_id
+
+        # Re-login in bare mode
+        self.cmd('az login --tenant {tenant} --skip-subscription-discovery')
+
+        # Should have only a tenant-level account
+        accounts = self.cmd('az account list').get_output_in_json()
+        self.assertEqual(len(accounts), 1)
+        self.assertEqual(accounts[0]['name'], _TENANT_LEVEL_ACCOUNT_NAME)
+
+        # Tenant-level operation should work
+        # Use 'az account get-access-token' to verify the credential is functional
+        # (avoid 'az ad' which may be blocked by Conditional Access policies)
+        result = self.cmd('az account get-access-token').get_output_in_json()
+        self.assertTrue(result.get('accessToken'), "accessToken should not be empty")
+
+    def test_skip_discovery_fast_path_validates_token(self):
+        """
+        az login --tenant T --skip-subscription-discovery --subscription S
+
+        After fast-path login, the credential should be functional for ARM calls
+        against the fetched subscription.
+        """
+        tenant_id, sub_id, _ = self._login_and_get_account_info()
+        self.cmd('az account clear')
+
+        self.kwargs.update({'tenant': tenant_id, 'sub_id': sub_id})
+
+        # Re-login with fast path
+        self.cmd('az login --tenant {tenant} --skip-subscription-discovery --subscription {sub_id}')
+
+        # Verify the token claims match the expected tenant
+        result = self.cmd('az account get-access-token').get_output_in_json()
+        self.assertIn('accessToken', result)
+        self.assertIn('expiresOn', result)
+
+        decoded = decode_access_token(result['accessToken'])
+        self.assertEqual(decoded['tid'], tenant_id)
+
+    def test_skip_discovery_requires_tenant(self):
+        """
+        az login --skip-subscription-discovery (without --tenant)
+
+        Should fail with a clear error message requiring --tenant.
+        """
+        with self.assertRaises(Exception):
+            self.cmd('az login --skip-subscription-discovery')
+
+    def test_skip_discovery_rejects_subscription_name(self):
+        """
+        az login --tenant T --skip-subscription-discovery --subscription "My Sub"
+
+        --skip-subscription-discovery requires a subscription GUID (not a name),
+        because it uses GET /subscriptions/{id} directly.
+        """
+        tenant_id, _, sub_name = self._login_and_get_account_info()
+        self.cmd('az account clear')
+
+        self.kwargs.update({'tenant': tenant_id, 'sub_name': sub_name})
+
+        with self.assertRaises(Exception):
+            self.cmd('az login --tenant {tenant} --skip-subscription-discovery '
+                     '--subscription "{sub_name}"')
+
+    def test_full_discovery_with_tenant(self):
+        """
+        az login --tenant T
+
+        Full discovery scoped to a specific tenant. Should list all subscriptions
+        accessible in that tenant only.
+        """
+        tenant_id, _, _ = self._login_and_get_account_info()
+        self.cmd('az account clear')
+
+        self.kwargs['tenant'] = tenant_id
+
+        # Re-login with specific tenant (full discovery within that tenant)
+        self.cmd('az login --tenant {tenant}')
+
+        # All returned subscriptions should belong to this tenant
+        accounts = self.cmd('az account list').get_output_in_json()
+        real_subs = [a for a in accounts if a.get('name') != _TENANT_LEVEL_ACCOUNT_NAME]
+        self.assertGreater(len(real_subs), 1, "Test requires access to more than one subscription")
+        for sub in real_subs:
+            self.assertEqual(sub['tenantId'], tenant_id)
+
+    def test_account_set_after_skip_discovery(self):
+        """
+        Login with --skip-subscription-discovery for two subscriptions sequentially.
+        After the second login, both should be in the profile and the second should be default.
+        Then 'az account set' should switch between them.
+        """
+        # Full discovery to get two real subscription IDs
+        self.cmd('az login')
+        accounts = self.cmd('az account list').get_output_in_json()
+        real_subs = [a for a in accounts if a.get('name') != _TENANT_LEVEL_ACCOUNT_NAME]
+        self.assertGreater(len(real_subs), 1, "Test requires access to more than one subscription")
+
+        tenant_id = real_subs[0]['tenantId']
+        sub_id_1 = real_subs[0]['id']
+        sub_id_2 = real_subs[1]['id']
+        self.cmd('az account clear')
+
+        self.kwargs.update({'tenant': tenant_id, 'sub1': sub_id_1, 'sub2': sub_id_2})
+
+        # Login with skip-discovery for sub 1
+        self.cmd('az login --tenant {tenant} --skip-subscription-discovery --subscription {sub1}')
+
+        # Should have only sub 1
+        accounts = self.cmd('az account list').get_output_in_json()
+        self.assertEqual(len(accounts), 1)
+        self.assertEqual(accounts[0]['id'], sub_id_1)
+
+        # Login with skip-discovery for sub 2 (should merge with sub 1)
+        self.cmd('az login --tenant {tenant} --skip-subscription-discovery --subscription {sub2}')
+
+        # Should have both subs, sub 2 is default
+        accounts = self.cmd('az account list').get_output_in_json()
+        self.assertEqual(len(accounts), 2)
+        account = self.cmd('az account show').get_output_in_json()
+        self.assertEqual(account['id'], sub_id_2)
+        self.assertTrue(account['isDefault'])
+
+        # Bare mode login (should add a tenant-level account, merging with existing subs)
+        self.cmd('az login --tenant {tenant} --skip-subscription-discovery')
+
+        # Should have 3: sub 1 + sub 2 + tenant-level account
+        accounts = self.cmd('az account list').get_output_in_json()
+        self.assertEqual(len(accounts), 3)
+        tenant_accounts = [a for a in accounts if a['name'] == _TENANT_LEVEL_ACCOUNT_NAME]
+        self.assertEqual(len(tenant_accounts), 1)


### PR DESCRIPTION
**Related command**
`az login`

**Description**
Wires `--skip-subscription-discovery` and `--subscription` parameters into `az login`. This enables fast login for tenants with 1M+ subscriptions by skipping full subscription enumeration.

Three login modes are now supported:

- `--skip-subscription-discovery --subscription S`: Fast path: fetches only the specified subscription via `GET /subscriptions/{id}` (1 API call)
- `--skip-subscription-discovery` (bare mode): No ARM calls and creates a tenant-level account for tenant-level operations (e.g., `az ad`)
- `--subscription S` (without skip): Full discovery, then sets S as the default

Both `--subscription` and `--skip-subscription-discovery` bypass the interactive subscription selector.

Related issues: #31939, #14933, #13285

**Testing Guide**
8 unit tests added in `TestLoginSubscriptionFilter`:

- Fast path with `--skip-subscription-discovery --subscription`  verifies `GET` called, not `LIST`
- Bare mode  verifies 0 ARM calls, tenant-level account created
- Inaccessible subscription with skip verifies error raised
- Inaccessible subscription with skip + `--allow-no-subscriptions`  verifies warning, tenant-level fallback
- `--subscription` without skip verifies full discovery + default set
- `--subscription` not found without skip verifies error
- Skip with subscription preserves prior subscriptions from other logins
- Bare mode preserves prior subscriptions from other logins

3 tests added in `test_profile_custom.py`:
﻿- `Add validation that --skip-subscription-discovery requires --tenant`
- `--skip-subscription-discovery` bypasses interactive selector
- `--subscription` bypasses interactive selector

Run tests:

```
python -m pytest src/azure-cli-core/azure/cli/core/tests/test_profile.py::TestLoginSubscriptionFilter -v
python -m pytest src/azure-cli/azure/cli/command_modules/profile/tests/latest/test_profile_custom.py -v -k "skip_subscription_discovery or default_subscription"
```
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
