### PR TITLE
{AKS} `az aks create/update`: Update container network logs error message to mention portal enablement of ACNS

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -2768,8 +2768,9 @@ class AKSManagedClusterContext(BaseAKSContext):
 
         if enable_cnl and (not acns_enabled or not monitoring_enabled or not cilium_enabled):
             raise InvalidArgumentValueError(
-                "Container network logs requires ACNS to be enabled, the monitoring addon to be enabled, "
-                "and the cilium network dataplane."
+                "Container network logs require Advanced Container Networking Services to be enabled. "
+                "Activate this service through the portal or use the CLI with --enable-acns flag. "
+                "Additionally, the monitoring addon must be enabled and the cilium network dataplane is required."
             )
         enable_cnl = bool(enable_cnl) if enable_cnl is not None else False
         disable_cnl = bool(disable_cnl) if disable_cnl is not None else False


### PR DESCRIPTION
**Related command**
`az aks create`, `az aks update`

**Description**

Updated the error message shown when a user tries to enable container network logs (CNL) without having Advanced Container Networking Services (ACNS) enabled. Previously, the message only referenced the `--enable-acns` CLI flag. Since ACNS can now also be enabled through the Azure portal, the error message has been updated to inform users of both options.

New message:
> "Container network logs require Advanced Container Networking Services to be enabled. Activate this service through the portal or use the CLI with --enable-acns flag. Additionally, the monitoring addon must be enabled and the cilium network dataplane is required."

**Testing Guide**

```bash
# Attempt to enable CNL without ACNS — should show updated error message
az aks create -g myRG -n myCluster --network-plugin azure --network-plugin-mode overlay --network-dataplane cilium --enable-addons monitoring --enable-container-network-logs
```

**History Notes**

[AKS] `az aks create/update`: Update container network logs error message to mention portal enablement of ACNS

---

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
