### PR TITLE
[AKS] `az aks nodepool upgrade`: Fix `--max-unavailable` being silently ignored

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -3167,6 +3167,8 @@ def aks_agentpool_upgrade(cmd, client, resource_group_name, cluster_name,
         instance.upgrade_settings.node_soak_duration_in_minutes = node_soak_duration
     if undrainable_node_behavior:
         instance.upgrade_settings.undrainable_node_behavior = undrainable_node_behavior
+    if max_unavailable:
+        instance.upgrade_settings.max_unavailable = max_unavailable
 
     # custom headers
     aks_custom_headers = extract_comma_separated_string(

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
@@ -25,6 +25,7 @@ from azure.cli.command_modules.acs.addonconfiguration import (
 from azure.cli.command_modules.acs.custom import (
     _get_command_context,
     _update_addons,
+    aks_agentpool_upgrade,
     aks_enable_addons,
     aks_stop,
     is_monitoring_addon_enabled,
@@ -1454,6 +1455,42 @@ class TestAksEnableAddonsAutoHLSM(unittest.TestCase):
         _, kwargs = mock_ensure.call_args
         self.assertIsNone(kwargs.get("enable_high_log_scale_mode"))
 
+
+class AksAgentpoolUpgradeTest(unittest.TestCase):
+    def setUp(self):
+        self.cli = MockCLI()
+        self.cmd = MockCmd(self.cli)
+        self.models = AKSManagedClusterModels(self.cmd, ResourceType.MGMT_CONTAINERSERVICE)
+
+    @mock.patch("azure.cli.command_modules.acs.custom.sdk_no_wait")
+    def test_aks_agentpool_upgrade_sets_max_unavailable(self, mock_sdk_no_wait):
+        """Test that max_unavailable is set on upgrade_settings during agentpool upgrade."""
+        AgentPoolUpgradeSettings = self.cmd.get_models(
+            "AgentPoolUpgradeSettings",
+            resource_type=ResourceType.MGMT_CONTAINERSERVICE,
+            operation_group="managed_clusters",
+        )
+        instance = mock.Mock()
+        instance.orchestrator_version = "1.32.0"
+        instance.provisioning_state = "Succeeded"
+        instance.upgrade_settings = AgentPoolUpgradeSettings()
+
+        client = mock.Mock()
+        client.get.return_value = instance
+
+        aks_agentpool_upgrade(
+            self.cmd,
+            client,
+            resource_group_name="rg",
+            cluster_name="cluster",
+            nodepool_name="nodepool1",
+            kubernetes_version="1.33.0",
+            max_unavailable="5",
+            yes=True,
+        )
+
+        self.assertEqual(instance.upgrade_settings.max_unavailable, "5")
+        mock_sdk_no_wait.assert_called_once()
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
  - Fix `az aks nodepool upgrade --max-unavailable` being silently ignored
  - The `--max-unavailable` parameter was accepted and validated but never assigned to the agent pool's `upgrade_settings` before the PUT request
  - Added the missing assignment: `instance.upgrade_settings.max_unavailable = max_unavailable`

  Fixes #33195

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
Run "az aks nodepool upgrade `--max-unavailable` <value>" and verify the value is applied

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
