### PR TITLE
fix(core): emit LF newlines for tsv output

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_output.py
+++ b/src/azure-cli-core/azure/cli/core/_output.py
@@ -14,11 +14,11 @@ class AzOutputProducer(knack.output.OutputProducer):
         return format_type in self._FORMAT_DICT
 
     def out(self, obj, formatter=None, out_file=None):
+        file = out_file or sys.stdout
         if get_output_format(self.cli_ctx) == "tsv":
-            file = out_file or sys.stdout
             if hasattr(file, "reconfigure"):
                 file.reconfigure(newline="\n")
-        super().out(obj, formatter=formatter, out_file=out_file)
+        return super().out(obj, formatter=formatter, out_file=file)
 
 
 def get_output_format(cli_ctx):

--- a/src/azure-cli-core/azure/cli/core/_output.py
+++ b/src/azure-cli-core/azure/cli/core/_output.py
@@ -3,6 +3,8 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+import sys
+
 import knack.output
 
 
@@ -10,6 +12,13 @@ class AzOutputProducer(knack.output.OutputProducer):
 
     def check_valid_format_type(self, format_type):
         return format_type in self._FORMAT_DICT
+
+    def out(self, obj, formatter=None, out_file=None):
+        if get_output_format(self.cli_ctx) == "tsv":
+            file = out_file or sys.stdout
+            if hasattr(file, "reconfigure"):
+                file.reconfigure(newline="\n")
+        super().out(obj, formatter=formatter, out_file=out_file)
 
 
 def get_output_format(cli_ctx):

--- a/src/azure-cli-core/azure/cli/core/tests/test_output.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_output.py
@@ -4,6 +4,8 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
+from io import BytesIO, TextIOWrapper
+from types import SimpleNamespace
 
 
 class TestCoreCLIOutput(unittest.TestCase):
@@ -15,6 +17,25 @@ class TestCoreCLIOutput(unittest.TestCase):
         self.assertEqual(7, len(output_producer._FORMAT_DICT))  # six types: json, jsonc, table, tsv, yaml, yamlc, none
         self.assertIn('yaml', output_producer._FORMAT_DICT)
         self.assertIn('none', output_producer._FORMAT_DICT)
+
+    def test_tsv_output_uses_lf_newlines(self):
+        from azure.cli.core._output import AzOutputProducer
+        from azure.cli.core.mock import DummyCli
+        from knack.util import CommandResultItem
+
+        cli = DummyCli()
+        cli.invocation = SimpleNamespace(data={'output': 'tsv'})
+        output_producer = AzOutputProducer(cli)
+        buffer = BytesIO()
+        out_file = TextIOWrapper(buffer, encoding='utf-8', newline='\r\n')
+
+        output_producer.out(
+            CommandResultItem(result=['first', 'second']),
+            formatter=output_producer.get_formatter('tsv'),
+            out_file=out_file)
+        out_file.flush()
+
+        self.assertEqual(b'first\nsecond\n', buffer.getvalue())
 
     # regression test for https://github.com/Azure/azure-cli/issues/9263
     def test_yaml_output_with_ordered_dict(self):


### PR DESCRIPTION
Fixes #33385

## Summary
This forces `tsv` output streams to use LF newlines before writing the formatted result.

## Why
On Windows, Python text-mode output can translate `\n` into `\r\n`. That makes `az ... -o tsv` unsafe in bash-style command substitution because intermediate values keep a trailing `\r`, which can then break follow-up CLI calls.

## Test plan
- `.venv/bin/python -m pytest src/azure-cli-core/azure/cli/core/tests/test_output.py`
- `.venv/bin/python -m compileall -q src/azure-cli-core/azure/cli/core/_output.py src/azure-cli-core/azure/cli/core/tests/test_output.py`
- `git diff --check`
