### PR TITLE
{NetAppFiles} Hotfix: Remove duplicate breaking announcement

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/netappfiles/_breaking_change.py
+++ b/src/azure-cli/azure/cli/command_modules/netappfiles/_breaking_change.py
@@ -8,26 +8,18 @@ from azure.cli.core.breaking_change import (
     register_other_breaking_change,
 )
 register_argument_deprecate('netappfiles volume update', '--remote-volume-resource-id')
-register_argument_deprecate('netappfiles volume create', '--default-group-quota',
-                            redirect='command group az netappfiles volume quota-rule')
-register_argument_deprecate('netappfiles volume update', '--default-group-quota',
-                            redirect='command group az netappfiles volume quota-rule')
-register_argument_deprecate('netappfiles volume create', '--default-user-quota',
-                            redirect='command group az netappfiles volume quota-rule')
-register_argument_deprecate('netappfiles volume update', '--default-user-quota',
-                            redirect='command group az netappfiles volume quota-rule')
 register_argument_deprecate('netappfiles volume create', '--is-default-quota-enabled',
-                            redirect='command group az netappfiles volume quota-rule')
+                            redirect='netappfiles volume quota-rule')
 register_argument_deprecate('netappfiles volume update', '--is-default-quota-enabled',
-                            redirect='command group az netappfiles volume quota-rule')
+                            redirect='netappfiles volume quota-rule')
 register_argument_deprecate('netappfiles volume create', '--default-group-quota-in-ki-bs',
-                            redirect='command group az netappfiles volume quota-rule')
+                            redirect='netappfiles volume quota-rule')
 register_argument_deprecate('netappfiles volume update', '--default-group-quota-in-ki-bs',
-                            redirect='command group az netappfiles volume quota-rule')
+                            redirect='netappfiles volume quota-rule')
 register_argument_deprecate('netappfiles volume create', '--default-user-quota-in-ki-bs',
-                            redirect='command group az netappfiles volume quota-rule')
+                            redirect='netappfiles volume quota-rule')
 register_argument_deprecate('netappfiles volume update', '--default-user-quota-in-ki-bs',
-                            redirect='command group az netappfiles volume quota-rule')
+                            redirect='netappfiles volume quota-rule')
 register_default_value_breaking_change('netappfiles volume create', '--network-features', 'Basic', 'Standard')
 register_other_breaking_change('netappfiles volume create',
                                'The basic option will not be accepted, use Standard instead',


### PR DESCRIPTION
## Description\n\nCherry-pick of #33141 to the `release` branch.\n\nThere are duplicate breaking change announcements that are causing the doc PR to fail: [MicrosoftDocs/azure-docs-cli#5903](https://github.com/MicrosoftDocs/azure-docs-cli/pull/5903)\n\nIn `az netappfiles volume create` command, `--default-group-quota` parameter is simply an alias for `--default-group-quota-in-ki-bs`. They should only be registered once. This PR removes the duplicate ones.\n\n## Testing Guide\n\n• NA - removing duplicate breaking change registrations\n\n---\n\n- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).\n- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).\n- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).