### PR TITLE
[MONITOR] Improve help documentation for 10 commands

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/monitor/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/_help.py
@@ -625,3 +625,144 @@ examples:
     text: |
         az monitor clone --source-resource /subscriptions/{subscriptionID}/resourceGroups/Space1999/providers/Microsoft.Compute/virtualMachines/vm1 --target-resource /subscriptions/{subscriptionID}/resourceGroups/Space1999/providers/Microsoft.Compute/virtualMachines/vm2
 """
+
+helps['monitor diagnostic-settings subscription list'] = """
+type: command
+short-summary: List the active subscription diagnostic settings for a specified subscription.
+"""
+
+helps['monitor log-analytics workspace list-link-target'] = """
+type: command
+short-summary: List workspaces which the current user administers and are not linked to an Azure Subscription.
+parameters:
+  - name: --change-reference
+    short-summary: The related change reference ID for this resource operation.
+  - name: --acquire-policy-token
+    short-summary: Acquiring an Azure Policy token automatically for this resource operation.
+examples:
+  - name: List link targets with specific change reference ID
+    text: |
+        az monitor log-analytics workspace list-link-target --change-reference CHG12345
+  - name: List link targets and acquire Azure Policy token
+    text: |
+        az monitor log-analytics workspace list-link-target --acquire-policy-token
+"""
+
+helps['monitor activity-log list-categories'] = """
+type: command
+short-summary: List the available event categories in the Activity Logs Service.
+parameters:
+  - name: --change-reference
+    short-summary: The related change reference ID for this resource operation.
+  - name: --acquire-policy-token
+    short-summary: Acquiring an Azure Policy token automatically for this resource operation.
+examples:
+  - name: List event categories with a specific change reference
+    text: |
+        az monitor activity-log list-categories --change-reference MyChangeRefID
+  - name: List event categories while acquiring a policy token
+    text: |
+        az monitor activity-log list-categories --acquire-policy-token
+"""
+
+helps['monitor log-analytics workspace list-available-service-tier'] = """
+type: command
+short-summary: List the available service tiers for the workspace.
+parameters:
+  - name: --resource-group -g
+    short-summary: Name of resource group. You can configure the default group using `az configure --defaults group=<name>`
+  - name: --workspace-name -n
+    short-summary: The name of the workspace.
+examples:
+  - name: List available service tiers for a specific workspace
+    text: |
+        az monitor log-analytics workspace list-available-service-tier --resource-group MyResourceGroup --workspace-name MyWorkspace
+"""
+
+helps['monitor log-analytics workspace data-export list'] = """
+type: command
+short-summary: List all data export rules for a given workspace.
+parameters:
+  - name: --resource-group -g
+    short-summary: Name of resource group. You can configure the default group using `az configure --defaults group=<name>`
+  - name: --workspace-name
+    short-summary: The name of the workspace.
+examples:
+  - name: List all data export rules for a workspace
+    text: |
+      az monitor log-analytics workspace data-export list --resource-group MyResourceGroup --workspace-name MyWorkspace
+"""
+
+helps['monitor log-profiles list'] = """
+type: command
+short-summary: List the log profiles.
+examples:
+  - name: List all log profiles
+    text: |
+        az monitor log-profiles list
+"""
+
+helps['monitor action-group list'] = """
+type: command
+short-summary: List action groups under a resource group or the current subscription.
+parameters:
+  - name: --resource-group -g
+    short-summary: Name of resource group. You can configure the default group using `az configure --defaults group=<name>`
+examples:
+  - name: List all action groups in a specific resource group
+    text: |
+        az monitor action-group list --resource-group MyResourceGroup
+  - name: List all action groups in the current subscription
+    text: |
+        az monitor action-group list
+"""
+
+helps['monitor action-group delete'] = """
+type: command
+short-summary: Delete an action group.
+parameters:
+  - name: --change-reference
+    short-summary: The related change reference ID for this resource operation.
+  - name: --acquire-policy-token
+    short-summary: Acquiring an Azure Policy token automatically for this resource operation.
+  - name: --action-group-name --name -n
+    short-summary: The name of the action group.
+  - name: --resource-group -g
+    short-summary: Name of resource group. You can configure the default group using `az configure --defaults group=<name>`.
+examples:
+  - name: Delete an action group in a specific resource group
+    text: |
+        az monitor action-group delete --action-group-name MyActionGroup --resource-group MyResourceGroup
+  - name: Delete an action group with change reference
+    text: |
+        az monitor action-group delete --action-group-name MyActionGroup --resource-group MyResourceGroup --change-reference 12345
+"""
+
+helps['monitor metrics alert show'] = """
+type: command
+short-summary: Show a metrics-based alert rule.
+parameters:
+  - name: --resource-group -g
+    short-summary: Name of resource group. You can configure the default group using `az configure --defaults group=<name>`
+  - name: --name -n
+    short-summary: Name of the alert rule.
+examples:
+  - name: Show a metrics-based alert rule.
+    text: |
+        az monitor metrics alert show --name MyAlertRule --resource-group MyResourceGroup
+"""
+
+helps['monitor log-analytics workspace list'] = """
+type: command
+short-summary: List workspaces under a resource group or a subscription.
+parameters:
+  - name: --resource-group -g
+    short-summary: Name of resource group. You can configure the default group using `az configure --defaults group=<name>`.
+examples:
+  - name: List all workspaces in a specific resource group
+    text: |
+        az monitor log-analytics workspace list --resource-group MyResourceGroup
+  - name: List all workspaces in the current subscription
+    text: |
+        az monitor log-analytics workspace list
+"""


### PR DESCRIPTION
> AI-generated code

## Azure CLI Help Documentation Improvements

This PR improves help documentation for commands with the lowest quality scores.

### Summary

| Command | Type | Original Score | New Score |
|---------|------|---------------|-----------|
| `monitor diagnostic-settings subscription list` | New | 2.0/10 | 3/10 |
| `monitor log-analytics workspace list-link-target` | New | 3.0/10 | 6/10 |
| `monitor activity-log list-categories` | New | 3.0/10 | 6/10 |
| `monitor log-analytics workspace list-available-service-tier` | New | 4.0/10 | 7/10 |
| `monitor log-analytics workspace data-export list` | New | 4.0/10 | 7/10 |
| `monitor log-profiles list` | New | 4.0/10 | 5/10 |
| `monitor action-group list` | New | 5.0/10 | 8/10 |
| `monitor action-group delete` | New | 5.0/10 | 7/10 |
| `monitor metrics alert show` | New | 5.0/10 | 6/10 |
| `monitor log-analytics workspace list` | New | 5.0/10 | 7/10 |

---

### `monitor diagnostic-settings subscription list` (New entry)

<details><summary>Command metadata (score: 2.0/10)</summary>

```
Command: monitor diagnostic-settings subscription list
======================================================================
name: monitor diagnostic-settings subscription list
is_aaz: True
desc: Gets the active subscription diagnostic settings list for the specified subscriptionId. :keyword callable cls: A custom type or function that will be passed the direct response:return: SubscriptionDiagnosticSettingsResourceCollection or the result of cls(response):rtype:  ~$(python-base-namespace).v2017_05_01_preview.models.SubscriptionDiagnosticSettingsResourceCollection:raises ~azure.core.exceptions.HttpResponseError:.
parameters:
```
</details>

<details><summary>New help (score: 3/10)</summary>

```
type: command
short-summary: List the active subscription diagnostic settings for a specified subscription.
```
</details>

---

### `monitor log-analytics workspace list-link-target` (New entry)

<details><summary>Command metadata (score: 3.0/10)</summary>

```
Command: monitor log-analytics workspace list-link-target
======================================================================
name: monitor log-analytics workspace list-link-target
is_aaz: True
desc: List a list of workspaces which the current user has administrator privileges and are not associated with an Azure Subscription.
parameters:
  Item 1:
    name: _change_reference
    options:
      - --change-reference
    desc: The related change reference ID for this resource operation
  Item 2:
    name: _acquire_policy_token
    options:
      - --acquire-policy-token
    desc: Acquiring an Azure Policy token automatically for this resource operation
```
</details>

<details><summary>New help (score: 6/10)</summary>

```
type: command
short-summary: List workspaces which the current user administers and are not linked to an Azure Subscription.
parameters:
  - name: --change-reference
    short-summary: The related change reference ID for this resource operation.
  - name: --acquire-policy-token
    short-summary: Acquiring an Azure Policy token automatically for this resource operation.
examples:
  - name: List link targets with specific change reference ID
    text: |
        az monitor log-analytics workspace list-link-target --change-reference CHG12345
  - name: List link targets and acquire Azure Policy token
    text: |
        az monitor log-analytics workspace list-link-target --acquire-policy-token
```
</details>

---

### `monitor activity-log list-categories` (New entry)

<details><summary>Command metadata (score: 3.0/10)</summary>

```
Command: monitor activity-log list-categories
======================================================================
name: monitor activity-log list-categories
is_aaz: True
desc: List the list of available event categories supported in the Activity Logs Service.
parameters:
  Item 1:
    name: _change_reference
    options:
      - --change-reference
    desc: The related change reference ID for this resource operation
  Item 2:
    name: _acquire_policy_token
    options:
      - --acquire-policy-token
    desc: Acquiring an Azure Policy token automatically for this resource operation
```
</details>

<details><summary>New help (score: 6/10)</summary>

```
type: command
short-summary: List the available event categories in the Activity Logs Service.
parameters:
  - name: --change-reference
    short-summary: The related change reference ID for this resource operation.
  - name: --acquire-policy-token
    short-summary: Acquiring an Azure Policy token automatically for this resource operation.
examples:
  - name: List event categories with a specific change reference
    text: |
        az monitor activity-log list-categories --change-reference MyChangeRefID
  - name: List event categories while acquiring a policy token
    text: |
        az monitor activity-log list-categories --acquire-policy-token
```
</details>

---

### `monitor log-analytics workspace list-available-service-tier` (New entry)

<details><summary>Command metadata (score: 4.0/10)</summary>

```
Command: monitor log-analytics workspace list-available-service-tier
======================================================================
name: monitor log-analytics workspace list-available-service-tier
is_aaz: True
desc: List the available service tiers for the workspace.
parameters:
  Item 1:
    name: _change_reference
    options:
      - --change-reference
    desc: The related change reference ID for this resource operation
  Item 2:
    name: _acquire_policy_token
    options:
      - --acquire-policy-token
    desc: Acquiring an Azure Policy token automatically for this resource operation
  Item 3:
    name: resource_group
    options:
      - --resource-group
      - -g
    required: True
    id_part: resource_group
    has_completer: True
    desc: Name of resource group. You can configure the default group using `az configure --defaults group=<name>`
    aaz_type: string
    type: string
  Item 4:
    name: workspace_name
    options:
      - --workspace-name
      - -n
    required: True
    id_part: name
    desc: The name of the workspace.
    aaz_type: string
    type: string
```
</details>

<details><summary>New help (score: 7/10)</summary>

```
type: command
short-summary: List the available service tiers for the workspace.
parameters:
  - name: --resource-group -g
    short-summary: Name of resource group. You can configure the default group using `az configure --defaults group=<name>`
  - name: --workspace-name -n
    short-summary: The name of the workspace.
examples:
  - name: List available service tiers for a specific workspace
    text: |
        az monitor log-analytics workspace list-available-service-tier --resource-group MyResourceGroup --workspace-name MyWorkspace
```
</details>

---

### `monitor log-analytics workspace data-export list` (New entry)

<details><summary>Command metadata (score: 4.0/10)</summary>

```
Command: monitor log-analytics workspace data-export list
======================================================================
name: monitor log-analytics workspace data-export list
is_aaz: True
desc: List all data export ruleses for a given workspace.
parameters:
  Item 1:
    name: resource_group
    options:
      - --resource-group
      - -g
    required: True
    id_part: resource_group
    has_completer: True
    desc: Name of resource group. You can configure the default group using `az configure --defaults group=<name>`
    aaz_type: string
    type: string
  Item 2:
    name: workspace_name
    options:
      - --workspace-name
    required: True
    desc: The name of the workspace.
    aaz_type: string
    type: string
```
</details>

<details><summary>New help (score: 7/10)</summary>

```
type: command
short-summary: List all data export rules for a given workspace.
parameters:
  - name: --resource-group -g
    short-summary: Name of resource group. You can configure the default group using `az configure --defaults group=<name>`
  - name: --workspace-name
    short-summary: The name of the workspace.
examples:
  - name: List all data export rules for a workspace
    text: |
      az monitor log-analytics workspace data-export list --resource-group MyResourceGroup --workspace-name MyWorkspace
```
</details>

---

### `monitor log-profiles list` (New entry)

<details><summary>Command metadata (score: 4.0/10)</summary>

```
Command: monitor log-profiles list
======================================================================
name: monitor log-profiles list
is_aaz: True
desc: List the log profiles.
parameters:
```
</details>

<details><summary>New help (score: 5/10)</summary>

```
type: command
short-summary: List the log profiles.
examples:
  - name: List all log profiles
    text: |
        az monitor log-profiles list
```
</details>

---

### `monitor action-group list` (New entry)

<details><summary>Command metadata (score: 5.0/10)</summary>

```
Command: monitor action-group list
======================================================================
name: monitor action-group list
is_aaz: True
desc: List action groups under a resource group or the current subscription.
parameters:
  Item 1:
    name: resource_group
    options:
      - --resource-group
      - -g
    id_part: resource_group
    has_completer: True
    desc: Name of resource group. You can configure the default group using `az configure --defaults group=<name>`
    aaz_type: string
    type: string
```
</details>

<details><summary>New help (score: 8/10)</summary>

```
type: command
short-summary: List action groups under a resource group or the current subscription.
parameters:
  - name: --resource-group -g
    short-summary: Name of resource group. You can configure the default group using `az configure --defaults group=<name>`
examples:
  - name: List all action groups in a specific resource group
    text: |
        az monitor action-group list --resource-group MyResourceGroup
  - name: List all action groups in the current subscription
    text: |
        az monitor action-group list
```
</details>

---

### `monitor action-group delete` (New entry)

<details><summary>Command metadata (score: 5.0/10)</summary>

```
Command: monitor action-group delete
======================================================================
name: monitor action-group delete
is_aaz: True
desc: Delete an action group.
parameters:
  Item 1:
    name: _change_reference
    options:
      - --change-reference
    desc: The related change reference ID for this resource operation
  Item 2:
    name: _acquire_policy_token
    options:
      - --acquire-policy-token
    desc: Acquiring an Azure Policy token automatically for this resource operation
  Item 3:
    name: action_group_name
    options:
      - --action-group-name
      - --name
      - -n
    required: True
    id_part: name
    desc: The name of the action group.
    aaz_type: string
    type: string
  Item 4:
    name: resource_group
    options:
      - --resource-group
      - -g
    required: True
    id_part: resource_group
    has_completer: True
    desc: Name of resource group. You can configure the default group using `az configure --defaults group=<name>`
    aaz_type: string
    type: string
```
</details>

<details><summary>New help (score: 7/10)</summary>

```
type: command
short-summary: Delete an action group.
parameters:
  - name: --change-reference
    short-summary: The related change reference ID for this resource operation.
  - name: --acquire-policy-token
    short-summary: Acquiring an Azure Policy token automatically for this resource operation.
  - name: --action-group-name --name -n
    short-summary: The name of the action group.
  - name: --resource-group -g
    short-summary: Name of resource group. You can configure the default group using `az configure --defaults group=<name>`.
examples:
  - name: Delete an action group in a specific resource group
    text: |
        az monitor action-group delete --action-group-name MyActionGroup --resource-group MyResourceGroup
  - name: Delete an action group with change reference
    text: |
        az monitor action-group delete --action-group-name MyActionGroup --resource-group MyResourceGroup --change-reference 12345
```
</details>

---

### `monitor metrics alert show` (New entry)

<details><summary>Command metadata (score: 5.0/10)</summary>

```
Command: monitor metrics alert show
======================================================================
name: monitor metrics alert show
is_aaz: True
examples:
  Item 1:
    name: Show a metrics-based alert rule.
    text: az --name MyAlertRule --resource-group MyResourceGroup
desc: Show a metrics-based alert rule.
parameters:
  Item 1:
    name: resource_group
    options:
      - --resource-group
      - -g
    required: True
    id_part: resource_group
    has_completer: True
    desc: Name of resource group. You can configure the default group using `az configure --defaults group=<name>`
    aaz_type: string
    type: string
  Item 2:
    name: name
    options:
      - --name
      - -n
    required: True
    id_part: name
    desc: Name of the alert rule.
    aaz_type: string
    type: string
```
</details>

<details><summary>New help (score: 6/10)</summary>

```
type: command
short-summary: Show a metrics-based alert rule.
parameters:
  - name: --resource-group -g
    short-summary: Name of resource group. You can configure the default group using `az configure --defaults group=<name>`
  - name: --name -n
    short-summary: Name of the alert rule.
examples:
  - name: Show a metrics-based alert rule.
    text: |
        az monitor metrics alert show --name MyAlertRule --resource-group MyResourceGroup
```
</details>

---

### `monitor log-analytics workspace list` (New entry)

<details><summary>Command metadata (score: 5.0/10)</summary>

```
Command: monitor log-analytics workspace list
======================================================================
name: monitor log-analytics workspace list
is_aaz: True
desc: Get a list of workspaces under a resource group or a subscription.
parameters:
  Item 1:
    name: resource_group
    options:
      - --resource-group
      - -g
    id_part: resource_group
    has_completer: True
    desc: Name of resource group. You can configure the default group using `az configure --defaults group=<name>`
    aaz_type: string
    type: string
```
</details>

<details><summary>New help (score: 7/10)</summary>

```
type: command
short-summary: List workspaces under a resource group or a subscription.
parameters:
  - name: --resource-group -g
    short-summary: Name of resource group. You can configure the default group using `az configure --defaults group=<name>`.
examples:
  - name: List all workspaces in a specific resource group
    text: |
        az monitor log-analytics workspace list --resource-group MyResourceGroup
  - name: List all workspaces in the current subscription
    text: |
        az monitor log-analytics workspace list
```
</details>


### Generated by: Azure CLI Help Improver