### PR TITLE
[AKS] Fix az aks update --enable-azure-monitor-metrics: Handle 409 RoleAssignmentExists in Grafana link

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/amg/link.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/amg/link.py
@@ -4,13 +4,17 @@
 # --------------------------------------------------------------------------------------------
 import json
 import uuid
+from knack.log import get_logger
 from knack.util import CLIError
+from azure.core.exceptions import HttpResponseError
 from azure.cli.command_modules.acs.azuremonitormetrics.constants import (
     GRAFANA_API,
     GRAFANA_ROLE_ASSIGNMENT_API,
     GrafanaLink
 )
 from azure.cli.command_modules.acs.azuremonitormetrics.helper import sanitize_resource_id
+
+logger = get_logger(__name__)
 
 
 # pylint: disable=line-too-long
@@ -70,9 +74,14 @@ def link_grafana_instance(cmd, raw_parameters, azure_monitor_workspace_resource_
                 GRAFANA_ROLE_ASSIGNMENT_API,
                 association_body
             )
-        except CLIError as e:
-            # If already exists (409), ignore, else print error
-            if not (hasattr(e, "status_code") and e.status_code == 409):
+        except HttpResponseError as e:
+            # If already exists (RoleAssignmentExists), warn and continue, else print error
+            if e.error and e.error.code == "RoleAssignmentExists":
+                logger.warning(
+                    "Monitoring Data Reader role assignment already exists on the Azure Monitor Workspace "
+                    "for the Grafana managed identity. Skipping role assignment."
+                )
+            else:
                 erroString = (
                     f"Role Assignment failed. Please manually assign the `Monitoring Data Reader` role\n"
                     f"to the Azure Monitor Workspace ({azure_monitor_workspace_resource_id}) "

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
@@ -8049,7 +8049,7 @@ spec:
         # wait for cluster to fully settle before issuing next update
         self.cmd('aks wait --resource-group={resource_group} --name={name} --updated --interval 30 --timeout 600')
         if self.is_live or self.in_recording:
-            time.sleep(60)
+            time.sleep(180)
 
         # update: disable-azure-monitor-metrics
         update_cmd = 'aks update --resource-group={resource_group} --name={name} --yes --output=json ' \

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/test_helper.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/test_helper.py
@@ -5,10 +5,13 @@
 import unittest
 from unittest.mock import ANY, patch, MagicMock
 
+from azure.core.exceptions import HttpResponseError, ODataV4Format
 from azure.cli.command_modules.acs.azuremonitormetrics.helper import (
     sanitize_resource_id,
     rp_registrations
 )
+from azure.cli.command_modules.acs.azuremonitormetrics.amg.link import link_grafana_instance
+from azure.cli.command_modules.acs.azuremonitormetrics.constants import GrafanaLink
 
 class TestHelper(unittest.TestCase):
 
@@ -37,6 +40,85 @@ class TestHelper(unittest.TestCase):
         # Assert that register_rps was called with the correct subscription_id
         mock_register_rps.assert_any_call(cmd, "mocked_subscription_id", ANY, ANY)
         mock_register_rps.assert_any_call(cmd, cluster_subscription_id, ANY, ANY)
+
+
+class TestLinkGrafanaInstance(unittest.TestCase):
+
+    def _build_mocks(self):
+        cmd = MagicMock()
+        mock_resources = MagicMock()
+        grafana_response = MagicMock()
+        grafana_response.identity = MagicMock()
+        grafana_response.identity.type = "SystemAssigned"
+        grafana_response.identity.principal_id = "test-principal-id"
+        grafana_response.as_dict.return_value = {
+            "properties": {
+                "grafanaIntegrations": {
+                    "azureMonitorWorkspaceIntegrations": []
+                }
+            }
+        }
+        mock_resources.get_by_id.return_value = grafana_response
+        return cmd, mock_resources
+
+    @patch('azure.cli.command_modules.acs._client_factory.get_resources_client')
+    def test_link_grafana_409_role_assignment_exists_continues(self, mock_get_client):
+        """409 RoleAssignmentExists should warn and continue, not abort."""
+        cmd, mock_resources = self._build_mocks()
+        mock_get_client.return_value = mock_resources
+
+        error = HttpResponseError(message="The role assignment already exists.")
+        error.status_code = 409
+        error.error = ODataV4Format({"error": {"code": "RoleAssignmentExists", "message": "exists"}})
+
+        # First call is get_by_id (grafana GET), second and third are begin_create_or_update_by_id
+        # Role assignment call (first begin_create_or_update_by_id) raises 409
+        mock_resources.begin_create_or_update_by_id.side_effect = [error, MagicMock()]
+
+        raw_parameters = {
+            "grafana_resource_id": "/subscriptions/00000000/resourceGroups/rg/providers/Microsoft.Dashboard/grafana/test",
+            "subscription_id": "00000000"
+        }
+        result = link_grafana_instance(cmd, raw_parameters, "/subscriptions/00000000/resourceGroups/rg/providers/microsoft.monitor/accounts/amw")
+
+        self.assertEqual(result, GrafanaLink.SUCCESS)
+        # begin_create_or_update_by_id called twice: role assignment (409) + AMW integration
+        self.assertEqual(mock_resources.begin_create_or_update_by_id.call_count, 2)
+
+    @patch('azure.cli.command_modules.acs._client_factory.get_resources_client')
+    def test_link_grafana_no_grafana_id_returns_noparamprovided(self, mock_get_client):
+        """No grafana_resource_id should return NOPARAMPROVIDED."""
+        cmd = MagicMock()
+        raw_parameters = {"grafana_resource_id": "", "subscription_id": "00000000"}
+        result = link_grafana_instance(cmd, raw_parameters, "/subscriptions/00000000/rg/providers/microsoft.monitor/accounts/amw")
+        self.assertEqual(result, GrafanaLink.NOPARAMPROVIDED)
+
+    @patch('azure.cli.command_modules.acs._client_factory.get_resources_client')
+    def test_link_grafana_amw_already_linked_returns_alreadypresent(self, mock_get_client):
+        """If AMW integration already exists on Grafana, return ALREADYPRESENT."""
+        cmd, mock_resources = self._build_mocks()
+        mock_get_client.return_value = mock_resources
+
+        amw_id = "/subscriptions/00000000/resourcegroups/rg/providers/microsoft.monitor/accounts/amw"
+        mock_resources.begin_create_or_update_by_id.return_value = MagicMock()  # role assignment succeeds
+        grafana_response = mock_resources.get_by_id.return_value
+        grafana_response.as_dict.return_value = {
+            "properties": {
+                "grafanaIntegrations": {
+                    "azureMonitorWorkspaceIntegrations": [
+                        {"azureMonitorWorkspaceResourceId": amw_id}
+                    ]
+                }
+            }
+        }
+
+        raw_parameters = {
+            "grafana_resource_id": "/subscriptions/00000000/resourceGroups/rg/providers/Microsoft.Dashboard/grafana/test",
+            "subscription_id": "00000000"
+        }
+        result = link_grafana_instance(cmd, raw_parameters, amw_id)
+        self.assertEqual(result, GrafanaLink.ALREADYPRESENT)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Related command**
`az aks update --enable-azure-monitor-metrics`

**Description**

When running `az aks update --enable-azure-monitor-metrics` with `--grafana-resource-id` on a cluster where the Monitoring Data Reader role assignment already exists on the Azure Monitor Workspace, the command fails with:

```
ERROR: (RoleAssignmentExists) The role assignment already exists.
```

This happens because the inner `except CLIError` in `amg/link.py` does not catch the Azure SDK's `HttpResponseError`. The exception bubbles up to the outer `except Exception` which re-raises it as `CLIError`, aborting the entire flow before:
- Grafana-AMW integration is created
- Recording rules are created
- The addon PUT (`azureMonitorProfile.metrics.enabled=true`) is applied

**Fix:**
- Changed the inner exception handler from `except CLIError` to `except HttpResponseError` (from `azure.core.exceptions`)
- On 409/RoleAssignmentExists, log a `logger.warning()` and continue instead of aborting
- Passes `azdev style acs` (pylint + flake8)

**Testing Guide**

1. Create an AKS cluster, AMW, and Grafana resource
2. Run `az aks update --enable-azure-monitor-metrics` with all three resource IDs - succeeds
3. Run `az aks update --disable-azure-monitor-metrics`
4. Run `az aks update --enable-azure-monitor-metrics` again (role assignment still exists from step 2)
   - **Before fix**: Fails with `ERROR: (RoleAssignmentExists)`
   - **After fix**: Prints `WARNING: Monitoring Data Reader role assignment already exists...` and completes successfully

**History Notes**

[AKS] `az aks update`: Fix `--enable-azure-monitor-metrics` failing with RoleAssignmentExists when Grafana role assignment already exists

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
