### PR TITLE
{Packaging} enable site in python._pth instead of deleting it

### DIFF
--- a/build_scripts/windows/scripts/build.cmd
+++ b/build_scripts/windows/scripts/build.cmd
@@ -110,10 +110,21 @@ if not exist %PYTHON_DIR% (
     del python-archive.zip
     echo Python downloaded and extracted successfully
 
-    REM Delete _pth file so that Lib\site-packages is included in sys.path
+    REM Append `import site` to python*._pth so site.py runs at startup
+    REM (which adds Lib\site-packages to sys.path). We keep the file (rather
+    REM than deleting it) because on Python 3.14+ removing it breaks pip's
+    REM PEP 517 isolated BuildEnvironment subprocess: the child python.exe
+    REM can no longer locate the stdlib zip and dies in init_fs_encoding
+    REM with ModuleNotFoundError: No module named 'encodings'.
+    REM Keeping an explicit _pth makes stdlib + site-packages discoverable
+    REM in both the parent and any spawned subprocess.
     REM https://github.com/pypa/pip/issues/4207#issuecomment-297396913
-    REM https://docs.python.org/3.10/using/windows.html#finding-modules
-    del python*._pth
+    REM https://docs.python.org/3/using/windows.html#finding-modules
+    if exist python*._pth (
+        for %%f in (python*._pth) do (
+            findstr /x "import site" "%%f" >nul || echo import site>> %%f
+        )
+    )
 
     echo Installing pip
     curl --output get-pip.py %GET_PIP_DOWNLOAD_URL%


### PR DESCRIPTION
### Description

Replace `del python*._pth` with an idempotent append of `import site` to the embedded Python's `._pth` file in the Windows MSI build pipeline.

### Motivation

The embedded Python distribution ships with a `python<XY>._pth` file that, when present, switches the interpreter into **isolated mode**: `site.py` is not imported automatically and `sys.path` is taken solely from the `._pth` contents. The long-standing workaround in `build.cmd` was to **delete** the file so the default initialization (including `site.py`, which adds `Lib\site-packages`) would run.

That trick stops working on Python 3.14+. With no `._pth` present, pip's PEP 517 isolated `BuildEnvironment` spawns a child `python.exe` that can no longer locate the stdlib zip and dies very early in `init_fs_encoding` with:

```
ModuleNotFoundError: No module named 'encodings'
```

Keeping an explicit `._pth` makes the stdlib zip **and** `Lib\site-packages` discoverable in both the parent interpreter and any spawned subprocess. Appending `import site` is the documented way to keep `._pth` while still running `site.py` at startup (see [Python docs — Finding modules](https://docs.python.org/3/using/windows.html#finding-modules)).

Notes on the implementation:

- **`if exist python*._pth (...)`** guards against the cmd-shell quirk where a `for` over a non-matching glob would otherwise iterate the literal token.
- **`findstr /x "import site" ... >nul || echo import site>> %%f`** makes the append idempotent — re-running the script (e.g. on a cached `%PYTHON_DIR%`) won't keep duplicating the line.

### Compatibility

- **Python 3.12 / 3.13 (current):** functionally identical to the previous behaviour — `site.py` runs, `Lib\site-packages` is on `sys.path`, pip works.
- **Python 3.14+ (incoming):** unblocks pip's isolated build subprocess.

### Testing

- Local Windows MSI build with the current embedded Python (3.12.x): `pip install`, `pip wheel`, and `az` CLI invocation all work as before.
- Local Windows MSI build with Python 3.14.5: previously failed in pip subprocess with the `encodings` error; with this change, builds succeed end-to-end.

### Relationship to PR #33313

PR #33313 (`feature/python314-support`) ships the full Python 3.14 upgrade and depends on this fix on Windows. Extracting the `_pth` change into this standalone PR keeps the fix reviewable on its own and lets it land first — it is already correct against the current Python 3.13 embedded build and is required by #33313.

### History notes

N/A