### PR TITLE
[AKS] `az aks update`: Fix `--outbound-type` validation for UDR and userAssignedNATGateway

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -2362,7 +2362,7 @@ class AKSManagedClusterContext(BaseAKSContext):
                 skuName = CONST_MANAGED_CLUSTER_SKU_NAME_BASE
         return skuName
 
-    def _get_outbound_type(
+    def _get_outbound_type(  # pylint: disable=too-many-branches
         self,
         enable_validation: bool = False,
         read_only: bool = False,
@@ -2436,15 +2436,31 @@ class AKSManagedClusterContext(BaseAKSContext):
 
             if outbound_type == CONST_OUTBOUND_TYPE_USER_DEFINED_ROUTING:
                 if self.get_vnet_subnet_id() in ["", None]:
-                    raise RequiredArgumentMissingError(
-                        "--vnet-subnet-id must be specified for userDefinedRouting and it must "
-                        "be pre-configured with a route table with egress rules"
+                    if self.decorator_mode == DecoratorMode.CREATE:
+                        raise RequiredArgumentMissingError(
+                            "--vnet-subnet-id must be specified for userDefinedRouting and it must "
+                            "be pre-configured with a route table with egress rules"
+                        )
+                    raise InvalidArgumentValueError(
+                        "Updating outbound type to userDefinedRouting is only supported for "
+                        "clusters using a custom (BYO) virtual network. Managed VNet clusters "
+                        "cannot be updated to userDefinedRouting. Please refer to "
+                        "https://learn.microsoft.com/en-us/azure/aks/egress-outboundtype"
+                        "#updating-outboundtype-after-cluster-creation for supported migration paths."
                     )
             if outbound_type == CONST_OUTBOUND_TYPE_USER_ASSIGNED_NAT_GATEWAY:
                 if self.get_vnet_subnet_id() in ["", None]:
-                    raise RequiredArgumentMissingError(
-                        "--vnet-subnet-id must be specified for userAssignedNATGateway and it must "
-                        "be pre-configured with a NAT gateway with outbound ips"
+                    if self.decorator_mode == DecoratorMode.CREATE:
+                        raise RequiredArgumentMissingError(
+                            "--vnet-subnet-id must be specified for userAssignedNATGateway and it must "
+                            "be pre-configured with a NAT gateway with outbound ips"
+                        )
+                    raise InvalidArgumentValueError(
+                        "Updating outbound type to userAssignedNATGateway is only supported for "
+                        "clusters using a custom (BYO) virtual network. Managed VNet clusters "
+                        "cannot be updated to userAssignedNATGateway. Please refer to "
+                        "https://learn.microsoft.com/en-us/azure/aks/egress-outboundtype"
+                        "#updating-outboundtype-after-cluster-creation for supported migration paths."
                     )
             if outbound_type == CONST_OUTBOUND_TYPE_MANAGED_NAT_GATEWAY:
                 if self.get_vnet_subnet_id() not in ["", None]:

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
@@ -25,6 +25,7 @@ from azure.cli.command_modules.acs._consts import (
     CONST_MONITORING_ADDON_NAME,
     CONST_MONITORING_LOG_ANALYTICS_WORKSPACE_RESOURCE_ID,
     CONST_OPEN_SERVICE_MESH_ADDON_NAME,
+    CONST_OUTBOUND_TYPE_USER_ASSIGNED_NAT_GATEWAY,
     CONST_OUTBOUND_TYPE_USER_DEFINED_ROUTING,
     CONST_OUTBOUND_TYPE_MANAGED_NAT_GATEWAY,
     CONST_OUTBOUND_TYPE_LOAD_BALANCER,
@@ -2121,6 +2122,94 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
         outbound_type_13 = ctx_13._get_outbound_type()
         expect_outbound_type_13 = CONST_OUTBOUND_TYPE_MANAGED_NAT_GATEWAY
         self.assertEqual(outbound_type_13,expect_outbound_type_13)
+
+    def test_get_outbound_type_update_udr_byo_vnet(self):
+        """UPDATE mode with UDR and BYO VNet (vnet_subnet_id present) should succeed."""
+        ctx = AKSManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict(
+                {
+                    "outbound_type": CONST_OUTBOUND_TYPE_USER_DEFINED_ROUTING,
+                }
+            ),
+            self.models,
+            DecoratorMode.UPDATE,
+        )
+        ctx.agentpool_context = mock.MagicMock()
+        ctx.agentpool_context.get_vnet_subnet_id.return_value = (
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/"
+            "providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+        )
+        self.assertEqual(ctx.get_outbound_type(), CONST_OUTBOUND_TYPE_USER_DEFINED_ROUTING)
+
+    def test_get_outbound_type_update_udr_managed_vnet(self):
+        """UPDATE mode with UDR and managed VNet (no vnet_subnet_id) should raise InvalidArgumentValueError."""
+        ctx = AKSManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict(
+                {
+                    "outbound_type": CONST_OUTBOUND_TYPE_USER_DEFINED_ROUTING,
+                }
+            ),
+            self.models,
+            DecoratorMode.UPDATE,
+        )
+        agentpool_ctx = AKSAgentPoolContext(
+            self.cmd,
+            AKSAgentPoolParamDict({}),
+            self.models,
+            DecoratorMode.UPDATE,
+            AgentPoolDecoratorMode.MANAGED_CLUSTER,
+        )
+        ctx.attach_agentpool_context(agentpool_ctx)
+        with self.assertRaises(InvalidArgumentValueError):
+            ctx.get_outbound_type()
+
+    def test_get_outbound_type_update_user_assigned_nat_gw_managed_vnet(self):
+        """UPDATE mode with userAssignedNATGateway and managed VNet should raise InvalidArgumentValueError."""
+        ctx = AKSManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict(
+                {
+                    "outbound_type": CONST_OUTBOUND_TYPE_USER_ASSIGNED_NAT_GATEWAY,
+                }
+            ),
+            self.models,
+            DecoratorMode.UPDATE,
+        )
+        agentpool_ctx = AKSAgentPoolContext(
+            self.cmd,
+            AKSAgentPoolParamDict({}),
+            self.models,
+            DecoratorMode.UPDATE,
+            AgentPoolDecoratorMode.MANAGED_CLUSTER,
+        )
+        ctx.attach_agentpool_context(agentpool_ctx)
+        with self.assertRaises(InvalidArgumentValueError):
+            ctx.get_outbound_type()
+
+    def test_get_outbound_type_create_udr_no_subnet(self):
+        """CREATE mode with UDR and no vnet_subnet_id should still raise RequiredArgumentMissingError."""
+        ctx = AKSManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict(
+                {
+                    "outbound_type": CONST_OUTBOUND_TYPE_USER_DEFINED_ROUTING,
+                }
+            ),
+            self.models,
+            DecoratorMode.CREATE,
+        )
+        agentpool_ctx = AKSAgentPoolContext(
+            self.cmd,
+            AKSAgentPoolParamDict({}),
+            self.models,
+            DecoratorMode.CREATE,
+            AgentPoolDecoratorMode.MANAGED_CLUSTER,
+        )
+        ctx.attach_agentpool_context(agentpool_ctx)
+        with self.assertRaises(RequiredArgumentMissingError):
+            ctx.get_outbound_type()
 
     def test_get_network_plugin_mode(self):
         # default


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

`az aks update`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Fixes https://github.com/Azure/azure-cli/issues/33204

The CLI incorrectly required --vnet-subnet-id when updating outbound type to userDefinedRouting or userAssignedNATGateway. This parameter is not registered for 'aks update', creating an impossible state for users.

Changes:
- In UPDATE mode, when vnet_subnet_id is empty, raise a clear InvalidArgumentValueError explaining that updating to UDR/ userAssignedNATGateway is only supported for BYO VNet clusters
- In CREATE mode, preserve existing RequiredArgumentMissingError
- For BYO VNet clusters, the subnet is already known from the agentpool, so validation passes and the update works correctly

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
