### PR TITLE
{Branch Management} Fix merge-base: Merge release 2.86.0 back to dev

### DIFF
--- a/scripts/ci/credscan/CredScanSuppressions.json
+++ b/scripts/ci/credscan/CredScanSuppressions.json
@@ -695,6 +695,10 @@
     {
       "placeholder": "client_id_456",
       "_justification": "[ARO] Dummy client_id value in test_validators.py unit tests"
+    },
+    {
+      "placeholder": "mypass",
+      "_justification": "[AppService] Dummy DOCKER_REGISTRY_SERVER_PASSWORD value in test_compose_convert.py unit tests"
     }
   ]
 }


### PR DESCRIPTION
## Fix merge-base between `release` and `dev`

PR #33279 (`{CI} Add suppression for dummy DOCKER_REGISTRY_SERVER_PASSWORD in unit tests`) was merged to `release` (commit `0c93c90f04`) to fix the Batch CI Credential Scanner failure during the 2.86.0 release.

This PR brings that fix from `release` back to `dev` so future scans on `dev` don't hit the same false positive.

### Current state (before this PR)

| Metric | Value |
|--------|-------|
| `upstream/release` HEAD | `0c93c90f04` (#33279 merged here) |
| `upstream/dev` HEAD     | `c81b61793b` |
| Commits in release not in dev | 1 (the credscan suppression fix) |

### What this PR does

This PR exists to satisfy the `azure-production-ruleset` PR requirement. It will be merged **locally** using `git merge --no-ff` and pushed, creating a 2-parent merge commit that links `release` history into `dev` and advances the merge-base.

### How to merge

🛑 **Do NOT use the GitHub UI merge button or GitHub CLI `gh pr merge`.**

Follow the documented hotfix process:
1. ✅ Create this PR (done)
2. ✅ Approve this PR in GitHub UI
3. Merge locally: `git checkout dev && git pull origin dev && git merge origin/release --no-ff -m "Merge release 2.86.0 back to dev"`
4. Push: `git push origin dev`
5. This PR will automatically be marked as Merged

### File changes

Only 1 file changed: `scripts/ci/credscan/CredScanSuppressions.json` (4 additions) — the credscan false positive fix from PR #33279.

### Reference

Same process as PR #32924 (`{Branch Management} Fix merge-base: Merge release 2.84.0 back to dev`).