### PR TITLE
[App Service] `az webapp create`: Add error message that clearly lists all valid options and tells them how to discover available runtimes

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -270,9 +270,10 @@ def create_webapp(cmd, resource_group_name, name, plan, runtime=None, startup_fi
                         multicontainer_config_file, deployment_container_image_name, sitecontainers_app]):
                 raise ArgumentUsageError('Creating a Linux webapp requires one of the following: '
                                          '--runtime, --container-image-name, '
-                                         '--multicontainer-config-type with --multicontainer-config-file, '
                                          'or --sitecontainers-app. '
-                                         "Run 'az webapp list-runtimes --os-type linux' for supported runtimes.")
+                                         "Run 'az webapp list-runtimes --os-type linux' for supported runtimes. "
+                                         "For custom containers, see 'az webapp sitecontainers create': "
+                                         "https://learn.microsoft.com/cli/azure/webapp/sitecontainers")
             if deployment_container_image_name:
                 raise ArgumentUsageError('Please specify both --multicontainer-config-type TYPE '
                                          'and --multicontainer-config-file FILE, '

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -266,6 +266,13 @@ def create_webapp(cmd, resource_group_name, name, plan, runtime=None, startup_fi
         if not validate_container_app_create_options(runtime, container_image_name,
                                                      multicontainer_config_type, multicontainer_config_file,
                                                      sitecontainers_app):
+            if not any([runtime, container_image_name, multicontainer_config_type,
+                        multicontainer_config_file, deployment_container_image_name, sitecontainers_app]):
+                raise ArgumentUsageError('Creating a Linux webapp requires one of the following: '
+                                         '--runtime, --container-image-name, '
+                                         '--multicontainer-config-type with --multicontainer-config-file, '
+                                         'or --sitecontainers-app. '
+                                         "Run 'az webapp list-runtimes --os linux' for supported runtimes.")
             if deployment_container_image_name:
                 raise ArgumentUsageError('Please specify both --multicontainer-config-type TYPE '
                                          'and --multicontainer-config-file FILE, '

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -272,7 +272,7 @@ def create_webapp(cmd, resource_group_name, name, plan, runtime=None, startup_fi
                                          '--runtime, --container-image-name, '
                                          'or --sitecontainers-app. '
                                          "Run 'az webapp list-runtimes --os-type linux' for supported runtimes. "
-                                         "For custom containers, see 'az webapp sitecontainers create': "
+                                         "For custom containers, see 'az webapp sitecontainers create --help': "
                                          "https://learn.microsoft.com/cli/azure/webapp/sitecontainers")
             if deployment_container_image_name:
                 raise ArgumentUsageError('Please specify both --multicontainer-config-type TYPE '

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -272,18 +272,18 @@ def create_webapp(cmd, resource_group_name, name, plan, runtime=None, startup_fi
                                          '--runtime, --container-image-name, '
                                          '--multicontainer-config-type with --multicontainer-config-file, '
                                          'or --sitecontainers-app. '
-                                         "Run 'az webapp list-runtimes --os linux' for supported runtimes.")
+                                         "Run 'az webapp list-runtimes --os-type linux' for supported runtimes.")
             if deployment_container_image_name:
                 raise ArgumentUsageError('Please specify both --multicontainer-config-type TYPE '
                                          'and --multicontainer-config-file FILE, '
                                          'and only specify one out of --runtime, '
                                          '--deployment-container-image-name, --multicontainer-config-type '
-                                         'or --sitecontainers_app')
+                                         'or --sitecontainers-app')
             raise ArgumentUsageError('Please specify both --multicontainer-config-type TYPE '
                                      'and --multicontainer-config-file FILE, '
                                      'and only specify one out of --runtime, '
                                      '--container-image-name, --multicontainer-config-type '
-                                     'or --sitecontainers_app')
+                                     'or --sitecontainers-app')
         if startup_file:
             site_config.app_command_line = startup_file
         if sitecontainers_app:

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands_thru_mock.py
@@ -10,10 +10,10 @@ from azure.core.exceptions import HttpResponseError
 
 from azure.mgmt.web import WebSiteManagementClient
 from knack.util import CLIError
-from azure.cli.core.azclierror import (ArgumentUsageError,
-                                       InvalidArgumentValueError,
+from azure.cli.core.azclierror import (InvalidArgumentValueError,
                                        MutuallyExclusiveArgumentError,
-                                       AzureResponseError)
+                                       AzureResponseError,
+                                       ArgumentUsageError)
 from azure.cli.command_modules.appservice.custom import (set_deployment_user,
                                                          update_git_token, add_hostname,
                                                          update_site_configs,
@@ -27,7 +27,6 @@ from azure.cli.command_modules.appservice.custom import (set_deployment_user,
                                                          get_streaming_log,
                                                          download_historical_logs,
                                                          validate_container_app_create_options,
-                                                         create_webapp,
                                                          restore_deleted_webapp,
                                                          list_snapshots,
                                                          restore_snapshot,
@@ -35,7 +34,8 @@ from azure.cli.command_modules.appservice.custom import (set_deployment_user,
                                                          add_github_actions,
                                                          update_app_settings,
                                                          update_application_settings_polling,
-                                                         update_webapp)
+                                                         update_webapp,
+                                                         create_webapp)
 
 # pylint: disable=line-too-long
 from azure.cli.core.profiles import ResourceType

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands_thru_mock.py
@@ -10,7 +10,8 @@ from azure.core.exceptions import HttpResponseError
 
 from azure.mgmt.web import WebSiteManagementClient
 from knack.util import CLIError
-from azure.cli.core.azclierror import (InvalidArgumentValueError,
+from azure.cli.core.azclierror import (ArgumentUsageError,
+                                       InvalidArgumentValueError,
                                        MutuallyExclusiveArgumentError,
                                        AzureResponseError)
 from azure.cli.command_modules.appservice.custom import (set_deployment_user,
@@ -26,6 +27,7 @@ from azure.cli.command_modules.appservice.custom import (set_deployment_user,
                                                          get_streaming_log,
                                                          download_historical_logs,
                                                          validate_container_app_create_options,
+                                                         create_webapp,
                                                          restore_deleted_webapp,
                                                          list_snapshots,
                                                          restore_snapshot,
@@ -435,6 +437,36 @@ class TestWebappMocked(unittest.TestCase):
         self.assertFalse(validate_container_app_create_options(some_runtime, test_docker_image, test_multi_container_config, None))
         self.assertFalse(validate_container_app_create_options(None, None, test_multi_container_config, None))
         self.assertFalse(validate_container_app_create_options(None, None, None, None))
+
+    @mock.patch('azure.cli.command_modules.appservice.custom.web_client_factory', autospec=True)
+    @mock.patch('azure.cli.command_modules.appservice.custom._StackRuntimeHelper', autospec=True)
+    @mock.patch('azure.cli.command_modules.appservice.custom.get_site_availability', autospec=True)
+    def test_linux_webapp_create_no_runtime_raises_error(self, get_site_avail_mock,
+                                                         stack_helper_mock, web_client_mock):
+        cmd_mock = _get_test_cmd()
+        SiteConfig, SkuDescription, NameValuePair = cmd_mock.get_models(
+            'SiteConfig', 'SkuDescription', 'NameValuePair')
+        cmd_mock.get_models = mock.MagicMock(return_value=(SiteConfig, SkuDescription, NameValuePair))
+
+        # Mock a Linux plan (reserved=True)
+        plan_info = mock.MagicMock()
+        plan_info.reserved = True
+        plan_info.location = 'eastus'
+        plan_info.id = '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Web/serverfarms/plan'
+        plan_info.sku = SkuDescription(name='F1')
+        web_client_mock.return_value.app_service_plans.get.return_value = plan_info
+
+        # Mock site availability (new app name)
+        name_validation = mock.MagicMock()
+        name_validation.name_available = True
+        get_site_avail_mock.return_value = name_validation
+
+        with self.assertRaises(ArgumentUsageError) as context:
+            create_webapp(cmd_mock, 'test-rg', 'test-app', 'test-plan')
+
+        self.assertIn('Creating a Linux webapp requires one of the following', str(context.exception))
+        self.assertIn('--runtime', str(context.exception))
+        self.assertIn('--os-type linux', str(context.exception))
 
     @mock.patch('azure.cli.command_modules.appservice.custom._verify_hostname_binding', autospec=True)
     @mock.patch('azure.cli.command_modules.appservice.custom.web_client_factory', autospec=True)


### PR DESCRIPTION
**Related command**
`az webapp create`

**Description**<!--Mandatory-->
The old message is misleading - it tells users to "specify both --multicontainer-config-type and --multicontainer-config-file" when they simply forgot --runtime. The new message clearly lists all valid options and tells them how to discover available runtimes.

Add error message that clearly lists all valid options and tells them how to discover available runtimes.

**Testing Guide**
Before:
<img width="1180" height="184" alt="image" src="https://github.com/user-attachments/assets/96c8be01-f45a-4c20-aa15-6a9ad4ba4c89" />

After:
ERROR: Creating a Linux webapp requires one of the following: --runtime, --container-image-name, or --sitecontainers-app. Run 'az webapp list-runtimes --os-type linux' for supported runtimes. For custom containers, see 'az webapp sitecontainers create': https://learn.microsoft.com/cli/azure/webapp/sitecontainers

<img width="1423" height="139" alt="image" src="https://github.com/user-attachments/assets/abd83598-384a-47bb-8c55-d6826d9205db" />


**History Notes**

`az webapp create`: Add error message that clearly lists all valid options and specifies how to discover available runtimes

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
