### PR TITLE
[Container app] Fix #33369: `az containerapp up`: Resolve OS/Architecture models from correct SDK package

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/containerapp/_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/containerapp/_utils.py
@@ -1344,14 +1344,14 @@ def queue_acr_build(cmd, registry_rg, registry_name, img_name, src_dir, dockerfi
     # So we need to update the docker_file_path
     docker_file_path = docker_file_in_tar
 
-    OS, Architecture = cmd.get_models('OS', 'Architecture', resource_type=ResourceType.MGMT_CONTAINERREGISTRY, operation_group='runs')
+    OS, Architecture = cmd.get_models('OS', 'Architecture', resource_type=ResourceType.MGMT_CONTAINERREGISTRYTASKS, operation_group='runs')
     # Default platform values
     platform_os = OS.linux.value
     platform_arch = Architecture.amd64.value
     platform_variant = None
 
     DockerBuildRequest, PlatformProperties = cmd.get_models('DockerBuildRequest', 'PlatformProperties',
-                                                            resource_type=ResourceType.MGMT_CONTAINERREGISTRY, operation_group='runs')
+                                                            resource_type=ResourceType.MGMT_CONTAINERREGISTRYTASKS, operation_group='runs')
     docker_build_request = DockerBuildRequest(
         image_names=[img_name],
         is_push_enabled=True,


### PR DESCRIPTION
**Related command**
`az containerapp up --source`

**Description**

`az containerapp up --source .` crashes with `AttributeError: 'NoneType' object has no attribute 'linux'` because `queue_acr_build()` in `_utils.py` resolves `OS`, `Architecture`, `DockerBuildRequest`, and `PlatformProperties` models via `cmd.get_models()` using `ResourceType.MGMT_CONTAINERREGISTRY` with `operation_group='runs'`.

These models have moved to the `azure-mgmt-containerregistrytasks` SDK package, so `cmd.get_models()` silently returns `None`, and the subsequent `OS.linux.value` call crashes.

This PR updates both `get_models()` calls in `queue_acr_build()` to use `ResourceType.MGMT_CONTAINERREGISTRYTASKS`, which is already a declared dependency and contains the correct models.

**Testing Guide**

```bash
# Create a directory with a Dockerfile
mkdir test-app && cd test-app
cat > Dockerfile <<EOF
FROM ubuntu:24.04
CMD ["sleep", "infinity"]
EOF

# This should no longer crash
az containerapp up -n my-app -g my-rg --environment my-env --source .
```

The existing `@live_only` tests in `test_containerapp_compose_registries.py` cover `queue_acr_build` and would validate this fix in the nightly live test run.

**History Notes**

[Container app] Fix #33369: `az containerapp up`: Resolve OS/Architecture models from correct SDK package

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).