### PR TITLE
{NetAppFiles} Fix empty parameters

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/netappfiles/_breaking_change.py
+++ b/src/azure-cli/azure/cli/command_modules/netappfiles/_breaking_change.py
@@ -8,26 +8,18 @@ from azure.cli.core.breaking_change import (
     register_other_breaking_change,
 )
 register_argument_deprecate('netappfiles volume update', '--remote-volume-resource-id')
-register_argument_deprecate('netappfiles volume create', '--default-group-quota',
-                            redirect='command group az netappfiles volume quota-rule')
-register_argument_deprecate('netappfiles volume update', '--default-group-quota',
-                            redirect='command group az netappfiles volume quota-rule')
-register_argument_deprecate('netappfiles volume create', '--default-user-quota',
-                            redirect='command group az netappfiles volume quota-rule')
-register_argument_deprecate('netappfiles volume update', '--default-user-quota',
-                            redirect='command group az netappfiles volume quota-rule')
 register_argument_deprecate('netappfiles volume create', '--is-default-quota-enabled',
-                            redirect='command group az netappfiles volume quota-rule')
+                            redirect='netappfiles volume quota-rule')
 register_argument_deprecate('netappfiles volume update', '--is-default-quota-enabled',
-                            redirect='command group az netappfiles volume quota-rule')
+                            redirect='netappfiles volume quota-rule')
 register_argument_deprecate('netappfiles volume create', '--default-group-quota-in-ki-bs',
-                            redirect='command group az netappfiles volume quota-rule')
+                            redirect='netappfiles volume quota-rule')
 register_argument_deprecate('netappfiles volume update', '--default-group-quota-in-ki-bs',
-                            redirect='command group az netappfiles volume quota-rule')
+                            redirect='netappfiles volume quota-rule')
 register_argument_deprecate('netappfiles volume create', '--default-user-quota-in-ki-bs',
-                            redirect='command group az netappfiles volume quota-rule')
+                            redirect='netappfiles volume quota-rule')
 register_argument_deprecate('netappfiles volume update', '--default-user-quota-in-ki-bs',
-                            redirect='command group az netappfiles volume quota-rule')
+                            redirect='netappfiles volume quota-rule')
 register_default_value_breaking_change('netappfiles volume create', '--network-features', 'Basic', 'Standard')
 register_other_breaking_change('netappfiles volume create',
                                'The basic option will not be accepted, use Standard instead',


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
There are some breaking change duplicate announcements that are causing our doc PR to fail:
https://github.com/MicrosoftDocs/azure-docs-cli/pull/5903/

For example, in `az netappfiles volume create` command, `--default-group-quota` parameter is simply an alias for `--default-group-quota-in-ki-bs`. They should only be registered once. 
This PR is just to remove the duplicate ones.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
