### PR TITLE
[Storage] WIP: align CLI with storage TypeSpec migration

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_params.py
@@ -227,9 +227,9 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
         arg_group='Azure Files Identity Based Authentication',
         help='Default share permission for users using Kerberos authentication if RBAC role is not assigned.')
 
-    t_blob_tier = self.get_sdk('_generated.models._azure_blob_storage_enums#AccessTierOptional',
+    t_blob_tier = self.get_sdk('_generated.models._enums#AccessTier',
                                resource_type=ResourceType.DATA_STORAGE_BLOB)
-    t_rehydrate_priority = self.get_sdk('_generated.models._azure_blob_storage_enums#RehydratePriority',
+    t_rehydrate_priority = self.get_sdk('_generated.models._enums#RehydratePriority',
                                         resource_type=ResourceType.DATA_STORAGE_BLOB)
     tier_type = CLIArgumentType(
         arg_type=get_enum_type(t_blob_tier),
@@ -922,7 +922,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
 
     with self.argument_context('storage blob list') as c:
         from ._validators import get_include_help_string
-        t_blob_include = self.get_sdk('_generated.models._azure_blob_storage_enums#ListBlobsIncludeItem',
+        t_blob_include = self.get_sdk('_generated.models._enums#ListBlobsIncludeItem',
                                       resource_type=ResourceType.DATA_STORAGE_BLOB)
         c.register_container_arguments()
         c.argument('delimiter',
@@ -1930,7 +1930,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
         c.argument('expiry', type=get_datetime_type(True), help='expiration UTC datetime in (Y-m-d\'T\'H:M:S\'Z\')')
 
     with self.argument_context('storage share delete') as c:
-        t_delete_snapshot = self.get_sdk('_generated.models._azure_file_storage_enums#DeleteSnapshotsOptionType',
+        t_delete_snapshot = self.get_sdk('_generated.models._enums#DeleteSnapshotsOptionType',
                                          resource_type=ResourceType.DATA_STORAGE_FILESHARE)
         c.extra('share_name', share_name_type, options_list=('--name', '-n'), required=True)
         c.argument('delete_snapshots', arg_type=get_enum_type(t_delete_snapshot),
@@ -2086,14 +2086,14 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
         c.extra('group', help='Only applicable to NFS Files. Only work together with parameter '
                               '`--owner-copy-mode Override`. The owner group identifier (GID) '
                               'to be set on the directory. The default value is 0 (root group).')
-        t_file_mode_copy_mode_type = self.get_sdk('_generated.models._azure_file_storage_enums#ModeCopyMode',
+        t_file_mode_copy_mode_type = self.get_sdk('_generated.models._enums#ModeCopyMode',
                                                   resource_type=ResourceType.DATA_STORAGE_FILESHARE)
         c.extra('file_mode_copy_mode',
                 arg_type=get_enum_type(t_file_mode_copy_mode_type),
                 help='Only applicable to NFS Files. Applicable only when the copy source is a File. '
                      'Determines the copy behavior of the mode bits of the destination file. '
                      'If not populated, the destination file will have the default File Mode.')
-        t_owner_copy_mode_type = self.get_sdk('_generated.models._azure_file_storage_enums#OwnerCopyMode',
+        t_owner_copy_mode_type = self.get_sdk('_generated.models._enums#OwnerCopyMode',
                                               resource_type=ResourceType.DATA_STORAGE_FILESHARE)
         c.extra('owner_copy_mode', arg_type=get_enum_type(t_owner_copy_mode_type),
                 help='Only applicable to NFS Files. Applicable only when the copy source is a File. '

--- a/src/azure-cli/azure/cli/command_modules/storage/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_validators.py
@@ -1400,11 +1400,11 @@ def page_blob_tier_validator_track2(cmd, namespace):
 
     try:
         namespace.premium_page_blob_tier = getattr(cmd.get_models(
-            '_generated.models._azure_blob_storage_enums#PremiumPageBlobAccessTier'), namespace.tier)
+            '_generated.models._enums#PremiumPageBlobAccessTier'), namespace.tier)
     except AttributeError:
         from azure.cli.command_modules.storage.sdkutil import get_blob_tier_names_track2
         tier_names = get_blob_tier_names_track2(
-            cmd.cli_ctx, '_generated.models._azure_blob_storage_enums#PremiumPageBlobAccessTier')
+            cmd.cli_ctx, '_generated.models._enums#PremiumPageBlobAccessTier')
         raise ValueError('Unknown premium page blob tier name. Choose among {}'.format(', '.join(tier_names)))
 
 


### PR DESCRIPTION
**WIP / Draft** — companion changes for the Azure Storage TypeSpec migration in azure-sdk-for-python.

The TSP-generated SDK renames the internal generated-enums module from `_azure_blob_storage_enums.py` / `_azure_file_storage_enums.py` to `_enums.py`, and consolidates the legacy `AccessTierOptional` enum into `AccessTier`. The CLI reaches into these private `_generated.*` paths via `cmd.get_models(...)` so it must be updated to follow the new layout.

### Changes
- `_params.py` — 6 lookups updated to `_generated.models._enums#X`; `AccessTierOptional` → `AccessTier`
- `_validators.py` — 2 lookups updated to `_generated.models._enums#X`

Tracks SDK PRs:
- Azure/azure-sdk-for-python#45133 (azure-storage-blob)
- Azure/azure-sdk-for-python#45828 (azure-storage-file-share)
- Azure/azure-sdk-for-python#45649 (azure-storage-queue)
- Azure/azure-sdk-for-python#45883 (azure-storage-file-datalake)