### PR TITLE
[POSTGRESQL] `az postgres flexible-server create`: Announce breaking change deprecation of `--cluster-option` argument

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/postgresql/_breaking_change.py
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/_breaking_change.py
@@ -4,10 +4,10 @@
 # --------------------------------------------------------------------------------------------
 
 from azure.cli.core.breaking_change import (
-NextBreakingChangeWindow,
-register_argument_deprecate,
-register_command_group_deprecate,
-register_other_breaking_change
+    NextBreakingChangeWindow,
+    register_argument_deprecate,
+    register_command_group_deprecate,
+    register_other_breaking_change
 )
 
 NETWORK_RESOURCE_BREAKING_CHANGE_MESSAGE = (

--- a/src/azure-cli/azure/cli/command_modules/postgresql/_breaking_change.py
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/_breaking_change.py
@@ -3,15 +3,14 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from azure.cli.core.breaking_change import (register_argument_deprecate, register_command_group_deprecate,
+from azure.cli.core.breaking_change import (NextBreakingChangeWindow, register_argument_deprecate, register_command_group_deprecate,
                                             register_other_breaking_change)
 
 NETWORK_RESOURCE_BREAKING_CHANGE_MESSAGE = (
     'This command will stop creating new network resources or altering existing ones which are required '
     'for the server to function, such as virtual networks, subnets, IP ranges, etc. It will instead '
     'require users to provide the necessary network resources created beforehand using the corresponding '
-    'commands from the `az network` module. This change will take effect in next breaking change '
-    'release scheduled for May 2026.'
+    'commands from the `az network` module.'
 )
 
 
@@ -109,11 +108,11 @@ register_other_breaking_change('postgres flexible-server migration',
 # Replica command argument changes
 register_argument_deprecate('postgres flexible-server replica create', '--replica-name', redirect='--name')
 
-# Elastic cluster command argument deprecated and will be removed in the future as cluster
-# option will be determined by node count argument alone, where any value provided for node
-# count will indicate an elastic cluster.
+# Elastic cluster command argument deprecated and will be removed in the future. Today,
+# users must specify both --cluster-option ElasticCluster and --node-count to create an
+# elastic cluster. In the future, providing --node-count alone will imply an elastic cluster.
 register_argument_deprecate(command='postgres flexible-server create', argument='--cluster-option',
-                            message='The --cluster-option argument has been deprecated and will be '
-                            'removed. When --node-count argument is passed, it will assume it refers '
-                            'to an elastic cluster. This change will take effect in next breaking '
-                            'change release scheduled for May 2026.')
+                            message='Currently, to create an elastic cluster you must specify '
+                            '--cluster-option ElasticCluster together with --node-count. In the '
+                            'future, providing --node-count alone will imply an elastic cluster.',
+                            target_version=NextBreakingChangeWindow())

--- a/src/azure-cli/azure/cli/command_modules/postgresql/_breaking_change.py
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/_breaking_change.py
@@ -108,3 +108,12 @@ register_other_breaking_change('postgres flexible-server migration',
 
 # Replica command argument changes
 register_argument_deprecate('postgres flexible-server replica create', '--replica-name', redirect='--name')
+
+# Elastic cluster command argument deprecated and will be removed in the future as cluster
+# option will be determined by node count argument alone, where any value provided for node
+# count will indicate an elastic cluster.
+register_argument_deprecate(command='postgres flexible-server create', argument='--cluster-option',
+                            message='The --cluster-option argument has been deprecated and will be '
+                            'removed. When --node-count argument is passed, it will assume it refers '
+                            'to an elastic cluster. This change will take effect in next breaking '
+                            'change release scheduled for May 2026.')

--- a/src/azure-cli/azure/cli/command_modules/postgresql/_breaking_change.py
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/_breaking_change.py
@@ -3,8 +3,12 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from azure.cli.core.breaking_change import (NextBreakingChangeWindow, register_argument_deprecate, register_command_group_deprecate,
-                                            register_other_breaking_change)
+from azure.cli.core.breaking_change import (
+NextBreakingChangeWindow,
+register_argument_deprecate,
+register_command_group_deprecate,
+register_other_breaking_change
+)
 
 NETWORK_RESOURCE_BREAKING_CHANGE_MESSAGE = (
     'This command will stop creating new network resources or altering existing ones which are required '


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az postgres flexible server create`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->
[PostgreSQL] `az postgres flexible-server create`: Announce breaking change deprecation of `--cluster-option` argument

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
