### PR TITLE
{CI} Make raw request header test Accept-Encoding resilient

### DIFF
--- a/src/azure-cli-core/azure/cli/core/tests/test_util.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_util.py
@@ -23,6 +23,20 @@ from azure.cli.core.mock import DummyCli
 
 class TestUtils(unittest.TestCase):
 
+    def _assert_headers(self, request_headers, expected_headers):
+        actual_headers = dict(request_headers)
+
+        encodings = {
+            encoding.strip().lower()
+            for encoding in actual_headers.get('Accept-Encoding', '').split(',')
+            if encoding.strip()
+        }
+        self.assertIn('gzip', encodings)
+        self.assertIn('deflate', encodings)
+
+        actual_headers.pop('Accept-Encoding', None)
+        self.assertDictEqual(actual_headers, expected_headers)
+
     def test_load_json_from_file(self):
         _, pathname = tempfile.mkstemp()
 
@@ -257,7 +271,6 @@ class TestUtils(unittest.TestCase):
 
         expected_header = {
             'User-Agent': get_az_rest_user_agent(),
-            'Accept-Encoding': 'gzip, deflate',
             'Accept': '*/*',
             'Connection': 'keep-alive',
             'Content-Type': 'application/json',
@@ -282,7 +295,7 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(request.url, 'https://myaccount.blob.core.windows.net/mycontainer/myblob?timeout=30&sv=2019-02-02&srt=s&ss=bf')
         self.assertEqual(request.body, '{"b1": "v1"}')
         # Verify no Authorization header
-        self.assertDictEqual(dict(request.headers), expected_header)
+        self._assert_headers(request.headers, expected_header)
         self.assertEqual(send_mock.call_args[1]["verify"], not should_disable_connection_verify())
 
         # Test Authorization header is skipped
@@ -291,7 +304,7 @@ class TestUtils(unittest.TestCase):
 
         get_raw_token_mock.assert_not_called()
         request = send_mock.call_args[0][1]
-        self.assertDictEqual(dict(request.headers), expected_header)
+        self._assert_headers(request.headers, expected_header)
 
         # Test Authorization header is already provided
         send_raw_request(cli_ctx, 'GET', full_arm_rest_url,
@@ -300,7 +313,7 @@ class TestUtils(unittest.TestCase):
 
         get_raw_token_mock.assert_not_called()
         request = send_mock.call_args[0][1]
-        self.assertDictEqual(dict(request.headers), {**expected_header, 'Authorization': 'Basic ABCDE'})
+        self._assert_headers(request.headers, {**expected_header, 'Authorization': 'Basic ABCDE'})
 
         # Test Authorization header is auto appended
         send_raw_request(cli_ctx, 'GET', full_arm_rest_url,
@@ -309,7 +322,7 @@ class TestUtils(unittest.TestCase):
 
         get_raw_token_mock.assert_called_with(mock.ANY, test_arm_active_directory_resource_id, subscription=subscription_id)
         request = send_mock.call_args[0][1]
-        self.assertDictEqual(dict(request.headers), expected_header_with_auth)
+        self._assert_headers(request.headers, expected_header_with_auth)
 
         # Test ARM Subscriptions - List
         # https://learn.microsoft.com/en-us/rest/api/resources/subscriptions/list
@@ -320,7 +333,7 @@ class TestUtils(unittest.TestCase):
         get_raw_token_mock.assert_called_with(mock.ANY, test_arm_active_directory_resource_id)
         request = send_mock.call_args[0][1]
         self.assertEqual(request.url, test_arm_endpoint.rstrip('/') + '/subscriptions?api-version=2020-01-01')
-        self.assertDictEqual(dict(request.headers), expected_header_with_auth)
+        self._assert_headers(request.headers, expected_header_with_auth)
 
         # Test ARM Tenants - List
         # https://learn.microsoft.com/en-us/rest/api/resources/tenants/list
@@ -331,7 +344,7 @@ class TestUtils(unittest.TestCase):
         get_raw_token_mock.assert_called_with(mock.ANY, test_arm_active_directory_resource_id)
         request = send_mock.call_args[0][1]
         self.assertEqual(request.url, test_arm_endpoint.rstrip('/') + '/tenants?api-version=2020-01-01')
-        self.assertDictEqual(dict(request.headers), expected_header_with_auth)
+        self._assert_headers(request.headers, expected_header_with_auth)
 
         # Test ARM resource ID
         # /subscriptions/00000001-0000-0000-0000-000000000000/resourcegroups/02?api-version=2019-07-01
@@ -341,7 +354,7 @@ class TestUtils(unittest.TestCase):
         get_raw_token_mock.assert_called_with(mock.ANY, test_arm_active_directory_resource_id, subscription=subscription_id)
         request = send_mock.call_args[0][1]
         self.assertEqual(request.url, full_arm_rest_url)
-        self.assertDictEqual(dict(request.headers), expected_header_with_auth)
+        self._assert_headers(request.headers, expected_header_with_auth)
 
         # Test full ARM URL
         # https://management.azure.com/subscriptions/00000001-0000-0000-0000-000000000000/resourcegroups/02?api-version=2019-07-01


### PR DESCRIPTION
## Summary

Updates `test_send_raw_requests` to avoid asserting an exact `Accept-Encoding` string, which varies by runtime/compression support (for example Python 3.14 adds `zstd`).

## Root cause

`requests`/`urllib3` now compute default `Accept-Encoding` based on available codecs.  
On Python 3.14, `compression.zstd` is available, so default headers include `zstd`, causing strict header dict equality checks to fail.

## What changed

- Added a helper assertion in the test to:
  - verify `Accept-Encoding` contains required values (`gzip`, `deflate`)
  - compare the rest of headers exactly
- Replaced strict full-header dict equality checks in `test_send_raw_requests` with the helper

## Why this is correct

This keeps strict validation of CLI-owned behavior (`User-Agent`, telemetry headers, auth headers, URL/body handling) while removing brittle coupling to dependency/runtime-specific transport defaults.

## Validation

- Python 3.13:
  - `python -m pytest src/azure-cli-core/azure/cli/core/tests/test_util.py -k test_send_raw_requests -q`
  - passed
- Python 3.14:
  - `python -m pytest src/azure-cli-core/azure/cli/core/tests/test_util.py -k test_send_raw_requests -q`
  - passed