### PR TITLE
{Core} Pre-warm shared Azure SDK imports to avoid Python 3.14 importl…

### DIFF
--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -42,6 +42,65 @@ MODULE_LOAD_TIMEOUT_SECONDS = 60
 # Maximum number of worker threads for parallel module loading.
 MAX_WORKER_THREAD_COUNT = 4
 
+# Shared Azure SDK trunks that many command modules import independently. Pre-warming
+# these on the main thread before parallel module loading prevents
+# importlib._DeadlockError on Python 3.14+ (which raises on concurrent imports of
+# the same module instead of blocking, as 3.13 and earlier did). Order matters:
+# import base packages before their subpackages so each lock is taken once.
+#
+# _REQUIRED_PREWARM_MODULES are hard dependencies of azure-cli-core
+# (see setup.py: azure-core, azure-mgmt-core). A ModuleNotFoundError on these
+# indicates a broken install and is propagated.
+#
+# _OPTIONAL_PREWARM_MODULES are transitive SDK packages that may or may not be
+# installed depending on which command modules / extensions are present. A
+# ModuleNotFoundError matching the optional name itself (or one of its parent
+# packages) is suppressed; unrelated ModuleNotFoundError raised from inside an
+# installed module still propagates.
+_REQUIRED_PREWARM_MODULES = (
+    'azure.core',
+    'azure.core.exceptions',
+    'azure.core.pipeline',
+    'azure.core.pipeline.policies',
+    'azure.mgmt.core',
+)
+_OPTIONAL_PREWARM_MODULES = (
+    'msrest',
+    'msrest.serialization',
+    'msrest.http_logger',
+    'msrestazure',
+    'msrestazure.azure_exceptions',
+)
+_prewarm_done = False
+
+
+def _prewarm_shared_imports():
+    """Import shared Azure SDK trunks once on the main thread.
+
+    See `_REQUIRED_PREWARM_MODULES` and `_OPTIONAL_PREWARM_MODULES` for rationale.
+    Safe to call repeatedly; a flag guards against repeated work. A
+    `ModuleNotFoundError` for an optional module (or one of its parent packages)
+    is ignored so this helper never blocks startup if an optional SDK package is
+    uninstalled. Missing required modules propagate so a broken install fails
+    loudly rather than deferring to a harder-to-debug location.
+    """
+    global _prewarm_done  # pylint: disable=global-statement
+    if _prewarm_done:
+        return
+    from importlib import import_module
+    for name in _REQUIRED_PREWARM_MODULES:
+        import_module(name)
+    for name in _OPTIONAL_PREWARM_MODULES:
+        try:
+            import_module(name)
+        except ModuleNotFoundError as ex:
+            missing_name = getattr(ex, 'name', None)
+            if missing_name == name or (missing_name and name.startswith(missing_name + '.')):
+                # Optional/transitive SDK module not present in this install.
+                continue
+            raise
+    _prewarm_done = True
+
 
 def _get_top_level_command(args):
     """Return normalized top-level command token or None when unavailable."""
@@ -668,6 +727,16 @@ class MainCommandsLoader(CLICommandsLoader):
         import concurrent.futures
         from concurrent.futures import ThreadPoolExecutor
         from azure.cli.core.commands import BLOCKED_MODS
+
+        # Pre-warm shared Azure SDK trunks on the main thread before fanning out to
+        # worker threads. On Python 3.14+, importlib raises _DeadlockError instead
+        # of blocking when two threads concurrently import the same module
+        # (https://docs.python.org/3.14/whatsnew/3.14.html). Many command modules
+        # independently `import azure.core` / `import msrest` etc., which races
+        # under the thread pool. By importing these once on the main thread first,
+        # worker threads see fully-initialized entries in sys.modules and never
+        # contend on the module lock.
+        _prewarm_shared_imports()
 
         results = []
         with ThreadPoolExecutor(max_workers=MAX_WORKER_THREAD_COUNT) as executor:

--- a/src/azure-cli-core/azure/cli/core/tests/test_prewarm_shared_imports.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_prewarm_shared_imports.py
@@ -1,0 +1,82 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import unittest
+from unittest import mock
+
+import azure.cli.core as core
+
+
+class PrewarmSharedImportsTest(unittest.TestCase):
+
+    def setUp(self):
+        # Reset the idempotency flag so each test exercises the full loop.
+        core._prewarm_done = False
+
+    def tearDown(self):
+        core._prewarm_done = False
+
+    def test_imports_all_modules_on_first_call(self):
+        with mock.patch('importlib.import_module') as m:
+            core._prewarm_shared_imports()
+        imported = [c.args[0] for c in m.call_args_list]
+        for name in core._REQUIRED_PREWARM_MODULES + core._OPTIONAL_PREWARM_MODULES:
+            self.assertIn(name, imported)
+        self.assertTrue(core._prewarm_done)
+
+    def test_idempotent(self):
+        with mock.patch('importlib.import_module') as m:
+            core._prewarm_shared_imports()
+            first_count = m.call_count
+            core._prewarm_shared_imports()
+            self.assertEqual(m.call_count, first_count)
+
+    def test_missing_optional_module_is_suppressed(self):
+        optional = core._OPTIONAL_PREWARM_MODULES[0]
+
+        def fake_import(name):
+            if name == optional:
+                raise ModuleNotFoundError(f"No module named '{optional}'", name=optional)
+            return mock.MagicMock()
+
+        with mock.patch('importlib.import_module', side_effect=fake_import):
+            # Must not raise.
+            core._prewarm_shared_imports()
+        self.assertTrue(core._prewarm_done)
+
+    def test_missing_required_module_propagates(self):
+        required = core._REQUIRED_PREWARM_MODULES[0]
+
+        def fake_import(name):
+            if name == required:
+                raise ModuleNotFoundError(f"No module named '{required}'", name=required)
+            return mock.MagicMock()
+
+        with mock.patch('importlib.import_module', side_effect=fake_import):
+            with self.assertRaises(ModuleNotFoundError):
+                core._prewarm_shared_imports()
+        # Flag should not be set when prewarm failed.
+        self.assertFalse(core._prewarm_done)
+
+    def test_unrelated_module_not_found_inside_optional_propagates(self):
+        # ModuleNotFoundError raised from inside an installed optional module
+        # (e.g. its own missing dep) must NOT be silently swallowed.
+        optional = core._OPTIONAL_PREWARM_MODULES[0]
+
+        def fake_import(name):
+            if name == optional:
+                # Simulate an installed module whose import fails because one of
+                # its own deps is missing.
+                raise ModuleNotFoundError("No module named 'some_unrelated_dep'",
+                                          name='some_unrelated_dep')
+            return mock.MagicMock()
+
+        with mock.patch('importlib.import_module', side_effect=fake_import):
+            with self.assertRaises(ModuleNotFoundError):
+                core._prewarm_shared_imports()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Problem

CPython 3.14 changed `importlib` so that when a thread tries to acquire a module lock that another thread already holds for the same module, it raises `_DeadlockError` instead of blocking (CPython issue python/cpython#99953).

Azure CLI's parallel command-module loader in `azure-cli-core` (`_load_modules` in `azure/cli/core/__init__.py`) uses a 4-thread `ThreadPoolExecutor`. Each worker thread loads a command module that independently imports shared Azure SDK trunks (`azure.core`, `azure.mgmt.core`, `msrest`, `msrestazure`, ...). On Python 3.14 this races and surfaces as cascading `_DeadlockError` → `KeyError` failures at `az` startup.

Local repro on Windows env314:

- Pre-fix: `az --debug` shows `_DeadlockError` for e.g. `cdn` and `msrest.http_logger`, with several modules failing to load.
- Post-fix: clean load of all 66 command modules.

## Fix

Add `_prewarm_shared_imports()` at module scope in `azure/cli/core/__init__.py` and call it from `_load_modules` **before** the thread pool starts. It imports the shared SDK trunks once on the main thread so worker threads see fully-initialized entries in `sys.modules` and never contend on the module lock.

- Split into `_REQUIRED_PREWARM_MODULES` (hard deps of `azure-cli-core`; `ModuleNotFoundError` propagates) and `_OPTIONAL_PREWARM_MODULES` (transitive SDK packages; `ModuleNotFoundError` on the optional name itself is suppressed, unrelated `ModuleNotFoundError` from inside an installed module still propagates).
- Idempotent via a `_prewarm_done` flag.
- No behavior change on Python ≤3.13.

Includes unit tests in `src/azure-cli-core/azure/cli/core/tests/test_prewarm_shared_imports.py` covering: all modules imported on first call, idempotency, suppressed optional `ModuleNotFoundError`, propagated required `ModuleNotFoundError`, and propagated unrelated `ModuleNotFoundError` raised from inside an optional module.

## Notes

- This is a no-op until Python 3.14 lands in CI (the version-bump PR), so safe to merge first to keep the 3.14 bump green.
- This may become unnecessary if #33250 (restore sequential module loading) merges; happy to drop it then.

## Testing Guide

- Unit tests: `python -m pytest src/azure-cli-core/azure/cli/core/tests/test_prewarm_shared_imports.py`
- Manual on Python 3.14: `az --debug` shows no `_DeadlockError`; all command modules load.
- Python ≤3.13: behavior unchanged.