### PR TITLE
[ACR] Support Custom ACR Scope for Disconnected Clouds (ALDO)

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
@@ -126,6 +126,28 @@ def _handle_challenge_phase(login_server,
     return token_params
 
 
+def _resolve_acr_scope(cli_ctx):
+    """Determine the AAD resource (audience) to request a token for, for the ACR /oauth2/exchange endpoint.
+
+    Resolution order:
+      1. ``az config set acr.audience_resource=<value>`` — operator override. If the value
+         starts with ``https://`` it is used verbatim, otherwise it is treated as a short
+         name and expanded to ``https://<value>.azure.net``.
+      2. The default public ACR audience ``https://containerregistry.azure.net``.
+
+    This lets disconnected environments (e.g. Azure Local Disconnected Operations) pin
+    the audience their local IDP knows about, instead of relying on runtime fallback.
+    """
+    configured = None
+    try:
+        configured = cli_ctx.config.get('acr', 'audience_resource', fallback=None)
+    except Exception:  # pylint: disable=broad-except
+        configured = None
+    if configured:
+        return configured if configured.startswith('https://') else "https://{}.azure.net".format(configured)
+    return "https://{}.azure.net".format(ACR_AUDIENCE_RESOURCE_NAME)
+
+
 def _get_aad_token_after_challenge(cli_ctx,
                                    token_params,
                                    login_server,
@@ -141,7 +163,7 @@ def _get_aad_token_after_challenge(cli_ctx,
     from azure.cli.core._profile import Profile
     profile = Profile(cli_ctx=cli_ctx)
 
-    scope = "https://{}.azure.net".format(ACR_AUDIENCE_RESOURCE_NAME)
+    scope = _resolve_acr_scope(cli_ctx)
 
     # this might be a cross tenant scenario, so pass subscription to get_raw_token
     creds, _, tenant = profile.get_raw_token(subscription=get_subscription_id(cli_ctx),

--- a/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_commands_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_commands_mock.py
@@ -44,11 +44,13 @@ from azure.cli.command_modules.acr._docker_utils import (
     get_access_credentials,
     get_authorization_header,
     get_manifest_authorization_header,
+    _resolve_acr_scope,
     RepoAccessTokenPermission,
     HelmAccessTokenPermission,
     EMPTY_GUID
 )
 from azure.cli.command_modules.acr._docker_utils import ResourceNotFound
+from azure.cli.command_modules.acr._constants import ACR_AUDIENCE_RESOURCE_NAME
 from azure.cli.core.mock import DummyCli
 
 
@@ -1446,3 +1448,43 @@ class AcrMockCommandsTests(unittest.TestCase):
         mock_sku.premium.value = 'Premium'
         cmd.get_models.return_value = mock_sku
         return cmd
+
+
+class ResolveAcrScopeTests(unittest.TestCase):
+    """Unit tests for _docker_utils._resolve_acr_scope.
+
+    The helper resolves the AAD audience used for ACR's /oauth2/exchange call.
+    Operators can override the default via ``az config set acr.audience_resource=<value>``.
+    """
+
+    @staticmethod
+    def _ctx(configured):
+        cli_ctx = mock.MagicMock()
+        cli_ctx.config.get.return_value = configured
+        return cli_ctx
+
+    def test_default_when_unset(self):
+        self.assertEqual(
+            _resolve_acr_scope(self._ctx(None)),
+            "https://{}.azure.net".format(ACR_AUDIENCE_RESOURCE_NAME),
+        )
+
+    def test_short_name_is_expanded(self):
+        self.assertEqual(
+            _resolve_acr_scope(self._ctx("containerregistry")),
+            "https://containerregistry.azure.net",
+        )
+
+    def test_full_url_is_used_verbatim(self):
+        self.assertEqual(
+            _resolve_acr_scope(self._ctx("https://customregistry.example.com")),
+            "https://customregistry.example.com",
+        )
+
+    def test_config_exception_falls_back_to_default(self):
+        cli_ctx = mock.MagicMock()
+        cli_ctx.config.get.side_effect = RuntimeError("no config")
+        self.assertEqual(
+            _resolve_acr_scope(cli_ctx),
+            "https://{}.azure.net".format(ACR_AUDIENCE_RESOURCE_NAME),
+        )


### PR DESCRIPTION
**Related command**
az acr login

**Description**<!--Mandatory-->
Support override ACR audience (https://containerregistry.azure.net/) when acquiring aad token to access container registry instance

**Testing Guide**
`az acr login --debug`

**History Notes**
[ACR] `az acr login`: Make ACR audience customizable in AAD token acquisition

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
