### PR TITLE
{App Service} Fix: header-aware duplicate check for access-restriction add

### DIFF
--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -3,6 +3,85 @@
 Release History
 ===============
 
+2.86.0
+++++++
+
+**ACR**
+
+* `az acr login`: Support Podman for `--name` parameter (#33115)
+* `az acr create`: Add `--regional-endpoints` parameter to enable or disable regional endpoints for a container registry (#33133)
+* `az acr update`: Add `--regional-endpoints` parameter to enable or disable regional endpoints for an existing container registry (#33133)
+* `az acr show-endpoints`: Display regional endpoint host names when regional endpoints are enabled (#33133)
+* `az acr login`: Add `--endpoint` parameter to log in to a specific regional endpoint of a container registry (#33133)
+* `az acr import`: Support importing images using regional endpoint URIs as the source (#33133)
+* `az acr network-rule`: Update `--ip-address` help message to include ipv6 address (#32537)
+
+**AKS**
+
+* `az aks create`, `az aks nodepool add/update`: Add option `AzureContainerLinux` to `--os-sku` parameter (#33129)
+* `az aks check-acr`: Fix command injection via unquoted tempfile path in subprocess call (#33155)
+* `az aks update`: Add `--enable-azure-monitor-app-monitoring` to support Azure Monitor Application Monitoring auto-instrumentation (#32712)
+* `az aks create`: Add parameters `--system-node-subnet-id`, `--node-subnet-id` and `--enable-hosted-system` to support BYO VNet for Automatic Managed System Pool clusters (#33259)
+* `az aks mesh enable/proxy-redirection-mechanism`: Add mesh Istio CNI commands (#32992)
+* `az aks nodepool add`: Add `Windows2025` as a supported value for `--os-sku` (#33246)
+* `az aks update`: Fix `--enable-azure-monitor-metrics` failing with RoleAssignmentExists when Grafana role assignment already exists (#33229)
+* `az aks create/update`: Add `--enable-gateway-api` and `--disable-gateway-api` parameters to manage Managed Gateway API installation (#33286)
+* `az aks create/update`: Add `--enable-app-routing-istio` and `--disable-app-routing-istio` to manage App Routing Istio gateway implementation (#33287)
+
+**App Service**
+
+* `az webapp create`: Add post-creation deployment guidance and startup command examples (#33088)
+* `az webapp deploy`: Add build automation guidance for Linux zip deployments (#33088)
+* `az webapp up`: Add logging for OS type, runtime auto-detection, and plan auto-generation (#33088)
+* Add warning for container image path when `--container-image-name` includes registry host (#33088)
+* `az webapp delete`: Add warning about App Service Plan deletion (#33088)
+* Fix #33180: `az functionapp plan create`: Simplify reserved parameter assignment in AppServicePlan (#33202)
+* `az webapp sitecontainers convert`: Add support for converting Docker Compose multi-container apps to Sitecontainers mode (#33131)
+* `az webapp up/deploy`: Add `--enriched-errors` parameter to see detailed deployment failure log (#32940)
+* `az webapp create`: Add error message that clearly lists all valid options and specifies how to discover available runtimes (#33252)
+* `az appservice plan create`: Make `P0V3` as default SKU when `--sku` is omitted for linux webapp (#33237)
+* `az appservice plan create`: Add `PREMIUM0V3` tier for elastic scale (#33237)
+
+**Cloud**
+
+* Fix #33183: `az cloud set`: Typo correction on AZURE_BLEU_CLOUD active directory endpoint
+
+**Compute**
+
+* `az sig create`: Add new argument group "Managed Service Identity" to configure the service identity of a Shared Image Gallery (SIG) (#33137)
+* `az sig show`: Update command to display the managed service identity of a Shared Image Gallery (SIG) (#33137)
+* `az sig identity`: Add new command group to manage the service identity of a Shared Image Gallery (SIG) (#33137)
+
+**Container app**
+
+* `az containerapp create`: Support other cloud for acr (#33160)
+
+**Network**
+
+* `az network express-route gateway`: Support VWAN gateway resiliency APIs (#32941)
+* `az network route-table create/update`: Add `--disable-peering-route` to support disable peering route (#33231)
+
+**PostgreSQL**
+
+* `az postgres flexible-server create`, `replica create`, `restore`, `geo-restore`, and `revive-dropped`: Add breaking change announcement for command behavioral change related to network resources (#33077)
+* `az postgres flexible-server create`: Announce breaking change deprecation of `--cluster-option` argument (#33225)
+* Fix #33090: `az postgres flexible-server server-logs list`: Command crashes with an AttributeError when listing log files (#33096)
+* `az postgres flexible-server`: Improve validation logic and style of error messages (#33114)
+* `az postgresql flexible-server replica create`: New argument `--storage-type` to select storage type as PremiumV2_LRS for read replica (#33134)
+* Fix #33205: `az postgres flexible-server create`: Update help text for `--storage-auto-grow` argument to reflect actual default value (#33206)
+* `az postgres flexible-server update`: Restart is no longer required for scaling storage size of Premium SSDv2 server (#33178)
+* `az postgres flexible-server create/upgrade`: Block SSDv2 creation for PG version earlier than 14 (#33119)
+
+**Profile**
+
+* `az login`: Add `--subscription` and `--skip-subscription-discovery` to filter subscriptions during login (#33181)
+
+**Storage**
+
+* `az storage account create/update`: Update description for tls 1.3 being not yet available, remove breaking change warning to deprecate tls1.0, tls1.1 (#33243)
+* `az storage blob/container/share/file/queue/fs generate-sas`: Add `--user-delegation-tid` to support cross tenant user delegated sas (#33187)
+* `az storage advanced-platform-metric create/update/show/list/delete`: Support Advanced Platform Metrics (#33224)
+
 2.85.0
 ++++++
 
@@ -40,7 +119,6 @@ Release History
 * `az appservice plan update`: Remove preview flag for `--elastic-scale` and `--max-elastic-worker-count` parameters (#32807)
 * `az webapp update`: Remove preview flag for `--minimum-elastic-instance-count` and `--prewarmed-instance-count` parameters (#32807)
 * `az webapp up`: Add parameter `--domain-name-scope` to support specifying the scope of uniqueness for the default hostname during resource creation (#32930)
-* `az webapp/functionapp config access-restriction add`: Allow adding multiple access-restriction rules with the same source IP, service tag, or subnet when the ``--http-header`` filters differ. The duplicate-rule check is now header-aware, matching the ARM API behavior. The IP comparison is also order-insensitive when multiple comma-separated CIDRs are provided in a single rule (#33272)
 
 **Cloud**
 

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -3,13 +3,6 @@
 Release History
 ===============
 
-Upcoming Release
-++++++++++++++++
-
-**App Service**
-
-* `az webapp/functionapp config access-restriction add`: Allow adding multiple access-restriction rules with the same source IP, service tag, or subnet when the ``--http-header`` filters differ. The duplicate-rule check is now header-aware, matching the ARM API behavior. The IP comparison is also order-insensitive when multiple comma-separated CIDRs are provided in a single rule.
-
 2.85.0
 ++++++
 
@@ -47,6 +40,7 @@ Upcoming Release
 * `az appservice plan update`: Remove preview flag for `--elastic-scale` and `--max-elastic-worker-count` parameters (#32807)
 * `az webapp update`: Remove preview flag for `--minimum-elastic-instance-count` and `--prewarmed-instance-count` parameters (#32807)
 * `az webapp up`: Add parameter `--domain-name-scope` to support specifying the scope of uniqueness for the default hostname during resource creation (#32930)
+* `az webapp/functionapp config access-restriction add`: Allow adding multiple access-restriction rules with the same source IP, service tag, or subnet when the ``--http-header`` filters differ. The duplicate-rule check is now header-aware, matching the ARM API behavior. The IP comparison is also order-insensitive when multiple comma-separated CIDRs are provided in a single rule (#33272)
 
 **Cloud**
 

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -3,84 +3,12 @@
 Release History
 ===============
 
-2.86.0
-++++++
-
-**ACR**
-
-* `az acr login`: Support Podman for `--name` parameter (#33115)
-* `az acr create`: Add `--regional-endpoints` parameter to enable or disable regional endpoints for a container registry (#33133)
-* `az acr update`: Add `--regional-endpoints` parameter to enable or disable regional endpoints for an existing container registry (#33133)
-* `az acr show-endpoints`: Display regional endpoint host names when regional endpoints are enabled (#33133)
-* `az acr login`: Add `--endpoint` parameter to log in to a specific regional endpoint of a container registry (#33133)
-* `az acr import`: Support importing images using regional endpoint URIs as the source (#33133)
-* `az acr network-rule`: Update `--ip-address` help message to include ipv6 address (#32537)
-
-**AKS**
-
-* `az aks create`, `az aks nodepool add/update`: Add option `AzureContainerLinux` to `--os-sku` parameter (#33129)
-* `az aks check-acr`: Fix command injection via unquoted tempfile path in subprocess call (#33155)
-* `az aks update`: Add `--enable-azure-monitor-app-monitoring` to support Azure Monitor Application Monitoring auto-instrumentation (#32712)
-* `az aks create`: Add parameters `--system-node-subnet-id`, `--node-subnet-id` and `--enable-hosted-system` to support BYO VNet for Automatic Managed System Pool clusters (#33259)
-* `az aks mesh enable/proxy-redirection-mechanism`: Add mesh Istio CNI commands (#32992)
-* `az aks nodepool add`: Add `Windows2025` as a supported value for `--os-sku` (#33246)
-* `az aks update`: Fix `--enable-azure-monitor-metrics` failing with RoleAssignmentExists when Grafana role assignment already exists (#33229)
-* `az aks create/update`: Add `--enable-gateway-api` and `--disable-gateway-api` parameters to manage Managed Gateway API installation (#33286)
-* `az aks create/update`: Add `--enable-app-routing-istio` and `--disable-app-routing-istio` to manage App Routing Istio gateway implementation (#33287)
+Upcoming Release
+++++++++++++++++
 
 **App Service**
 
-* `az webapp create`: Add post-creation deployment guidance and startup command examples (#33088)
-* `az webapp deploy`: Add build automation guidance for Linux zip deployments (#33088)
-* `az webapp up`: Add logging for OS type, runtime auto-detection, and plan auto-generation (#33088)
-* Add warning for container image path when `--container-image-name` includes registry host (#33088)
-* `az webapp delete`: Add warning about App Service Plan deletion (#33088)
-* Fix #33180: `az functionapp plan create`: Simplify reserved parameter assignment in AppServicePlan (#33202)
-* `az webapp sitecontainers convert`: Add support for converting Docker Compose multi-container apps to Sitecontainers mode (#33131)
-* `az webapp up/deploy`: Add `--enriched-errors` parameter to see detailed deployment failure log (#32940)
-* `az webapp create`: Add error message that clearly lists all valid options and specifies how to discover available runtimes (#33252)
-* `az appservice plan create`: Make `P0V3` as default SKU when `--sku` is omitted for linux webapp (#33237)
-* `az appservice plan create`: Add `PREMIUM0V3` tier for elastic scale (#33237)
-
-**Cloud**
-
-* Fix #33183: `az cloud set`: Typo correction on AZURE_BLEU_CLOUD active directory endpoint
-
-**Compute**
-
-* `az sig create`: Add new argument group "Managed Service Identity" to configure the service identity of a Shared Image Gallery (SIG) (#33137)
-* `az sig show`: Update command to display the managed service identity of a Shared Image Gallery (SIG) (#33137)
-* `az sig identity`: Add new command group to manage the service identity of a Shared Image Gallery (SIG) (#33137)
-
-**Container app**
-
-* `az containerapp create`: Support other cloud for acr (#33160)
-
-**Network**
-
-* `az network express-route gateway`: Support VWAN gateway resiliency APIs (#32941)
-* `az network route-table create/update`: Add `--disable-peering-route` to support disable peering route (#33231)
-
-**PostgreSQL**
-
-* `az postgres flexible-server create`, `replica create`, `restore`, `geo-restore`, and `revive-dropped`: Add breaking change announcement for command behavioral change related to network resources (#33077)
-* `az postgres flexible-server create`: Announce breaking change deprecation of `--cluster-option` argument (#33225)
-* Fix #33090: `az postgres flexible-server server-logs list`: Command crashes with an AttributeError when listing log files (#33096)
-* `az postgres flexible-server`: Improve validation logic and style of error messages (#33114)
-* `az postgresql flexible-server replica create`: New argument `--storage-type` to select storage type as PremiumV2_LRS for read replica (#33134)
-* Fix #33205: `az postgres flexible-server create`: Update help text for `--storage-auto-grow` argument to reflect actual default value (#33206)
-* `az postgres flexible-server update`: Restart is no longer required for scaling storage size of Premium SSDv2 server (#33178)
-* `az postgres flexible-server create/upgrade`: Block SSDv2 creation for PG version earlier than 14 (#33119)
-
-**Profile**
-
-* `az login`: Add `--subscription` and `--skip-subscription-discovery` to filter subscriptions during login (#33181)
-
-**Storage**
-
-* `az storage account create/update`: Update description for tls 1.3 being not yet available, remove breaking change warning to deprecate tls1.0, tls1.1 (#33243)
-* `az storage blob/container/share/file/queue/fs generate-sas`: Add `--user-delegation-tid` to support cross tenant user delegated sas (#33187)
-* `az storage advanced-platform-metric create/update/show/list/delete`: Support Advanced Platform Metrics (#33224)
+* `az webapp/functionapp config access-restriction add`: Allow adding multiple access-restriction rules with the same source IP, service tag, or subnet when the ``--http-header`` filters differ. The duplicate-rule check is now header-aware, matching the ARM API behavior. The IP comparison is also order-insensitive when multiple comma-separated CIDRs are provided in a single rule.
 
 2.85.0
 ++++++

--- a/src/azure-cli/azure/cli/command_modules/appservice/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_validators.py
@@ -319,10 +319,70 @@ def _validate_ip_address_existence(cmd, namespace):
     scm_site = namespace.scm_site
     configs = _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'get_configuration', slot)
     access_rules = configs.scm_ip_security_restrictions if scm_site else configs.ip_security_restrictions
-    ip_exists = [x.ip_address == namespace.ip_address for x in access_rules]
-    if True in ip_exists:
-        raise ArgumentUsageError('IP address: ' + namespace.ip_address + ' already exists. '
-                                 'Cannot add duplicate IP address values.')
+    new_headers = _normalize_http_headers(getattr(namespace, 'http_headers', None))
+    new_ip_set = _normalize_ip_address_list(namespace.ip_address)
+    for rule in access_rules or []:
+        if _normalize_ip_address_list(rule.ip_address) != new_ip_set:
+            continue
+        if _normalize_http_headers(rule.headers) == new_headers:
+            raise ArgumentUsageError(
+                "An access-restriction rule with IP address '{}' and the same HTTP header filter "
+                "already exists. Cannot add a duplicate rule. Use a different IP address or vary "
+                "the --http-header values to create an additional rule.".format(namespace.ip_address))
+
+
+def _normalize_ip_address_list(ip_address):
+    """Return a frozenset of canonical CIDR strings parsed from a comma-separated input.
+
+    The CLI accepts up to 8 comma-separated CIDRs in a single rule's ``--ip-address``. ARM stores
+    them in the same comma-separated form on the rule's ``ip_address`` attribute. Two rules
+    represent the same source set regardless of the order in which the CIDRs appear, so duplicate
+    detection should compare unordered sets. Returns ``frozenset()`` for missing/empty input.
+    """
+    if not ip_address:
+        return frozenset()
+    return frozenset(part.strip() for part in ip_address.split(',') if part.strip())
+
+
+def _normalize_http_headers(headers):
+    """Normalize an http-header collection for duplicate-rule comparison.
+
+    Accepts either the CLI input form (list of "name=value" strings, as supplied via --http-header)
+    or the SDK/ARM form (dict mapping header name to a list of values). Returns a dict whose keys
+    are lowercased header names and whose values are frozensets of value strings, so that order of
+    values within a single header (which ARM treats as a set) does not affect equality. None and
+    an empty collection are both normalized to an empty dict so that a rule with no headers
+    compares equal to itself regardless of representation.
+    """
+    if not headers:
+        return {}
+    result = {}
+    if isinstance(headers, dict):
+        for header_name, values in headers.items():
+            if header_name is None:
+                continue
+            normalized_name = header_name.strip().lower()
+            if values is None:
+                continue
+            if isinstance(values, str):
+                values = [values]
+            value_set = frozenset(v for v in values if v)
+            if value_set:
+                result[normalized_name] = value_set
+        return result
+    # CLI input form: list of "name=value" strings.
+    for header_str in headers:
+        if header_str is None or '=' not in header_str:
+            continue
+        header_name, _, header_value = header_str.partition('=')
+        normalized_name = header_name.strip().lower()
+        normalized_value = header_value.strip()
+        if not normalized_name or not normalized_value:
+            continue
+        existing = set(result.get(normalized_name, frozenset()))
+        existing.add(normalized_value)
+        result[normalized_name] = frozenset(existing)
+    return result
 
 
 def validate_service_tag(cmd, namespace):
@@ -369,10 +429,16 @@ def _validate_service_tag_existence(cmd, namespace):
     input_tag_value = namespace.service_tag.replace(' ', '')
     configs = _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'get_configuration', slot)
     access_rules = configs.scm_ip_security_restrictions if scm_site else configs.ip_security_restrictions
-    for rule in access_rules:
-        if rule.ip_address and rule.ip_address.lower() == input_tag_value.lower():
-            raise ArgumentUsageError('Service Tag: ' + namespace.service_tag + ' already exists. '
-                                     'Cannot add duplicate Service Tag values.')
+    new_headers = _normalize_http_headers(getattr(namespace, 'http_headers', None))
+    for rule in access_rules or []:
+        if not rule.ip_address or rule.ip_address.lower() != input_tag_value.lower():
+            continue
+        if _normalize_http_headers(rule.headers) == new_headers:
+            raise ArgumentUsageError(
+                "A service-tag access-restriction rule with value '{}' and the same HTTP header "
+                "filter already exists. Cannot add a duplicate rule. Use a different service tag "
+                "or vary the --http-header values to create an additional rule.".format(
+                    namespace.service_tag))
 
 
 def validate_public_cloud(cmd):

--- a/src/azure-cli/azure/cli/command_modules/appservice/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_validators.py
@@ -325,6 +325,11 @@ def _validate_ip_address_existence(cmd, namespace):
         if _normalize_ip_address_list(rule.ip_address) != new_ip_set:
             continue
         if _normalize_http_headers(rule.headers) == new_headers:
+            if not new_headers:
+                raise ArgumentUsageError(
+                    "An access-restriction rule with IP address '{}' already exists. Cannot add a "
+                    "duplicate rule. Use a different IP address, or add a --http-header filter to "
+                    "create an additional rule.".format(namespace.ip_address))
             raise ArgumentUsageError(
                 "An access-restriction rule with IP address '{}' and the same HTTP header filter "
                 "already exists. Cannot add a duplicate rule. Use a different IP address or vary "
@@ -434,6 +439,11 @@ def _validate_service_tag_existence(cmd, namespace):
         if not rule.ip_address or rule.ip_address.lower() != input_tag_value.lower():
             continue
         if _normalize_http_headers(rule.headers) == new_headers:
+            if not new_headers:
+                raise ArgumentUsageError(
+                    "A service-tag access-restriction rule with value '{}' already exists. Cannot "
+                    "add a duplicate rule. Use a different service tag, or add a --http-header "
+                    "filter to create an additional rule.".format(namespace.service_tag))
             raise ArgumentUsageError(
                 "A service-tag access-restriction rule with value '{}' and the same HTTP header "
                 "filter already exists. Cannot add a duplicate rule. Use a different service tag "

--- a/src/azure-cli/azure/cli/command_modules/appservice/access_restrictions.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/access_restrictions.py
@@ -13,6 +13,7 @@ from importlib import import_module
 from knack.log import get_logger
 
 from ._appservice_utils import _generic_site_operation
+from ._validators import _normalize_http_headers
 from .custom import get_site_configs
 
 logger = get_logger(__name__)
@@ -59,11 +60,18 @@ def add_webapp_access_restriction(
         subnet_id = _validate_subnet(cmd.cli_ctx, subnet, vnet_name, vnet_rg)
         if not ignore_missing_vnet_service_endpoint:
             _ensure_subnet_service_endpoint(cmd.cli_ctx, subnet_id)
-        # check for duplicates
+        # check for duplicates (header-aware: same subnet + identical http-header filter)
         for rule in list(access_rules):
-            if rule.vnet_subnet_resource_id and rule.vnet_subnet_resource_id.lower() == subnet_id.lower():
-                raise ArgumentUsageError('Service endpoint rule for: ' + subnet_id + ' already exists. '
-                                         'Cannot add duplicate service endpoint rules.')
+            if not rule.vnet_subnet_resource_id:
+                continue
+            if rule.vnet_subnet_resource_id.lower() != subnet_id.lower():
+                continue
+            if _normalize_http_headers(rule.headers) == _normalize_http_headers(http_headers):
+                raise ArgumentUsageError(
+                    "A service-endpoint access-restriction rule for subnet '{}' with the same "
+                    "HTTP header filter already exists. Cannot add a duplicate rule. Use a "
+                    "different subnet or vary the --http-header values to create an additional "
+                    "rule.".format(subnet_id))
         rule_instance = IpSecurityRestriction(
             name=rule_name, vnet_subnet_resource_id=subnet_id,
             priority=priority, action=action, tag='Default', description=description)

--- a/src/azure-cli/azure/cli/command_modules/appservice/access_restrictions.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/access_restrictions.py
@@ -35,6 +35,10 @@ def show_webapp_access_restrictions(cmd, resource_group_name, name, slot=None):
     return access_rules
 
 
+# pylint: disable=too-many-locals
+# Adding the hoisted ``new_headers`` local plus the existing ones in this function
+# pushes the count just past pylint's default cap; the readability gain of computing
+# the normalized header dict once is worth the suppression.
 def add_webapp_access_restriction(
         cmd, resource_group_name, name, priority, rule_name=None,
         action='Allow', ip_address=None, subnet=None,
@@ -61,12 +65,18 @@ def add_webapp_access_restriction(
         if not ignore_missing_vnet_service_endpoint:
             _ensure_subnet_service_endpoint(cmd.cli_ctx, subnet_id)
         # check for duplicates (header-aware: same subnet + identical http-header filter)
+        new_headers = _normalize_http_headers(http_headers)
         for rule in list(access_rules):
             if not rule.vnet_subnet_resource_id:
                 continue
             if rule.vnet_subnet_resource_id.lower() != subnet_id.lower():
                 continue
-            if _normalize_http_headers(rule.headers) == _normalize_http_headers(http_headers):
+            if _normalize_http_headers(rule.headers) == new_headers:
+                if not new_headers:
+                    raise ArgumentUsageError(
+                        "A service-endpoint access-restriction rule for subnet '{}' already "
+                        "exists. Cannot add a duplicate rule. Use a different subnet, or add a "
+                        "--http-header filter to create an additional rule.".format(subnet_id))
                 raise ArgumentUsageError(
                     "A service-endpoint access-restriction rule for subnet '{}' with the same "
                     "HTTP header filter already exists. Cannot add a duplicate rule. Use a "

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_appservice_validators_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_appservice_validators_thru_mock.py
@@ -1,0 +1,313 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import unittest
+from unittest import mock
+
+from azure.cli.core.azclierror import ArgumentUsageError
+
+from azure.cli.command_modules.appservice._validators import (
+    _normalize_http_headers,
+    _normalize_ip_address_list,
+    _validate_ip_address_existence,
+    _validate_service_tag_existence,
+)
+
+
+class _StubRule:
+    """Minimal stand-in for azure.mgmt.web.models.IpSecurityRestriction."""
+
+    def __init__(self, ip_address, headers=None):
+        self.ip_address = ip_address
+        self.headers = headers
+
+
+class NormalizeHttpHeadersTest(unittest.TestCase):
+    def test_none_and_empty_normalize_equally(self):
+        self.assertEqual(_normalize_http_headers(None), {})
+        self.assertEqual(_normalize_http_headers([]), {})
+        self.assertEqual(_normalize_http_headers({}), {})
+
+    def test_cli_form_lowercases_header_names(self):
+        result = _normalize_http_headers(['X-Forwarded-For=10.0.0.1/32'])
+        self.assertEqual(result, {'x-forwarded-for': frozenset({'10.0.0.1/32'})})
+
+    def test_cli_form_repeated_names_accumulate(self):
+        result = _normalize_http_headers([
+            'x-forwarded-for=10.0.0.1/32',
+            'x-forwarded-for=10.0.0.2/32',
+        ])
+        self.assertEqual(result, {'x-forwarded-for': frozenset({'10.0.0.1/32', '10.0.0.2/32'})})
+
+    def test_sdk_form_value_order_insensitive(self):
+        a = _normalize_http_headers({'x-forwarded-for': ['10.0.0.1/32', '10.0.0.2/32']})
+        b = _normalize_http_headers({'x-forwarded-for': ['10.0.0.2/32', '10.0.0.1/32']})
+        self.assertEqual(a, b)
+
+    def test_cli_and_sdk_forms_compare_equal(self):
+        cli = _normalize_http_headers([
+            'x-forwarded-for=10.0.0.1/32',
+            'x-forwarded-for=10.0.0.2/32',
+        ])
+        sdk = _normalize_http_headers({'x-forwarded-for': ['10.0.0.2/32', '10.0.0.1/32']})
+        self.assertEqual(cli, sdk)
+
+    def test_drops_empty_values(self):
+        self.assertEqual(_normalize_http_headers(['x-forwarded-for=']), {})
+        self.assertEqual(_normalize_http_headers({'x-forwarded-for': [None, '']}), {})
+
+    def test_ignores_malformed_cli_entries_without_equals(self):
+        self.assertEqual(_normalize_http_headers(['no-equals-here']), {})
+
+
+class NormalizeIpAddressListTest(unittest.TestCase):
+    def test_empty_inputs(self):
+        self.assertEqual(_normalize_ip_address_list(None), frozenset())
+        self.assertEqual(_normalize_ip_address_list(''), frozenset())
+
+    def test_single_cidr(self):
+        self.assertEqual(
+            _normalize_ip_address_list('10.0.0.1/32'),
+            frozenset({'10.0.0.1/32'}),
+        )
+
+    def test_order_independent(self):
+        a = _normalize_ip_address_list('10.0.0.1/32,10.0.0.2/32')
+        b = _normalize_ip_address_list('10.0.0.2/32,10.0.0.1/32')
+        self.assertEqual(a, b)
+
+    def test_strips_whitespace_around_entries(self):
+        self.assertEqual(
+            _normalize_ip_address_list('10.0.0.1/32, 10.0.0.2/32'),
+            frozenset({'10.0.0.1/32', '10.0.0.2/32'}),
+        )
+
+
+class ValidateIpAddressExistenceTest(unittest.TestCase):
+    def _make_namespace(self, ip_address, http_headers=None, scm_site=False):
+        ns = mock.MagicMock()
+        ns.resource_group_name = 'rg'
+        ns.name = 'app'
+        ns.slot = None
+        ns.scm_site = scm_site
+        ns.ip_address = ip_address
+        ns.http_headers = http_headers
+        return ns
+
+    def _patch_configs(self, rules):
+        configs = mock.MagicMock()
+        configs.ip_security_restrictions = rules
+        configs.scm_ip_security_restrictions = []
+        return mock.patch(
+            'azure.cli.command_modules.appservice._validators._generic_site_operation',
+            return_value=configs,
+        )
+
+    def test_blocks_exact_duplicate_no_headers(self):
+        cmd = mock.MagicMock()
+        ns = self._make_namespace('36.12.195.236/32')
+        with self._patch_configs([_StubRule('36.12.195.236/32')]):
+            with self.assertRaises(ArgumentUsageError):
+                _validate_ip_address_existence(cmd, ns)
+
+    def test_allows_same_ip_with_different_xff(self):
+        cmd = mock.MagicMock()
+        ns = self._make_namespace(
+            '36.12.195.236/32',
+            http_headers=['x-forwarded-for=10.0.0.2/32'],
+        )
+        existing = _StubRule(
+            '36.12.195.236/32',
+            headers={'x-forwarded-for': ['10.0.0.1/32']},
+        )
+        with self._patch_configs([existing]):
+            try:
+                _validate_ip_address_existence(cmd, ns)
+            except ArgumentUsageError:
+                self.fail('Different XFF filter should be allowed')
+
+    def test_allows_same_ip_with_headers_vs_no_headers(self):
+        cmd = mock.MagicMock()
+        ns = self._make_namespace(
+            '36.12.195.236/32',
+            http_headers=['x-forwarded-for=10.0.0.1/32'],
+        )
+        with self._patch_configs([_StubRule('36.12.195.236/32', headers=None)]):
+            try:
+                _validate_ip_address_existence(cmd, ns)
+            except ArgumentUsageError:
+                self.fail('Existing rule without headers should not block a header-filtered rule')
+
+    def test_blocks_same_ip_and_identical_headers(self):
+        cmd = mock.MagicMock()
+        ns = self._make_namespace(
+            '36.12.195.236/32',
+            http_headers=['x-forwarded-for=10.0.0.1/32'],
+        )
+        existing = _StubRule(
+            '36.12.195.236/32',
+            headers={'x-forwarded-for': ['10.0.0.1/32']},
+        )
+        with self._patch_configs([existing]):
+            with self.assertRaises(ArgumentUsageError):
+                _validate_ip_address_existence(cmd, ns)
+
+    def test_blocks_when_value_order_differs_for_same_header(self):
+        cmd = mock.MagicMock()
+        ns = self._make_namespace(
+            '36.12.195.236/32',
+            http_headers=[
+                'x-forwarded-for=10.0.0.2/32',
+                'x-forwarded-for=10.0.0.1/32',
+            ],
+        )
+        existing = _StubRule(
+            '36.12.195.236/32',
+            headers={'x-forwarded-for': ['10.0.0.1/32', '10.0.0.2/32']},
+        )
+        with self._patch_configs([existing]):
+            with self.assertRaises(ArgumentUsageError):
+                _validate_ip_address_existence(cmd, ns)
+
+    def test_allows_different_ip(self):
+        cmd = mock.MagicMock()
+        ns = self._make_namespace('36.12.195.236/32')
+        with self._patch_configs([_StubRule('1.2.3.4/32')]):
+            try:
+                _validate_ip_address_existence(cmd, ns)
+            except ArgumentUsageError:
+                self.fail('Different IP should not be blocked')
+
+    def test_handles_none_access_rules(self):
+        cmd = mock.MagicMock()
+        ns = self._make_namespace('10.0.0.1/32')
+        with self._patch_configs(None):
+            try:
+                _validate_ip_address_existence(cmd, ns)
+            except ArgumentUsageError:
+                self.fail('No existing rules should not raise')
+
+    def test_multi_ip_blocks_when_order_differs_but_set_matches(self):
+        """Comma-separated IP lists in a single rule are unordered for ARM purposes."""
+        cmd = mock.MagicMock()
+        ns = self._make_namespace('10.0.0.2/32,10.0.0.1/32')
+        existing = _StubRule('10.0.0.1/32,10.0.0.2/32')
+        with self._patch_configs([existing]):
+            with self.assertRaises(ArgumentUsageError):
+                _validate_ip_address_existence(cmd, ns)
+
+    def test_multi_ip_allows_when_set_differs(self):
+        cmd = mock.MagicMock()
+        ns = self._make_namespace('10.0.0.1/32,10.0.0.3/32')
+        existing = _StubRule('10.0.0.1/32,10.0.0.2/32')
+        with self._patch_configs([existing]):
+            try:
+                _validate_ip_address_existence(cmd, ns)
+            except ArgumentUsageError:
+                self.fail('Different IP set should not be blocked')
+
+    def test_scm_path_is_isolated_from_main(self):
+        """scm_site=True must inspect scm_ip_security_restrictions only."""
+        cmd = mock.MagicMock()
+        ns = self._make_namespace('36.12.195.236/32', scm_site=True)
+        configs = mock.MagicMock()
+        configs.ip_security_restrictions = [_StubRule('36.12.195.236/32')]
+        configs.scm_ip_security_restrictions = []
+        with mock.patch(
+            'azure.cli.command_modules.appservice._validators._generic_site_operation',
+            return_value=configs,
+        ):
+            try:
+                _validate_ip_address_existence(cmd, ns)
+            except ArgumentUsageError:
+                self.fail('Main-site duplicate must not affect SCM path')
+
+    def test_namespace_without_http_headers_attr(self):
+        """Real argparse Namespaces may omit http_headers when not declared."""
+        from types import SimpleNamespace
+        cmd = mock.MagicMock()
+        ns = SimpleNamespace(
+            resource_group_name='rg',
+            name='app',
+            slot=None,
+            scm_site=False,
+            ip_address='10.0.0.1/32',
+        )
+        with self._patch_configs([]):
+            try:
+                _validate_ip_address_existence(cmd, ns)
+            except ArgumentUsageError:
+                self.fail('Missing http_headers attribute should be treated as no headers')
+
+
+class ValidateServiceTagExistenceTest(unittest.TestCase):
+    def _make_namespace(self, service_tag, http_headers=None, scm_site=False):
+        ns = mock.MagicMock()
+        ns.resource_group_name = 'rg'
+        ns.name = 'app'
+        ns.slot = None
+        ns.scm_site = scm_site
+        ns.service_tag = service_tag
+        ns.http_headers = http_headers
+        return ns
+
+    def _patch_configs(self, rules):
+        configs = mock.MagicMock()
+        configs.ip_security_restrictions = rules
+        configs.scm_ip_security_restrictions = []
+        return mock.patch(
+            'azure.cli.command_modules.appservice._validators._generic_site_operation',
+            return_value=configs,
+        )
+
+    def test_blocks_exact_duplicate(self):
+        cmd = mock.MagicMock()
+        ns = self._make_namespace('AzureFrontDoor.Backend')
+        with self._patch_configs([_StubRule('AzureFrontDoor.Backend')]):
+            with self.assertRaises(ArgumentUsageError):
+                _validate_service_tag_existence(cmd, ns)
+
+    def test_allows_same_tag_with_different_fdid(self):
+        cmd = mock.MagicMock()
+        ns = self._make_namespace(
+            'AzureFrontDoor.Backend',
+            http_headers=['x-azure-fdid=22222222-2222-2222-2222-222222222222'],
+        )
+        existing = _StubRule(
+            'AzureFrontDoor.Backend',
+            headers={'x-azure-fdid': ['11111111-1111-1111-1111-111111111111']},
+        )
+        with self._patch_configs([existing]):
+            try:
+                _validate_service_tag_existence(cmd, ns)
+            except ArgumentUsageError:
+                self.fail('Different x-azure-fdid filter should be allowed')
+
+    def test_blocks_when_tag_and_headers_match(self):
+        cmd = mock.MagicMock()
+        ns = self._make_namespace(
+            'AzureFrontDoor.Backend',
+            http_headers=['x-azure-fdid=11111111-1111-1111-1111-111111111111'],
+        )
+        existing = _StubRule(
+            'AzureFrontDoor.Backend',
+            headers={'x-azure-fdid': ['11111111-1111-1111-1111-111111111111']},
+        )
+        with self._patch_configs([existing]):
+            with self.assertRaises(ArgumentUsageError):
+                _validate_service_tag_existence(cmd, ns)
+
+    def test_handles_none_access_rules(self):
+        cmd = mock.MagicMock()
+        ns = self._make_namespace('AzureFrontDoor.Backend')
+        with self._patch_configs(None):
+            try:
+                _validate_service_tag_existence(cmd, ns)
+            except ArgumentUsageError:
+                self.fail('No existing rules should not raise')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_appservice_validators_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_appservice_validators_thru_mock.py
@@ -109,8 +109,12 @@ class ValidateIpAddressExistenceTest(unittest.TestCase):
         cmd = mock.MagicMock()
         ns = self._make_namespace('36.12.195.236/32')
         with self._patch_configs([_StubRule('36.12.195.236/32')]):
-            with self.assertRaises(ArgumentUsageError):
+            with self.assertRaises(ArgumentUsageError) as ctx:
                 _validate_ip_address_existence(cmd, ns)
+        msg = str(ctx.exception)
+        self.assertIn('already exists', msg)
+        self.assertNotIn('HTTP header filter', msg)
+        self.assertIn('add a --http-header filter', msg)
 
     def test_allows_same_ip_with_different_xff(self):
         cmd = mock.MagicMock()
@@ -151,8 +155,11 @@ class ValidateIpAddressExistenceTest(unittest.TestCase):
             headers={'x-forwarded-for': ['10.0.0.1/32']},
         )
         with self._patch_configs([existing]):
-            with self.assertRaises(ArgumentUsageError):
+            with self.assertRaises(ArgumentUsageError) as ctx:
                 _validate_ip_address_existence(cmd, ns)
+        msg = str(ctx.exception)
+        self.assertIn('HTTP header filter', msg)
+        self.assertIn('vary the --http-header values', msg)
 
     def test_blocks_when_value_order_differs_for_same_header(self):
         cmd = mock.MagicMock()


### PR DESCRIPTION
## Related issue
Fixes CSS case 2604010030001925.

## Description
`az webapp/functionapp config access-restriction add` previously rejected valid duplicate-IP rules whose `--http-header` values differed, even though the ARM API allows multiple rules with the same source as long as the header filters differ. The CLI's duplicate-detection logic only compared `ip_address`, ignoring `headers`.

This PR makes the duplicate-rule check **header-aware** for all three rule kinds:

- **IP** rules: `_validate_ip_address_existence` now compares the (IP-set, header-set) tuple. The IP-set comparison is also order-insensitive when multiple comma-separated CIDRs are provided in a single rule.
- **Service-tag** rules: `_validate_service_tag_existence` is now header-aware (e.g. allows the same `AzureFrontDoor.Backend` tag with different `x-azure-fdid` filters — common Front Door scenario).
- **Subnet** rules: the inline duplicate check in `add_webapp_access_restriction` is now header-aware.

A new `_normalize_http_headers` helper accepts both the CLI input form (list of `name=value` strings) and the SDK/ARM form (dict of name→list-of-values) and returns a comparable representation that's case- and order-insensitive.

## Testing
- 26 new unit tests in `test_appservice_validators_thru_mock.py` (CLI/SDK header-form parity, multi-IP order normalization, SCM path isolation, missing-attribute safety, service-tag header-awareness).
- All 13 existing access-restriction scenario tests still pass.
- Live BEFORE/AFTER repro performed on a Demo Three Subscription webapp:
  - **BEFORE** (origin/dev): `ERROR: IP address: 36.12.195.236/32 already exists. Cannot add duplicate IP address values.` — customer's exact error.
  - **AFTER** (this branch): both rules created and persisted in ARM with the differing `x-forwarded-for` values; identical-duplicate negative case still blocks correctly.
