### PR TITLE
{CI} Fix githook when upstream is renamed

### DIFF
--- a/.githooks/pre-push.ps1
+++ b/.githooks/pre-push.ps1
@@ -26,22 +26,31 @@ if ($editableLocation) {
 # Get extension repo paths and join them with spaces
 $Extensions = (azdev extension repo list -o tsv) -join ' '
 
-# Fetch upstream/dev branch
-Write-Host "Fetching upstream/dev branch..." -ForegroundColor Green
-git fetch upstream dev
+# Detect the remote pointing to Azure/azure-cli
+$remoteLines = git remote -v | Select-String -Pattern "Azure/azure-cli" | Select-String -Pattern "\(fetch\)"
+$UpstreamRemote = if ($remoteLines) { ($remoteLines[0] -split "\s+")[0] } else { $null }
+if (-not $UpstreamRemote) {
+    Write-Host "Error: No remote found pointing to Azure/azure-cli. Please run 'git remote add upstream https://github.com/Azure/azure-cli.git' first." -ForegroundColor Red
+    exit 1
+}
+Write-Host "Using remote: $UpstreamRemote" -ForegroundColor Cyan
+
+# Fetch remote dev branch
+Write-Host "Fetching $UpstreamRemote/dev branch..." -ForegroundColor Green
+git fetch $UpstreamRemote dev
 if ($LASTEXITCODE -ne 0) {
-    Write-Host "Error: Failed to fetch upstream/dev branch. Please run 'git remote add upstream https://github.com/Azure/azure-cli.git' first." -ForegroundColor Red
+    Write-Host "Error: Failed to fetch $UpstreamRemote/dev branch." -ForegroundColor Red
     exit 1
 }
 
 # Check if current branch needs rebasing
-$mergeBase = git merge-base HEAD upstream/dev
-$upstreamHead = git rev-parse upstream/dev
+$mergeBase = git merge-base HEAD "$UpstreamRemote/dev"
+$upstreamHead = git rev-parse "$UpstreamRemote/dev"
 Write-Host "Initial mergeBase: $mergeBase" -ForegroundColor Cyan
 
 if ($mergeBase -ne $upstreamHead) {
     Write-Host ""
-    Write-Host "Your branch is not up to date with upstream/dev." -ForegroundColor Yellow
+    Write-Host "Your branch is not up to date with $UpstreamRemote/dev." -ForegroundColor Yellow
     Write-Host "Would you like to automatically rebase and setup? [Y/n]" -ForegroundColor Yellow
 
     try {
@@ -55,14 +64,14 @@ if ($mergeBase -ne $upstreamHead) {
     }
 
     if ($input -match '^[Yy]$') {
-        Write-Host "Rebasing with upstream/dev..." -ForegroundColor Green
-        git rebase upstream/dev
+        Write-Host "Rebasing with $UpstreamRemote/dev..." -ForegroundColor Green
+        git rebase "$UpstreamRemote/dev"
         if ($LASTEXITCODE -ne 0) {
             Write-Host "Rebase failed. Please resolve conflicts and try again." -ForegroundColor Red
             exit 1
         }
         Write-Host "Rebase completed successfully." -ForegroundColor Green
-        $mergeBase = git merge-base HEAD upstream/dev
+        $mergeBase = git merge-base HEAD "$UpstreamRemote/dev"
         Write-Host "Updated mergeBase: $mergeBase" -ForegroundColor Cyan
 
         Write-Host "Running azdev setup..." -ForegroundColor Green

--- a/.githooks/pre-push.sh
+++ b/.githooks/pre-push.sh
@@ -23,34 +23,42 @@ fi
 # Get extension repo paths and join them with spaces
 EXTENSIONS=$(azdev extension repo list -o tsv | tr '\n' ' ' | sed 's/ $//')
 
-# Fetch upstream/dev branch
-printf "\033[0;32mFetching upstream/dev branch...\033[0m\n"
-git fetch upstream dev
+# Detect the remote pointing to Azure/azure-cli
+UPSTREAM_REMOTE=$(git remote -v | grep -i "Azure/azure-cli" | grep "(fetch)" | head -1 | awk '{print $1}')
+if [ -z "$UPSTREAM_REMOTE" ]; then
+    printf "\033[0;31mError: No remote found pointing to Azure/azure-cli. Please run 'git remote add upstream https://github.com/Azure/azure-cli.git' first.\033[0m\n"
+    exit 1
+fi
+printf "\033[0;36mUsing remote: %s\033[0m\n" "$UPSTREAM_REMOTE"
+
+# Fetch remote dev branch
+printf "\033[0;32mFetching %s/dev branch...\033[0m\n" "$UPSTREAM_REMOTE"
+git fetch "$UPSTREAM_REMOTE" dev
 if [ $? -ne 0 ]; then
-    printf "\033[0;31mError: Failed to fetch upstream/dev branch. Please run 'git remote add upstream https://github.com/Azure/azure-cli.git' first.\033[0m\n"
+    printf "\033[0;31mError: Failed to fetch %s/dev branch.\033[0m\n" "$UPSTREAM_REMOTE"
     exit 1
 fi
 
 # Check if current branch needs rebasing
-MERGE_BASE=$(git merge-base HEAD upstream/dev)
-UPSTREAM_HEAD=$(git rev-parse upstream/dev)
+MERGE_BASE=$(git merge-base HEAD "$UPSTREAM_REMOTE/dev")
+UPSTREAM_HEAD=$(git rev-parse "$UPSTREAM_REMOTE/dev")
 printf "\033[0;36mInitial mergeBase: %s\033[0m\n" "$MERGE_BASE"
 
 if [ "$MERGE_BASE" != "$UPSTREAM_HEAD" ]; then
     printf "\n"
-    printf "\033[1;33mYour branch is not up to date with upstream/dev.\033[0m\n"
+    printf "\033[1;33mYour branch is not up to date with %s/dev.\033[0m\n" "$UPSTREAM_REMOTE"
     printf "\033[1;33mWould you like to automatically rebase and setup? [Y/n]\033[0m\n"
 
     read -r INPUT < /dev/tty
     if [ "$INPUT" = "Y" ] || [ "$INPUT" = "y" ]; then
-        printf "\033[0;32mRebasing with upstream/dev...\033[0m\n"
-        git rebase upstream/dev
+        printf "\033[0;32mRebasing with %s/dev...\033[0m\n" "$UPSTREAM_REMOTE"
+        git rebase "$UPSTREAM_REMOTE/dev"
         if [ $? -ne 0 ]; then
             printf "\033[0;31mRebase failed. Please resolve conflicts and try again.\033[0m\n"
             exit 1
         fi
         printf "\033[0;32mRebase completed successfully.\033[0m\n"
-        MERGE_BASE=$(git merge-base HEAD upstream/dev)
+        MERGE_BASE=$(git merge-base HEAD "$UPSTREAM_REMOTE/dev")
         printf "\033[0;36mUpdated mergeBase: %s\033[0m\n" "$MERGE_BASE"
 
         printf "\033[0;32mRunning azdev setup...\033[0m\n"


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

N/A

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

The before-push githook errors out when the remote is renamed, i.e. not named `upstream`. This PR fixes it. 


**Testing Guide**
<!--Example commands with explanations.-->

Run `git push` on bash and pwsh, the git hook was able to reconginze my remote (named `azure`) instead of the hardcoded `upstream`.

<img width="676" height="235" alt="image" src="https://github.com/user-attachments/assets/aed714e6-9b5c-4df3-bc23-a5c5cdee9df8" />

<img width="685" height="211" alt="image" src="https://github.com/user-attachments/assets/c56a285a-15ce-43b7-ad33-47fb5f3493fd" />


**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
