### PR TITLE
[ACR] Support ARM scoped token in ACR for Azure Local Disconnected Operations

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
@@ -126,6 +126,22 @@ def _handle_challenge_phase(login_server,
     return token_params
 
 
+def _acquire_aad_token_for_acr_exchange(cli_ctx, profile):
+    unknown_resource_markers = ('invalid_resource', 'AADSTS50001')
+    subscription = get_subscription_id(cli_ctx)
+    acr_resource = "https://{}.azure.net".format(ACR_AUDIENCE_RESOURCE_NAME)
+    try:
+        creds, _, tenant = profile.get_raw_token(subscription=subscription, resource=acr_resource)
+    except CLIError as e:
+        arm_resource = getattr(cli_ctx.cloud.endpoints, 'active_directory_resource_id', None)
+        if not arm_resource or not any(m in str(e) for m in unknown_resource_markers):
+            raise
+        logger.warning("AAD resource '%s' not registered in this cloud; falling back to ARM resource '%s' "
+                       "(expected in disconnected environments such as ALDO).", acr_resource, arm_resource)
+        creds, _, tenant = profile.get_raw_token(subscription=subscription, resource=arm_resource)
+    return creds, tenant
+
+
 def _get_aad_token_after_challenge(cli_ctx,
                                    token_params,
                                    login_server,
@@ -141,11 +157,7 @@ def _get_aad_token_after_challenge(cli_ctx,
     from azure.cli.core._profile import Profile
     profile = Profile(cli_ctx=cli_ctx)
 
-    scope = "https://{}.azure.net".format(ACR_AUDIENCE_RESOURCE_NAME)
-
-    # this might be a cross tenant scenario, so pass subscription to get_raw_token
-    creds, _, tenant = profile.get_raw_token(subscription=get_subscription_id(cli_ctx),
-                                             resource=scope)
+    creds, tenant = _acquire_aad_token_for_acr_exchange(cli_ctx, profile)
 
     headers = {'Content-Type': 'application/x-www-form-urlencoded'}
     content = {


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az acr login`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Azure Local Disconnected Operations (ALDO) does not use AAD scoped tokens for token exchange and rely on ARM scoped tokens to acquire ACR token. 

**Testing Guide**
az acr login --debug

**History Notes**
[ACR] az acr login: Support fallback for ARM scoped tokens for token exchange

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
