### PR TITLE
[MySQL] BREAKING CHANGE `az mysql flexible-server backup create/restore/geo-restore/replica`: Remove `--storage-redundancy`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/mysql/_breaking_change.py
+++ b/src/azure-cli/azure/cli/command_modules/mysql/_breaking_change.py
@@ -2,10 +2,3 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
-
-from azure.cli.core.breaking_change import register_argument_deprecate
-
-register_argument_deprecate('mysql flexible-server create', '--storage-redundancy')
-register_argument_deprecate('mysql flexible-server restore', '--storage-redundancy')
-register_argument_deprecate('mysql flexible-server geo-restore', '--storage-redundancy')
-register_argument_deprecate('mysql flexible-server replica create', '--storage-redundancy')

--- a/src/azure-cli/azure/cli/command_modules/mysql/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/mysql/_params.py
@@ -134,12 +134,6 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
         help='Enable or disable Auto scale IOPS configuration for both the source and the newly provisioned replica server to enable faster provisioning.'
     )
 
-    storage_redundancy_arg_type = CLIArgumentType(
-        arg_type=get_enum_type(['LocalRedundancy', 'ZoneRedundancy']),
-        options_list=['--storage-redundancy'],
-        help='Enable local redundancy or zone redundancy. Zone redundancy only supports Business Critical tier.'
-    )
-
     maintenance_policy_patch_strategy_arg_type = CLIArgumentType(
         arg_type=get_enum_type(['Regular', 'VirtualCanary']),
         options_list=['--maintenance-policy-patch-strategy', '--patch-strategy'],
@@ -372,7 +366,6 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
         c.argument('public_access', arg_type=public_access_create_arg_type)
         c.argument('vnet', arg_type=vnet_arg_type)
         c.argument('vnet_address_prefix', arg_type=vnet_address_prefix_arg_type)
-        c.argument('storage_redundancy', arg_type=storage_redundancy_arg_type, default="LocalRedundancy")
         c.argument('subnet', arg_type=subnet_arg_type)
         c.argument('subnet_address_prefix', arg_type=subnet_address_prefix_arg_type)
         c.argument('private_dns_zone_arguments', private_dns_zone_arguments_arg_type)
@@ -431,7 +424,6 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
         c.argument('vnet_address_prefix', arg_type=vnet_address_prefix_arg_type)
         c.argument('subnet', arg_type=subnet_arg_type)
         c.argument('subnet_address_prefix', arg_type=subnet_address_prefix_arg_type)
-        c.argument('storage_redundancy', arg_type=storage_redundancy_arg_type)
         c.argument('private_dns_zone_arguments', private_dns_zone_arguments_arg_type)
         c.argument('zone', arg_type=zone_arg_type)
         c.argument('tags', tags_type)
@@ -464,7 +456,6 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
         c.argument('storage_gb', arg_type=storage_gb_arg_type)
         c.argument('auto_grow', arg_type=auto_grow_arg_type)
         c.argument('accelerated_logs', arg_type=accelerated_logs_arg_type)
-        c.argument('storage_redundancy', arg_type=storage_redundancy_arg_type)
         c.argument('backup_retention', arg_type=mysql_backup_retention_arg_type)
         c.argument('geo_redundant_backup', arg_type=geo_redundant_backup_arg_type)
         c.argument('public_access', options_list=['--public-access'], arg_type=get_enum_type(['Enabled', 'Disabled']), help='Determines the public access. ')
@@ -594,7 +585,6 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
         c.argument('sku_name', arg_type=sku_name_arg_type)
         c.argument('storage_gb', arg_type=storage_gb_arg_type)
         c.argument('iops', arg_type=iops_arg_type)
-        c.argument('storage_redundancy', arg_type=storage_redundancy_arg_type, default="LocalRedundancy")
         c.argument('faster_provisioning', arg_type=faster_provisioning_arg_type)
         c.argument('database_port', arg_type=database_port_arg_type)
         c.argument('backup_retention', arg_type=mysql_backup_retention_arg_type)

--- a/src/azure-cli/azure/cli/command_modules/mysql/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/mysql/custom.py
@@ -344,7 +344,7 @@ def flexible_server_create(cmd, client,
                            subnet=None, subnet_address_prefix=None, vnet=None, vnet_address_prefix=None,
                            private_dns_zone_arguments=None, public_access=None,
                            high_availability=None, zone=None, standby_availability_zone=None,
-                           iops=None, auto_grow=None, auto_scale_iops=None, accelerated_logs=None, storage_redundancy=None,
+                           iops=None, auto_grow=None, auto_scale_iops=None, accelerated_logs=None,
                            geo_redundant_backup=None, byok_identity=None, backup_byok_identity=None, byok_key=None, backup_byok_key=None,
                            backup_interval=None, maintenance_policy_patch_strategy=None, yes=False):
     # Generate missing parameters
@@ -416,8 +416,7 @@ def flexible_server_create(cmd, client,
                              iops=iops,
                              auto_grow=auto_grow,
                              auto_io_scaling=auto_scale_iops,
-                             log_on_disk=accelerated_logs,
-                             storage_redundancy=storage_redundancy)
+                             log_on_disk=accelerated_logs)
 
     backup = models.Backup(backup_retention_days=backup_retention, backup_interval_hours=backup_interval, geo_redundant_backup=geo_redundant_backup)
 
@@ -712,8 +711,8 @@ def flexible_server_import_replica_stop(client, resource_group_name, server_name
 def flexible_server_restore(cmd, client, resource_group_name, server_name, source_server, restore_point_in_time=None, zone=None,
                             no_wait=False, subnet=None, subnet_address_prefix=None, vnet=None, vnet_address_prefix=None,
                             private_dns_zone_arguments=None, public_access=None, yes=False, sku_name=None, tier=None, database_port=None,
-                            storage_gb=None, auto_grow=None, accelerated_logs=None, faster_restore=None, storage_redundancy=None,
-                            backup_retention=None, geo_redundant_backup=None, tags=None):
+                            storage_gb=None, auto_grow=None, accelerated_logs=None, faster_restore=None, backup_retention=None,
+                            geo_redundant_backup=None, tags=None):
     provider = 'Microsoft.DBforMySQL'
     server_name = server_name.lower()
 
@@ -773,9 +772,6 @@ def flexible_server_restore(cmd, client, resource_group_name, server_name, sourc
         else:
             auto_io_scaling = _determine_auto_io_scaling_by_faster_restore(faster_restore)
 
-        if not storage_redundancy:
-            storage_redundancy = source_server_object.storage.storage_redundancy
-
         if not backup_retention:
             backup_retention = source_server_object.backup.backup_retention_days
         else:
@@ -799,7 +795,7 @@ def flexible_server_restore(cmd, client, resource_group_name, server_name, sourc
 
         storage = models.Storage(storage_size_gb=storage_gb, iops=iops, auto_grow=auto_grow,
                                  auto_io_scaling=auto_io_scaling,
-                                 log_on_disk=accelerated_logs, storage_redundancy=storage_redundancy)
+                                 log_on_disk=accelerated_logs)
 
         backup = models.Backup(backup_retention_days=backup_retention, geo_redundant_backup=geo_redundant_backup)
 
@@ -872,8 +868,7 @@ def flexible_server_restore(cmd, client, resource_group_name, server_name, sourc
 def flexible_server_georestore(cmd, client, resource_group_name, server_name, source_server, location, zone=None, no_wait=False,
                                subnet=None, subnet_address_prefix=None, vnet=None, vnet_address_prefix=None, tags=None,
                                private_dns_zone_arguments=None, public_access=None, yes=False, sku_name=None, tier=None,
-                               storage_gb=None, auto_grow=None, accelerated_logs=None, storage_redundancy=None,
-                               backup_retention=None, geo_redundant_backup=None):
+                               storage_gb=None, auto_grow=None, accelerated_logs=None, backup_retention=None, geo_redundant_backup=None):
     provider = 'Microsoft.DBforMySQL'
     server_name = server_name.lower()
 
@@ -922,9 +917,6 @@ def flexible_server_georestore(cmd, client, resource_group_name, server_name, so
         else:
             mysql_accelerated_logs_validator(accelerated_logs, tier)
 
-        if not storage_redundancy:
-            storage_redundancy = source_server_object.storage.storage_redundancy
-
         if not backup_retention:
             backup_retention = source_server_object.backup.backup_retention_days
         else:
@@ -951,7 +943,7 @@ def flexible_server_georestore(cmd, client, resource_group_name, server_name, so
 
         storage = models.Storage(storage_size_gb=storage_gb, iops=iops, auto_grow=auto_grow,
                                  auto_io_scaling=source_server_object.storage.auto_io_scaling,
-                                 log_on_disk=accelerated_logs, storage_redundancy=storage_redundancy)
+                                 log_on_disk=accelerated_logs)
 
         backup = models.Backup(backup_retention_days=backup_retention, geo_redundant_backup=geo_redundant_backup)
 
@@ -1334,8 +1326,8 @@ def flexible_parameter_update_batch(client, server_name, resource_group_name, so
 # Custom functions for server replica, will add MySQL part after backend ready in future
 def flexible_replica_create(cmd, client, resource_group_name, source_server, replica_name, location=None, tags=None, sku_name=None,
                             private_dns_zone_arguments=None, vnet=None, subnet=None, zone=None, public_access=None, no_wait=False,
-                            storage_gb=None, iops=None, storage_redundancy=None, faster_provisioning=None, geo_redundant_backup=None,
-                            backup_retention=None, tier=None, database_port=None):
+                            storage_gb=None, iops=None, faster_provisioning=None, geo_redundant_backup=None, backup_retention=None,
+                            tier=None, database_port=None):
     provider = 'Microsoft.DBforMySQL'
     replica_name = replica_name.lower()
 
@@ -1391,8 +1383,7 @@ def flexible_replica_create(cmd, client, resource_group_name, source_server, rep
     storage = models.Storage(storage_size_gb=storage_gb,
                              iops=iops,
                              auto_grow="Enabled",
-                             auto_io_scaling=auto_io_scaling,
-                             storage_redundancy=storage_redundancy)
+                             auto_io_scaling=auto_io_scaling)
 
     backup = models.Backup(backup_retention_days=backup_retention, geo_redundant_backup=geo_redundant_backup)
 

--- a/src/azure-cli/azure/cli/command_modules/mysql/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/mysql/custom.py
@@ -795,7 +795,8 @@ def flexible_server_restore(cmd, client, resource_group_name, server_name, sourc
 
         storage = models.Storage(storage_size_gb=storage_gb, iops=iops, auto_grow=auto_grow,
                                  auto_io_scaling=auto_io_scaling,
-                                 log_on_disk=accelerated_logs)
+                                 log_on_disk=accelerated_logs,
+                                 storage_redundancy=source_server_object.storage.storage_redundancy)
 
         backup = models.Backup(backup_retention_days=backup_retention, geo_redundant_backup=geo_redundant_backup)
 
@@ -943,7 +944,8 @@ def flexible_server_georestore(cmd, client, resource_group_name, server_name, so
 
         storage = models.Storage(storage_size_gb=storage_gb, iops=iops, auto_grow=auto_grow,
                                  auto_io_scaling=source_server_object.storage.auto_io_scaling,
-                                 log_on_disk=accelerated_logs)
+                                 log_on_disk=accelerated_logs,
+                                 storage_redundancy=source_server_object.storage.storage_redundancy)
 
         backup = models.Backup(backup_retention_days=backup_retention, geo_redundant_backup=geo_redundant_backup)
 


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az mysql flexible-server create --storage-redundancy
az mysql flexible-server restore --storage-redundancy
az mysql flexible-server geo-restore --storage-redundancy
az mysql flexible-server replica --storage-redundancy
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Remove storage redundancy for mysql server creation, restore and replica. Backend has been not supported this feature.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[MySQL] BREAKING CHANGE `az mysql flexible-server backup create/restore/geo-restore/replica`: Remove `--storage-redundancy`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
