### PR TITLE
[MONITOR] Improve help documentation for 5 commands

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/monitor/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/_help.py
@@ -34,10 +34,15 @@ short-summary: Manage activity log alert rules.
 
 helps['monitor activity-log alert list'] = """
 type: command
-short-summary: List activity log alert rules under a resource group or the current subscription.
+short-summary: List activity log alert rules under a specified resource group or the current subscription.
 parameters:
   - name: --resource-group -g
-    short-summary: Name of the resource group under which the activity log alert rules are being listed. If it is omitted, all the activity log alert rules under the current subscription are listed.
+    short-summary: Specify the name of the resource group to list its activity log alert rules. If omitted, lists all the activity log alert rules under the current subscription.
+examples:
+  - name: List all activity log alert rules in a specific resource group
+    text: az monitor activity-log alert list --resource-group myResourceGroup
+  - name: List all activity log alert rules in the current subscription
+    text: az monitor activity-log alert list
 """
 
 helps['monitor activity-log list'] = """
@@ -624,4 +629,52 @@ examples:
   - name: Clone the metric alert settings from one VM to another
     text: |
         az monitor clone --source-resource /subscriptions/{subscriptionID}/resourceGroups/Space1999/providers/Microsoft.Compute/virtualMachines/vm1 --target-resource /subscriptions/{subscriptionID}/resourceGroups/Space1999/providers/Microsoft.Compute/virtualMachines/vm2
+"""
+
+helps['monitor diagnostic-settings subscription list'] = """
+type: command
+short-summary: List the active subscription diagnostic settings for the specified subscription.
+"""
+
+helps['monitor log-profiles list'] = """
+type: command
+short-summary: List the log profiles.
+examples:
+  - name: List all log profiles
+    text: |
+        az monitor log-profiles list
+"""
+
+helps['monitor diagnostic-settings subscription delete'] = """
+type: command
+short-summary: Delete existing subscription diagnostic settings for a specified resource.
+parameters:
+  - name: --name -n
+    short-summary: The name of the diagnostic setting.
+  - name: --yes -y
+    short-summary: Do not prompt for confirmation.
+examples:
+  - name: Delete diagnostic settings without confirmation
+    text: |
+        az monitor diagnostic-settings subscription delete --name MyDiagnosticSetting --yes
+  - name: Delete diagnostic settings prompting for confirmation
+    text: |
+        az monitor diagnostic-settings subscription delete --name MyDiagnosticSetting
+"""
+
+helps['monitor activity-log list-categories'] = """
+type: command
+short-summary: List the available event categories supported in the Activity Logs Service.
+parameters:
+  - name: --change-reference
+    short-summary: The related change reference ID for this resource operation
+  - name: --acquire-policy-token
+    short-summary: Acquiring an Azure Policy token automatically for this resource operation
+examples:
+  - name: List available event categories with a specific change reference ID
+    text: |
+        az monitor activity-log list-categories --change-reference 12345
+  - name: List available event categories while acquiring a policy token
+    text: |
+        az monitor activity-log list-categories --acquire-policy-token
 """


### PR DESCRIPTION
> AI-generated code

## Azure CLI Help Documentation Improvements

This PR improves help documentation for commands with the lowest quality scores.

### Summary

| Command | Type | Original Score | New Score |
|---------|------|---------------|-----------|
| `monitor diagnostic-settings subscription list` | New | 3.0/10 | 3/10 |
| `monitor log-profiles list` | New | 3.0/10 | 5/10 |
| `monitor diagnostic-settings subscription delete` | New | 4.0/10 | 7/10 |
| `monitor activity-log list-categories` | New | 4.0/10 | 6/10 |
| `monitor activity-log alert list` | Improved | 4.0/10 | 8/10 |

---

### `monitor diagnostic-settings subscription list` (New entry)

<details><summary>Command metadata (score: 3.0/10)</summary>

```
Command: monitor diagnostic-settings subscription list
======================================================================
name: monitor diagnostic-settings subscription list
is_aaz: True
desc: Gets the active subscription diagnostic settings list for the specified subscriptionId. :keyword callable cls: A custom type or function that will be passed the direct response:return: SubscriptionDiagnosticSettingsResourceCollection or the result of cls(response):rtype:  ~$(python-base-namespace).v2017_05_01_preview.models.SubscriptionDiagnosticSettingsResourceCollection:raises ~azure.core.exceptions.HttpResponseError:.
parameters:
```
</details>

<details><summary>New help (score: 3/10)</summary>

```
type: command
short-summary: List the active subscription diagnostic settings for the specified subscription.
```
</details>

---

### `monitor log-profiles list` (New entry)

<details><summary>Command metadata (score: 3.0/10)</summary>

```
Command: monitor log-profiles list
======================================================================
name: monitor log-profiles list
is_aaz: True
desc: List the log profiles.
parameters:
```
</details>

<details><summary>New help (score: 5/10)</summary>

```
type: command
short-summary: List the log profiles.
examples:
  - name: List all log profiles
    text: |
        az monitor log-profiles list
```
</details>

---

### `monitor diagnostic-settings subscription delete` (New entry)

<details><summary>Command metadata (score: 4.0/10)</summary>

```
Command: monitor diagnostic-settings subscription delete
======================================================================
name: monitor diagnostic-settings subscription delete
is_aaz: True
desc: Deletes existing subscription diagnostic settings for the specified resource.
parameters:
  Item 1:
    name: _change_reference
    options:
      - --change-reference
    desc: The related change reference ID for this resource operation
  Item 2:
    name: _acquire_policy_token
    options:
      - --acquire-policy-token
    desc: Acquiring an Azure Policy token automatically for this resource operation
  Item 3:
    name: name
    options:
      - --name
      - -n
    required: True
    id_part: name
    desc: The name of the diagnostic setting.
    aaz_type: string
    type: string
  Item 4:
    name: yes
    options:
      - --yes
      - -y
    desc: Do not prompt for confirmation.
```
</details>

<details><summary>New help (score: 7/10)</summary>

```
type: command
short-summary: Delete existing subscription diagnostic settings for a specified resource.
parameters:
  - name: --name -n
    short-summary: The name of the diagnostic setting.
  - name: --yes -y
    short-summary: Do not prompt for confirmation.
examples:
  - name: Delete diagnostic settings without confirmation
    text: |
        az monitor diagnostic-settings subscription delete --name MyDiagnosticSetting --yes
  - name: Delete diagnostic settings prompting for confirmation
    text: |
        az monitor diagnostic-settings subscription delete --name MyDiagnosticSetting
```
</details>

---

### `monitor activity-log list-categories` (New entry)

<details><summary>Command metadata (score: 4.0/10)</summary>

```
Command: monitor activity-log list-categories
======================================================================
name: monitor activity-log list-categories
is_aaz: True
desc: List the list of available event categories supported in the Activity Logs Service.
parameters:
  Item 1:
    name: _change_reference
    options:
      - --change-reference
    desc: The related change reference ID for this resource operation
  Item 2:
    name: _acquire_policy_token
    options:
      - --acquire-policy-token
    desc: Acquiring an Azure Policy token automatically for this resource operation
```
</details>

<details><summary>New help (score: 6/10)</summary>

```
type: command
short-summary: List the available event categories supported in the Activity Logs Service.
parameters:
  - name: --change-reference
    short-summary: The related change reference ID for this resource operation
  - name: --acquire-policy-token
    short-summary: Acquiring an Azure Policy token automatically for this resource operation
examples:
  - name: List available event categories with a specific change reference ID
    text: |
        az monitor activity-log list-categories --change-reference 12345
  - name: List available event categories while acquiring a policy token
    text: |
        az monitor activity-log list-categories --acquire-policy-token
```
</details>

---

### `monitor activity-log alert list` (Improved)

<details><summary>Original help (score: 4.0/10)</summary>

```
Command: monitor activity-log alert list
======================================================================
name: monitor activity-log alert list
is_aaz: True
desc: List activity log alert rules under a resource group or the current subscription.
parameters:
  Item 1:
    name: resource_group
    options:
      - --resource-group
      - -g
    id_part: resource_group
    has_completer: True
    desc: Name of resource group. You can configure the default group using `az configure --defaults group=<name>`
    aaz_type: string
    type: string
```
</details>

<details><summary>Improved help (score: 8/10)</summary>

```
type: command
short-summary: List activity log alert rules under a specified resource group or the current subscription.
parameters:
  - name: --resource-group -g
    short-summary: Specify the name of the resource group to list its activity log alert rules. If omitted, lists all the activity log alert rules under the current subscription.
examples:
  - name: List all activity log alert rules in a specific resource group
    text: az monitor activity-log alert list --resource-group myResourceGroup
  - name: List all activity log alert rules in the current subscription
    text: az monitor activity-log alert list
```
</details>


### Generated by: Azure CLI Help Improver