### PR TITLE
[POSTGRESQL] BREAKING CHANGE: `az postgres flexible-server backup create`: Remove backup name requirement and implement automatic name generation for backups

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/postgresql/_breaking_change.py
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/_breaking_change.py
@@ -53,11 +53,6 @@ register_command_group_deprecate(command_group='postgres flexible-server long-te
                                  message='Long term retention command group will be removed. '
                                  'For more information, open a support incident.')
 
-# Name of new backup no longer required in backup create command
-register_other_breaking_change('postgres flexible-server backup create',
-                               message='The argument for backup name will no longer be required '
-                               'in next breaking change release(2.86.0) scheduled for May 2026.')
-
 # LTR command argument changes
 register_other_breaking_change('postgres flexible-server long-term-retention',
                                message='The --backup-name/-b argument has been deprecated and will be removed '

--- a/src/azure-cli/azure/cli/command_modules/postgresql/commands/backup_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/commands/backup_commands.py
@@ -4,16 +4,39 @@
 # --------------------------------------------------------------------------------------------
 
 # pylint: disable=unused-argument, line-too-long
+from datetime import datetime
 from azure.cli.core.util import user_confirmation
 from knack.log import get_logger
 from ..utils.validators import validate_resource_group, validate_backup_name
 
 logger = get_logger(__name__)
 
+_BACKUP_NAME_PREFIX = "ondemandbackup"
 
-def backup_create_func(client, resource_group_name, server_name, backup_name):
+
+def _generate_backup_name(client, resource_group_name, server_name):
+    existing_backups = client.list_by_server(resource_group_name, server_name)
+    existing_names = {backup.name for backup in existing_backups}
+
+    on_demand_count = sum(1 for name in existing_names if name.startswith(_BACKUP_NAME_PREFIX))
+
+    date_str = datetime.utcnow().strftime("%m%d%Y")
+    backup_name = f"{_BACKUP_NAME_PREFIX}-{date_str}-{on_demand_count + 1}"
+
+    if backup_name in existing_names:
+        backup_name = f"{_BACKUP_NAME_PREFIX}-{date_str}-{on_demand_count + 2}"
+
+    return backup_name
+
+
+def backup_create_func(client, resource_group_name, server_name, backup_name=None):
     validate_resource_group(resource_group_name)
-    validate_backup_name(backup_name)
+
+    if not backup_name:
+        backup_name = _generate_backup_name(client, resource_group_name, server_name)
+        logger.warning("No backup name provided. Using generated name: %s", backup_name)
+    else:
+        validate_backup_name(backup_name)
 
     return client.begin_create(
         resource_group_name,


### PR DESCRIPTION
**Related command**
az postgres flexible-server backup create


**Description**<!--Mandatory-->
Remove backup name requirement and implement automatic name generation for backups


**Testing Guide**
```
The --backup-name/-b argument has been deprecated and will be removed in next breaking change release(2.86.0) scheduled for May 2026.
The --name/-n argument will be repurposed to specify the backup name. The --server-name/-s argument will be introduced to specify the server name in next breaking change release(2.86.0) scheduled for May 2026.
No backup name provided. Using generated name: ondemandbackup-05082026-2
```

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[POSTGRESQL] BREAKING CHANGE: `az postgres flexible-server backup create`: Remove backup name requirement and implement automatic name generation for backups


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
