### PR TITLE
{CI} Fix parser spellchecker test by setting explicit parser prog

### DIFF
--- a/src/azure-cli-core/azure/cli/core/tests/test_parser.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_parser.py
@@ -204,7 +204,8 @@ class TestParser(unittest.TestCase):
 
         cli.loader.load_command_table(None)
 
-        parser = cli.parser_cls(cli)
+        global_parser = cli.parser_cls.create_global_parser(cli_ctx=cli)
+        parser = cli.parser_cls(cli, prog=cli.name, parents=[global_parser])
         parser.load_command_table(cli.loader)
 
         logger_msgs = []


### PR DESCRIPTION
## Summary

This updates the parser spellchecker test to construct the parser the same way production does, with an explicit `prog` value and the global parser parent.

## Why

Python 3.14 changed `argparse` default `prog` behavior to reflect how `__main__` was actually executed. In this test, the parser was being created without an explicit `prog`, so the effective `prog` differed between Python 3.13 and Python 3.14 under `pytest`.

That difference leaked into the dynamic extension install path and made the test fail on Python 3.14 even though production code always sets `prog` explicitly.

## What changed

- Updated the test to create the global parser
- Constructed the parser with `prog=cli.name`
- Passed the global parser via `parents` to match the real runtime setup

This is a test-only fix. No product behavior is changed.

## Validation

- Passed on Python 3.13:
  - `python -m pytest src/azure-cli-core/azure/cli/core/tests/test_parser.py -k test_parser_error_spellchecker -q`
- Passed on Python 3.14:
  - `python -m pytest src/azure-cli-core/azure/cli/core/tests/test_parser.py -k test_parser_error_spellchecker -q`

## Notes

This keeps the test focused on parser spellchecking and dynamic extension install behavior, instead of depending on interpreter-specific `argparse` defaults.