### PR TITLE
{Compute} `az vm image list`: Fall back on invalid image alias doc

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/_actions.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_actions.py
@@ -191,7 +191,12 @@ def load_images_from_aliases_doc(cli_ctx, publisher=None, offer=None, sku=None, 
         try:
             response = requests.get(target_url, verify=not should_disable_connection_verify())
             if response.status_code == 200:
-                dic = json.loads(response.content.decode())
+                try:
+                    dic = json.loads(response.content.decode())
+                except json.JSONDecodeError as ex:
+                    logger.warning("Failed to parse image alias doc '%s'. Error: '%s'. Use local copy instead.",
+                                   target_url, ex)
+                    dic = json.loads(alias_json)
             else:
                 logger.warning("Failed to retrieve image alias doc '%s'. Error: '%s'. Use local copy instead.",
                                target_url, response)

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_image.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_image.py
@@ -69,6 +69,18 @@ class TestVMImage(unittest.TestCase):
                                      'offer': 'CentOS', 'sku': '8_5-gen2', 'version': 'latest',
                                      'architecture': 'x64'})
 
+    @mock.patch('requests.get', autospec=True)
+    def test_when_alias_doc_is_invalid_json(self, mock_get):
+        from azure.cli.command_modules.vm._actions import load_images_from_aliases_doc
+        cli_ctx = DummyCli()
+        cli_ctx.cloud.endpoints.vm_image_alias_doc = 'https://example.invalid/aliases.json'
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.content = b'404: Not Found'
+
+        images = load_images_from_aliases_doc(cli_ctx)
+
+        self.assertEqual(images[0]['urnAlias'], 'AzureLinux4')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #33162

## Summary
This makes `az vm image list` fall back to the bundled image alias document when the remote alias document returns HTTP 200 but the body is not valid JSON.

## Why
Today that path raises a raw `JSONDecodeError`, which makes the command fail with a Python traceback. If the alias endpoint is intercepted or returns a small error body, the CLI should behave like the existing fetch-failure paths and use the local alias copy instead.

## Test plan
- `PYTHONPATH=src/azure-cli:src/azure-cli-core .venv/bin/python -m py_compile src/azure-cli/azure/cli/command_modules/vm/_actions.py src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_image.py`
- `git diff --check`

Note: I also tried the focused pytest for the new test, but the local venv is missing `vcr`, required by `azure-cli-testsdk` during test collection.
