### PR TITLE
{Packaging} Bump knack to 0.14.0

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -52,7 +52,7 @@ DEPENDENCIES = [
     'distro; sys_platform == "linux"',
     'humanfriendly~=10.0',
     'jmespath',
-    'knack~=0.11.0',
+    'knack~=0.14.0',
     'microsoft-security-utilities-secret-masker~=1.0.0b4',
     'msal-extensions==1.3.1',
     'msal[broker]==1.35.1; sys_platform == "win32"',

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -108,7 +108,7 @@ isodate==0.6.1
 javaproperties==0.5.1
 jmespath==0.9.5
 jsondiff==2.0.0
-knack==0.11.0
+knack==0.14.0
 msal-extensions==1.3.1
 msal==1.35.1
 msrest==0.7.1

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -109,7 +109,7 @@ isodate==0.6.1
 javaproperties==0.5.1
 jmespath==0.9.5
 jsondiff==2.0.0
-knack==0.11.0
+knack==0.14.0
 msal-extensions==1.3.1
 msal==1.35.1
 msrest==0.7.1

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -108,7 +108,7 @@ isodate==0.6.1
 javaproperties==0.5.1
 jmespath==0.9.5
 jsondiff==2.0.0
-knack==0.11.0
+knack==0.14.0
 msal-extensions==1.3.1
 msal[broker]==1.35.1
 msrest==0.7.1


### PR DESCRIPTION
### Description

Bumps the `knack` dependency from `0.11.0` to `0.14.0`.

Updated files:
- `src/azure-cli-core/setup.py` — `knack~=0.11.0` → `knack~=0.14.0`
- `src/azure-cli/requirements.py3.Darwin.txt` — `knack==0.11.0` → `knack==0.14.0`
- `src/azure-cli/requirements.py3.Linux.txt` — `knack==0.11.0` → `knack==0.14.0`
- `src/azure-cli/requirements.py3.windows.txt` — `knack==0.11.0` → `knack==0.14.0`

### Testing Guide

CI should validate that the new `knack` version is installable and all existing tests pass.

### History Notes

[Component Governance] Bump `knack` from `0.11.0` to `0.14.0`.