### PR TITLE
[Core] Bump pymsalruntime to 0.20.6

### DIFF
--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -122,7 +122,7 @@ psutil==6.1.0
 pycomposefile==0.0.34
 PyGithub==1.55
 PyJWT==2.12.0
-pymsalruntime==0.20.5
+pymsalruntime==0.20.6
 PyNaCl==1.6.2
 pyOpenSSL==26.0.0
 PySocks==1.7.1


### PR DESCRIPTION
**Related command**
`az login`

**Description**
Bump `pymsalruntime` from `0.20.5` to `0.20.6` in `requirements.py3.windows.txt` for addressing some issues that MSAL team highly recommend us updating
**Testing Guide**
az login can login successfully

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).