### PR TITLE
[KeyVault] Reporter claims `--expires` flag on `az keyvault secret set` silently passes invalid dates to the service, but the existing `datetime_type` validator in keyvault/_validators.py should already catch this case. (#33233)

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/keyvault/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_validators.py
@@ -510,7 +510,9 @@ def datetime_type(string):
             return datetime.strptime(string, form).replace(tzinfo=timezone.utc)
         except ValueError:  # checks next format
             pass
-    raise ValueError("Input '{}' not valid. Valid example: 2000-12-31T12:59:59Z".format(string))
+    raise ValueError(
+        "Input '{}' not valid. Expected format: YYYY-MM-DD, YYYY-MM-DDTHHZ, "
+        "YYYY-MM-DDTHH:MMZ, or YYYY-MM-DDTHH:MM:SSZ (e.g., 2000-12-31T12:59:59Z)".format(string))
 
 
 def _get_base_url_type(cli_ctx, service):


### PR DESCRIPTION
## Fix: Reporter claims `--expires` flag on `az keyvault secret set` silently passes invalid dates to the service, but the existing `datetime_type` validator in keyvault/_validators.py should already catch this case. (#33233)

### Problem
Reporter claims `--expires` flag on `az keyvault secret set` silently passes invalid dates to the service, but the existing `datetime_type` validator in keyvault/_validators.py should already catch this case.

### Root Cause
The `--expires` parameter for `az keyvault secret set` is defined in `src/azure-cli/azure/cli/command_modules/keyvault/_params.py` (line 529) with `type=datetime_type`. The `datetime_type` function is implemented in `_validators.py` (lines 503-513) and tries parsing the input against four accepted formats: `%Y-%m-%dT%H:%M:%SZ`, `%Y-%m-%dT%H:%MZ`, `%Y-%m-%dT%HZ`, and `%Y-%m-%d`. If none match, it raises `ValueError("Input '...' not valid. Valid example: 2000-12-31T12:59:59Z")`. Python's `datetime.strptime` correctly rejects '2025-13-45' with the `%Y-%m-%d` format because month 13 is invalid. This means the CLI **should already catch this invalid input** before sending the request. The reported behavior (400 Bad Request from the service) is likely not reproducible with the current codebase (v2.85.0). However, the error message raised by the validator could be improved for clarity — it currently says 'Input X not valid. Valid example: 2000-12-31T12:59:59Z' rather than a more user-friendly format explanation. Note: The issue body explicitly states '*This is a test issue for demonstrating the Sentinel triage agent.*'

### Fix
If the bug is confirmed reproducible, investigate whether the `type=datetime_type` is being bypassed in some code path. If it's just an error message improvement, update the ValueError message in `datetime_type()` in `_validators.py` (line 513) to be more descriptive: e.g., `"Invalid date format for input '{}'. Expected format: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ (e.g., 2000-12-31T12:59:59Z)"`.

### Agent Output
<details>
<summary>Sentinel fix generation log</summary>



```json
{
  "issue_number": 33233,
  "repository": "Azure/azure-cli",
  "summary": "Reporter claims `--expires` flag on `az keyvault secret set` silently passes invalid dates to the service, but the existing `datetime_type` validator in keyvault/_validators.py already catches this case.",
  "category": "bug",
  "severity": "P3-low",
  "component": "KeyVault",
  "root_cause_analysis": "The `--expires` parameter is defined in `_params.py` (line 529) with `type=datetime_type`. The `datetime_type` function in `_validators.py` (lines 503-513) already validates against four formats and raises ValueError on mismatch. Python's `strptime` correctly rejects '2025-13-45'. The reported 400 Bad Request from the service is likely not reproducible on current versions. The issue is a test issue for demonstrating the Sentinel triage agent.",
  "duplicate_check": "No duplicates found.",
  "scope": "in-scope",
  "scope_reasoning": "KeyVault commands are owned by the Identity Squad.",
  "verdict": "ActionRequired",
  "recommended_labels": ["KeyVault", "bug", "act-identity-squad"],
  "fix_feasibility": "easy",
  "fix_description": "Improved the ValueError message in `datetime_type()` to explicitly list all four accepted date formats instead of showing a single example.",
  "fix_status": "completed",
  "fix_branch": "sentinel/fix-33233",
  "fix_files_changed": [
    "src/azure-cli/azure/cli/command_modules/keyvault/_validators.py"
  ],
  "fix_summary": "Changed error message from 'Input X not valid. Valid example: 2000-12-31T12:59:59Z' to 'Input X not valid. Expected format: YYYY-MM-DD, YYYY-MM-DDTHHZ, YYYY-MM-DDTHH:MMZ, or YYYY-MM-DDTHH:MM:SSZ (e.g., 2000-12-31T12:59:59Z)'. Branch pushed; PR creation deferred to human reviewer.",
  "tests_passed": true
}
```

</details>

---
Fixes #33233

*🤖 Generated by Sentinel — ACT Identity Squad triage agent.*
*This PR requires human review before merge.*
