### PR TITLE
{Core} Restore sequential module loading

### DIFF
--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -318,6 +318,7 @@ class MainCommandsLoader(CLICommandsLoader):
 
             start_time = time.perf_counter()
             logger.debug("Loading command modules...")
+            logger.debug(self.header_mod)
             results = self._load_modules(args, command_modules)
 
             count, cumulative_group_count, cumulative_command_count = \
@@ -680,6 +681,8 @@ class MainCommandsLoader(CLICommandsLoader):
             module_command_table, module_group_table, command_loader = _load_module_command_loader(self, args, mod)
             import_module_breaking_changes(mod)
             elapsed_time = time.perf_counter() - start_time
+            logger.debug(self.item_format_string, mod, elapsed_time,
+                         len(module_group_table), len(module_command_table))
             return ModuleLoadResult(mod, module_command_table, module_group_table, elapsed_time, command_loader=command_loader)
         except Exception as ex:  # pylint: disable=broad-except
             tb_str = traceback.format_exc()
@@ -712,13 +715,9 @@ class MainCommandsLoader(CLICommandsLoader):
         self.command_table.update(result.command_table)
         self.command_group_table.update(result.group_table)
 
-        logger.debug(self.item_format_string, result.module_name, result.elapsed_time,
-                     len(result.group_table), len(result.command_table))
-
     def _process_results_with_timing(self, results):
         """Process pre-loaded module results with timing and progress reporting."""
         logger.debug("Loaded command modules:")
-        logger.debug(self.header_mod)
 
         count = 0
         cumulative_group_count = 0

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -37,10 +37,6 @@ REFRESH_EXTENSION_HELP_OVERLAY_SENTINEL = '__refresh_extension_help_overlay__'
 ALWAYS_LOADED_MODULES = []
 # Extensions that will always be loaded if installed. They don't expose commands but hook into CLI core.
 ALWAYS_LOADED_EXTENSIONS = ['azext_ai_examples', 'azext_next']
-# Timeout (in seconds) for loading a single module. Acts as a safety valve to prevent indefinite hangs
-MODULE_LOAD_TIMEOUT_SECONDS = 60
-# Maximum number of worker threads for parallel module loading.
-MAX_WORKER_THREAD_COUNT = 4
 
 
 def _get_top_level_command(args):
@@ -664,42 +660,14 @@ class MainCommandsLoader(CLICommandsLoader):
                 loader._update_command_definitions()  # pylint: disable=protected-access
 
     def _load_modules(self, args, command_modules):
-        """Load command modules using ThreadPoolExecutor with timeout protection."""
-        import concurrent.futures
-        from concurrent.futures import ThreadPoolExecutor
+        """Load command modules sequentially."""
         from azure.cli.core.commands import BLOCKED_MODS
 
         results = []
-        with ThreadPoolExecutor(max_workers=MAX_WORKER_THREAD_COUNT) as executor:
-            future_to_module = {executor.submit(self._load_single_module, mod, args): mod
-                                for mod in command_modules if mod not in BLOCKED_MODS}
-
-            try:
-                for future in concurrent.futures.as_completed(future_to_module, timeout=MODULE_LOAD_TIMEOUT_SECONDS):
-                    try:
-                        result = future.result()
-                        results.append(result)
-                    except (ImportError, AttributeError, TypeError, ValueError) as ex:
-                        mod = future_to_module[future]
-                        logger.warning("Module '%s' load failed: %s", mod, ex)
-                        results.append(ModuleLoadResult(mod, {}, {}, 0, ex))
-                    except Exception as ex:  # pylint: disable=broad-exception-caught
-                        mod = future_to_module[future]
-                        logger.warning("Module '%s' load failed with unexpected exception: %s", mod, ex)
-                        results.append(ModuleLoadResult(mod, {}, {}, 0, ex))
-            except concurrent.futures.TimeoutError:
-                for future, mod in future_to_module.items():
-                    if future.done():
-                        try:
-                            result = future.result()
-                            results.append(result)
-                        except Exception as ex:  # pylint: disable=broad-exception-caught
-                            logger.warning("Module '%s' load failed: %s", mod, ex)
-                            results.append(ModuleLoadResult(mod, {}, {}, 0, ex))
-                    else:
-                        logger.warning("Module '%s' load timeout after %s seconds", mod, MODULE_LOAD_TIMEOUT_SECONDS)
-                        results.append(ModuleLoadResult(mod, {}, {}, 0,
-                                                        Exception(f"Module '{mod}' load timeout")))
+        for mod in command_modules:
+            if mod in BLOCKED_MODS:
+                continue
+            results.append(self._load_single_module(mod, args))
 
         return results
 
@@ -749,7 +717,7 @@ class MainCommandsLoader(CLICommandsLoader):
 
     def _process_results_with_timing(self, results):
         """Process pre-loaded module results with timing and progress reporting."""
-        logger.debug("Loaded command modules in parallel:")
+        logger.debug("Loaded command modules:")
         logger.debug(self.header_mod)
 
         count = 0

--- a/src/azure-cli-core/azure/cli/core/tests/test_command_registration.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_command_registration.py
@@ -284,7 +284,7 @@ class TestCommandRegistration(unittest.TestCase):
 
         # Load all commands.
         cmd_tbl = loader.load_command_table(None)
-        
+
         # Verify EVERY command in command_table has an entry in cmd_to_loader_map
         # This is exactly what azdev does before it hits KeyError
         for cmd_name in cmd_tbl:

--- a/src/azure-cli-core/azure/cli/core/tests/test_command_registration.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_command_registration.py
@@ -275,14 +275,14 @@ class TestCommandRegistration(unittest.TestCase):
     @mock.patch('azure.cli.core.commands._load_command_loader', _mock_load_command_loader)
     @mock.patch('azure.cli.core.extension.get_extension_modname', _mock_get_extension_modname)
     @mock.patch('azure.cli.core.extension.get_extensions', _mock_get_extensions)
-    def test_cmd_to_loader_map_populated_after_parallel_loading(self):
+    def test_cmd_to_loader_map_populated_after_command_loading(self):
         """
         Validates that all commands in command_table have corresponding entries in cmd_to_loader_map.
         """
         cli = DummyCli()
         loader = cli.commands_loader
 
-        # Load all commands (triggers parallel module loading)
+        # Load all commands.
         cmd_tbl = loader.load_command_table(None)
         
         # Verify EVERY command in command_table has an entry in cmd_to_loader_map


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

In #32730 we implemented a thread pool to speed command module loading. However since that improvement we have implemented a pre-built command index which removes the main performance bottleneck we were trying to improve (situations where all core modules needed to be loaded). 

Since adding a thread pool adds complexity and risk, and the reason for introducing it has been addressed via a superior solution, we consider it safer to remove the usage of a thread pool. 

An issue with deadlocks seems to be pronounced when using Python 3.14 (#32980), Python 3.14 is not yet supported by Azure-cli, but will be soon. (#32869)

**Testing Guide**
<!--Example commands with explanations.-->

To reproduce error:

Create and setup a `venv` using Python 3.14,

Attempt a command such as `az aks --help` on `dev` branch. 

You may see an error such as:
<img width="1297" height="492" alt="image" src="https://github.com/user-attachments/assets/ce62101a-ab2a-4f06-8ddb-6b3045433fab" />

With `core.use_command_index` set to `true`, the error may be sporadic, if you set: `az config set core.use_command_index=false`, you should see it a lot more frequently. 

The above commands/config on this branch on a `3.14` venv should not produce those errors.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
