### PR TITLE
[Key Vault] `az keyvault create`: Fix keyvault create RequestDisallowedByPolicy error by explicitly setting `enableSoftDelete` in the request body

### DIFF
--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -68,7 +68,7 @@ Release History
 
 **Key Vault**
 
-* `az keyvault create`: Fix `RequestDisallowedByPolicy` error by explicitly setting `enableSoftDelete` in the request body to satisfy Azure Policy checks (#<PR_OR_ISSUE_NUMBER>)
+* `az keyvault create`: Fix `RequestDisallowedByPolicy` error by explicitly setting `enableSoftDelete` in the request body to satisfy Azure Policy checks (#33265)
 
 **NetAppFiles**
 

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -66,6 +66,10 @@ Release History
 
 * Fix #31108, #32073: `az eventhubs`: Regex updated for commands with `--namespace-name` arguments (#32472)
 
+**Key Vault**
+
+* `az keyvault create`: Fix `RequestDisallowedByPolicy` error by explicitly setting `enableSoftDelete` in the request body to satisfy Azure Policy checks
+
 **NetAppFiles**
 
 * `az netapfiles volume create/update`: Add paramter `--desired-ransomware-protection-state` to support advanced ransomware reports (#32828)

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -66,10 +66,6 @@ Release History
 
 * Fix #31108, #32073: `az eventhubs`: Regex updated for commands with `--namespace-name` arguments (#32472)
 
-**Key Vault**
-
-* `az keyvault create`: Fix `RequestDisallowedByPolicy` error by explicitly setting `enableSoftDelete` in the request body to satisfy Azure Policy checks (#33265)
-
 **NetAppFiles**
 
 * `az netapfiles volume create/update`: Add paramter `--desired-ransomware-protection-state` to support advanced ransomware reports (#32828)

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -68,7 +68,7 @@ Release History
 
 **Key Vault**
 
-* `az keyvault create`: Fix `RequestDisallowedByPolicy` error by explicitly setting `enableSoftDelete` in the request body to satisfy Azure Policy checks
+* `az keyvault create`: Fix `RequestDisallowedByPolicy` error by explicitly setting `enableSoftDelete` in the request body to satisfy Azure Policy checks (#<PR_OR_ISSUE_NUMBER>)
 
 **NetAppFiles**
 

--- a/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
@@ -649,6 +649,8 @@ def create_vault(cmd, client,  # pylint: disable=too-many-locals, too-many-state
                                  enabled_for_disk_encryption=enabled_for_disk_encryption,
                                  enabled_for_template_deployment=enabled_for_template_deployment,
                                  enable_rbac_authorization=enable_rbac_authorization,
+                                 # Intentionally include this field in the request body to satisfy
+                                 # Azure Policy checks that require soft delete to be explicitly set.
                                  enable_soft_delete=True,
                                  enable_purge_protection=enable_purge_protection,
                                  soft_delete_retention_in_days=int(retention_days),

--- a/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
@@ -649,6 +649,7 @@ def create_vault(cmd, client,  # pylint: disable=too-many-locals, too-many-state
                                  enabled_for_disk_encryption=enabled_for_disk_encryption,
                                  enabled_for_template_deployment=enabled_for_template_deployment,
                                  enable_rbac_authorization=enable_rbac_authorization,
+                                 enable_soft_delete=True,
                                  enable_purge_protection=enable_purge_protection,
                                  soft_delete_retention_in_days=int(retention_days),
                                  public_network_access=public_network_access)

--- a/src/azure-cli/azure/cli/command_modules/keyvault/tests/latest/test_keyvault_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/tests/latest/test_keyvault_commands.py
@@ -106,6 +106,54 @@ class DateTimeParseTest(unittest.TestCase):
         self.assertEqual(_asn1_to_iso8601("20170424163720Z"), expected)
 
 
+class CreateVaultSoftDeleteTest(unittest.TestCase):
+    """Verify that create_vault explicitly sets enable_soft_delete=True in the request body
+    so that Azure Policy checks requiring the property to be present are satisfied."""
+
+    @mock.patch('azure.cli.command_modules.keyvault.custom._create_network_rule_set', return_value=None)
+    @mock.patch('azure.cli.core._profile.Profile')
+    @mock.patch('azure.cli.core.util.sdk_no_wait')
+    def test_create_vault_sets_enable_soft_delete_true(self, mock_sdk_no_wait, mock_profile, _mock_network):
+        from azure.cli.command_modules.keyvault.custom import create_vault
+
+        mock_profile.return_value.get_subscription.return_value = {
+            'tenantId': '00000000-0000-0000-0000-000000000000'
+        }
+
+        # Build a minimal cmd mock that returns simple model classes
+        cmd = mock.MagicMock()
+        cmd.cli_ctx.data = {}
+
+        # get_models returns a simple class that records its kwargs
+        def fake_get_models(name, **kwargs):
+            return type(name, (), {'__init__': lambda self, **kw: self.__dict__.update(kw)})
+
+        cmd.get_models.side_effect = fake_get_models
+
+        # Client whose get() raises so vault-already-exists check is skipped
+        client = mock.MagicMock()
+        client.get.side_effect = HttpResponseError()
+
+        create_vault(
+            cmd, client,
+            resource_group_name='rg',
+            vault_name='testvault',
+            location='eastus',
+            retention_days='90',
+            no_self_perms=True,
+        )
+
+        # sdk_no_wait is called with the VaultCreateOrUpdateParameters as 'parameters'
+        mock_sdk_no_wait.assert_called_once()
+        call_kwargs = mock_sdk_no_wait.call_args
+        parameters = call_kwargs.kwargs.get('parameters') or call_kwargs[1].get('parameters')
+        vault_properties = parameters.properties
+
+        self.assertIs(vault_properties.enable_soft_delete, True,
+                      "create_vault must explicitly set enable_soft_delete=True in the request body "
+                      "to satisfy Azure Policy checks")
+
+
 class KeyVaultPrivateLinkResourceScenarioTest(ScenarioTest):
     @ResourceGroupPreparer(name_prefix='cli_test_keyvault_plr')
     @KeyVaultPreparer(name_prefix='cli-test-kv-plr-', location='eastus2')


### PR DESCRIPTION
Explicitly set enableSoftDelete=True in the request body for az keyvault create to satisfy Azure Policy checks that require the property to be present.

**Related command**
az keyvault create

**Description**<!--Mandatory-->
Explicitly set enableSoftDelete=True in the VaultProperties constructor when creating a Key Vault. While soft delete is already enabled by default on the service side, Azure Policy checks may require the property to be explicitly present in the
request body. Without it, az keyvault create fails with a RequestDisallowedByPolicy error when such policies are enforced. This is a non-breaking fix — no new parameters are exposed and customer behavior is unchanged.

**Testing Guide**
# Basic vault creation (should succeed without RequestDisallowedByPolicy)
 az keyvault create --name <vault-name> --resource-group <rg-name> --location <location>
 
 # Verify soft delete is enabled on the created vault
 az keyvault show --name <vault-name> --query "properties.enableSoftDelete"
 # Expected: true

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
