### PR TITLE
[Batch] `az batch task file download`: Fixed AttributeError when downloading batch task files

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/batch/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/batch/_validators.py
@@ -239,7 +239,7 @@ def validate_file_destination(namespace):
     file_path = path
     file_dir = os.path.dirname(path)
     if os.path.isdir(path):
-        file_name = os.path.basename(namespace.file_name)
+        file_name = os.path.basename(namespace.file_path)
         file_path = os.path.join(path, file_name)
     elif not os.path.isdir(file_dir):
         try:


### PR DESCRIPTION
**Related command**
az batch task file download

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
This PR fixes a bug when downloading a file from the working directory (wd/) of a batch task. The command
```bash
az batch task file download \
    --job-id "job-1" \
    --task-id "task-1" \
    --file-path "wd/path/to/file.txt" \
    --destination "local/machine/output/"
```

will throw an error such as: 

```
AttributeError: 'Namespace' object has no attribute 'file_name'. Did you mean: 'file_path'?

cli.azure.cli.core.azclierror: 'Namespace' object has no attribute 'file_name'
az_command_data_logger: 'Namespace' object has no attribute 'file_name'
```

This PR fixes that incorrect attribute name such that the command will work as intended.


**Testing Guide**
Consider a batch job (`job-1`) with a task (`task-1`). Create a directory on the local machine in your working directory, (`./output/`) and run the following to extract the `stdout.txt` file from the task, assuming it exists.

```bash
az batch task file download \
    --job-id "job-1" \
    --task-id "task-1" \
    --file-path "wd/stdout.txt" \
    --destination "./output/"
```


**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Batch] `az batch task file download`: Fixed AttributeError when downloading batch task files

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
