### PR TITLE
{CI} Ship .yaml test fixtures in azure_cli_fulltest wheel

### DIFF
--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -154,6 +154,7 @@ cat >>$testsrc_dir/setup.py <<EOL
                        '*.txt',
                        '*.xml',
                        '*.yml',
+                       '*.yaml',
                        '*.zip',
                        '**/*.bat',
                        '**/*.byok',
@@ -171,6 +172,8 @@ cat >>$testsrc_dir/setup.py <<EOL
                        '**/*.txt',
                        '**/*.txt',
                        '**/*.xml',
+                       '**/*.yml',
+                       '**/*.yaml',
                        'data/*',
                        'recordings/*.yaml']},
     install_requires=DEPENDENCIES


### PR DESCRIPTION
Add *.yaml and **/*.yaml to package_data in scripts/ci/build.sh so non-recording fixtures (e.g. acr/tests/latest/taskfilesample.yaml) are included in the ephemeral azure_cli_fulltest wheel installed by TestRpmPackagesAzureLinux. Fixes test_acr_task FileNotFoundError after #33135 removed its @live_only decorator.

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
