### PR TITLE
{Core} Remove deprecated ADAL_PYTHON_SSL_NO_VERIFY environment variable (#33322)

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_debug.py
+++ b/src/azure-cli-core/azure/cli/core/_debug.py
@@ -12,7 +12,6 @@ from .util import should_disable_connection_verify, DISABLE_VERIFY_VARIABLE_NAME
 
 logger = get_logger(__name__)
 
-ADAL_PYTHON_SSL_NO_VERIFY = "ADAL_PYTHON_SSL_NO_VERIFY"
 REQUESTS_CA_BUNDLE = "REQUESTS_CA_BUNDLE"
 
 
@@ -20,7 +19,6 @@ def change_ssl_cert_verification(client):
     if should_disable_connection_verify():
         logger.warning("Connection verification disabled by environment variable %s",
                        DISABLE_VERIFY_VARIABLE_NAME)
-        os.environ[ADAL_PYTHON_SSL_NO_VERIFY] = '1'
         client.config.connection.verify = False
     elif REQUESTS_CA_BUNDLE in os.environ:
         ca_bundle_file = os.environ[REQUESTS_CA_BUNDLE]
@@ -36,7 +34,6 @@ def change_ssl_cert_verification_track2():
     if should_disable_connection_verify():
         logger.warning("Connection verification disabled by environment variable %s",
                        DISABLE_VERIFY_VARIABLE_NAME)
-        os.environ[ADAL_PYTHON_SSL_NO_VERIFY] = '1'
         client_kwargs['connection_verify'] = False
     elif REQUESTS_CA_BUNDLE in os.environ:
         ca_bundle_file = os.environ[REQUESTS_CA_BUNDLE]


### PR DESCRIPTION
**Related command**
N/A – internal core cleanup, no az command affected.

**Description**
ADAL (Active Directory Authentication Library) was replaced by MSAL. 
The `ADAL_PYTHON_SSL_NO_VERIFY` environment variable was previously used 
to disable SSL verification in ADAL, but it no longer has any effect since 
the migration. This PR removes the dead constant and the two `os.environ` 
assignments referencing it in `_debug.py`.

No behavior change — `AZURE_CLI_DISABLE_CONNECTION_VERIFICATION` remains 
the correct way to disable SSL verification.

Closes #33322

**Testing Guide**
1. Set `AZURE_CLI_DISABLE_CONNECTION_VERIFICATION=1` and run any az command — 
   SSL verification should still be disabled as expected.
2. Verify `ADAL_PYTHON_SSL_NO_VERIFY` is no longer set in the environment 
   during a debug session.

**History Notes**
{Core} Remove deprecated ADAL_PYTHON_SSL_NO_VERIFY environment variable