### PR TITLE
[App Service] `az webapp up`: Add warning message for future deprecation

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -131,7 +131,8 @@ def load_command_table(self, _):
 
     with self.command_group('webapp', webapp_sdk) as g:
         g.custom_command('create', 'create_webapp', exception_handler=ex_handler_factory(), validator=validate_vnet_integration)
-        g.custom_command('up', 'webapp_up', exception_handler=ex_handler_factory(), validator=validate_webapp_up)
+        g.custom_command('up', 'webapp_up', exception_handler=ex_handler_factory(), validator=validate_webapp_up,
+                         deprecate_info=g.deprecate(redirect='webapp create and webapp deploy'))
         g.custom_command('ssh', 'ssh_webapp', exception_handler=ex_handler_factory(), is_preview=True)
         g.custom_command('list', 'list_webapp', table_transformer=transform_web_list_output)
         g.custom_show_command('show', 'show_app', table_transformer=transform_web_output)


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az webapp up

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
App Service Team is deprecating az webapp up. This command continues to function, this PR will only add a deprecation warning so az cli users are notified ahead of eventual removal.

Users will see a warning directing them to az webapp create and az webapp deploy.
No expiration version is set - this is a warning only phase.

**Testing Guide**
<!--Example commands with explanations.-->
Ran az webapp -help to confirm az webapp up is deprecated in command group:
<img width="1004" height="947" alt="image" src="https://github.com/user-attachments/assets/facbad80-49f3-4ebf-b65b-12ec5edd157c" />

Ran az webapp up --help to confirm help shows it is deprecated:
<img width="990" height="404" alt="image" src="https://github.com/user-attachments/assets/229c9a5d-4a2b-436d-ada5-e147e16b6cda" />

Ran az webapp up --dryrun to show summary of the operation. Confirmed it shows it is deprecated:
<img width="1141" height="352" alt="image" src="https://github.com/user-attachments/assets/e724a40d-6458-4376-92ce-4ee78d692598" />

azdev style appservice
<img width="678" height="324" alt="image" src="https://github.com/user-attachments/assets/d63e9f7e-cff7-4eaa-b2a9-6ef5220fc6df" />

azdev linter appservice
<img width="999" height="1223" alt="image" src="https://github.com/user-attachments/assets/15584372-a1e3-4030-8b5e-89acd7db4e25" />

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
