### PR TITLE
{Packaging} Fix azps.ps1 wrapper to propagate exit codes and forward stdin

### DIFF
--- a/build_scripts/windows/scripts/azps.ps1
+++ b/build_scripts/windows/scripts/azps.ps1
@@ -1,5 +1,10 @@
 $env:AZ_INSTALLER="MSI"
-$input | & "$PSScriptRoot\..\python.exe" -IBm azure.cli $args
+if ($MyInvocation.ExpectingInput) {
+    $input | & "$PSScriptRoot\..\python.exe" -IBm azure.cli $args
+}
+else {
+    & "$PSScriptRoot\..\python.exe" -IBm azure.cli $args
+}
 exit $LASTEXITCODE
 
 # SIG # Begin signature block

--- a/build_scripts/windows/scripts/azps.ps1
+++ b/build_scripts/windows/scripts/azps.ps1
@@ -1,5 +1,6 @@
 $env:AZ_INSTALLER="MSI"
-& "$PSScriptRoot\..\python.exe" -IBm azure.cli $args
+$input | & "$PSScriptRoot\..\python.exe" -IBm azure.cli $args
+exit $LASTEXITCODE
 
 # SIG # Begin signature block
 # MIInuQYJKoZIhvcNAQcCoIInqjCCJ6YCAQExDzANBglghkgBZQMEAgEFADB5Bgor

--- a/build_scripts/windows/scripts/test_msi_installation.ps1
+++ b/build_scripts/windows/scripts/test_msi_installation.ps1
@@ -74,3 +74,37 @@ if ($installed_version -ne $artifact_version){
 # Test bundled pip with extension installation
 & $az_full_path extension add -n account
 & $az_full_path self-test
+
+# ---------------------------------------------------------------------
+# azps.ps1 wrapper regression tests
+# ---------------------------------------------------------------------
+$azps_full_path = Join-Path (Split-Path $az_full_path -Parent) "azps.ps1"
+if (-not (Test-Path $azps_full_path)) {
+    Write-Output "azps.ps1 was not installed at $azps_full_path"
+    Exit 1
+}
+
+# Baseline: the wrapper runs and --version returns success.
+& $azps_full_path --version
+if ($LASTEXITCODE -ne 0) {
+    Write-Output "azps.ps1 --version returned $LASTEXITCODE (expected 0)"
+    Exit 1
+}
+
+# A .ps1 wrapper must propagate non-zero exit codes from the
+# child process. Unknown commands exit with code 2; an unfixed wrapper
+# would exit 0 here.
+& $azps_full_path this-command-does-not-exist-xyz *> $null
+if ($LASTEXITCODE -eq 0) {
+    Write-Output "azps.ps1 did not propagate a failure exit code"
+    Exit 1
+}
+
+# When pwsh.exe invokes a .ps1 via
+# -Command, the script's exit code is only surfaced if the script
+# itself calls 'exit N'.
+& pwsh.exe -NoProfile -Command "& '$azps_full_path' this-command-does-not-exist-xyz *> `$null; exit `$LASTEXITCODE"
+if ($LASTEXITCODE -eq 0) {
+    Write-Output "azps.ps1 exit code swallowed when invoked via 'pwsh.exe -Command'"
+    Exit 1
+}

--- a/build_scripts/windows/scripts/test_msi_installation.ps1
+++ b/build_scripts/windows/scripts/test_msi_installation.ps1
@@ -102,9 +102,16 @@ if ($LASTEXITCODE -eq 0) {
 
 # When pwsh.exe invokes a .ps1 via
 # -Command, the script's exit code is only surfaced if the script
-# itself calls 'exit N'.
-& pwsh.exe -NoProfile -Command "& '$azps_full_path' this-command-does-not-exist-xyz *> `$null; exit `$LASTEXITCODE"
-if ($LASTEXITCODE -eq 0) {
-    Write-Output "azps.ps1 exit code swallowed when invoked via 'pwsh.exe -Command'"
-    Exit 1
+# itself calls 'exit N'. Skip this check if pwsh.exe is unavailable
+# so we don't false-pass on a stale $LASTEXITCODE value.
+if (Get-Command pwsh.exe -ErrorAction SilentlyContinue) {
+    $global:LASTEXITCODE = 0
+    & pwsh.exe -NoProfile -Command "& '$azps_full_path' this-command-does-not-exist-xyz *> `$null; exit `$LASTEXITCODE"
+    if (-not $? -or $LASTEXITCODE -eq 0) {
+        Write-Output "azps.ps1 exit code swallowed when invoked via 'pwsh.exe -Command'"
+        Exit 1
+    }
+}
+else {
+    Write-Output "pwsh.exe not found; skipping pwsh.exe -Command regression check"
 }

--- a/src/azure-cli/azps.ps1
+++ b/src/azure-cli/azps.ps1
@@ -2,12 +2,14 @@ $env:AZ_INSTALLER="PIP"
 
 if (Test-Path "$PSScriptRoot\python.exe") {
     # Perfer python.exe in venv
-    & "$PSScriptRoot\python.exe" -m azure.cli $args
+    $input | & "$PSScriptRoot\python.exe" -m azure.cli $args
 }
 else {
     # Run system python.exe
-    python.exe -m azure.cli $args
+    $input | python.exe -m azure.cli $args
 }
+
+exit $LASTEXITCODE
 
 # SIG # Begin signature block
 # MIInqgYJKoZIhvcNAQcCoIInmzCCJ5cCAQExDzANBglghkgBZQMEAgEFADB5Bgor

--- a/src/azure-cli/azps.ps1
+++ b/src/azure-cli/azps.ps1
@@ -1,12 +1,22 @@
 $env:AZ_INSTALLER="PIP"
 
 if (Test-Path "$PSScriptRoot\python.exe") {
-    # Perfer python.exe in venv
-    $input | & "$PSScriptRoot\python.exe" -m azure.cli $args
+    # Prefer python.exe in venv
+    if ($MyInvocation.ExpectingInput) {
+        $input | & "$PSScriptRoot\python.exe" -m azure.cli $args
+    }
+    else {
+        & "$PSScriptRoot\python.exe" -m azure.cli $args
+    }
 }
 else {
     # Run system python.exe
-    $input | python.exe -m azure.cli $args
+    if ($MyInvocation.ExpectingInput) {
+        $input | python.exe -m azure.cli $args
+    }
+    else {
+        python.exe -m azure.cli $args
+    }
 }
 
 exit $LASTEXITCODE


### PR DESCRIPTION
### Related command

`azps.ps1` (Windows PowerShell wrapper installed by the MSI and available in the pip package)

### Description

The `azps.ps1` wrapper scripts had two minor issues previously discussed:

1. **Exit codes not propagated.** The wrapper invoked `python.exe -m azure.cli` with `&` but never re-emitted `$LASTEXITCODE`. When the wrapper is invoked through `pwsh.exe -Command` (a very common pattern in CI), PowerShell only surfaces the script's exit code if the script itself calls `exit N`. As a result, failed CLI invocations appeared to succeed.
2. **Stdin not forwarded.** Data piped into `azps.ps1` was not passed through to the Python process, so any command that reads from stdin received nothing.

### Fix

- Pipe `$input` into the child `python.exe` invocation in both wrappers (`build_scripts/windows/scripts/azps.ps1` for the MSI build, and `src/azure-cli/azps.ps1` for pip).
- Add an explicit `exit $LASTEXITCODE` at the end so the exit code surfaces correctly even under `pwsh.exe -Command`.
- Add regression tests in `build_scripts/windows/scripts/test_msi_installation.ps1` covering both the direct-invocation and `pwsh.exe -Command` paths.

### Testing

New assertions in `test_msi_installation.ps1` exercise:

- `azps.ps1 --version` succeeds.
- `azps.ps1 <bad-command>` returns a non-zero exit code (direct invocation).
- `pwsh.exe -NoProfile -Command "& azps.ps1 <bad-command>; exit $LASTEXITCODE"` returns a non-zero exit code.