### PR TITLE
{Core} Bump pymsalruntime version to 0.20.6 for fixing Windows 2016 issue

### DIFF
--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -122,7 +122,7 @@ psutil==6.1.0
 pycomposefile==0.0.34
 PyGithub==1.55
 PyJWT==2.12.0
-pymsalruntime==0.20.5
+pymsalruntime==0.20.6
 PyNaCl==1.6.2
 pyOpenSSL==26.0.0
 PySocks==1.7.1


### PR DESCRIPTION
## Description

Bump `pymsalruntime` from **0.20.5** to **0.20.6** in `src/azure-cli/requirements.py3.windows.txt`. For Windows 2016 issue fix

## Change

- Updated `pymsalruntime==0.20.5` → `pymsalruntime==0.20.6` in the Windows Python 3 requirements file.

## Testing

This is a dependency version bump. No functional code changes.