### PR TITLE
[App Service] Fix #31394: `az functionapp deployment source config-zip`: Never ending loop on flex function app health check

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -823,8 +823,7 @@ def check_flex_app_after_deployment(cmd, resource_group_name, name):
         if 200 <= response.status_code <= 299:
             break
         if response.status_code == 403 and response.reason == 'Ip Forbidden':
-            logger.warning("Failed to check health due to IP restriction")
-            break
+            return "Deployment was successful but health check failed due to IP restriction."
         num_trials = num_trials + 1
 
     if response.status_code != 200:

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -822,6 +822,10 @@ def check_flex_app_after_deployment(cmd, resource_group_name, name):
                                 verify=not should_disable_connection_verify())
         if 200 <= response.status_code <= 299:
             break
+        if response.status_code == 403 and response.reason == 'Ip Forbidden':
+            logger.warning("Failed to check health due to IP restriction")
+            break
+        num_trials = num_trials + 1
 
     if response.status_code != 200:
         raise CLIError("Deployment was successful but the app appears to be unhealthy. Please "

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands_thru_mock.py
@@ -12,6 +12,7 @@ from azure.cli.command_modules.appservice.custom import (
     enable_zip_deploy_functionapp,
     enable_zip_deploy,
     enable_zip_deploy_flex,
+    check_flex_app_after_deployment,
     add_remote_build_app_settings,
     remove_remote_build_app_settings,
     config_source_control,
@@ -19,6 +20,7 @@ from azure.cli.command_modules.appservice.custom import (
     update_container_settings_functionapp)
 from azure.cli.core.profiles import ResourceType
 from azure.cli.core.azclierror import (AzureInternalError, UnclassifiedUserFault)
+from azure.cli.core.azclierror import ResourceNotFoundError
 
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))
 
@@ -252,6 +254,113 @@ class TestFunctionappMocked(unittest.TestCase):
         # TODO improve authorization matcher
         check_zip_deployment_status_mock.assert_called_with(cmd_mock, 'rg', 'name',
                                                             'https://mock-scm/api/deployments/latest', None)
+
+    @mock.patch('time.sleep')
+    @mock.patch('requests.get', autospec=True)
+    @mock.patch('azure.cli.core.util.should_disable_connection_verify', return_value=False)
+    @mock.patch('azure.cli.command_modules.appservice.custom.list_host_keys')
+    @mock.patch('azure.cli.command_modules.appservice.custom._get_host_url',
+                return_value='https://mock-func.azurewebsites.net')
+    def test_check_flex_app_after_deployment_success(self,
+                                                     get_host_url_mock,
+                                                     list_host_keys_mock,
+                                                     should_disable_verify_mock,
+                                                     requests_get_mock,
+                                                     sleep_mock):
+        # prepare
+        cmd_mock = _get_test_cmd()
+        list_host_keys_mock.return_value = mock.Mock(master_key='master-key')
+        response = mock.Mock(status_code=200, reason='OK')
+        requests_get_mock.return_value = response
+
+        # action
+        result = check_flex_app_after_deployment(cmd_mock, 'rg', 'name')
+
+        # assert
+        self.assertEqual(result, "Deployment was successful.")
+        requests_get_mock.assert_called_with('https://mock-func.azurewebsites.net/admin/host/status',
+                                             headers={"x-functions-key": 'master-key'},
+                                             verify=True)
+
+    @mock.patch('time.sleep')
+    @mock.patch('azure.cli.command_modules.appservice.custom._get_host_url', side_effect=ValueError())
+    def test_check_flex_app_after_deployment_host_url_fetch_failure(self,
+                                                                    get_host_url_mock,
+                                                                    sleep_mock):
+        # prepare
+        cmd_mock = _get_test_cmd()
+
+        # action
+        with self.assertRaises(ResourceNotFoundError):
+            check_flex_app_after_deployment(cmd_mock, 'rg', 'name')
+
+        # assert
+        get_host_url_mock.assert_called_once_with(cmd_mock, 'rg', 'name')
+
+    @mock.patch('time.sleep')
+    @mock.patch('azure.cli.command_modules.appservice.custom.list_host_keys', side_effect=Exception())
+    @mock.patch('azure.cli.command_modules.appservice.custom._get_host_url',
+                return_value='https://mock-func.azurewebsites.net')
+    def test_check_flex_app_after_deployment_host_key_fetch_failure(self,
+                                                                    get_host_url_mock,
+                                                                    list_host_keys_mock,
+                                                                    sleep_mock):
+        # prepare
+        cmd_mock = _get_test_cmd()
+
+        # action
+        with self.assertRaises(ResourceNotFoundError):
+            check_flex_app_after_deployment(cmd_mock, 'rg', 'name')
+
+        # assert
+        list_host_keys_mock.assert_called_once_with(cmd_mock, 'rg', 'name')
+
+    @mock.patch('time.sleep')
+    @mock.patch('requests.get', autospec=True)
+    @mock.patch('azure.cli.core.util.should_disable_connection_verify', return_value=False)
+    @mock.patch('azure.cli.command_modules.appservice.custom.list_host_keys')
+    @mock.patch('azure.cli.command_modules.appservice.custom._get_host_url',
+                return_value='https://mock-func.azurewebsites.net')
+    def test_check_flex_app_after_deployment_ip_restriction(self,
+                                                            get_host_url_mock,
+                                                            list_host_keys_mock,
+                                                            should_disable_verify_mock,
+                                                            requests_get_mock,
+                                                            sleep_mock):
+        # prepare
+        cmd_mock = _get_test_cmd()
+        list_host_keys_mock.return_value = mock.Mock(master_key='master-key')
+        requests_get_mock.return_value = mock.Mock(status_code=403, reason='Ip Forbidden')
+
+        # action
+        result = check_flex_app_after_deployment(cmd_mock, 'rg', 'name')
+
+        # assert
+        self.assertEqual(result, "Deployment was successful but health check failed due to IP restriction.")
+
+    @mock.patch('time.sleep')
+    @mock.patch('requests.get', autospec=True)
+    @mock.patch('azure.cli.core.util.should_disable_connection_verify', return_value=False)
+    @mock.patch('azure.cli.command_modules.appservice.custom.list_host_keys')
+    @mock.patch('azure.cli.command_modules.appservice.custom._get_host_url',
+                return_value='https://mock-func.azurewebsites.net')
+    def test_check_flex_app_after_deployment_unhealthy(self,
+                                                       get_host_url_mock,
+                                                       list_host_keys_mock,
+                                                       should_disable_verify_mock,
+                                                       requests_get_mock,
+                                                       sleep_mock):
+        # prepare
+        cmd_mock = _get_test_cmd()
+        list_host_keys_mock.return_value = mock.Mock(master_key='master-key')
+        requests_get_mock.return_value = mock.Mock(status_code=500, reason='Internal Server Error')
+
+        # action
+        with self.assertRaises(CLIError):
+            check_flex_app_after_deployment(cmd_mock, 'rg', 'name')
+
+        # assert
+        self.assertEqual(requests_get_mock.call_count, 15)
 
 
     @mock.patch('azure.cli.command_modules.appservice.custom.get_scm_site_headers')
@@ -494,7 +603,7 @@ class TestFunctionappMocked(unittest.TestCase):
         Site, DaprConfig, ResourceConfig = cmd_mock.get_models('Site', 'DaprConfig', 'ResourceConfig')
         site = Site(dapr_config=None, location='westus', name='name', resource_config=ResourceConfig())
         site_op_mock.return_value = site
-        
+
         is_centauri_functionapp_mock.return_value = True
 
         check_language_runtime_mock.return_value = True


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

az functionapp deployment source config-zip

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

The `check_flex_app_after_deployment` function called after a deployment had a never ending re-try loop for non-2xx response status codes. This PR adds the missing `num_trials` increment. It also breaks out of the health check when an IP restriction is found preventing the client from calling the health check.

Fixes #31394

**Testing Guide**
<!--Example commands with explanations.-->

An existing function app with a default network rule of Deny has no access from the client to the app. Run the deployment command:

```sh
az functionapp deployment source config-zip \
 --resource-group MyResourceGroup  \
 --name MyUniqueAppName \
 --src funcapp.zip
```

Before it would hang forever, but now transient errors are handled and retries are done up the the limit. An IP restriction will complete successfully with a message saying the health check was not possible

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
