### PR TITLE
[ACR] `az acr login`: Fix regional endpoint matching for registries with DNL suffix

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/custom.py
@@ -402,7 +402,9 @@ def acr_login(cmd,
         RegionalEndpoints = cmd.get_models('RegionalEndpoints')
         if registry.regional_endpoints == RegionalEndpoints.ENABLED and registry.regional_endpoint_host_names:
             # Build the expected regional endpoint prefix: registryname.region.geo.
-            regional_endpoint_prefix = f"{registry_name}.{endpoint}.geo.".lower()
+            # Use login_server hostname (before the first dot) to account for the DNL suffix if set.
+            login_server_name = registry.login_server.split('.')[0]
+            regional_endpoint_prefix = f"{login_server_name}.{endpoint}.geo.".lower()
             matching_endpoint = next(
                 (url for url in registry.regional_endpoint_host_names
                  if url.lower().strip().startswith(regional_endpoint_prefix)), None)

--- a/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_regional_endpoint_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_regional_endpoint_utils.py
@@ -45,3 +45,55 @@ class TestRegionalEndpointUriConversion(unittest.TestCase):
         for uri in test_cases:
             result = acr_import._regional_endpoint_uri_to_login_server(uri, login_server_suffix)
             self.assertEqual(result, uri)
+
+    @staticmethod
+    def _match_regional_endpoint(login_server, endpoint, regional_endpoint_host_names):
+        """Replicate the matching logic from acr_login for unit testing."""
+        login_server_name = login_server.split('.')[0]
+        regional_endpoint_prefix = f"{login_server_name}.{endpoint}.geo.".lower()
+        return next(
+            (url for url in regional_endpoint_host_names
+             if url.lower().strip().startswith(regional_endpoint_prefix)), None)
+
+    def test_match_standard_registry(self):
+        """Registry without DNL — login_server starts with registry name."""
+        login_server = 'myregistry.azurecr.io'
+        hosts = [
+            'myregistry.eastus.geo.azurecr.io',
+            'myregistry.westus.geo.azurecr.io',
+        ]
+        self.assertEqual(
+            self._match_regional_endpoint(login_server, 'eastus', hosts),
+            'myregistry.eastus.geo.azurecr.io')
+        self.assertEqual(
+            self._match_regional_endpoint(login_server, 'westus', hosts),
+            'myregistry.westus.geo.azurecr.io')
+
+    def test_match_dnl_registry(self):
+        """Registry with DNL suffix — login_server has a hash appended."""
+        login_server = 'myregistry-d7ezgzevdwfvc8ht.azurecr.io'
+        hosts = [
+            'myregistry-d7ezgzevdwfvc8ht.eastus.geo.azurecr.io',
+            'myregistry-d7ezgzevdwfvc8ht.westus.geo.azurecr.io',
+        ]
+        self.assertEqual(
+            self._match_regional_endpoint(login_server, 'eastus', hosts),
+            'myregistry-d7ezgzevdwfvc8ht.eastus.geo.azurecr.io')
+        self.assertEqual(
+            self._match_regional_endpoint(login_server, 'westus', hosts),
+            'myregistry-d7ezgzevdwfvc8ht.westus.geo.azurecr.io')
+
+    def test_no_match_returns_none(self):
+        """Endpoint region not in the host list returns None."""
+        login_server = 'myregistry.azurecr.io'
+        hosts = ['myregistry.eastus.geo.azurecr.io']
+        self.assertIsNone(
+            self._match_regional_endpoint(login_server, 'westus', hosts))
+
+    def test_match_case_insensitive(self):
+        """Matching is case-insensitive for both endpoint arg and host names."""
+        login_server = 'MyRegistry.azurecr.io'
+        hosts = ['MyRegistry.EastUS.geo.azurecr.io']
+        self.assertEqual(
+            self._match_regional_endpoint(login_server, 'eastus', hosts),
+            'MyRegistry.EastUS.geo.azurecr.io')


### PR DESCRIPTION
**Related command**
`az acr login`

**Description**
When a registry has a DNL suffix, the registry_name does not match the prefix of the regional endpoint hostname. This fix uses registry.login_server.split('.')[0] (the login server hostname before the first dot) instead of registry_name when constructing the regional endpoint prefix, so that DNL registries correctly resolve to their regional login endpoint.

**Testing Guide**
<img width="1834" height="150" alt="image" src="https://github.com/user-attachments/assets/ea4f00e2-1a97-4b04-8bff-272943dc33e2" />

**History Notes**
 [ACR] `az acr login`: Fix regional endpoint matching for registries with DNL suffix

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
