### PR TITLE
[AKS] `az aks create`: Add parameters `--system-node-subnet-id`, `--node-subnet-id` and `--enable-hosted-system` to support BYO VNet for Automatic Managed System Pool clusters

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -345,6 +345,25 @@ parameters:
   - name: --apiserver-subnet-id
     type: string
     short-summary: The ID of a subnet in an existing VNet into which to assign control plane apiserver pods(requires --enable-apiserver-vnet-integration)
+  - name: --system-node-subnet-id
+    type: string
+    short-summary: (Automatic SKU) Subnet ID of an existing VNet for the hosted system node pool (BYO VNet HOBO).
+    long-summary: |
+      When provided alongside `--node-subnet-id` and `--apiserver-subnet-id` on `--sku automatic`,
+      the cluster is created with BYO VNet for its Hosted Overlay System Pool. All three subnets
+      must be supplied together.
+  - name: --node-subnet-id
+    type: string
+    short-summary: (Automatic SKU) Subnet ID of an existing VNet for user node pools (BYO VNet HOBO).
+    long-summary: |
+      Used together with `--system-node-subnet-id` and `--apiserver-subnet-id` on `--sku automatic`
+      to bring your own VNet for the cluster.
+  - name: --disable-hosted-system
+    type: bool
+    short-summary: (Automatic SKU) Deterministically opt this cluster out of the Hosted Overlay System Pool (HOBO).
+    long-summary: |
+      Only valid on `--sku automatic`. Cannot be combined with `--system-node-subnet-id`
+      or `--node-subnet-id`.
   - name: --enable-private-cluster
     type: string
     short-summary: Enable private cluster.

--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -347,17 +347,20 @@ parameters:
     short-summary: The ID of a subnet in an existing VNet into which to assign control plane apiserver pods(requires --enable-apiserver-vnet-integration)
   - name: --system-node-subnet-id
     type: string
-    short-summary: (Automatic SKU) Subnet ID of an existing VNet for the Managed System Pool for Automatic cluster.
+    short-summary: (Automatic SKU) Subnet ID of an existing VNet to be used by the Managed System Pool in the Automatic cluster.
     long-summary: |
-      When provided alongside `--node-subnet-id` and `--apiserver-subnet-id` on `--sku automatic`,
-      the cluster is created with a bring-your-own VNet for its Managed System Pool. All three
-      subnets must be supplied together.
+      Bring-your-own VNet for an Automatic cluster requires three subnets supplied together:
+      `--system-node-subnet-id` (this flag, for the Managed System Pool), `--node-subnet-id`
+      (for user node pools), and `--apiserver-subnet-id` (for the control plane API server).
+      All three subnets must belong to the same VNet and can only be used with `--sku automatic`.
   - name: --node-subnet-id
     type: string
-    short-summary: (Automatic SKU) Subnet ID of an existing VNet for user node pools of an Automatic cluster.
+    short-summary: (Automatic SKU) Subnet ID of an existing VNet to be used by user node pools in the Automatic cluster.
     long-summary: |
-      Used together with `--system-node-subnet-id` and `--apiserver-subnet-id` on `--sku automatic`
-      to bring your own VNet for the cluster.
+      Bring-your-own VNet for an Automatic cluster requires three subnets supplied together:
+      `--system-node-subnet-id` (for the Managed System Pool), `--node-subnet-id` (this flag,
+      for user node pools), and `--apiserver-subnet-id` (for the control plane API server).
+      All three subnets must belong to the same VNet and can only be used with `--sku automatic`.
   - name: --enable-private-cluster
     type: string
     short-summary: Enable private cluster.

--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -347,7 +347,7 @@ parameters:
     short-summary: The ID of a subnet in an existing VNet into which to assign control plane apiserver pods(requires --enable-apiserver-vnet-integration)
   - name: --system-node-subnet-id
     type: string
-    short-summary: (Automatic SKU) Subnet ID of an existing VNet to be used by the Managed System Pool in the Automatic cluster.
+    short-summary: (Automatic SKU) The ID of a subnet in an existing VNet to be used by the Managed System Pool in an Automatic cluster.
     long-summary: |
       Bring-your-own VNet for an Automatic cluster requires three subnets supplied together:
       `--system-node-subnet-id` (this flag, for the Managed System Pool), `--node-subnet-id`
@@ -355,7 +355,7 @@ parameters:
       All three subnets must belong to the same VNet and can only be used with `--sku automatic`.
   - name: --node-subnet-id
     type: string
-    short-summary: (Automatic SKU) Subnet ID of an existing VNet to be used by user node pools in the Automatic cluster.
+    short-summary: (Automatic SKU) The ID of a subnet in an existing VNet to be used by user node pools in an Automatic cluster.
     long-summary: |
       Bring-your-own VNet for an Automatic cluster requires three subnets supplied together:
       `--system-node-subnet-id` (for the Managed System Pool), `--node-subnet-id` (this flag,

--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -361,6 +361,14 @@ parameters:
       `--system-node-subnet-id` (for the Managed System Pool), `--node-subnet-id` (this flag,
       for user node pools), and `--apiserver-subnet-id` (for the control plane API server).
       All three subnets must belong to the same VNet and can only be used with `--sku automatic`.
+  - name: --enable-hosted-system
+    type: bool
+    short-summary: (Automatic SKU) Explicitly opt in to a Managed System Pool for the Automatic cluster.
+    long-summary: |
+      Only valid with `--sku automatic`. Use this flag when you want to deterministically
+      request a Managed System Pool regardless of region defaults. It is also implied when
+      you supply the bring-your-own VNet subnet trio (`--system-node-subnet-id`,
+      `--node-subnet-id`, `--apiserver-subnet-id`).
   - name: --enable-private-cluster
     type: string
     short-summary: Enable private cluster.

--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -347,23 +347,17 @@ parameters:
     short-summary: The ID of a subnet in an existing VNet into which to assign control plane apiserver pods(requires --enable-apiserver-vnet-integration)
   - name: --system-node-subnet-id
     type: string
-    short-summary: (Automatic SKU) Subnet ID of an existing VNet for the hosted system node pool (BYO VNet HOBO).
+    short-summary: (Automatic SKU) Subnet ID of an existing VNet for the Managed System Pool for Automatic cluster.
     long-summary: |
       When provided alongside `--node-subnet-id` and `--apiserver-subnet-id` on `--sku automatic`,
-      the cluster is created with BYO VNet for its Hosted Overlay System Pool. All three subnets
-      must be supplied together.
+      the cluster is created with a bring-your-own VNet for its Managed System Pool. All three
+      subnets must be supplied together.
   - name: --node-subnet-id
     type: string
-    short-summary: (Automatic SKU) Subnet ID of an existing VNet for user node pools (BYO VNet HOBO).
+    short-summary: (Automatic SKU) Subnet ID of an existing VNet for user node pools of an Automatic cluster.
     long-summary: |
       Used together with `--system-node-subnet-id` and `--apiserver-subnet-id` on `--sku automatic`
       to bring your own VNet for the cluster.
-  - name: --disable-hosted-system
-    type: bool
-    short-summary: (Automatic SKU) Deterministically opt this cluster out of the Hosted Overlay System Pool (HOBO).
-    long-summary: |
-      Only valid on `--sku automatic`. Cannot be combined with `--system-node-subnet-id`
-      or `--node-subnet-id`.
   - name: --enable-private-cluster
     type: string
     short-summary: Enable private cluster.

--- a/src/azure-cli/azure/cli/command_modules/acs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_params.py
@@ -446,6 +446,7 @@ def load_arguments(self, _):
         c.argument('apiserver_subnet_id', validator=validate_apiserver_subnet_id)
         c.argument('system_node_subnet_id', validator=validate_system_node_subnet_id)
         c.argument('node_subnet_id', validator=validate_node_subnet_id)
+        c.argument('enable_hosted_system', action='store_true')
         c.argument('private_dns_zone')
         c.argument('disable_public_fqdn', action='store_true')
         c.argument('service_principal')

--- a/src/azure-cli/azure/cli/command_modules/acs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_params.py
@@ -446,7 +446,6 @@ def load_arguments(self, _):
         c.argument('apiserver_subnet_id', validator=validate_apiserver_subnet_id)
         c.argument('system_node_subnet_id', validator=validate_system_node_subnet_id)
         c.argument('node_subnet_id', validator=validate_node_subnet_id)
-        c.argument('disable_hosted_system', action='store_true')
         c.argument('private_dns_zone')
         c.argument('disable_public_fqdn', action='store_true')
         c.argument('service_principal')

--- a/src/azure-cli/azure/cli/command_modules/acs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_params.py
@@ -444,11 +444,7 @@ def load_arguments(self, _):
         c.argument('enable_private_cluster', action='store_true')
         c.argument('enable_apiserver_vnet_integration', action='store_true')
         c.argument('apiserver_subnet_id', validator=validate_apiserver_subnet_id)
-        c.argument(
-            'system_node_subnet_id',
-            options_list=['--system-node-subnet-id', '--sys-node-subnet-id'],
-            validator=validate_system_node_subnet_id,
-        )
+        c.argument('system_node_subnet_id', validator=validate_system_node_subnet_id)
         c.argument('node_subnet_id', validator=validate_node_subnet_id)
         c.argument('disable_hosted_system', action='store_true')
         c.argument('private_dns_zone')

--- a/src/azure-cli/azure/cli/command_modules/acs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_params.py
@@ -133,6 +133,7 @@ from azure.cli.command_modules.acs._validators import (
     validate_disable_windows_outbound_nat,
     validate_asm_egress_name,
     validate_crg_id, validate_apiserver_subnet_id,
+    validate_system_node_subnet_id, validate_node_subnet_id,
     validate_azure_service_mesh_revision,
     validate_message_of_the_day,
     validate_custom_ca_trust_certificates,
@@ -443,6 +444,13 @@ def load_arguments(self, _):
         c.argument('enable_private_cluster', action='store_true')
         c.argument('enable_apiserver_vnet_integration', action='store_true')
         c.argument('apiserver_subnet_id', validator=validate_apiserver_subnet_id)
+        c.argument(
+            'system_node_subnet_id',
+            options_list=['--system-node-subnet-id', '--sys-node-subnet-id'],
+            validator=validate_system_node_subnet_id,
+        )
+        c.argument('node_subnet_id', validator=validate_node_subnet_id)
+        c.argument('disable_hosted_system', action='store_true')
         c.argument('private_dns_zone')
         c.argument('disable_public_fqdn', action='store_true')
         c.argument('service_principal')

--- a/src/azure-cli/azure/cli/command_modules/acs/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_validators.py
@@ -455,6 +455,14 @@ def validate_apiserver_subnet_id(namespace):
     _validate_subnet_id(namespace.apiserver_subnet_id, "--apiserver-subnet-id")
 
 
+def validate_system_node_subnet_id(namespace):
+    _validate_subnet_id(namespace.system_node_subnet_id, "--system-node-subnet-id")
+
+
+def validate_node_subnet_id(namespace):
+    _validate_subnet_id(namespace.node_subnet_id, "--node-subnet-id")
+
+
 def _validate_subnet_id(subnet_id, name):
     if subnet_id is None or subnet_id == '':
         return

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -1032,6 +1032,10 @@ def aks_create(
     # apiserver vnet integration
     enable_apiserver_vnet_integration=False,
     apiserver_subnet_id=None,
+    # BYO VNet HOBO (Automatic SKU)
+    system_node_subnet_id=None,
+    node_subnet_id=None,
+    disable_hosted_system=False,
     # node provisioning
     node_provisioning_mode=None,
     node_provisioning_default_pools=None,
@@ -1273,7 +1277,7 @@ def aks_upgrade(cmd,
     instance = client.get(resource_group_name, name)
 
     vmas_cluster = False
-    for agent_profile in instance.agent_pool_profiles:
+    for agent_profile in (instance.agent_pool_profiles or []):
         if agent_profile.type.lower() == "availabilityset":
             vmas_cluster = True
             break
@@ -1290,7 +1294,7 @@ def aks_upgrade(cmd,
 
         # This only provide convenience for customer at client side so they can run az aks upgrade to upgrade all
         # nodepools of a cluster. The SDK only support upgrade single nodepool at a time.
-        for agent_pool_profile in instance.agent_pool_profiles:
+        for agent_pool_profile in (instance.agent_pool_profiles or []):
             if vmas_cluster:
                 raise CLIError('This cluster is using AvailabilitySet. Node image upgrade only operation '
                                'can only be applied on VirtualMachineScaleSets or VirtualMachines cluster.')
@@ -1354,7 +1358,7 @@ def aks_upgrade(cmd,
                 return None
 
     if upgrade_all:
-        for agent_profile in instance.agent_pool_profiles:
+        for agent_profile in (instance.agent_pool_profiles or []):
             agent_profile.orchestrator_version = kubernetes_version
             agent_profile.creation_data = None
 

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -1035,6 +1035,7 @@ def aks_create(
     # BYO VNet for Managed System Pool (Automatic SKU)
     system_node_subnet_id=None,
     node_subnet_id=None,
+    enable_hosted_system=False,
     # node provisioning
     node_provisioning_mode=None,
     node_provisioning_default_pools=None,

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -1442,12 +1442,17 @@ def _upgrade_single_nodepool_image_version(no_wait, client, resource_group_name,
 def aks_scale(cmd, client, resource_group_name, name, node_count, nodepool_name="", no_wait=False):
     instance = client.get(resource_group_name, name)
 
-    if len(instance.agent_pool_profiles) > 1 and nodepool_name == "":
+    agent_pool_profiles = instance.agent_pool_profiles or []
+    if not agent_pool_profiles:
+        raise CLIError('The cluster has no scalable node pools (this may be a Hosted System Pool / Automatic cluster). '
+                       'Use az aks nodepool add/scale against a user node pool instead.')
+
+    if len(agent_pool_profiles) > 1 and nodepool_name == "":
         raise CLIError('There are more than one node pool in the cluster. '
                        'Please specify nodepool name or use az aks nodepool command to scale node pool')
 
-    for agent_profile in instance.agent_pool_profiles:
-        if agent_profile.name == nodepool_name or (nodepool_name == "" and len(instance.agent_pool_profiles) == 1):
+    for agent_profile in agent_pool_profiles:
+        if agent_profile.name == nodepool_name or (nodepool_name == "" and len(agent_pool_profiles) == 1):
             if agent_profile.enable_auto_scaling:
                 raise CLIError(
                     "Cannot scale cluster autoscaler enabled node pool.")

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -1032,10 +1032,9 @@ def aks_create(
     # apiserver vnet integration
     enable_apiserver_vnet_integration=False,
     apiserver_subnet_id=None,
-    # BYO VNet HOBO (Automatic SKU)
+    # BYO VNet for Managed System Pool (Automatic SKU)
     system_node_subnet_id=None,
     node_subnet_id=None,
-    disable_hosted_system=False,
     # node provisioning
     node_provisioning_mode=None,
     node_provisioning_default_pools=None,
@@ -1444,8 +1443,8 @@ def aks_scale(cmd, client, resource_group_name, name, node_count, nodepool_name=
 
     agent_pool_profiles = instance.agent_pool_profiles or []
     if not agent_pool_profiles:
-        raise CLIError('The cluster has no scalable node pools (this may be a Hosted System Pool / Automatic cluster). '
-                       'Use az aks nodepool add/scale against a user node pool instead.')
+        raise CLIError('The cluster has no scalable node pools (this may be a Managed System Pool for '
+                       'Automatic cluster). Use az aks nodepool add/scale against a user node pool instead.')
 
     if len(agent_pool_profiles) > 1 and nodepool_name == "":
         raise CLIError('There are more than one node pool in the cluster. '

--- a/src/azure-cli/azure/cli/command_modules/acs/linter_exclusions.yml
+++ b/src/azure-cli/azure/cli/command_modules/acs/linter_exclusions.yml
@@ -7,6 +7,9 @@ aks create:
       node_subnet_id:
           rule_exclusions:
           - missing_parameter_test_coverage
+      enable_hosted_system:
+          rule_exclusions:
+          - missing_parameter_test_coverage
       appgw_watch_namespace:
           rule_exclusions:
           - option_length_too_long

--- a/src/azure-cli/azure/cli/command_modules/acs/linter_exclusions.yml
+++ b/src/azure-cli/azure/cli/command_modules/acs/linter_exclusions.yml
@@ -1,6 +1,15 @@
 ---
 aks create:
   parameters:
+      system_node_subnet_id:
+          rule_exclusions:
+          - missing_parameter_test_coverage
+      node_subnet_id:
+          rule_exclusions:
+          - missing_parameter_test_coverage
+      disable_hosted_system:
+          rule_exclusions:
+          - missing_parameter_test_coverage
       appgw_watch_namespace:
           rule_exclusions:
           - option_length_too_long

--- a/src/azure-cli/azure/cli/command_modules/acs/linter_exclusions.yml
+++ b/src/azure-cli/azure/cli/command_modules/acs/linter_exclusions.yml
@@ -7,9 +7,6 @@ aks create:
       node_subnet_id:
           rule_exclusions:
           - missing_parameter_test_coverage
-      disable_hosted_system:
-          rule_exclusions:
-          - missing_parameter_test_coverage
       appgw_watch_namespace:
           rule_exclusions:
           - option_length_too_long

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -4240,6 +4240,85 @@ class AKSManagedClusterContext(BaseAKSContext):
         """
         return self._get_apiserver_subnet_id(enable_validation=True)
 
+    def get_system_node_subnet_id(self) -> Union[str, None]:
+        """Obtain the value of system_node_subnet_id (BYO VNet HOBO).
+
+        :return: str or None
+        """
+        system_node_subnet_id = self.raw_param.get("system_node_subnet_id")
+        if self.decorator_mode == DecoratorMode.CREATE:
+            if (
+                self.mc and
+                self.mc.hosted_system_profile and
+                getattr(self.mc.hosted_system_profile, "system_node_subnet_id", None) is not None
+            ):
+                system_node_subnet_id = self.mc.hosted_system_profile.system_node_subnet_id
+        return system_node_subnet_id
+
+    def get_node_subnet_id(self) -> Union[str, None]:
+        """Obtain the value of node_subnet_id (BYO VNet HOBO).
+
+        :return: str or None
+        """
+        node_subnet_id = self.raw_param.get("node_subnet_id")
+        if self.decorator_mode == DecoratorMode.CREATE:
+            if (
+                self.mc and
+                self.mc.hosted_system_profile and
+                getattr(self.mc.hosted_system_profile, "node_subnet_id", None) is not None
+            ):
+                node_subnet_id = self.mc.hosted_system_profile.node_subnet_id
+        return node_subnet_id
+
+    def get_disable_hosted_system(self) -> bool:
+        """Obtain the value of disable_hosted_system.
+
+        :return: bool
+        """
+        return bool(self.raw_param.get("disable_hosted_system"))
+
+    def _validate_byo_hobo_subnets(self) -> None:
+        """Validate BYO HOBO subnet trio and mutual exclusion with --disable-hosted-system.
+
+        - If any of system-node / node / apiserver subnet is set, all three must be provided.
+        - --disable-hosted-system cannot be combined with any of the three subnets.
+        - BYO HOBO (subnet trio) requires --sku automatic.
+        """
+        if self.decorator_mode != DecoratorMode.CREATE:
+            return
+        system_node_subnet_id = self.raw_param.get("system_node_subnet_id")
+        node_subnet_id = self.raw_param.get("node_subnet_id")
+        apiserver_subnet_id = self.raw_param.get("apiserver_subnet_id")
+        disable_hosted_system = self.get_disable_hosted_system()
+
+        any_set = any([system_node_subnet_id, node_subnet_id])
+        if disable_hosted_system and any_set:
+            raise MutuallyExclusiveArgumentError(
+                '"--disable-hosted-system" cannot be combined with '
+                '"--system-node-subnet-id" or "--node-subnet-id".'
+            )
+        if any_set:
+            missing = []
+            if not system_node_subnet_id:
+                missing.append("--system-node-subnet-id")
+            if not node_subnet_id:
+                missing.append("--node-subnet-id")
+            if not apiserver_subnet_id:
+                missing.append("--apiserver-subnet-id")
+            if missing:
+                raise RequiredArgumentMissingError(
+                    "BYO VNet for Automatic (HOBO) clusters requires all three subnets. "
+                    "Missing: " + ", ".join(missing) + "."
+                )
+            if self.get_sku_name() != CONST_MANAGED_CLUSTER_SKU_NAME_AUTOMATIC:
+                raise RequiredArgumentMissingError(
+                    '"--system-node-subnet-id" / "--node-subnet-id" require "--sku automatic".'
+                )
+        if disable_hosted_system and self.get_sku_name() != CONST_MANAGED_CLUSTER_SKU_NAME_AUTOMATIC:
+            raise RequiredArgumentMissingError(
+                '"--disable-hosted-system" requires "--sku automatic".'
+            )
+
     def _get_enable_private_cluster(self, enable_validation: bool = False) -> bool:
         """Internal function to obtain the value of enable_private_cluster.
 
@@ -7004,6 +7083,41 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
         mc.fqdn_subdomain = fqdn_subdomain
         return mc
 
+    def set_up_hosted_system_profile(self, mc: ManagedCluster) -> ManagedCluster:
+        """Set up hosted_system_profile on the ManagedCluster for Automatic SKU clusters.
+
+        - When any of `--system-node-subnet-id` / `--node-subnet-id` / `--apiserver-subnet-id`
+          are provided (BYO VNet HOBO), validate the trio and populate
+          `mc.hosted_system_profile.{system_node_subnet_id, node_subnet_id}`. `enabled` is left
+          unset so the server side keeps ownership of the default/opt-in decision.
+        - When `--disable-hosted-system` is provided, set
+          `mc.hosted_system_profile = ManagedClusterHostedSystemProfile(enabled=False)` so
+          HOBO is deterministically opted out for Automatic clusters.
+
+        :return: the ManagedCluster object
+        """
+        self._ensure_mc(mc)
+
+        # Run cross-flag validation (mutual exclusion + trio completeness + SKU gate)
+        self.context._validate_byo_hobo_subnets()
+
+        system_node_subnet_id = self.context.get_system_node_subnet_id()
+        node_subnet_id = self.context.get_node_subnet_id()
+        disable_hosted_system = self.context.get_disable_hosted_system()
+
+        if disable_hosted_system:
+            mc.hosted_system_profile = self.models.ManagedClusterHostedSystemProfile(enabled=False)
+            return mc
+
+        if system_node_subnet_id or node_subnet_id:
+            if mc.hosted_system_profile is None:
+                mc.hosted_system_profile = self.models.ManagedClusterHostedSystemProfile()
+            if system_node_subnet_id:
+                mc.hosted_system_profile.system_node_subnet_id = system_node_subnet_id
+            if node_subnet_id:
+                mc.hosted_system_profile.node_subnet_id = node_subnet_id
+        return mc
+
     def set_up_identity(self, mc: ManagedCluster) -> ManagedCluster:
         """Set up identity for the ManagedCluster object.
 
@@ -7484,6 +7598,8 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
         mc = self.set_up_oidc_issuer_profile(mc)
         # set up api server access profile and fqdn subdomain
         mc = self.set_up_api_server_access_profile(mc)
+        # set up hosted system profile (BYO VNet HOBO)
+        mc = self.set_up_hosted_system_profile(mc)
         # set up identity
         mc = self.set_up_identity(mc)
         # set up identity profile

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -4302,9 +4302,12 @@ class AKSManagedClusterContext(BaseAKSContext):
         if self.decorator_mode != DecoratorMode.CREATE:
             return False
         explicit = bool(self.raw_param.get("enable_hosted_system"))
-        implicit = bool(
-            self.raw_param.get("system_node_subnet_id") or
-            self.raw_param.get("node_subnet_id")
+        implicit = all(
+            [
+                self.raw_param.get("system_node_subnet_id"),
+                self.raw_param.get("node_subnet_id"),
+                self.raw_param.get("apiserver_subnet_id"),
+            ]
         )
         return explicit or implicit
 
@@ -7193,6 +7196,19 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
         mc.fqdn_subdomain = fqdn_subdomain
         return mc
 
+    def _remove_cli_synthesized_default_agent_pool(self, mc: ManagedCluster) -> None:
+        agent_pool_profiles = mc.agent_pool_profiles
+        if not agent_pool_profiles:
+            return
+
+        # `set_up_agentpool_profile` always adds the first pool for `az aks create`.
+        # A Managed System Pool cluster gets that system pool from `hosted_system_profile`;
+        # preserve any additional pools that may have been appended by other create-time logic.
+        if len(agent_pool_profiles) == 1:
+            mc.agent_pool_profiles = None
+        else:
+            mc.agent_pool_profiles = agent_pool_profiles[1:]
+
     def set_up_hosted_system_profile(self, mc: ManagedCluster) -> ManagedCluster:
         """Set up hosted_system_profile on the ManagedCluster for Automatic SKU clusters.
 
@@ -7202,11 +7218,9 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
           - `mc.hosted_system_profile.enabled` is set to True so the RP treats this
             as a Managed System Pool request.
           - `system_node_subnet_id` / `node_subnet_id` are populated when supplied.
-          - `mc.agent_pool_profiles` is cleared. The CLI unconditionally synthesizes
-            a default agent pool via `set_up_agentpool_profile`; on a Managed System
+          - The CLI-synthesized default agent pool is removed. On a Managed System
             Pool cluster the system pool is provisioned server-side from
-            `hosted_system_profile`, so the CLI default is stale and (in the BYO case)
-            actively conflicts with the BYO VNet.
+            `hosted_system_profile`, so the CLI default is stale.
 
         :return: the ManagedCluster object
         """
@@ -7228,12 +7242,7 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
                 mc.hosted_system_profile.system_node_subnet_id = system_node_subnet_id
             if node_subnet_id:
                 mc.hosted_system_profile.node_subnet_id = node_subnet_id
-            # Clear the CLI-synthesized default agent pool — the RP provisions the
-            # system pool from hosted_system_profile instead. Leaving it in causes
-            # the RP to reject BYO VNet clusters and produces a ghost pool on
-            # non-BYO Automatic clusters.
-            if mc.agent_pool_profiles is not None:
-                mc.agent_pool_profiles = None
+            self._remove_cli_synthesized_default_agent_pool(mc)
         return mc
 
     def set_up_identity(self, mc: ManagedCluster) -> ManagedCluster:

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -6338,6 +6338,11 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
 
         agentpool_profile = self.agentpool_decorator.construct_agentpool_profile_default()
         mc.agent_pool_profiles = [agentpool_profile]
+        self.context.set_intermediate(
+            "cli_synthesized_default_agent_pool",
+            agentpool_profile,
+            overwrite_exists=True,
+        )
         return mc
 
     def set_up_mc_properties(self, mc: ManagedCluster) -> ManagedCluster:
@@ -7201,13 +7206,22 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
         if not agent_pool_profiles:
             return
 
-        # `set_up_agentpool_profile` always adds the first pool for `az aks create`.
+        cli_default_agent_pool = self.context.get_intermediate(
+            "cli_synthesized_default_agent_pool", default_value=None
+        )
+        if cli_default_agent_pool is None:
+            return
+
+        # Remove only the exact pool object created by `set_up_agentpool_profile`.
         # A Managed System Pool cluster gets that system pool from `hosted_system_profile`;
         # preserve any additional pools that may have been appended by other create-time logic.
-        if len(agent_pool_profiles) == 1:
-            mc.agent_pool_profiles = None
-        else:
-            mc.agent_pool_profiles = agent_pool_profiles[1:]
+        remaining_agent_pool_profiles = [
+            profile for profile in agent_pool_profiles
+            if profile is not cli_default_agent_pool
+        ]
+        if len(remaining_agent_pool_profiles) == len(agent_pool_profiles):
+            return
+        mc.agent_pool_profiles = remaining_agent_pool_profiles or None
 
     def set_up_hosted_system_profile(self, mc: ManagedCluster) -> ManagedCluster:
         """Set up hosted_system_profile on the ManagedCluster for Automatic SKU clusters.

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -6454,6 +6454,19 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
             mc.service_principal_profile = service_principal_profile
         return mc
 
+    def _get_byo_hosted_system_subnet_ids(self) -> List[str]:
+        if not self.context.get_enable_hosted_system():
+            return []
+
+        subnet_ids = []
+        seen = set()
+        for raw_key in ("system_node_subnet_id", "node_subnet_id", "apiserver_subnet_id"):
+            subnet_id = self.context.raw_param.get(raw_key)
+            if subnet_id and subnet_id not in seen:
+                subnet_ids.append(subnet_id)
+                seen.add(subnet_id)
+        return subnet_ids
+
     def process_add_role_assignment_for_vnet_subnet(self, mc: ManagedCluster) -> None:
         """Add role assignment for vent subnet.
 
@@ -6469,6 +6482,10 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
         :return: None
         """
         self._ensure_mc(mc)
+
+        # Validate before granting roles so a malformed BYO trio does not leave
+        # partial Network Contributor assignments behind.
+        self.context.validate_byo_hobo_subnets()
 
         need_post_creation_vnet_permission_granting = False
         vnet_subnet_id = self.context.get_vnet_subnet_id()
@@ -6514,6 +6531,50 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
                     ):
                         logger.warning(
                             "Could not create a role assignment for subnet. Are you an Owner on this subscription?"
+                        )
+        byo_hosted_system_subnet_ids = self._get_byo_hosted_system_subnet_ids()
+        if byo_hosted_system_subnet_ids and not skip_subnet_role_assignment:
+            service_principal_profile = mc.service_principal_profile
+            assign_identity = self.context.get_assign_identity()
+            pending_post_creation_subnets = []
+            if service_principal_profile is None and not assign_identity:
+                for subnet_id in byo_hosted_system_subnet_ids:
+                    if not self.context.external_functions.subnet_role_assignment_exists(self.cmd, subnet_id):
+                        pending_post_creation_subnets.append(subnet_id)
+                if pending_post_creation_subnets:
+                    need_post_creation_vnet_permission_granting = True
+                    self.context.set_intermediate(
+                        "byo_hosted_system_subnets_pending_grant",
+                        pending_post_creation_subnets,
+                        overwrite_exists=True,
+                    )
+            else:
+                identity_object_id = None
+                if assign_identity:
+                    identity_object_id = self.context.get_user_assigned_identity_object_id()
+                for subnet_id in byo_hosted_system_subnet_ids:
+                    if self.context.external_functions.subnet_role_assignment_exists(self.cmd, subnet_id):
+                        continue
+                    if assign_identity:
+                        added = self.context.external_functions.add_role_assignment(
+                            self.cmd,
+                            "Network Contributor",
+                            identity_object_id,
+                            is_service_principal=False,
+                            scope=subnet_id,
+                        )
+                    else:
+                        added = self.context.external_functions.add_role_assignment(
+                            self.cmd,
+                            "Network Contributor",
+                            service_principal_profile.client_id,
+                            scope=subnet_id,
+                        )
+                    if not added:
+                        logger.warning(
+                            "Could not create a role assignment for subnet %s. "
+                            "Are you an Owner on this subscription?",
+                            subnet_id,
                         )
         # store need_post_creation_vnet_permission_granting as an intermediate
         self.context.set_intermediate(
@@ -7767,16 +7828,27 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
             # Grant vnet permission to system assigned identity RIGHT AFTER the cluster is put, this operation can
             # reduce latency for the role assignment take effect
             instant_cluster = self.client.get(self.context.get_resource_group_name(), self.context.get_name())
-            if not self.context.external_functions.add_role_assignment(
-                self.cmd,
-                "Network Contributor",
-                instant_cluster.identity.principal_id,
-                scope=self.context.get_vnet_subnet_id(),
-                is_service_principal=False,
-            ):
-                logger.warning(
-                    "Could not create a role assignment for subnet. Are you an Owner on this subscription?"
-                )
+            scopes = []
+            vnet_subnet_id = self.context.get_vnet_subnet_id()
+            if vnet_subnet_id:
+                scopes.append(vnet_subnet_id)
+            byo_hosted_system_subnet_ids = self.context.get_intermediate(
+                "byo_hosted_system_subnets_pending_grant", default_value=[]
+            )
+            for subnet_id in byo_hosted_system_subnet_ids or []:
+                if subnet_id and subnet_id not in scopes:
+                    scopes.append(subnet_id)
+            for scope in scopes:
+                if not self.context.external_functions.add_role_assignment(
+                    self.cmd,
+                    "Network Contributor",
+                    instant_cluster.identity.principal_id,
+                    scope=scope,
+                    is_service_principal=False,
+                ):
+                    logger.warning(
+                        "Could not create a role assignment for subnet. Are you an Owner on this subscription?"
+                    )
 
     # pylint: disable=too-many-locals
     def postprocessing_after_mc_created(self, cluster: ManagedCluster) -> None:

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -6336,13 +6336,11 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
         """
         self._ensure_mc(mc)
 
+        if self.context.get_enable_hosted_system():
+            return mc
+
         agentpool_profile = self.agentpool_decorator.construct_agentpool_profile_default()
         mc.agent_pool_profiles = [agentpool_profile]
-        self.context.set_intermediate(
-            "cli_synthesized_default_agent_pool",
-            agentpool_profile,
-            overwrite_exists=True,
-        )
         return mc
 
     def set_up_mc_properties(self, mc: ManagedCluster) -> ManagedCluster:
@@ -7201,28 +7199,6 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
         mc.fqdn_subdomain = fqdn_subdomain
         return mc
 
-    def _remove_cli_synthesized_default_agent_pool(self, mc: ManagedCluster) -> None:
-        agent_pool_profiles = mc.agent_pool_profiles
-        if not agent_pool_profiles:
-            return
-
-        cli_default_agent_pool = self.context.get_intermediate(
-            "cli_synthesized_default_agent_pool", default_value=None
-        )
-        if cli_default_agent_pool is None:
-            return
-
-        # Remove only the exact pool object created by `set_up_agentpool_profile`.
-        # A Managed System Pool cluster gets that system pool from `hosted_system_profile`;
-        # preserve any additional pools that may have been appended by other create-time logic.
-        remaining_agent_pool_profiles = [
-            profile for profile in agent_pool_profiles
-            if profile is not cli_default_agent_pool
-        ]
-        if len(remaining_agent_pool_profiles) == len(agent_pool_profiles):
-            return
-        mc.agent_pool_profiles = remaining_agent_pool_profiles or None
-
     def set_up_hosted_system_profile(self, mc: ManagedCluster) -> ManagedCluster:
         """Set up hosted_system_profile on the ManagedCluster for Automatic SKU clusters.
 
@@ -7232,9 +7208,8 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
           - `mc.hosted_system_profile.enabled` is set to True so the RP treats this
             as a Managed System Pool request.
           - `system_node_subnet_id` / `node_subnet_id` are populated when supplied.
-          - The CLI-synthesized default agent pool is removed. On a Managed System
-            Pool cluster the system pool is provisioned server-side from
-            `hosted_system_profile`, so the CLI default is stale.
+          - `set_up_agentpool_profile` does not synthesize the default agent pool,
+            because the system pool is provisioned server-side from `hosted_system_profile`.
 
         :return: the ManagedCluster object
         """
@@ -7256,7 +7231,6 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
                 mc.hosted_system_profile.system_node_subnet_id = system_node_subnet_id
             if node_subnet_id:
                 mc.hosted_system_profile.node_subnet_id = node_subnet_id
-            self._remove_cli_synthesized_default_agent_pool(mc)
         return mc
 
     def set_up_identity(self, mc: ManagedCluster) -> ManagedCluster:

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -2418,7 +2418,8 @@ class AKSManagedClusterContext(BaseAKSContext):
             skuName == CONST_MANAGED_CLUSTER_SKU_NAME_AUTOMATIC and
             isVnetSubnetIdEmpty and
             not read_from_mc and
-            not byo_subnets_set
+            not byo_subnets_set and
+            outbound_type == CONST_OUTBOUND_TYPE_LOAD_BALANCER
         ):
             # outbound_type of Automatic SKU should be ManagedNATGateway if no subnet id provided.
             outbound_type = CONST_OUTBOUND_TYPE_MANAGED_NAT_GATEWAY
@@ -2448,12 +2449,26 @@ class AKSManagedClusterContext(BaseAKSContext):
 
             if outbound_type == CONST_OUTBOUND_TYPE_USER_DEFINED_ROUTING:
                 if self.get_vnet_subnet_id() in ["", None] and not byo_subnets_set:
+                    if skuName == CONST_MANAGED_CLUSTER_SKU_NAME_AUTOMATIC:
+                        raise RequiredArgumentMissingError(
+                            "--vnet-subnet-id must be specified for userDefinedRouting. For an Automatic cluster "
+                            "using Managed System Pool BYO VNet, specify --system-node-subnet-id, --node-subnet-id "
+                            "and --apiserver-subnet-id instead. The subnet must be pre-configured with a route "
+                            "table with egress rules"
+                        )
                     raise RequiredArgumentMissingError(
                         "--vnet-subnet-id must be specified for userDefinedRouting and it must "
                         "be pre-configured with a route table with egress rules"
                     )
             if outbound_type == CONST_OUTBOUND_TYPE_USER_ASSIGNED_NAT_GATEWAY:
                 if self.get_vnet_subnet_id() in ["", None] and not byo_subnets_set:
+                    if skuName == CONST_MANAGED_CLUSTER_SKU_NAME_AUTOMATIC:
+                        raise RequiredArgumentMissingError(
+                            "--vnet-subnet-id must be specified for userAssignedNATGateway. For an Automatic cluster "
+                            "using Managed System Pool BYO VNet, specify --system-node-subnet-id, --node-subnet-id "
+                            "and --apiserver-subnet-id instead. The subnet must be pre-configured with a NAT gateway "
+                            "with outbound ips"
+                        )
                     raise RequiredArgumentMissingError(
                         "--vnet-subnet-id must be specified for userAssignedNATGateway and it must "
                         "be pre-configured with a NAT gateway with outbound ips"

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -4211,7 +4211,14 @@ class AKSManagedClusterContext(BaseAKSContext):
         if enable_validation:
             if self.decorator_mode == DecoratorMode.CREATE:
                 vnet_subnet_id = self.get_vnet_subnet_id()
-                if apiserver_subnet_id and vnet_subnet_id is None:
+                # For BYO VNet HOBO (--sku automatic with subnet trio), --vnet-subnet-id is
+                # not used: system-node / node subnets replace it. Only require --vnet-subnet-id
+                # when neither --system-node-subnet-id nor --node-subnet-id is provided.
+                byo_hobo_subnets_set = (
+                    self.raw_param.get("system_node_subnet_id") or
+                    self.raw_param.get("node_subnet_id")
+                )
+                if apiserver_subnet_id and vnet_subnet_id is None and not byo_hobo_subnets_set:
                     raise RequiredArgumentMissingError(
                         '"--apiserver-subnet-id" requires "--vnet-subnet-id".')
 
@@ -4291,13 +4298,20 @@ class AKSManagedClusterContext(BaseAKSContext):
         apiserver_subnet_id = self.raw_param.get("apiserver_subnet_id")
         disable_hosted_system = self.get_disable_hosted_system()
 
-        any_set = any([system_node_subnet_id, node_subnet_id])
-        if disable_hosted_system and any_set:
+        hobo_specific_set = bool(system_node_subnet_id or node_subnet_id)
+        any_trio_set = bool(hobo_specific_set or apiserver_subnet_id)
+
+        # --disable-hosted-system is mutually exclusive with any HOBO-specific subnet flag.
+        # (We deliberately don't include --apiserver-subnet-id here: it keeps its existing
+        # general-purpose meaning for --enable-apiserver-vnet-integration flows.)
+        if disable_hosted_system and hobo_specific_set:
             raise MutuallyExclusiveArgumentError(
                 '"--disable-hosted-system" cannot be combined with '
                 '"--system-node-subnet-id" or "--node-subnet-id".'
             )
-        if any_set:
+
+        # Partial trio: if any HOBO-specific subnet is set, require the full trio.
+        if hobo_specific_set:
             missing = []
             if not system_node_subnet_id:
                 missing.append("--system-node-subnet-id")
@@ -4318,6 +4332,7 @@ class AKSManagedClusterContext(BaseAKSContext):
             raise RequiredArgumentMissingError(
                 '"--disable-hosted-system" requires "--sku automatic".'
             )
+        _ = any_trio_set  # reserved for future per-flag gating
 
     def _get_enable_private_cluster(self, enable_validation: bool = False) -> bool:
         """Internal function to obtain the value of enable_private_cluster.
@@ -7056,6 +7071,10 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
         :return: the ManagedCluster object
         """
         self._ensure_mc(mc)
+
+        # Run BYO HOBO trio validation first so clearer errors surface before the
+        # generic --apiserver-subnet-id checks inside _get_apiserver_subnet_id.
+        self.context._validate_byo_hobo_subnets()
 
         api_server_access_profile = None
         api_server_authorized_ip_ranges = self.context.get_api_server_authorized_ip_ranges()

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -2417,6 +2417,7 @@ class AKSManagedClusterContext(BaseAKSContext):
             skuName is not None and
             skuName == CONST_MANAGED_CLUSTER_SKU_NAME_AUTOMATIC and
             isVnetSubnetIdEmpty and
+            not read_from_mc and
             not byo_subnets_set
         ):
             # outbound_type of Automatic SKU should be ManagedNATGateway if no subnet id provided.

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -2362,6 +2362,30 @@ class AKSManagedClusterContext(BaseAKSContext):
                 skuName = CONST_MANAGED_CLUSTER_SKU_NAME_BASE
         return skuName
 
+    @staticmethod
+    def _raise_missing_vnet_subnet_for_outbound_type(outbound_type: str, sku_name: str) -> None:
+        if outbound_type == CONST_OUTBOUND_TYPE_USER_DEFINED_ROUTING:
+            subnet_requirement = "a route table with egress rules"
+        else:
+            subnet_requirement = "a NAT gateway with outbound ips"
+
+        if sku_name == CONST_MANAGED_CLUSTER_SKU_NAME_AUTOMATIC:
+            raise RequiredArgumentMissingError(
+                "--vnet-subnet-id must be specified for {outbound_type}. For an Automatic cluster "
+                "using Managed System Pool BYO VNet, specify --system-node-subnet-id, --node-subnet-id "
+                "and --apiserver-subnet-id instead. The subnet must be pre-configured with {requirement}".format(
+                    outbound_type=outbound_type,
+                    requirement=subnet_requirement,
+                )
+            )
+        raise RequiredArgumentMissingError(
+            "--vnet-subnet-id must be specified for {outbound_type} and it must "
+            "be pre-configured with {requirement}".format(
+                outbound_type=outbound_type,
+                requirement=subnet_requirement,
+            )
+        )
+
     def _get_outbound_type(
         self,
         enable_validation: bool = False,
@@ -2413,14 +2437,14 @@ class AKSManagedClusterContext(BaseAKSContext):
             self.raw_param.get("system_node_subnet_id") or
             self.raw_param.get("node_subnet_id")
         )
-        if (
+        use_automatic_managed_nat_gateway = (
             skuName is not None and
             skuName == CONST_MANAGED_CLUSTER_SKU_NAME_AUTOMATIC and
             isVnetSubnetIdEmpty and
             not read_from_mc and
-            not byo_subnets_set and
-            outbound_type == CONST_OUTBOUND_TYPE_LOAD_BALANCER
-        ):
+            not byo_subnets_set
+        )
+        if use_automatic_managed_nat_gateway and outbound_type == CONST_OUTBOUND_TYPE_LOAD_BALANCER:
             # outbound_type of Automatic SKU should be ManagedNATGateway if no subnet id provided.
             outbound_type = CONST_OUTBOUND_TYPE_MANAGED_NAT_GATEWAY
 
@@ -2447,32 +2471,12 @@ class AKSManagedClusterContext(BaseAKSContext):
                     )
                 return outbound_type  # basic sku lb doesn't support outbound type
 
-            if outbound_type == CONST_OUTBOUND_TYPE_USER_DEFINED_ROUTING:
+            if outbound_type in [
+                CONST_OUTBOUND_TYPE_USER_DEFINED_ROUTING,
+                CONST_OUTBOUND_TYPE_USER_ASSIGNED_NAT_GATEWAY,
+            ]:
                 if self.get_vnet_subnet_id() in ["", None] and not byo_subnets_set:
-                    if skuName == CONST_MANAGED_CLUSTER_SKU_NAME_AUTOMATIC:
-                        raise RequiredArgumentMissingError(
-                            "--vnet-subnet-id must be specified for userDefinedRouting. For an Automatic cluster "
-                            "using Managed System Pool BYO VNet, specify --system-node-subnet-id, --node-subnet-id "
-                            "and --apiserver-subnet-id instead. The subnet must be pre-configured with a route "
-                            "table with egress rules"
-                        )
-                    raise RequiredArgumentMissingError(
-                        "--vnet-subnet-id must be specified for userDefinedRouting and it must "
-                        "be pre-configured with a route table with egress rules"
-                    )
-            if outbound_type == CONST_OUTBOUND_TYPE_USER_ASSIGNED_NAT_GATEWAY:
-                if self.get_vnet_subnet_id() in ["", None] and not byo_subnets_set:
-                    if skuName == CONST_MANAGED_CLUSTER_SKU_NAME_AUTOMATIC:
-                        raise RequiredArgumentMissingError(
-                            "--vnet-subnet-id must be specified for userAssignedNATGateway. For an Automatic cluster "
-                            "using Managed System Pool BYO VNet, specify --system-node-subnet-id, --node-subnet-id "
-                            "and --apiserver-subnet-id instead. The subnet must be pre-configured with a NAT gateway "
-                            "with outbound ips"
-                        )
-                    raise RequiredArgumentMissingError(
-                        "--vnet-subnet-id must be specified for userAssignedNATGateway and it must "
-                        "be pre-configured with a NAT gateway with outbound ips"
-                    )
+                    self._raise_missing_vnet_subnet_for_outbound_type(outbound_type, skuName)
             if outbound_type == CONST_OUTBOUND_TYPE_MANAGED_NAT_GATEWAY:
                 if self.get_vnet_subnet_id() not in ["", None] or byo_subnets_set:
                     raise InvalidArgumentValueError(

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -2417,8 +2417,7 @@ class AKSManagedClusterContext(BaseAKSContext):
             skuName is not None and
             skuName == CONST_MANAGED_CLUSTER_SKU_NAME_AUTOMATIC and
             isVnetSubnetIdEmpty and
-            not byo_hobo_subnets_set and
-            self.raw_param.get("outbound_type") is None
+            not byo_hobo_subnets_set
         ):
             # outbound_type of Automatic SKU should be ManagedNATGateway if no subnet id provided.
             outbound_type = CONST_OUTBOUND_TYPE_MANAGED_NAT_GATEWAY
@@ -8146,6 +8145,12 @@ class AKSManagedClusterUpdateDecorator(BaseAKSManagedClusterDecorator):
         :return: the ManagedCluster object
         """
         self._ensure_mc(mc)
+
+        # HOBO (Hosted Overlay System Pool) clusters manage node pools on the
+        # server side and surface `agent_pool_profiles` as None. Skip the
+        # default agent pool update in that case.
+        if mc.hosted_system_profile and mc.hosted_system_profile.enabled:
+            return mc
 
         if not mc.agent_pool_profiles:
             raise UnknownError(

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -2407,9 +2407,9 @@ class AKSManagedClusterContext(BaseAKSContext):
 
         skuName = self.get_sku_name()
         isVnetSubnetIdEmpty = self.get_vnet_subnet_id() in ["", None]
-        # For BYO VNet HOBO (Automatic SKU with system-node/node subnet trio), the user's
-        # subnet IDs replace --vnet-subnet-id; don't force ManagedNATGateway in that case.
-        byo_hobo_subnets_set = bool(
+        # For BYO VNet Managed System Pool (Automatic SKU with system-node/node subnet trio),
+        # the user's subnet IDs replace --vnet-subnet-id; don't force ManagedNATGateway in that case.
+        byo_subnets_set = bool(
             self.raw_param.get("system_node_subnet_id") or
             self.raw_param.get("node_subnet_id")
         )
@@ -2417,7 +2417,7 @@ class AKSManagedClusterContext(BaseAKSContext):
             skuName is not None and
             skuName == CONST_MANAGED_CLUSTER_SKU_NAME_AUTOMATIC and
             isVnetSubnetIdEmpty and
-            not byo_hobo_subnets_set
+            not byo_subnets_set
         ):
             # outbound_type of Automatic SKU should be ManagedNATGateway if no subnet id provided.
             outbound_type = CONST_OUTBOUND_TYPE_MANAGED_NAT_GATEWAY
@@ -4222,14 +4222,15 @@ class AKSManagedClusterContext(BaseAKSContext):
         if enable_validation:
             if self.decorator_mode == DecoratorMode.CREATE:
                 vnet_subnet_id = self.get_vnet_subnet_id()
-                # For BYO VNet HOBO (--sku automatic with subnet trio), --vnet-subnet-id is
-                # not used: system-node / node subnets replace it. Only require --vnet-subnet-id
-                # when neither --system-node-subnet-id nor --node-subnet-id is provided.
-                byo_hobo_subnets_set = (
+                # For BYO VNet Managed System Pool (--sku automatic with subnet trio),
+                # --vnet-subnet-id is not used: system-node / node subnets replace it. Only
+                # require --vnet-subnet-id when neither --system-node-subnet-id nor
+                # --node-subnet-id is provided.
+                byo_subnets_set = (
                     self.raw_param.get("system_node_subnet_id") or
                     self.raw_param.get("node_subnet_id")
                 )
-                if apiserver_subnet_id and vnet_subnet_id is None and not byo_hobo_subnets_set:
+                if apiserver_subnet_id and vnet_subnet_id is None and not byo_subnets_set:
                     raise RequiredArgumentMissingError(
                         '"--apiserver-subnet-id" requires "--vnet-subnet-id".')
 
@@ -4259,7 +4260,7 @@ class AKSManagedClusterContext(BaseAKSContext):
         return self._get_apiserver_subnet_id(enable_validation=True)
 
     def get_system_node_subnet_id(self) -> Union[str, None]:
-        """Obtain the value of system_node_subnet_id (BYO VNet HOBO).
+        """Obtain the value of system_node_subnet_id (BYO VNet for Automatic cluster).
 
         :return: str or None
         """
@@ -4274,7 +4275,7 @@ class AKSManagedClusterContext(BaseAKSContext):
         return system_node_subnet_id
 
     def get_node_subnet_id(self) -> Union[str, None]:
-        """Obtain the value of node_subnet_id (BYO VNet HOBO).
+        """Obtain the value of node_subnet_id (BYO VNet for Automatic cluster).
 
         :return: str or None
         """
@@ -4288,48 +4289,28 @@ class AKSManagedClusterContext(BaseAKSContext):
                 node_subnet_id = self.mc.hosted_system_profile.node_subnet_id
         return node_subnet_id
 
-    def get_disable_hosted_system(self) -> bool:
-        """Obtain the value of disable_hosted_system.
-
-        :return: bool
-        """
-        return bool(self.raw_param.get("disable_hosted_system"))
-
     def validate_byo_hobo_subnets(self) -> None:
-        """Validate BYO HOBO subnet trio and mutual exclusion with --disable-hosted-system.
+        """Validate the BYO VNet subnet trio for Managed System Pool (Automatic cluster).
 
-        BYO VNet HOBO is triggered by --system-node-subnet-id / --node-subnet-id
-        (the HOBO-specific flags). --apiserver-subnet-id is intentionally NOT part of the
-        trigger because it keeps its existing general-purpose meaning for
-        --enable-apiserver-vnet-integration flows on non-HOBO clusters.
+        BYO VNet for a Managed System Pool is triggered by --system-node-subnet-id /
+        --node-subnet-id. --apiserver-subnet-id is intentionally NOT part of the trigger
+        because it keeps its existing general-purpose meaning for
+        --enable-apiserver-vnet-integration flows on non-Automatic clusters.
 
         - If either --system-node-subnet-id or --node-subnet-id is set, the full trio
           (--system-node-subnet-id, --node-subnet-id, --apiserver-subnet-id) must be
           provided and --sku must be automatic.
-        - --disable-hosted-system is mutually exclusive with the HOBO-specific
-          subnet flags (--system-node-subnet-id, --node-subnet-id) and also requires
-          --sku automatic.
         """
         if self.decorator_mode != DecoratorMode.CREATE:
             return
         system_node_subnet_id = self.raw_param.get("system_node_subnet_id")
         node_subnet_id = self.raw_param.get("node_subnet_id")
         apiserver_subnet_id = self.raw_param.get("apiserver_subnet_id")
-        disable_hosted_system = self.get_disable_hosted_system()
 
-        hobo_specific_set = bool(system_node_subnet_id or node_subnet_id)
+        byo_specific_set = bool(system_node_subnet_id or node_subnet_id)
 
-        # --disable-hosted-system is mutually exclusive with any HOBO-specific subnet flag.
-        # (We deliberately don't include --apiserver-subnet-id here: it keeps its existing
-        # general-purpose meaning for --enable-apiserver-vnet-integration flows.)
-        if disable_hosted_system and hobo_specific_set:
-            raise MutuallyExclusiveArgumentError(
-                '"--disable-hosted-system" cannot be combined with '
-                '"--system-node-subnet-id" or "--node-subnet-id".'
-            )
-
-        # Partial trio: if any HOBO-specific subnet is set, require the full trio.
-        if hobo_specific_set:
+        # Partial trio: if any BYO subnet is set, require the full trio.
+        if byo_specific_set:
             missing = []
             if not system_node_subnet_id:
                 missing.append("--system-node-subnet-id")
@@ -4339,17 +4320,13 @@ class AKSManagedClusterContext(BaseAKSContext):
                 missing.append("--apiserver-subnet-id")
             if missing:
                 raise RequiredArgumentMissingError(
-                    "BYO VNet for Automatic (HOBO) clusters requires all three subnets. "
-                    "Missing: " + ", ".join(missing) + "."
+                    "BYO VNet for a Managed System Pool (Automatic cluster) requires all three "
+                    "subnets. Missing: " + ", ".join(missing) + "."
                 )
             if self.get_sku_name() != CONST_MANAGED_CLUSTER_SKU_NAME_AUTOMATIC:
                 raise RequiredArgumentMissingError(
                     '"--system-node-subnet-id" / "--node-subnet-id" require "--sku automatic".'
                 )
-        if disable_hosted_system and self.get_sku_name() != CONST_MANAGED_CLUSTER_SKU_NAME_AUTOMATIC:
-            raise RequiredArgumentMissingError(
-                '"--disable-hosted-system" requires "--sku automatic".'
-            )
 
     def _get_enable_private_cluster(self, enable_validation: bool = False) -> bool:
         """Internal function to obtain the value of enable_private_cluster.
@@ -7089,7 +7066,7 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
         """
         self._ensure_mc(mc)
 
-        # Run BYO HOBO trio validation first so clearer errors surface before the
+        # Run BYO VNet trio validation first so clearer errors surface before the
         # generic --apiserver-subnet-id checks inside _get_apiserver_subnet_id.
         self.context.validate_byo_hobo_subnets()
 
@@ -7113,9 +7090,10 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
             if api_server_access_profile is None:
                 api_server_access_profile = self.models.ManagedClusterAPIServerAccessProfile()
             api_server_access_profile.subnet_id = self.context.get_apiserver_subnet_id()
-            # BYO VNet HOBO (Automatic SKU) requires apiserver VNet integration. When the
-            # BYO HOBO subnet trio is provided, auto-enable vnet integration so users are
-            # not forced to pass --enable-apiserver-vnet-integration alongside the subnet IDs.
+            # BYO VNet for Managed System Pool (Automatic SKU) requires apiserver VNet
+            # integration. When the BYO subnet trio is provided, auto-enable vnet
+            # integration so users are not forced to pass --enable-apiserver-vnet-integration
+            # alongside the subnet IDs.
             if (
                 self.context.get_system_node_subnet_id() or
                 self.context.get_node_subnet_id()
@@ -7130,44 +7108,36 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
     def set_up_hosted_system_profile(self, mc: ManagedCluster) -> ManagedCluster:
         """Set up hosted_system_profile on the ManagedCluster for Automatic SKU clusters.
 
-        - When the BYO VNet HOBO trio (`--system-node-subnet-id` / `--node-subnet-id` /
-          `--apiserver-subnet-id`) is provided, populate
-          `mc.hosted_system_profile.{enabled=True, system_node_subnet_id, node_subnet_id}`
-          and clear `mc.agent_pool_profiles` because HOBO manages node pools server-side.
-          The RP requires `enabled=True` to treat the request as BYO VNet rather than
-          default-VNet mode.
-        - When `--disable-hosted-system` is provided, set
-          `mc.hosted_system_profile = ManagedClusterHostedSystemProfile(enabled=False)` so
-          HOBO is deterministically opted out for Automatic clusters.
+        When the BYO VNet trio (`--system-node-subnet-id` / `--node-subnet-id` /
+        `--apiserver-subnet-id`) is provided, populate
+        `mc.hosted_system_profile.{enabled=True, system_node_subnet_id, node_subnet_id}`
+        and clear `mc.agent_pool_profiles` because the Managed System Pool manages node
+        pools server-side. The RP requires `enabled=True` to treat the request as BYO
+        VNet rather than default-VNet mode.
 
         :return: the ManagedCluster object
         """
         self._ensure_mc(mc)
 
-        # Run cross-flag validation (mutual exclusion + trio completeness + SKU gate)
+        # Run cross-flag validation (trio completeness + SKU gate)
         self.context.validate_byo_hobo_subnets()
 
         system_node_subnet_id = self.context.get_system_node_subnet_id()
         node_subnet_id = self.context.get_node_subnet_id()
-        disable_hosted_system = self.context.get_disable_hosted_system()
-
-        if disable_hosted_system:
-            mc.hosted_system_profile = self.models.ManagedClusterHostedSystemProfile(enabled=False)
-            return mc
 
         if system_node_subnet_id or node_subnet_id:
             if mc.hosted_system_profile is None:
                 mc.hosted_system_profile = self.models.ManagedClusterHostedSystemProfile()
-            # BYO VNet HOBO requires explicit enablement so the RP treats this as
-            # a BYO VNet cluster (not default-vnet) when BYO subnets are supplied.
+            # BYO VNet requires explicit enablement so the RP treats this as a BYO VNet
+            # cluster (not default-vnet) when BYO subnets are supplied.
             mc.hosted_system_profile.enabled = True
             if system_node_subnet_id:
                 mc.hosted_system_profile.system_node_subnet_id = system_node_subnet_id
             if node_subnet_id:
                 mc.hosted_system_profile.node_subnet_id = node_subnet_id
-            # The HOBO server manages node pools; drop the default agent pool so the
-            # RP doesn't reject the request for having an unrelated default nodepool
-            # in a VNet other than the BYO HOBO trio's VNet.
+            # The Managed System Pool manages node pools; drop the default agent pool so
+            # the RP doesn't reject the request for having an unrelated default nodepool
+            # in a VNet other than the BYO trio's VNet.
             if mc.agent_pool_profiles is not None:
                 mc.agent_pool_profiles = None
         return mc
@@ -7652,7 +7622,7 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
         mc = self.set_up_oidc_issuer_profile(mc)
         # set up api server access profile and fqdn subdomain
         mc = self.set_up_api_server_access_profile(mc)
-        # set up hosted system profile (BYO VNet HOBO)
+        # set up hosted system profile (BYO VNet for Managed System Pool)
         mc = self.set_up_hosted_system_profile(mc)
         # set up identity
         mc = self.set_up_identity(mc)
@@ -8154,7 +8124,7 @@ class AKSManagedClusterUpdateDecorator(BaseAKSManagedClusterDecorator):
         """
         self._ensure_mc(mc)
 
-        # HOBO (Hosted Overlay System Pool) clusters manage node pools on the
+        # Automatic clusters with a Managed System Pool manage node pools on the
         # server side and surface `agent_pool_profiles` as None. Skip the
         # default agent pool update in that case.
         if mc.hosted_system_profile and mc.hosted_system_profile.enabled:

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -7130,10 +7130,12 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
     def set_up_hosted_system_profile(self, mc: ManagedCluster) -> ManagedCluster:
         """Set up hosted_system_profile on the ManagedCluster for Automatic SKU clusters.
 
-        - When any of `--system-node-subnet-id` / `--node-subnet-id` / `--apiserver-subnet-id`
-          are provided (BYO VNet HOBO), validate the trio and populate
-          `mc.hosted_system_profile.{system_node_subnet_id, node_subnet_id}`. `enabled` is left
-          unset so the server side keeps ownership of the default/opt-in decision.
+        - When the BYO VNet HOBO trio (`--system-node-subnet-id` / `--node-subnet-id` /
+          `--apiserver-subnet-id`) is provided, populate
+          `mc.hosted_system_profile.{enabled=True, system_node_subnet_id, node_subnet_id}`
+          and clear `mc.agent_pool_profiles` because HOBO manages node pools server-side.
+          The RP requires `enabled=True` to treat the request as BYO VNet rather than
+          default-VNet mode.
         - When `--disable-hosted-system` is provided, set
           `mc.hosted_system_profile = ManagedClusterHostedSystemProfile(enabled=False)` so
           HOBO is deterministically opted out for Automatic clusters.

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -2407,7 +2407,19 @@ class AKSManagedClusterContext(BaseAKSContext):
 
         skuName = self.get_sku_name()
         isVnetSubnetIdEmpty = self.get_vnet_subnet_id() in ["", None]
-        if skuName is not None and skuName == CONST_MANAGED_CLUSTER_SKU_NAME_AUTOMATIC and isVnetSubnetIdEmpty:
+        # For BYO VNet HOBO (Automatic SKU with system-node/node subnet trio), the user's
+        # subnet IDs replace --vnet-subnet-id; don't force ManagedNATGateway in that case.
+        byo_hobo_subnets_set = bool(
+            self.raw_param.get("system_node_subnet_id") or
+            self.raw_param.get("node_subnet_id")
+        )
+        if (
+            skuName is not None and
+            skuName == CONST_MANAGED_CLUSTER_SKU_NAME_AUTOMATIC and
+            isVnetSubnetIdEmpty and
+            not byo_hobo_subnets_set and
+            self.raw_param.get("outbound_type") is None
+        ):
             # outbound_type of Automatic SKU should be ManagedNATGateway if no subnet id provided.
             outbound_type = CONST_OUTBOUND_TYPE_MANAGED_NAT_GATEWAY
 
@@ -7096,6 +7108,14 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
             if api_server_access_profile is None:
                 api_server_access_profile = self.models.ManagedClusterAPIServerAccessProfile()
             api_server_access_profile.subnet_id = self.context.get_apiserver_subnet_id()
+            # BYO VNet HOBO (Automatic SKU) requires apiserver VNet integration. When the
+            # BYO HOBO subnet trio is provided, auto-enable vnet integration so users are
+            # not forced to pass --enable-apiserver-vnet-integration alongside the subnet IDs.
+            if (
+                self.context.get_system_node_subnet_id() or
+                self.context.get_node_subnet_id()
+            ):
+                api_server_access_profile.enable_vnet_integration = True
         mc.api_server_access_profile = api_server_access_profile
 
         fqdn_subdomain = self.context.get_fqdn_subdomain()
@@ -7131,10 +7151,18 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
         if system_node_subnet_id or node_subnet_id:
             if mc.hosted_system_profile is None:
                 mc.hosted_system_profile = self.models.ManagedClusterHostedSystemProfile()
+            # BYO VNet HOBO requires explicit enablement so the RP treats this as
+            # a BYO VNet cluster (not default-vnet) when BYO subnets are supplied.
+            mc.hosted_system_profile.enabled = True
             if system_node_subnet_id:
                 mc.hosted_system_profile.system_node_subnet_id = system_node_subnet_id
             if node_subnet_id:
                 mc.hosted_system_profile.node_subnet_id = node_subnet_id
+            # The HOBO server manages node pools; drop the default agent pool so the
+            # RP doesn't reject the request for having an unrelated default nodepool
+            # in a VNet other than the BYO HOBO trio's VNet.
+            if mc.agent_pool_profiles is not None:
+                mc.agent_pool_profiles = None
         return mc
 
     def set_up_identity(self, mc: ManagedCluster) -> ManagedCluster:

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -4295,7 +4295,7 @@ class AKSManagedClusterContext(BaseAKSContext):
         """
         return bool(self.raw_param.get("disable_hosted_system"))
 
-    def _validate_byo_hobo_subnets(self) -> None:
+    def validate_byo_hobo_subnets(self) -> None:
         """Validate BYO HOBO subnet trio and mutual exclusion with --disable-hosted-system.
 
         BYO VNet HOBO is triggered by --system-node-subnet-id / --node-subnet-id
@@ -7091,7 +7091,7 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
 
         # Run BYO HOBO trio validation first so clearer errors surface before the
         # generic --apiserver-subnet-id checks inside _get_apiserver_subnet_id.
-        self.context._validate_byo_hobo_subnets()
+        self.context.validate_byo_hobo_subnets()
 
         api_server_access_profile = None
         api_server_authorized_ip_ranges = self.context.get_api_server_authorized_ip_ranges()
@@ -7143,7 +7143,7 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
         self._ensure_mc(mc)
 
         # Run cross-flag validation (mutual exclusion + trio completeness + SKU gate)
-        self.context._validate_byo_hobo_subnets()
+        self.context.validate_byo_hobo_subnets()
 
         system_node_subnet_id = self.context.get_system_node_subnet_id()
         node_subnet_id = self.context.get_node_subnet_id()

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -2447,21 +2447,22 @@ class AKSManagedClusterContext(BaseAKSContext):
                 return outbound_type  # basic sku lb doesn't support outbound type
 
             if outbound_type == CONST_OUTBOUND_TYPE_USER_DEFINED_ROUTING:
-                if self.get_vnet_subnet_id() in ["", None]:
+                if self.get_vnet_subnet_id() in ["", None] and not byo_subnets_set:
                     raise RequiredArgumentMissingError(
                         "--vnet-subnet-id must be specified for userDefinedRouting and it must "
                         "be pre-configured with a route table with egress rules"
                     )
             if outbound_type == CONST_OUTBOUND_TYPE_USER_ASSIGNED_NAT_GATEWAY:
-                if self.get_vnet_subnet_id() in ["", None]:
+                if self.get_vnet_subnet_id() in ["", None] and not byo_subnets_set:
                     raise RequiredArgumentMissingError(
                         "--vnet-subnet-id must be specified for userAssignedNATGateway and it must "
                         "be pre-configured with a NAT gateway with outbound ips"
                     )
             if outbound_type == CONST_OUTBOUND_TYPE_MANAGED_NAT_GATEWAY:
-                if self.get_vnet_subnet_id() not in ["", None]:
+                if self.get_vnet_subnet_id() not in ["", None] or byo_subnets_set:
                     raise InvalidArgumentValueError(
-                        "--vnet-subnet-id cannot be specified for managedNATGateway"
+                        "--vnet-subnet-id, --system-node-subnet-id and --node-subnet-id cannot be "
+                        "specified for managedNATGateway"
                     )
             if outbound_type != CONST_OUTBOUND_TYPE_LOAD_BALANCER:
                 if (

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -4295,7 +4295,7 @@ class AKSManagedClusterContext(BaseAKSContext):
         """Obtain the value of enable_hosted_system.
 
         Returns True when the user explicitly opts in via --enable-hosted-system,
-        or implicitly via the BYO VNet subnet trio (which is HOBO-only).
+        or implicitly via the BYO VNet subnet trio for Managed System Pool.
 
         :return: bool
         """
@@ -4311,7 +4311,7 @@ class AKSManagedClusterContext(BaseAKSContext):
         )
         return explicit or implicit
 
-    def validate_byo_hobo_subnets(self) -> None:
+    def validate_byo_hosted_system_subnets(self) -> None:
         """Validate the BYO VNet subnet trio and the --enable-hosted-system flag.
 
         BYO VNet for a Managed System Pool is triggered by --system-node-subnet-id /
@@ -6493,7 +6493,7 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
 
         # Validate before granting roles so a malformed BYO trio does not leave
         # partial Network Contributor assignments behind.
-        self.context.validate_byo_hobo_subnets()
+        self.context.validate_byo_hosted_system_subnets()
 
         need_post_creation_vnet_permission_granting = False
         vnet_subnet_id = self.context.get_vnet_subnet_id()
@@ -7162,7 +7162,7 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
 
         # Run BYO VNet trio validation first so clearer errors surface before the
         # generic --apiserver-subnet-id checks inside _get_apiserver_subnet_id.
-        self.context.validate_byo_hobo_subnets()
+        self.context.validate_byo_hosted_system_subnets()
 
         api_server_access_profile = None
         api_server_authorized_ip_ranges = self.context.get_api_server_authorized_ip_ranges()
@@ -7216,7 +7216,7 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
         self._ensure_mc(mc)
 
         # Run cross-flag validation (--enable-hosted-system SKU gate + BYO trio completeness)
-        self.context.validate_byo_hobo_subnets()
+        self.context.validate_byo_hosted_system_subnets()
 
         system_node_subnet_id = self.context.get_system_node_subnet_id()
         node_subnet_id = self.context.get_node_subnet_id()

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -4298,9 +4298,17 @@ class AKSManagedClusterContext(BaseAKSContext):
     def _validate_byo_hobo_subnets(self) -> None:
         """Validate BYO HOBO subnet trio and mutual exclusion with --disable-hosted-system.
 
-        - If any of system-node / node / apiserver subnet is set, all three must be provided.
-        - --disable-hosted-system cannot be combined with any of the three subnets.
-        - BYO HOBO (subnet trio) requires --sku automatic.
+        BYO VNet HOBO is triggered by --system-node-subnet-id / --node-subnet-id
+        (the HOBO-specific flags). --apiserver-subnet-id is intentionally NOT part of the
+        trigger because it keeps its existing general-purpose meaning for
+        --enable-apiserver-vnet-integration flows on non-HOBO clusters.
+
+        - If either --system-node-subnet-id or --node-subnet-id is set, the full trio
+          (--system-node-subnet-id, --node-subnet-id, --apiserver-subnet-id) must be
+          provided and --sku must be automatic.
+        - --disable-hosted-system is mutually exclusive with the HOBO-specific
+          subnet flags (--system-node-subnet-id, --node-subnet-id) and also requires
+          --sku automatic.
         """
         if self.decorator_mode != DecoratorMode.CREATE:
             return
@@ -4310,7 +4318,6 @@ class AKSManagedClusterContext(BaseAKSContext):
         disable_hosted_system = self.get_disable_hosted_system()
 
         hobo_specific_set = bool(system_node_subnet_id or node_subnet_id)
-        any_trio_set = bool(hobo_specific_set or apiserver_subnet_id)
 
         # --disable-hosted-system is mutually exclusive with any HOBO-specific subnet flag.
         # (We deliberately don't include --apiserver-subnet-id here: it keeps its existing
@@ -4343,7 +4350,6 @@ class AKSManagedClusterContext(BaseAKSContext):
             raise RequiredArgumentMissingError(
                 '"--disable-hosted-system" requires "--sku automatic".'
             )
-        _ = any_trio_set  # reserved for future per-flag gating
 
     def _get_enable_private_cluster(self, enable_validation: bool = False) -> bool:
         """Internal function to obtain the value of enable_private_cluster.

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -4289,8 +4289,25 @@ class AKSManagedClusterContext(BaseAKSContext):
                 node_subnet_id = self.mc.hosted_system_profile.node_subnet_id
         return node_subnet_id
 
+    def get_enable_hosted_system(self) -> bool:
+        """Obtain the value of enable_hosted_system.
+
+        Returns True when the user explicitly opts in via --enable-hosted-system,
+        or implicitly via the BYO VNet subnet trio (which is HOBO-only).
+
+        :return: bool
+        """
+        if self.decorator_mode != DecoratorMode.CREATE:
+            return False
+        explicit = bool(self.raw_param.get("enable_hosted_system"))
+        implicit = bool(
+            self.raw_param.get("system_node_subnet_id") or
+            self.raw_param.get("node_subnet_id")
+        )
+        return explicit or implicit
+
     def validate_byo_hobo_subnets(self) -> None:
-        """Validate the BYO VNet subnet trio for Managed System Pool (Automatic cluster).
+        """Validate the BYO VNet subnet trio and the --enable-hosted-system flag.
 
         BYO VNet for a Managed System Pool is triggered by --system-node-subnet-id /
         --node-subnet-id. --apiserver-subnet-id is intentionally NOT part of the trigger
@@ -4300,14 +4317,22 @@ class AKSManagedClusterContext(BaseAKSContext):
         - If either --system-node-subnet-id or --node-subnet-id is set, the full trio
           (--system-node-subnet-id, --node-subnet-id, --apiserver-subnet-id) must be
           provided and --sku must be automatic.
+        - --enable-hosted-system is only valid with --sku automatic.
         """
         if self.decorator_mode != DecoratorMode.CREATE:
             return
         system_node_subnet_id = self.raw_param.get("system_node_subnet_id")
         node_subnet_id = self.raw_param.get("node_subnet_id")
         apiserver_subnet_id = self.raw_param.get("apiserver_subnet_id")
+        enable_hosted_system = bool(self.raw_param.get("enable_hosted_system"))
 
         byo_specific_set = bool(system_node_subnet_id or node_subnet_id)
+
+        # --enable-hosted-system requires --sku automatic.
+        if enable_hosted_system and self.get_sku_name() != CONST_MANAGED_CLUSTER_SKU_NAME_AUTOMATIC:
+            raise RequiredArgumentMissingError(
+                '"--enable-hosted-system" requires "--sku automatic".'
+            )
 
         # Partial trio: if any BYO subnet is set, require the full trio.
         if byo_specific_set:
@@ -7108,39 +7133,42 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
     def set_up_hosted_system_profile(self, mc: ManagedCluster) -> ManagedCluster:
         """Set up hosted_system_profile on the ManagedCluster for Automatic SKU clusters.
 
-        When the BYO VNet trio (`--system-node-subnet-id` / `--node-subnet-id` /
-        `--apiserver-subnet-id`) is provided, populate
-        `mc.hosted_system_profile.{enabled=True, system_node_subnet_id, node_subnet_id}`
-        and clear `mc.agent_pool_profiles` because the Managed System Pool manages node
-        pools server-side. The RP requires `enabled=True` to treat the request as BYO
-        VNet rather than default-VNet mode.
+        Triggered when the user explicitly opts in via `--enable-hosted-system`, or
+        implicitly by supplying the BYO VNet subnet trio (`--system-node-subnet-id` /
+        `--node-subnet-id` / `--apiserver-subnet-id`). In either case:
+          - `mc.hosted_system_profile.enabled` is set to True so the RP treats this
+            as a Managed System Pool request.
+          - `system_node_subnet_id` / `node_subnet_id` are populated when supplied.
+          - `mc.agent_pool_profiles` is cleared. The CLI unconditionally synthesizes
+            a default agent pool via `set_up_agentpool_profile`; on a Managed System
+            Pool cluster the system pool is provisioned server-side from
+            `hosted_system_profile`, so the CLI default is stale and (in the BYO case)
+            actively conflicts with the BYO VNet.
 
         :return: the ManagedCluster object
         """
         self._ensure_mc(mc)
 
-        # Run cross-flag validation (trio completeness + SKU gate)
+        # Run cross-flag validation (--enable-hosted-system SKU gate + BYO trio completeness)
         self.context.validate_byo_hobo_subnets()
 
         system_node_subnet_id = self.context.get_system_node_subnet_id()
         node_subnet_id = self.context.get_node_subnet_id()
+        enable_hosted_system = self.context.get_enable_hosted_system()
 
-        if system_node_subnet_id or node_subnet_id:
+        if enable_hosted_system:
             if mc.hosted_system_profile is None:
                 mc.hosted_system_profile = self.models.ManagedClusterHostedSystemProfile()
-            # BYO VNet requires explicit enablement so the RP treats this as a BYO VNet
-            # cluster (not default-vnet) when BYO subnets are supplied.
+            # Explicit enablement so the RP treats this as a Managed System Pool cluster.
             mc.hosted_system_profile.enabled = True
             if system_node_subnet_id:
                 mc.hosted_system_profile.system_node_subnet_id = system_node_subnet_id
             if node_subnet_id:
                 mc.hosted_system_profile.node_subnet_id = node_subnet_id
-            # On an Automatic cluster with BYO VNet, the system pool is provisioned by
-            # the RP from `hosted_system_profile` (using `system_node_subnet_id`), so
-            # the CLI-synthesized default `agent_pool_profiles` entry is unnecessary
-            # and would conflict: its `vnet_subnet_id` is unset (or bound to the
-            # default VNet), which the RP rejects against the BYO trio. Clear it and
-            # let the RP populate pools from `hosted_system_profile`.
+            # Clear the CLI-synthesized default agent pool — the RP provisions the
+            # system pool from hosted_system_profile instead. Leaving it in causes
+            # the RP to reject BYO VNet clusters and produces a ghost pool on
+            # non-BYO Automatic clusters.
             if mc.agent_pool_profiles is not None:
                 mc.agent_pool_profiles = None
         return mc

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -7135,9 +7135,12 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
                 mc.hosted_system_profile.system_node_subnet_id = system_node_subnet_id
             if node_subnet_id:
                 mc.hosted_system_profile.node_subnet_id = node_subnet_id
-            # The Managed System Pool manages node pools; drop the default agent pool so
-            # the RP doesn't reject the request for having an unrelated default nodepool
-            # in a VNet other than the BYO trio's VNet.
+            # On an Automatic cluster with BYO VNet, the system pool is provisioned by
+            # the RP from `hosted_system_profile` (using `system_node_subnet_id`), so
+            # the CLI-synthesized default `agent_pool_profiles` entry is unnecessary
+            # and would conflict: its `vnet_subnet_id` is unset (or bound to the
+            # default VNet), which the RP rejects against the BYO trio. Clear it and
+            # let the RP populate pools from `hosted_system_profile`.
             if mc.agent_pool_profiles is not None:
                 mc.agent_pool_profiles = None
         return mc

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
@@ -4426,6 +4426,95 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
         with self.assertRaises(RequiredArgumentMissingError):
             ctx_6.get_apiserver_subnet_id()
 
+    def test_byo_hobo_subnets_validation(self):
+        system_subnet = "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/v/subnets/sys"
+        node_subnet = "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/v/subnets/nod"
+        api_subnet = "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/v/subnets/api"
+
+        # disable + subnet -> MutuallyExclusiveArgumentError
+        ctx = AKSManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict({
+                "sku": "automatic",
+                "disable_hosted_system": True,
+                "system_node_subnet_id": system_subnet,
+            }),
+            self.models,
+            decorator_mode=DecoratorMode.CREATE,
+        )
+        with self.assertRaises(MutuallyExclusiveArgumentError):
+            ctx._validate_byo_hobo_subnets()
+
+        # partial trio -> RequiredArgumentMissingError
+        ctx = AKSManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict({
+                "sku": "automatic",
+                "system_node_subnet_id": system_subnet,
+            }),
+            self.models,
+            decorator_mode=DecoratorMode.CREATE,
+        )
+        with self.assertRaises(RequiredArgumentMissingError):
+            ctx._validate_byo_hobo_subnets()
+
+        # trio without --sku automatic -> RequiredArgumentMissingError
+        ctx = AKSManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict({
+                "sku": "base",
+                "system_node_subnet_id": system_subnet,
+                "node_subnet_id": node_subnet,
+                "apiserver_subnet_id": api_subnet,
+            }),
+            self.models,
+            decorator_mode=DecoratorMode.CREATE,
+        )
+        with self.assertRaises(RequiredArgumentMissingError):
+            ctx._validate_byo_hobo_subnets()
+
+        # disable_hosted_system without automatic -> RequiredArgumentMissingError
+        ctx = AKSManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict({
+                "sku": "base",
+                "disable_hosted_system": True,
+            }),
+            self.models,
+            decorator_mode=DecoratorMode.CREATE,
+        )
+        with self.assertRaises(RequiredArgumentMissingError):
+            ctx._validate_byo_hobo_subnets()
+
+        # happy path: full trio + automatic
+        ctx = AKSManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict({
+                "sku": "automatic",
+                "system_node_subnet_id": system_subnet,
+                "node_subnet_id": node_subnet,
+                "apiserver_subnet_id": api_subnet,
+            }),
+            self.models,
+            decorator_mode=DecoratorMode.CREATE,
+        )
+        ctx._validate_byo_hobo_subnets()
+        self.assertEqual(ctx.get_system_node_subnet_id(), system_subnet)
+        self.assertEqual(ctx.get_node_subnet_id(), node_subnet)
+
+        # happy path: disable + automatic
+        ctx = AKSManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict({
+                "sku": "automatic",
+                "disable_hosted_system": True,
+            }),
+            self.models,
+            decorator_mode=DecoratorMode.CREATE,
+        )
+        ctx._validate_byo_hobo_subnets()
+        self.assertTrue(ctx.get_disable_hosted_system())
+
     def test_get_private_dns_zone(self):
         # default
         ctx_1 = AKSManagedClusterContext(

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
@@ -4474,6 +4474,33 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
         ctx.validate_byo_hobo_subnets()
         self.assertEqual(ctx.get_system_node_subnet_id(), system_subnet)
         self.assertEqual(ctx.get_node_subnet_id(), node_subnet)
+        self.assertTrue(ctx.get_enable_hosted_system())  # BYO trio implies enable_hosted_system
+
+        # --enable-hosted-system without --sku automatic -> RequiredArgumentMissingError
+        ctx = AKSManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict({
+                "sku": "base",
+                "enable_hosted_system": True,
+            }),
+            self.models,
+            decorator_mode=DecoratorMode.CREATE,
+        )
+        with self.assertRaises(RequiredArgumentMissingError):
+            ctx.validate_byo_hobo_subnets()
+
+        # happy path: --enable-hosted-system alone on automatic
+        ctx = AKSManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict({
+                "sku": "automatic",
+                "enable_hosted_system": True,
+            }),
+            self.models,
+            decorator_mode=DecoratorMode.CREATE,
+        )
+        ctx.validate_byo_hobo_subnets()
+        self.assertTrue(ctx.get_enable_hosted_system())
 
     def test_get_private_dns_zone(self):
         # default

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
@@ -4431,20 +4431,6 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
         node_subnet = "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/v/subnets/nod"
         api_subnet = "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/v/subnets/api"
 
-        # disable + subnet -> MutuallyExclusiveArgumentError
-        ctx = AKSManagedClusterContext(
-            self.cmd,
-            AKSManagedClusterParamDict({
-                "sku": "automatic",
-                "disable_hosted_system": True,
-                "system_node_subnet_id": system_subnet,
-            }),
-            self.models,
-            decorator_mode=DecoratorMode.CREATE,
-        )
-        with self.assertRaises(MutuallyExclusiveArgumentError):
-            ctx.validate_byo_hobo_subnets()
-
         # partial trio -> RequiredArgumentMissingError
         ctx = AKSManagedClusterContext(
             self.cmd,
@@ -4473,19 +4459,6 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
         with self.assertRaises(RequiredArgumentMissingError):
             ctx.validate_byo_hobo_subnets()
 
-        # disable_hosted_system without automatic -> RequiredArgumentMissingError
-        ctx = AKSManagedClusterContext(
-            self.cmd,
-            AKSManagedClusterParamDict({
-                "sku": "base",
-                "disable_hosted_system": True,
-            }),
-            self.models,
-            decorator_mode=DecoratorMode.CREATE,
-        )
-        with self.assertRaises(RequiredArgumentMissingError):
-            ctx.validate_byo_hobo_subnets()
-
         # happy path: full trio + automatic
         ctx = AKSManagedClusterContext(
             self.cmd,
@@ -4501,19 +4474,6 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
         ctx.validate_byo_hobo_subnets()
         self.assertEqual(ctx.get_system_node_subnet_id(), system_subnet)
         self.assertEqual(ctx.get_node_subnet_id(), node_subnet)
-
-        # happy path: disable + automatic
-        ctx = AKSManagedClusterContext(
-            self.cmd,
-            AKSManagedClusterParamDict({
-                "sku": "automatic",
-                "disable_hosted_system": True,
-            }),
-            self.models,
-            decorator_mode=DecoratorMode.CREATE,
-        )
-        ctx.validate_byo_hobo_subnets()
-        self.assertTrue(ctx.get_disable_hosted_system())
 
     def test_get_private_dns_zone(self):
         # default

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
@@ -6541,6 +6541,22 @@ class AKSManagedClusterCreateDecoratorTestCase(unittest.TestCase):
         ground_truth_mc_1.agent_pool_profiles = [ground_truth_agentpool_profile_1]
         self.assertEqual(dec_mc_1, ground_truth_mc_1)
 
+        # Managed System Pool clusters get their system pool from hosted_system_profile,
+        # so the CLI should not synthesize a default agent pool up front.
+        dec_2 = AKSManagedClusterCreateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "sku": "automatic",
+                "enable_hosted_system": True,
+            },
+            ResourceType.MGMT_CONTAINERSERVICE,
+        )
+        mc_2 = self.models.ManagedCluster(location="test_location")
+        dec_2.context.attach_mc(mc_2)
+        dec_mc_2 = dec_2.set_up_agentpool_profile(mc_2)
+        self.assertIsNone(dec_mc_2.agent_pool_profiles)
+
     def test_set_up_mc_properties(self):
         dec_1 = AKSManagedClusterCreateDecorator(
             self.cmd,
@@ -7120,9 +7136,6 @@ class AKSManagedClusterCreateDecoratorTestCase(unittest.TestCase):
         )
         mc_1 = self.models.ManagedCluster(location="test_location")
         dec_1.context.attach_mc(mc_1)
-        cli_default_pool = self.models.ManagedClusterAgentPoolProfile(name="nodepool1")
-        mc_1.agent_pool_profiles = [cli_default_pool]
-        dec_1.context.set_intermediate("cli_synthesized_default_agent_pool", cli_default_pool)
 
         dec_1.set_up_hosted_system_profile(mc_1)
 
@@ -7142,34 +7155,13 @@ class AKSManagedClusterCreateDecoratorTestCase(unittest.TestCase):
         )
         mc_2 = self.models.ManagedCluster(location="test_location")
         dec_2.context.attach_mc(mc_2)
-        cli_default_pool = self.models.ManagedClusterAgentPoolProfile(name="nodepool1")
         user_pool = self.models.ManagedClusterAgentPoolProfile(name="userpool")
-        mc_2.agent_pool_profiles = [cli_default_pool, user_pool]
-        dec_2.context.set_intermediate("cli_synthesized_default_agent_pool", cli_default_pool)
+        mc_2.agent_pool_profiles = [user_pool]
 
         dec_2.set_up_hosted_system_profile(mc_2)
 
         self.assertTrue(mc_2.hosted_system_profile.enabled)
         self.assertEqual(mc_2.agent_pool_profiles, [user_pool])
-
-        dec_3 = AKSManagedClusterCreateDecorator(
-            self.cmd,
-            self.client,
-            {
-                "sku": "automatic",
-                "enable_hosted_system": True,
-            },
-            ResourceType.MGMT_CONTAINERSERVICE,
-        )
-        mc_3 = self.models.ManagedCluster(location="test_location")
-        dec_3.context.attach_mc(mc_3)
-        user_pool = self.models.ManagedClusterAgentPoolProfile(name="userpool")
-        mc_3.agent_pool_profiles = [user_pool]
-
-        dec_3.set_up_hosted_system_profile(mc_3)
-
-        self.assertTrue(mc_3.hosted_system_profile.enabled)
-        self.assertEqual(mc_3.agent_pool_profiles, [user_pool])
 
     def test_set_up_network_profile(self):
         # default value in `aks_create`

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
@@ -6885,6 +6885,101 @@ class AKSManagedClusterCreateDecoratorTestCase(unittest.TestCase):
                 False,
             )
 
+        # BYO VNet for Managed System Pool with user-assigned identity grants all BYO subnets.
+        system_subnet = "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/v/subnets/system"
+        node_subnet = "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/v/subnets/node"
+        api_subnet = "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/v/subnets/api"
+        identity_obj = Mock(
+            principal_id="test_object_id",
+        )
+        with patch(
+            "azure.cli.command_modules.acs.managed_cluster_decorator.AKSManagedClusterContext.get_identity_by_msi_client",
+            return_value=identity_obj,
+        ):
+            dec_6 = AKSManagedClusterCreateDecorator(
+                self.cmd,
+                self.client,
+                {
+                    "enable_managed_identity": True,
+                    "sku": "automatic",
+                    "system_node_subnet_id": system_subnet,
+                    "node_subnet_id": node_subnet,
+                    "apiserver_subnet_id": api_subnet,
+                    "skip_subnet_role_assignment": False,
+                    "assign_identity": "test_assign_identity",
+                },
+                ResourceType.MGMT_CONTAINERSERVICE,
+            )
+            mc_6 = self.models.ManagedCluster(location="test_location")
+            dec_6.context.attach_mc(mc_6)
+            with patch(
+                "azure.cli.command_modules.acs.managed_cluster_decorator.subnet_role_assignment_exists",
+                return_value=False,
+            ), patch(
+                "azure.cli.command_modules.acs.managed_cluster_decorator.add_role_assignment",
+                return_value=True,
+            ) as add_role_assignment:
+                dec_6.process_add_role_assignment_for_vnet_subnet(mc_6)
+            add_role_assignment.assert_has_calls([
+                call(
+                    self.cmd,
+                    "Network Contributor",
+                    "test_object_id",
+                    is_service_principal=False,
+                    scope=system_subnet,
+                ),
+                call(
+                    self.cmd,
+                    "Network Contributor",
+                    "test_object_id",
+                    is_service_principal=False,
+                    scope=node_subnet,
+                ),
+                call(
+                    self.cmd,
+                    "Network Contributor",
+                    "test_object_id",
+                    is_service_principal=False,
+                    scope=api_subnet,
+                ),
+            ])
+            self.assertEqual(add_role_assignment.call_count, 3)
+            self.assertEqual(
+                dec_6.context.get_intermediate("need_post_creation_vnet_permission_granting"),
+                False,
+            )
+
+        # BYO VNet for Managed System Pool with system-assigned identity defers all BYO subnets.
+        dec_7 = AKSManagedClusterCreateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "enable_managed_identity": True,
+                "sku": "automatic",
+                "system_node_subnet_id": system_subnet,
+                "node_subnet_id": node_subnet,
+                "apiserver_subnet_id": api_subnet,
+                "skip_subnet_role_assignment": False,
+                "assign_identity": None,
+            },
+            ResourceType.MGMT_CONTAINERSERVICE,
+        )
+        mc_7 = self.models.ManagedCluster(location="test_location")
+        dec_7.context.attach_mc(mc_7)
+        with patch(
+            "azure.cli.command_modules.acs.managed_cluster_decorator.subnet_role_assignment_exists",
+            return_value=False,
+        ):
+            dec_7.process_add_role_assignment_for_vnet_subnet(mc_7)
+        self.assertEqual(
+            dec_7.context.get_intermediate("need_post_creation_vnet_permission_granting"),
+            True,
+        )
+        self.assertEqual(
+            dec_7.context.get_intermediate("byo_hosted_system_subnets_pending_grant"),
+            [system_subnet, node_subnet, api_subnet],
+        )
+
     def test_process_attach_acr(self):
         # default value in `aks_create`
         dec_1 = AKSManagedClusterCreateDecorator(
@@ -8616,6 +8711,49 @@ class AKSManagedClusterCreateDecoratorTestCase(unittest.TestCase):
             scope="test_vnet_subnet_id",
             is_service_principal=False,
         )
+
+        dec_2 = AKSManagedClusterCreateDecorator(
+            self.cmd,
+            self.client,
+            {},
+            ResourceType.MGMT_CONTAINERSERVICE,
+        )
+        mc_2 = self.models.ManagedCluster(location="test_location")
+        dec_2.context.attach_mc(mc_2)
+        dec_2.context.set_intermediate("need_post_creation_vnet_permission_granting", True)
+        dec_2.context.set_intermediate(
+            "byo_hosted_system_subnets_pending_grant",
+            ["test_system_subnet_id", "test_node_subnet_id", "test_api_subnet_id"],
+        )
+        self.client.get = Mock(return_value=Mock(identity=Mock(principal_id="test_principal_id")))
+        with patch(
+            "azure.cli.command_modules.acs.managed_cluster_decorator.add_role_assignment", return_value=True
+        ) as mock_add:
+            dec_2.immediate_processing_after_request(mc_2)
+        mock_add.assert_has_calls([
+            call(
+                self.cmd,
+                "Network Contributor",
+                "test_principal_id",
+                scope="test_system_subnet_id",
+                is_service_principal=False,
+            ),
+            call(
+                self.cmd,
+                "Network Contributor",
+                "test_principal_id",
+                scope="test_node_subnet_id",
+                is_service_principal=False,
+            ),
+            call(
+                self.cmd,
+                "Network Contributor",
+                "test_principal_id",
+                scope="test_api_subnet_id",
+                is_service_principal=False,
+            ),
+        ])
+        self.assertEqual(mock_add.call_count, 3)
 
     def test_postprocessing_after_mc_created(self):
         dec_1 = AKSManagedClusterCreateDecorator(

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
@@ -4443,7 +4443,7 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
             decorator_mode=DecoratorMode.CREATE,
         )
         with self.assertRaises(MutuallyExclusiveArgumentError):
-            ctx._validate_byo_hobo_subnets()
+            ctx.validate_byo_hobo_subnets()
 
         # partial trio -> RequiredArgumentMissingError
         ctx = AKSManagedClusterContext(
@@ -4456,7 +4456,7 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
             decorator_mode=DecoratorMode.CREATE,
         )
         with self.assertRaises(RequiredArgumentMissingError):
-            ctx._validate_byo_hobo_subnets()
+            ctx.validate_byo_hobo_subnets()
 
         # trio without --sku automatic -> RequiredArgumentMissingError
         ctx = AKSManagedClusterContext(
@@ -4471,7 +4471,7 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
             decorator_mode=DecoratorMode.CREATE,
         )
         with self.assertRaises(RequiredArgumentMissingError):
-            ctx._validate_byo_hobo_subnets()
+            ctx.validate_byo_hobo_subnets()
 
         # disable_hosted_system without automatic -> RequiredArgumentMissingError
         ctx = AKSManagedClusterContext(
@@ -4484,7 +4484,7 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
             decorator_mode=DecoratorMode.CREATE,
         )
         with self.assertRaises(RequiredArgumentMissingError):
-            ctx._validate_byo_hobo_subnets()
+            ctx.validate_byo_hobo_subnets()
 
         # happy path: full trio + automatic
         ctx = AKSManagedClusterContext(
@@ -4498,7 +4498,7 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
             self.models,
             decorator_mode=DecoratorMode.CREATE,
         )
-        ctx._validate_byo_hobo_subnets()
+        ctx.validate_byo_hobo_subnets()
         self.assertEqual(ctx.get_system_node_subnet_id(), system_subnet)
         self.assertEqual(ctx.get_node_subnet_id(), node_subnet)
 
@@ -4512,7 +4512,7 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
             self.models,
             decorator_mode=DecoratorMode.CREATE,
         )
-        ctx._validate_byo_hobo_subnets()
+        ctx.validate_byo_hobo_subnets()
         self.assertTrue(ctx.get_disable_hosted_system())
 
     def test_get_private_dns_zone(self):

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
@@ -2142,6 +2142,40 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
         ctx_14.attach_mc(mc_14)
         self.assertEqual(ctx_14.get_outbound_type(), CONST_OUTBOUND_TYPE_LOAD_BALANCER)
 
+        ctx_14_1 = AKSManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict({
+                "sku": "automatic",
+                "outbound_type": CONST_OUTBOUND_TYPE_USER_DEFINED_ROUTING,
+            }),
+            self.models,
+            decorator_mode=DecoratorMode.CREATE,
+        )
+        ctx_14_1.agentpool_context = mock.MagicMock()
+        ctx_14_1.agentpool_context.get_vnet_subnet_id.return_value = None
+        with self.assertRaisesRegex(
+            RequiredArgumentMissingError,
+            "--system-node-subnet-id, --node-subnet-id and --apiserver-subnet-id",
+        ):
+            ctx_14_1.get_outbound_type()
+
+        ctx_14_2 = AKSManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict({
+                "sku": "automatic",
+                "outbound_type": CONST_OUTBOUND_TYPE_USER_ASSIGNED_NAT_GATEWAY,
+            }),
+            self.models,
+            decorator_mode=DecoratorMode.CREATE,
+        )
+        ctx_14_2.agentpool_context = mock.MagicMock()
+        ctx_14_2.agentpool_context.get_vnet_subnet_id.return_value = None
+        with self.assertRaisesRegex(
+            RequiredArgumentMissingError,
+            "--system-node-subnet-id, --node-subnet-id and --apiserver-subnet-id",
+        ):
+            ctx_14_2.get_outbound_type()
+
         byo_params = {
             "sku": "automatic",
             "system_node_subnet_id": "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/v/subnets/sys",

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
@@ -7122,6 +7122,7 @@ class AKSManagedClusterCreateDecoratorTestCase(unittest.TestCase):
         dec_1.context.attach_mc(mc_1)
         cli_default_pool = self.models.ManagedClusterAgentPoolProfile(name="nodepool1")
         mc_1.agent_pool_profiles = [cli_default_pool]
+        dec_1.context.set_intermediate("cli_synthesized_default_agent_pool", cli_default_pool)
 
         dec_1.set_up_hosted_system_profile(mc_1)
 
@@ -7144,11 +7145,31 @@ class AKSManagedClusterCreateDecoratorTestCase(unittest.TestCase):
         cli_default_pool = self.models.ManagedClusterAgentPoolProfile(name="nodepool1")
         user_pool = self.models.ManagedClusterAgentPoolProfile(name="userpool")
         mc_2.agent_pool_profiles = [cli_default_pool, user_pool]
+        dec_2.context.set_intermediate("cli_synthesized_default_agent_pool", cli_default_pool)
 
         dec_2.set_up_hosted_system_profile(mc_2)
 
         self.assertTrue(mc_2.hosted_system_profile.enabled)
         self.assertEqual(mc_2.agent_pool_profiles, [user_pool])
+
+        dec_3 = AKSManagedClusterCreateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "sku": "automatic",
+                "enable_hosted_system": True,
+            },
+            ResourceType.MGMT_CONTAINERSERVICE,
+        )
+        mc_3 = self.models.ManagedCluster(location="test_location")
+        dec_3.context.attach_mc(mc_3)
+        user_pool = self.models.ManagedClusterAgentPoolProfile(name="userpool")
+        mc_3.agent_pool_profiles = [user_pool]
+
+        dec_3.set_up_hosted_system_profile(mc_3)
+
+        self.assertTrue(mc_3.hosted_system_profile.enabled)
+        self.assertEqual(mc_3.agent_pool_profiles, [user_pool])
 
     def test_set_up_network_profile(self):
         # default value in `aks_create`

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
@@ -2122,6 +2122,25 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
         expect_outbound_type_13 = CONST_OUTBOUND_TYPE_MANAGED_NAT_GATEWAY
         self.assertEqual(outbound_type_13,expect_outbound_type_13)
 
+        network_profile_14 = self.models.ContainerServiceNetworkProfile(
+            outbound_type=CONST_OUTBOUND_TYPE_LOAD_BALANCER
+        )
+        mc_14 = self.models.ManagedCluster(
+            location="test_location",
+            network_profile=network_profile_14,
+            sku=self.models.ManagedClusterSKU(name="Automatic"),
+        )
+        ctx_14 = AKSManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict({}),
+            self.models,
+            DecoratorMode.UPDATE,
+        )
+        ctx_14.agentpool_context = mock.MagicMock()
+        ctx_14.agentpool_context.get_vnet_subnet_id.return_value = None
+        ctx_14.attach_mc(mc_14)
+        self.assertEqual(ctx_14.get_outbound_type(), CONST_OUTBOUND_TYPE_LOAD_BALANCER)
+
     def test_get_network_plugin_mode(self):
         # default
         ctx_1 = AKSManagedClusterContext(

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
@@ -26,6 +26,7 @@ from azure.cli.command_modules.acs._consts import (
     CONST_MONITORING_LOG_ANALYTICS_WORKSPACE_RESOURCE_ID,
     CONST_OPEN_SERVICE_MESH_ADDON_NAME,
     CONST_OUTBOUND_TYPE_USER_DEFINED_ROUTING,
+    CONST_OUTBOUND_TYPE_USER_ASSIGNED_NAT_GATEWAY,
     CONST_OUTBOUND_TYPE_MANAGED_NAT_GATEWAY,
     CONST_OUTBOUND_TYPE_LOAD_BALANCER,
     CONST_PRIVATE_DNS_ZONE_NONE,
@@ -2140,6 +2141,43 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
         ctx_14.agentpool_context.get_vnet_subnet_id.return_value = None
         ctx_14.attach_mc(mc_14)
         self.assertEqual(ctx_14.get_outbound_type(), CONST_OUTBOUND_TYPE_LOAD_BALANCER)
+
+        byo_params = {
+            "sku": "automatic",
+            "system_node_subnet_id": "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/v/subnets/sys",
+            "node_subnet_id": "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/v/subnets/node",
+            "apiserver_subnet_id": "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/v/subnets/api",
+        }
+        ctx_15 = AKSManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict({**byo_params, "outbound_type": CONST_OUTBOUND_TYPE_USER_ASSIGNED_NAT_GATEWAY}),
+            self.models,
+            decorator_mode=DecoratorMode.CREATE,
+        )
+        ctx_15.agentpool_context = mock.MagicMock()
+        ctx_15.agentpool_context.get_vnet_subnet_id.return_value = None
+        self.assertEqual(ctx_15.get_outbound_type(), CONST_OUTBOUND_TYPE_USER_ASSIGNED_NAT_GATEWAY)
+
+        ctx_16 = AKSManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict({**byo_params, "outbound_type": CONST_OUTBOUND_TYPE_USER_DEFINED_ROUTING}),
+            self.models,
+            decorator_mode=DecoratorMode.CREATE,
+        )
+        ctx_16.agentpool_context = mock.MagicMock()
+        ctx_16.agentpool_context.get_vnet_subnet_id.return_value = None
+        self.assertEqual(ctx_16.get_outbound_type(), CONST_OUTBOUND_TYPE_USER_DEFINED_ROUTING)
+
+        ctx_17 = AKSManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict({**byo_params, "outbound_type": CONST_OUTBOUND_TYPE_MANAGED_NAT_GATEWAY}),
+            self.models,
+            decorator_mode=DecoratorMode.CREATE,
+        )
+        ctx_17.agentpool_context = mock.MagicMock()
+        ctx_17.agentpool_context.get_vnet_subnet_id.return_value = None
+        with self.assertRaises(InvalidArgumentValueError):
+            ctx_17.get_outbound_type()
 
     def test_get_network_plugin_mode(self):
         # default

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
@@ -4483,7 +4483,7 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
         with self.assertRaises(RequiredArgumentMissingError):
             ctx_6.get_apiserver_subnet_id()
 
-    def test_byo_hobo_subnets_validation(self):
+    def test_byo_hosted_system_subnets_validation(self):
         system_subnet = "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/v/subnets/sys"
         node_subnet = "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/v/subnets/nod"
         api_subnet = "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/v/subnets/api"
@@ -4499,7 +4499,7 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
             decorator_mode=DecoratorMode.CREATE,
         )
         with self.assertRaises(RequiredArgumentMissingError):
-            ctx.validate_byo_hobo_subnets()
+            ctx.validate_byo_hosted_system_subnets()
 
         # trio without --sku automatic -> RequiredArgumentMissingError
         ctx = AKSManagedClusterContext(
@@ -4514,7 +4514,7 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
             decorator_mode=DecoratorMode.CREATE,
         )
         with self.assertRaises(RequiredArgumentMissingError):
-            ctx.validate_byo_hobo_subnets()
+            ctx.validate_byo_hosted_system_subnets()
 
         # happy path: full trio + automatic
         ctx = AKSManagedClusterContext(
@@ -4528,7 +4528,7 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
             self.models,
             decorator_mode=DecoratorMode.CREATE,
         )
-        ctx.validate_byo_hobo_subnets()
+        ctx.validate_byo_hosted_system_subnets()
         self.assertEqual(ctx.get_system_node_subnet_id(), system_subnet)
         self.assertEqual(ctx.get_node_subnet_id(), node_subnet)
         self.assertTrue(ctx.get_enable_hosted_system())  # BYO trio implies enable_hosted_system
@@ -4544,7 +4544,7 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
             decorator_mode=DecoratorMode.CREATE,
         )
         with self.assertRaises(RequiredArgumentMissingError):
-            ctx.validate_byo_hobo_subnets()
+            ctx.validate_byo_hosted_system_subnets()
 
         # happy path: --enable-hosted-system alone on automatic
         ctx = AKSManagedClusterContext(
@@ -4556,7 +4556,7 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
             self.models,
             decorator_mode=DecoratorMode.CREATE,
         )
-        ctx.validate_byo_hobo_subnets()
+        ctx.validate_byo_hosted_system_subnets()
         self.assertTrue(ctx.get_enable_hosted_system())
 
     def test_get_private_dns_zone(self):

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
@@ -7102,6 +7102,54 @@ class AKSManagedClusterCreateDecoratorTestCase(unittest.TestCase):
             dec_3.process_attach_acr(mc_3)
         ensure_assignment.assert_called_once_with(self.cmd, "test_service_principal", "test_registry_id", False, True, None)
 
+    def test_set_up_hosted_system_profile(self):
+        system_subnet = "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/v/subnets/system"
+        node_subnet = "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/v/subnets/node"
+        api_subnet = "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/v/subnets/api"
+
+        dec_1 = AKSManagedClusterCreateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "sku": "automatic",
+                "system_node_subnet_id": system_subnet,
+                "node_subnet_id": node_subnet,
+                "apiserver_subnet_id": api_subnet,
+            },
+            ResourceType.MGMT_CONTAINERSERVICE,
+        )
+        mc_1 = self.models.ManagedCluster(location="test_location")
+        dec_1.context.attach_mc(mc_1)
+        cli_default_pool = self.models.ManagedClusterAgentPoolProfile(name="nodepool1")
+        mc_1.agent_pool_profiles = [cli_default_pool]
+
+        dec_1.set_up_hosted_system_profile(mc_1)
+
+        self.assertTrue(mc_1.hosted_system_profile.enabled)
+        self.assertEqual(mc_1.hosted_system_profile.system_node_subnet_id, system_subnet)
+        self.assertEqual(mc_1.hosted_system_profile.node_subnet_id, node_subnet)
+        self.assertIsNone(mc_1.agent_pool_profiles)
+
+        dec_2 = AKSManagedClusterCreateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "sku": "automatic",
+                "enable_hosted_system": True,
+            },
+            ResourceType.MGMT_CONTAINERSERVICE,
+        )
+        mc_2 = self.models.ManagedCluster(location="test_location")
+        dec_2.context.attach_mc(mc_2)
+        cli_default_pool = self.models.ManagedClusterAgentPoolProfile(name="nodepool1")
+        user_pool = self.models.ManagedClusterAgentPoolProfile(name="userpool")
+        mc_2.agent_pool_profiles = [cli_default_pool, user_pool]
+
+        dec_2.set_up_hosted_system_profile(mc_2)
+
+        self.assertTrue(mc_2.hosted_system_profile.enabled)
+        self.assertEqual(mc_2.agent_pool_profiles, [user_pool])
+
     def test_set_up_network_profile(self):
         # default value in `aks_create`
         dec_1 = AKSManagedClusterCreateDecorator(


### PR DESCRIPTION
## Summary

Adds core `az aks create` support for Automatic SKU Managed System Pool BYO VNet, plus fixes follow-up AKS commands against clusters whose server-side `agentPoolProfiles` is `null`.

New `az aks create` flags:

- `--system-node-subnet-id`
- `--node-subnet-id`
- `--enable-hosted-system`

Behavior:

- `--enable-hosted-system` is valid only with `--sku automatic`. It sets `hostedSystemProfile.enabled=true` and skips synthesizing the CLI default `agentPoolProfiles`, because the RP provisions the Managed System Pool server-side.
- BYO VNet is implied when `--system-node-subnet-id`, `--node-subnet-id`, and the existing `--apiserver-subnet-id` are supplied together on `--sku automatic`.
- BYO VNet populates `hostedSystemProfile.systemNodeSubnetID`, `hostedSystemProfile.nodeSubnetID`, and `apiServerAccessProfile.subnetId`; it also sets `apiServerAccessProfile.enableVnetIntegration=true`.
- BYO VNet defaults to `loadBalancer` outbound instead of the normal Automatic no-VNet `managedNATGateway` default. BYO subnets also satisfy the VNet requirement for `userAssignedNATGateway` and `userDefinedRouting`; `managedNATGateway` is rejected with BYO/custom VNet input.
- The CLI grants Network Contributor on all BYO subnets for service-principal/user-assigned identity creates, and defers the grants for system-assigned identity creates until the cluster identity exists.
- `az aks upgrade`, `az aks scale`, and `az aks update` now handle Managed System Pool clusters with `agentPoolProfiles=null`; update also preserves the existing outbound type instead of reapplying the Automatic create default.

Validation:

- Partial BYO trio -> `RequiredArgumentMissingError` listing missing flags.
- BYO trio without `--sku automatic` -> `RequiredArgumentMissingError`.
- `--enable-hosted-system` without `--sku automatic` -> `RequiredArgumentMissingError`.

## Test plan

- [x] `python -m pytest src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py` - 248 passed
- [x] `git diff --check`
- [x] Verified local core CLI import path is `src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py`
- [x] Verified `aks-preview` is not installed; `az aks create -h` shows the new core CLI flags from this PR
- [x] Live EUAP BYO VNet create in `eastus2euap` succeeded with `hostedSystemProfile.enabled=true`, `agentPoolProfiles=null`, `nodeProvisioningProfile.mode=Auto`, and `networkProfile.outboundType=loadBalancer`
- [x] Verified the user-assigned identity has Network Contributor assignments on the system-node, node, and apiserver BYO subnets
- [x] Live `az aks nodepool list` returned `[]`; `az aks get-credentials` succeeded
- [x] Live `az aks scale` returned a friendly "no scalable node pools" error instead of crashing
- [x] Live `az aks upgrade --node-image-only --yes` completed without a `NoneType` crash
- [x] Live `az aks update --tags ...` was accepted by the RP; the smoke-test tag is visible and `outboundType` remains `loadBalancer` while the RP operation continues