### PR TITLE
{Role} Escape datetime help percent signs

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_params.py
@@ -185,7 +185,7 @@ def load_arguments(self, _):
 
     with self.argument_context('ad sp create-for-rbac') as c:
         c.argument('display_name', options_list=['--display-name', '--name', '-n'],
-                   help='Display name of the service principal. If not present, default to azure-cli-%%Y-%%m-%%d-%%H-%%M-%%S '
+                   help='Display name of the service principal. If not present, defaults to azure-cli-%%Y-%%m-%%d-%%H-%%M-%%S '
                         'where the suffix is the time of creation.')
         c.argument('create_password', arg_type=get_three_state_flag(), arg_group='Credential',
                    help='Create a password credential (secret) on the the application. This is the default behavior. '
@@ -359,7 +359,7 @@ def load_arguments(self, _):
         c.argument('include_groups', action='store_true',
                    help='Include extra assignments to the groups of which the user is a member (transitively).')
 
-    time_help = 'The {} of the query in the format of %%Y-%%m-%%dT%%H:%%M:%%SZ, e.g. 2000-12-31T12:59:59Z. Defaults to {}'
+    time_help = 'The {} for the query in the format of %%Y-%%m-%%dT%%H:%%M:%%SZ, e.g. 2000-12-31T12:59:59Z. Defaults to {}'
     with self.argument_context('role assignment list-changelogs') as c:
         c.argument('start_time', help=time_help.format('start time', '1 Hour prior to the current time'))
         c.argument('end_time', help=time_help.format('end time', 'the current time'))

--- a/src/azure-cli/azure/cli/command_modules/role/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_params.py
@@ -185,7 +185,7 @@ def load_arguments(self, _):
 
     with self.argument_context('ad sp create-for-rbac') as c:
         c.argument('display_name', options_list=['--display-name', '--name', '-n'],
-                   help='Display name of the service principal. If not present, default to azure-cli-%Y-%m-%d-%H-%M-%S '
+                   help='Display name of the service principal. If not present, default to azure-cli-%%Y-%%m-%%d-%%H-%%M-%%S '
                         'where the suffix is the time of creation.')
         c.argument('create_password', arg_type=get_three_state_flag(), arg_group='Credential',
                    help='Create a password credential (secret) on the the application. This is the default behavior. '
@@ -359,7 +359,7 @@ def load_arguments(self, _):
         c.argument('include_groups', action='store_true',
                    help='Include extra assignments to the groups of which the user is a member (transitively).')
 
-    time_help = 'The {} of the query in the format of %Y-%m-%dT%H:%M:%SZ, e.g. 2000-12-31T12:59:59Z. Defaults to {}'
+    time_help = 'The {} of the query in the format of %%Y-%%m-%%dT%%H:%%M:%%SZ, e.g. 2000-12-31T12:59:59Z. Defaults to {}'
     with self.argument_context('role assignment list-changelogs') as c:
         c.argument('start_time', help=time_help.format('start time', '1 Hour prior to the current time'))
         c.argument('end_time', help=time_help.format('end time', 'the current time'))


### PR DESCRIPTION
Fixes #33409

## Summary

This escapes the literal datetime `%` tokens in role command help text.

## Why

Python 3.14 validates argparse help strings more strictly. The `ad sp create-for-rbac` and `role assignment list-changelogs` help text used examples like `%Y-%m-%d` directly, which argparse treats as printf-style formatting and raises `ValueError: badly formed help string`.

Escaping these as `%%Y`, `%%m`, and so on keeps the rendered help text the same while avoiding the parser crash.

## Test plan

- Parsed `src/azure-cli/azure/cli/command_modules/role/_params.py` and validated the edited help strings with `argparse.ArgumentParser(...).format_help()`.
- `git diff --check`
