### PR TITLE
[App Config] Update retry policy for az appconfig dataplane commands

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appconfig/_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/_utils.py
@@ -173,18 +173,11 @@ class AuthHeaderRequestsTransport(RequestsTransport):  # pylint: disable=too-few
 
 def get_appconfig_data_client(cmd, name, connection_string, auth_mode, endpoint):
     azconfig_client = None
-    # Retry backoff schedule (exponential, factor=0.5, cap=30s, timeout=100s):
-    #   Retry 1: 0.5s  (cumulative:  0.5s)
-    #   Retry 2: 1.0s  (cumulative:  1.5s)
-    #   Retry 3: 2.0s  (cumulative:  3.5s)
-    #   Retry 4: 4.0s  (cumulative:  7.5s)
-    #   Retry 5: 8.0s  (cumulative: 15.5s)
-    #   Retry 6: 16.0s (cumulative: 31.5s)
-    #   Retry 7: 30.0s (cumulative: 61.5s)
-    #   Retry 8: 30.0s (cumulative: 91.5s)
-    #   Retry 9: timeout fires (~100s)
-    # We set retry count to a high number to allow the retry policy to retry until the timeout is reached,
-    # as the presence of a retry-after header from the service will cause the retry policy to ignore the exponential backoff
+    # Configure retries with exponential backoff (factor=0.5) capped at 30 seconds,
+    # with an overall retry timeout of 100 seconds.
+    # We set retry count to a high number so the retry policy can continue retrying until
+    # the timeout is reached. The actual retry timing may vary, for example when the service
+    # returns a Retry-After header and the policy uses that delay instead of the exponential backoff.
     retry_count = 9999
     retry_policy = RetryPolicy(
         retry_total=retry_count,

--- a/src/azure-cli/azure/cli/command_modules/appconfig/_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/_utils.py
@@ -183,9 +183,14 @@ def get_appconfig_data_client(cmd, name, connection_string, auth_mode, endpoint)
     #   Retry 7: 30.0s (cumulative: 61.5s)
     #   Retry 8: 30.0s (cumulative: 91.5s)
     #   Retry 9: timeout fires (~100s)
+    # We set retry count to a high number to allow the retry policy to retry until the timeout is reached,
+    # as the presence of a retry-after header from the service will cause the retry policy to ignore the exponential backoff
+    retry_count = 9999
     retry_policy = RetryPolicy(
-        retry_total=9,
-        retry_status=9,
+        retry_total=retry_count,
+        retry_connect=retry_count,
+        retry_read=retry_count,
+        retry_status=retry_count,
         retry_backoff_factor=0.5,
         retry_backoff_max=30,
         timeout=100  # seconds

--- a/src/azure-cli/azure/cli/command_modules/appconfig/_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/_utils.py
@@ -15,6 +15,7 @@ from azure.cli.core.azclierror import (ValidationError,
                                        ResourceNotFoundError,
                                        RequiredArgumentMissingError,
                                        MutuallyExclusiveArgumentError)
+from azure.core.pipeline.policies import RetryPolicy
 from azure.core.pipeline.transport import RequestsTransport  # pylint: disable=no-name-in-module
 from ._client_factory import cf_configstore
 from ._constants import HttpHeaders, FeatureFlagConstants
@@ -172,6 +173,23 @@ class AuthHeaderRequestsTransport(RequestsTransport):  # pylint: disable=too-few
 
 def get_appconfig_data_client(cmd, name, connection_string, auth_mode, endpoint):
     azconfig_client = None
+    # Retry backoff schedule (exponential, factor=0.5, cap=30s, timeout=100s):
+    #   Retry 1: 0.5s  (cumulative:  0.5s)
+    #   Retry 2: 1.0s  (cumulative:  1.5s)
+    #   Retry 3: 2.0s  (cumulative:  3.5s)
+    #   Retry 4: 4.0s  (cumulative:  7.5s)
+    #   Retry 5: 8.0s  (cumulative: 15.5s)
+    #   Retry 6: 16.0s (cumulative: 31.5s)
+    #   Retry 7: 30.0s (cumulative: 61.5s)
+    #   Retry 8: 30.0s (cumulative: 91.5s)
+    #   Retry 9: timeout fires (~100s)
+    retry_policy = RetryPolicy(
+        retry_total=9,
+        retry_status=9,
+        retry_backoff_factor=0.5,
+        retry_backoff_max=30,
+        timeout=100 # seconds
+    )
 
     if auth_mode == "anonymous":
         try:
@@ -180,7 +198,8 @@ def get_appconfig_data_client(cmd, name, connection_string, auth_mode, endpoint)
                 credential=AzureKeyCredential(key=""),
                 id_credential="",
                 user_agent=HttpHeaders.USER_AGENT,
-                transport=AuthHeaderRequestsTransport())
+                transport=AuthHeaderRequestsTransport(),
+                retry_policy=retry_policy)
         except (ValueError, TypeError) as ex:
             raise CLIError("Failed to initialize AzureAppConfigurationClient due to an exception: {}".format(str(ex)))
 
@@ -188,7 +207,8 @@ def get_appconfig_data_client(cmd, name, connection_string, auth_mode, endpoint)
         connection_string = resolve_connection_string(cmd, name, connection_string)
         try:
             azconfig_client = AzureAppConfigurationClient.from_connection_string(connection_string=connection_string,
-                                                                                 user_agent=HttpHeaders.USER_AGENT)
+                                                                                 user_agent=HttpHeaders.USER_AGENT,
+                                                                                 retry_policy=retry_policy)
         except ValueError as ex:
             raise CLIError("Failed to initialize AzureAppConfigurationClient due to an exception: {}".format(str(ex)))
 
@@ -216,7 +236,8 @@ def get_appconfig_data_client(cmd, name, connection_string, auth_mode, endpoint)
         try:
             azconfig_client = AzureAppConfigurationClient(credential=AppConfigurationCliCredential(cred, token_audience),
                                                           base_url=endpoint,
-                                                          user_agent=HttpHeaders.USER_AGENT)
+                                                          user_agent=HttpHeaders.USER_AGENT,
+                                                          retry_policy=retry_policy)
         except (ValueError, TypeError) as ex:
             raise CLIError("Failed to initialize AzureAppConfigurationClient due to an exception: {}".format(str(ex)))
 

--- a/src/azure-cli/azure/cli/command_modules/appconfig/_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/_utils.py
@@ -188,7 +188,7 @@ def get_appconfig_data_client(cmd, name, connection_string, auth_mode, endpoint)
         retry_status=9,
         retry_backoff_factor=0.5,
         retry_backoff_max=30,
-        timeout=100 # seconds
+        timeout=100  # seconds
     )
 
     if auth_mode == "anonymous":


### PR DESCRIPTION
**Related command**
`az appconfig kv import`, `az appconfig kv export`, `az appconfig kv set`, `az appconfig kv list`, and all other App Configuration data-plane commands.

**Description**
The App Configuration data-plane client (`AzureAppConfigurationClient`) was using azure-core's default retry settings: 3 status-code retries with a 0.8s backoff factor. This resulted in a cumulative retry window of only ~5.6 seconds before giving up, which was not enough to effectively cover temporary server or network issues. 

This PR configures an explicit `RetryPolicy` on the `AzureAppConfigurationClient` in `get_appconfig_data_client()` with a timeout-driven retry strategy:

- `retry_total` / `retry_connect` / `retry_read` / `retry_status` all set to `9999` — a deliberately high count so retries are governed by the timeout rather than a fixed attempt limit
- `retry_backoff_factor=0.5` — exponential backoff starting at 0.5s
- `retry_backoff_max=30` — cap individual backoff delays at 30s
- `timeout=100` — hard ceiling of 100s across all retry attempts

The high retry count ensures the policy keeps retrying until the 100-second timeout is reached, rather than stopping after a fixed number of attempts. This accommodates scenarios where the service returns `Retry-After` headers with varying delays. The retry policy is applied to all three client construction paths (key, login, and anonymous auth modes).

**Testing Guide**
Existing appconfig tests should pass unchanged — the retry policy only activates on transient failures.

```
azdev test appconfig
```

**History Notes**

[App Configuration] `az appconfig`: Increase retry resilience for data-plane operations to better handle transient server throttling (HTTP 429) and network errors

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
