### PR TITLE
[POSTGRESQL] Fix #33205: `az postgres flexible-server create`: Update help text for `--storage-auto-grow` argument to reflect actual default value

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/postgresql/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/_params.py
@@ -170,7 +170,7 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
         auto_grow_arg_type = CLIArgumentType(
             arg_type=get_enum_type(['Enabled', 'Disabled']),
             options_list=['--storage-auto-grow'],
-            help='Enable or disable autogrow of the storage. Default value is Enabled.'
+            help='Enable or disable autogrow of the storage. Default value is Disabled.'
         )
 
         storage_type_arg_type = CLIArgumentType(


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az postgres flexible-server create`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
The help text for the `--storage-auto-grow` argument describes an incorrect default value
Fix #33205 

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
