### PR TITLE
[App Service] Fix #33180: `az functionapp plan create`: Simplify reserved parameter assignment in AppServicePlan

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -1196,7 +1196,7 @@ subscription than the app service environment, please use the resource ID for --
                    completer=get_resource_name_completion_list('Microsoft.Web/serverFarms'),
                    configured_default='appserviceplan', id_part='name',
                    local_context_attribute=LocalContextAttribute(name='plan_name', actions=[LocalContextAction.GET]))
-        c.argument('is_linux', arg_type=get_three_state_flag(return_label=True), required=False,
+        c.argument('is_linux', arg_type=get_three_state_flag(), required=False,
                    help='host function app on Linux worker')
         c.argument('number_of_workers', options_list=['--number-of-workers', '--min-instances'],
                    help='The number of workers for the app service plan.')

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -4254,7 +4254,7 @@ has been deployed ".format(app_service_environment)
     # the api is odd on parameter naming, have to live with it for now
     sku_def = SkuDescription(tier=get_sku_tier(sku), name=_normalize_sku(sku), capacity=number_of_workers)
     plan_def = AppServicePlan(location=location, tags=tags, sku=sku_def,
-                              reserved=(is_linux or None), hyper_v=(hyper_v or None),
+                              reserved=is_linux, hyper_v=(hyper_v or None),
                               per_site_scaling=per_site_scaling, hosting_environment_profile=ase_def,
                               async_scaling_enabled=async_scaling_enabled)
 
@@ -7100,7 +7100,7 @@ def create_functionapp_app_service_plan(cmd, resource_group_name, name, is_linux
         number_of_workers = validate_range_of_int_flag('--number-of-workers', number_of_workers, min_val=0, max_val=20)
     sku_def = SkuDescription(tier=tier, name=sku, capacity=number_of_workers)
     plan_def = AppServicePlan(location=location, tags=tags, sku=sku_def,
-                              reserved=(is_linux or None), maximum_elastic_worker_count=max_burst,
+                              reserved=is_linux, maximum_elastic_worker_count=max_burst,
                               hyper_v=None, name=name)
 
     if zone_redundant:


### PR DESCRIPTION
**Related command**

```
az functionapp plan create \
  --name <App Service Plan Name> \
  --resource-group <Resource Group> \
  --location japaneast \
  --sku EP1 \
  --is-linux false
```

**Description**<!--Mandatory-->

close: https://github.com/Azure/azure-cli/issues/33180



**Testing Guide**
I had confirmed `"reserved": false,` and see on the Azure Portal.

```
((.venv) ) komayama@komayama:~/Gitlocal/azure-cli$ az functionapp plan create \
  --name test2-win-ep1 \
  --resource-group cli-azurefunc-ep \
  --location japaneast \
  --sku EP1 \
  --is-linux false
/home/komayama/Gitlocal/azure-cli/.venv/bin/az:4: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
  __import__('pkg_resources').require('azure-cli==2.85.0')
Readonly attribute name will be ignored in class <class 'azure.mgmt.web.v2024_11_01.models._models_py3.AppServicePlan'>
{
  "asyncScalingEnabled": false,
  "elasticScaleEnabled": true,
  "extendedLocation": null,
  "freeOfferExpirationTime": null,
  "geoRegion": "Japan East",
  "hostingEnvironmentProfile": null,
  "hyperV": false,
  "id": "/subscriptions/XXXXXXXXXXXXXXXXXXXXXXXXX/resourceGroups/cli-azurefunc-ep/providers/Microsoft.Web/serverfarms/test2-win-ep1",
  "isSpot": false,
  "isXenon": false,
  "kind": "elastic",
  "kubeEnvironmentProfile": null,
  "location": "japaneast",
  "maximumElasticWorkerCount": 1,
  "maximumNumberOfWorkers": 0,
  "name": "test2-win-ep1",
  "numberOfSites": 0,
  "numberOfWorkers": 1,
  "perSiteScaling": false,
  "provisioningState": "Succeeded",
  "reserved": false,
  "resourceGroup": "cli-azurefunc-ep",
  "sku": {
    "capabilities": null,
    "capacity": 1,
    "family": "EP",
    "locations": null,
    "name": "EP1",
    "size": "EP1",
    "skuCapacity": null,
    "tier": "ElasticPremium"
  },
  "spotExpirationTime": null,
  "status": "Ready",
  "subscription": "XXXXXXXXXXXXXXXXXXXXXXXXX",
  "tags": null,
  "targetWorkerCount": 0,
  "targetWorkerSizeId": 0,
  "type": "Microsoft.Web/serverfarms",
  "workerTierName": null,
  "zoneRedundant": false
}
```

<img width="2560" height="714" alt="image" src="https://github.com/user-attachments/assets/f33d00d7-189e-4712-b92b-7e3d6abadc67" />


Run Test command
> azdev test appservice

<img width="3228" height="1365" alt="image" src="https://github.com/user-attachments/assets/c6d7ffab-a258-4ca6-bfc2-c70572938e1a" />


This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
