### PR TITLE
Improve help documentation for 1 search commands

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/search/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/search/_help.py
@@ -115,14 +115,17 @@ examples:
 
 helps['search service shared-private-link-resource create'] = """
 type: command
-short-summary: Create a shared private link resource for a given Azure Search service.
+short-summary: Create or update a shared private link resource managed by the Azure AI Search service.
 examples:
   - name: Create a shared private link resource for a Search service.
     text: >
-        az search service shared-private-link-resource create --resource-group MyResourceGroup --search-service-name MySearchService --name MySharedPrivateLinkResource --group-id MyGroupId --resource-id /subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/{provider}/{resourceType}/{resourceName}
-  - name: Create a shared private link resource and specify a request message.
+        az search service shared-private-link-resource create --resource-group myResourceGroup --search-service-name mySearchService --name mySharedPrivateLinkResource --group-id myGroupId --resource-id /subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/{provider}/{resourceType}/{resourceName}
+  - name: Create a shared private link resource with a request message.
     text: >
-        az search service shared-private-link-resource create --resource-group MyResourceGroup --search-service-name MySearchService --name MySharedPrivateLinkResource --group-id MyGroupId --resource-id /subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/{provider}/{resourceType}/{resourceName} --request-message "Please approve this connection."
+        az search service shared-private-link-resource create --resource-group myResourceGroup --search-service-name mySearchService --name mySharedPrivateLinkResource --group-id myGroupId --resource-id /subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/{provider}/{resourceType}/{resourceName} --request-message "Please approve this connection."
+  - name: Create a shared private link resource without waiting for the operation to complete.
+    text: >
+        az search service shared-private-link-resource create --resource-group myResourceGroup --search-service-name mySearchService --name mySharedPrivateLinkResource --group-id myGroupId --resource-id /subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/{provider}/{resourceType}/{resourceName} --no-wait
 """
 
 helps['search service shared-private-link-resource update'] = """


### PR DESCRIPTION
## Azure CLI Help Documentation Improvements

This PR improves help documentation for commands with the lowest quality scores.

### Summary

| Command | Original Score | New Score |
|---------|---------------|-----------|
| `search service shared-private-link-resource create` | 5.0/10 | 7/10 |

### Skipped Commands

The following commands were selected for improvement but skipped because they
have no `_help.py` entry (e.g. aaz/codegen commands with inline help):

- `search service list` (score: 5.0/10) — no _help.py entry found (likely aaz/codegen command)
- `search service query-key delete` (score: 5.0/10) — no _help.py entry found (likely aaz/codegen command)
- `search service private-link-resource list` (score: 5.0/10) — no _help.py entry found (likely aaz/codegen command)
- `search service shared-private-link-resource delete` (score: 5.0/10) — no _help.py entry found (likely aaz/codegen command)

---

### `search service shared-private-link-resource create`

<details><summary>Original help (score: 5.0/10)</summary>

```
Command: search service shared-private-link-resource create
======================================================================
name: search service shared-private-link-resource create
is_aaz: True
supports_no_wait: True
desc: Create the creation or update of a shared private link resource managed by the search service in the given resource group.
parameters:
  Item 1:
    name: _change_reference
    options:
      - --change-reference
    desc: The related change reference ID for this resource operation
  Item 2:
    name: _acquire_policy_token
    options:
      - --acquire-policy-token
    desc: Acquiring an Azure Policy token automatically for this resource operation
  Item 3:
    name: no_wait
    options:
      - --no-wait
    choices:
      - 0
      - 1
      - f
      - false
      - n
      - no
      - t
      - true
      - y
      - yes
    nargs: ?
    desc: Do not wait for the long-running operation to finish.
    aaz_type: bool
    type: bool
  Item 4:
    name: resource_group
    options:
      - --resource-group
      - -g
    required: True
    id_part: resource_group
    has_completer: True
    desc: Name of resource group. You can configure the default group using `az configure --defaults group=<name>`
    aaz_type: string
    type: string
  Item 5:
    name: search_service_name
    options:
      - --search-service-name
    required: True
    desc: The name of the Azure AI Search service associated with the specified resource group.
    aaz_type: string
    type: string
  Item 6:
    name: shared_private_link_resource_name
    options:
      - --name
      - --shared-private-link-resource-name
      - -n
    required: True
    desc: The name of the shared private link resource managed by the Azure AI Search service within the specified resource group.
    aaz_type: string
    type: string
  Item 7:
    name: group_id
    options:
      - --group-id
    desc: The group ID from the provider of resource the shared private link resource is for.
    aaz_type: string
    type: string
  Item 8:
    name: private_link_resource_id
    options:
      - --private-link-resource-id
      - --resource-id
    desc: The resource ID of the resource the shared private link resource is for.
    aaz_type: string
    type: string
  Item 9:
    name: provisioning_state
    options:
      - --provisioning-state
    choices:
      - Deleting
      - Failed
      - Incomplete
      - Succeeded
      - Updating
    desc: The provisioning state of the shared private link resource. Valid values are Updating, Deleting, Failed, Succeeded or Incomplete.
    aaz_type: string
    type: string
  Item 10:
    name: request_message
    options:
      - --request-message
    desc: The message for requesting approval of the shared private link resource.
    aaz_type: string
    type: string
  Item 11:
    name: resource_region
    options:
      - --resource-region
    desc: Optional. Can be used to specify the Azure Resource Manager location of the resource for which a shared private link is being created. This is only required for those resources whose DNS configuration are regional (such as Azure Kubernetes Service).
    aaz_type: string
    type: string
  Item 12:
    name: status
    options:
      - --status
    choices:
      - Approved
      - Disconnected
      - Pending
      - Rejected
    desc: Status of the shared private link resource. Valid values are Pending, Approved, Rejected or Disconnected.
    aaz_type: string
    type: string
```
</details>

<details><summary>Improved help (score: 7/10)</summary>

type: command
short-summary: Create or update a shared private link resource managed by the Azure AI Search service.
examples:
  - name: Create a shared private link resource for a Search service.
    text: >
        az search service shared-private-link-resource create --resource-group myResourceGroup --search-service-name mySearchService --name mySharedPrivateLinkResource --group-id myGroupId --resource-id /subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/{provider}/{resourceType}/{resourceName}
  - name: Create a shared private link resource with a request message.
    text: >
        az search service shared-private-link-resource create --resource-group myResourceGroup --search-service-name mySearchService --name mySharedPrivateLinkResource --group-id myGroupId --resource-id /subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/{provider}/{resourceType}/{resourceName} --request-message "Please approve this connection."
  - name: Create a shared private link resource without waiting for the operation to complete.
    text: >
        az search service shared-private-link-resource create --resource-group myResourceGroup --search-service-name mySearchService --name mySharedPrivateLinkResource --group-id myGroupId --resource-id /subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/{provider}/{resourceType}/{resourceName} --no-wait

</details>


### Generated by: Azure CLI Help Improver