### PR TITLE
[KeyVault] Fix #33367 az keyvault show-deleted: Fix keyvault show-deleted missing-arg hint and add regression test

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/keyvault/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_validators.py
@@ -426,7 +426,7 @@ def validate_deleted_vault_or_hsm_name(cmd, ns):
     hsm_name = getattr(ns, 'hsm_name', None)
 
     if not vault_name and not hsm_name:
-        raise CLIError('Please specify --vault-name or --hsm-name.')
+        raise CLIError('Please specify --name or --hsm-name.')
 
     if vault_name:
         resource_name = vault_name

--- a/src/azure-cli/azure/cli/command_modules/keyvault/tests/latest/test_keyvault_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/tests/latest/test_keyvault_validators.py
@@ -1,0 +1,18 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import argparse
+from unittest import TestCase, mock
+
+from knack.util import CLIError
+
+
+class DeletedVaultOrHsmValidatorTest(TestCase):
+    def test_validate_deleted_vault_or_hsm_name_without_name(self):
+        from azure.cli.command_modules.keyvault._validators import validate_deleted_vault_or_hsm_name
+
+        ns = argparse.Namespace(vault_name=None, hsm_name=None)
+        with self.assertRaisesRegex(CLIError, 'Please specify --name or --hsm-name.'):
+            validate_deleted_vault_or_hsm_name(mock.Mock(), ns)


### PR DESCRIPTION
**Related command**

az keyvault show-deleted

**Description**

Correct the parameter name returned in error message

**Testing Guide**

`az keyvault show-deleted --query ""`

Should now return error message mentioning `--name` instead of `--vault-name`
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).

Agent-Logs-Url: https://github.com/flcdrg/azure-cli/sessions/3235ca65-38e7-45ad-95d2-b1515574eb7b

Co-authored-by: flcdrg <384747+flcdrg@users.noreply.github.com>