### PR TITLE
[App Service] `az functionapp deployment source config-zip`: Fix KeyError 'FUNCTIONS_WORKER_RUNTIME' for Go on Flex Consumption

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -7768,7 +7768,7 @@ class _FlexFunctionAppStackRuntimeHelper:
                         continue
 
                     runtime_settings = minor_version['stackSettings']['linuxRuntimeSettings']
-                    runtime_name = (runtime_settings['appSettingsDictionary']['FUNCTIONS_WORKER_RUNTIME'] or
+                    runtime_name = (runtime_settings.get('appSettingsDictionary', {}).get('FUNCTIONS_WORKER_RUNTIME') or
                                     runtime['name'])
 
                     skus = runtime_settings['Sku']

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands_thru_mock.py
@@ -681,3 +681,62 @@ class TestFunctionappMocked(unittest.TestCase):
 
         # assert
         self.assertEqual(response.git_hub_action_configuration.container_configuration.password, None)
+
+    def test_flex_parse_raw_stacks_handles_empty_app_settings_dictionary(self):
+        from azure.cli.command_modules.appservice.custom import _FlexFunctionAppStackRuntimeHelper
+
+        # prepare
+        cmd_mock = _get_test_cmd()
+        go_stack = {
+            'name': 'go',
+            'properties': {'majorVersions': [{'minorVersions': [{
+                'value': '1.0',
+                'stackSettings': {'linuxRuntimeSettings': {
+                    'appSettingsDictionary': {},
+                    'Sku': [{'skuCode': 'FC1'}],
+                    'gitHubActionSettings': {'isSupported': True},
+                    'appInsightsSettings': {'isSupported': True},
+                    'isDefault': True,
+                }},
+            }]}]},
+        }
+
+        # action
+        with mock.patch.object(_FlexFunctionAppStackRuntimeHelper,
+                               'get_flex_raw_function_app_stacks',
+                               return_value=[go_stack]):
+            matched = _FlexFunctionAppStackRuntimeHelper(cmd_mock, 'westcentralus', 'go').resolve('go', '1.0')
+
+        # assert
+        self.assertEqual(matched.name, 'go')
+        self.assertEqual(matched.version, '1.0')
+
+    def test_flex_parse_raw_stacks_prefers_functions_worker_runtime_when_present(self):
+        # FUNCTIONS_WORKER_RUNTIME overrides runtime['name'] when set (e.g., dotnet-isolated under the dotnet stack).
+        from azure.cli.command_modules.appservice.custom import _FlexFunctionAppStackRuntimeHelper
+
+        # prepare
+        cmd_mock = _get_test_cmd()
+        dotnet_isolated_stack = {
+            'name': 'dotnet',
+            'properties': {'majorVersions': [{'minorVersions': [{
+                'value': '8.0',
+                'stackSettings': {'linuxRuntimeSettings': {
+                    'appSettingsDictionary': {'FUNCTIONS_WORKER_RUNTIME': 'dotnet-isolated'},
+                    'Sku': [{'skuCode': 'FC1'}],
+                    'gitHubActionSettings': {'isSupported': True},
+                    'appInsightsSettings': {'isSupported': True},
+                    'isDefault': True,
+                }},
+            }]}]},
+        }
+
+        # action
+        with mock.patch.object(_FlexFunctionAppStackRuntimeHelper,
+                               'get_flex_raw_function_app_stacks',
+                               return_value=[dotnet_isolated_stack]):
+            matched = _FlexFunctionAppStackRuntimeHelper(
+                cmd_mock, 'westcentralus', 'dotnet-isolated').resolve('dotnet-isolated', '8.0')
+
+        # assert
+        self.assertEqual(matched.name, 'dotnet-isolated')


### PR DESCRIPTION
**Related command** 
`az functionapp deployment source config-zip`

(Also affects every other `az functionapp` command that goes through `_FlexFunctionAppStackRuntimeHelper`: `functionapp create`, `functionapp config set` for runtime, `functionapp list-flexconsumption-runtimes`, `functionapp list-flexconsumption-locations`, `functionapp deployment github-actions add`, `functionapp flex-migration`.)

**Description**

`az functionapp deployment source config-zip` crashes with `KeyError: 'FUNCTIONS_WORKER_RUNTIME'` for every Go function app on Flex Consumption, before any zip is uploaded. The crash is in `_FlexFunctionAppStackRuntimeHelper._parse_raw_stacks` at [`custom.py:7771`](https://github.com/Azure/azure-cli/blob/dev/src/azure-cli/azure/cli/command_modules/appservice/custom.py#L7771):

```python
runtime_name = (runtime_settings['appSettingsDictionary']['FUNCTIONS_WORKER_RUNTIME'] or
                runtime['name'])
```

The intent is to prefer `FUNCTIONS_WORKER_RUNTIME` but fall back to `runtime['name']` when FWR isn't set. But the dictionary access is hard-indexed instead of using `.get()`, so Python raises `KeyError` before the `or` fallback can execute.

This is fine for node/python/java/powershell/dotnet — their stack definitions populate `appSettingsDictionary.FUNCTIONS_WORKER_RUNTIME` in the API response. It breaks for Go because Flex Consumption Go apps deliberately return `appSettingsDictionary: {}` (Go on Flex doesn't require FWR on the app at runtime — native binaries, no managed worker). The Go stack definition isn't introducing this bug; it's exposing a latent over-assumption in the CLI parser that was hidden only because every prior Flex language happened to populate FWR.

**Fix**: change the chained `[ ]` lookup to use `.get()` so the existing `or runtime['name']` fallback can run. This matches the defensive pattern already used by the sibling Windows/Linux helper `_FunctionAppStackRuntimeHelper._parse_minor_version` in the same file.

For Go, `runtime['name']` resolves to `"go"`, the stack registers as `"go"`, and downstream `resolve("go")` matches the deployed app's `functionAppConfig.runtime.name == "go"` cleanly. Other languages are unaffected — their FWR value is truthy, so `or` short-circuits before the fallback.

**Testing Guide**

1. Existing mock test suite still passes (25/25):
   ```
   python -m unittest azure.cli.command_modules.appservice.tests.latest.test_functionapp_commands_thru_mock
   ```
2. Two new regression tests added (also pass):
   - `test_flex_parse_raw_stacks_handles_empty_app_settings_dictionary` — feeds a Go-shaped stack with `appSettingsDictionary: {}` and asserts `resolve('go', '1.0')` returns a runtime named `"go"` (this test fails on the current `dev` branch with `KeyError`).
   - `test_flex_parse_raw_stacks_prefers_functions_worker_runtime_when_present` — feeds a `dotnet-isolated` stack and asserts FWR overrides `runtime['name']` (preserves canonical-name semantics).
3. Verified end-to-end against a live Go Flex Consumption app using the editable install:
   ```
   az functionapp deployment source config-zip -g <rg> -n <app> --src <zip>
   # -> "Deployment was successful."
   ```

**History Notes**

[App Service] `az functionapp deployment source config-zip`: Fix `KeyError` `'FUNCTIONS_WORKER_RUNTIME'` for Go function apps on Flex Consumption
