### PR TITLE
[MySQL] fix resolve api version in vnet or subnet existence check

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/mysql/_util.py
+++ b/src/azure-cli/azure/cli/command_modules/mysql/_util.py
@@ -364,6 +364,8 @@ def _resolve_api_version(client, provider_namespace, resource_type, parent_path)
           if t.resource_type.lower() == resource_type_str.lower()]
     if not rt:
         raise InvalidArgumentValueError('Resource type {} not found.'.format(resource_type_str))
+    if len(rt) == 1 and rt[0].default_api_version not in (None, ''):
+        return rt[0].default_api_version
     if len(rt) == 1 and rt[0].api_versions:
         npv = [v for v in rt[0].api_versions if 'preview' not in v.lower()]
         return npv[0] if npv else rt[0].api_versions[0]

--- a/src/azure-cli/azure/cli/command_modules/mysql/tests/latest/recordings/test_mysql_flexible_server_cross_region_replica_mgmt.yaml
+++ b/src/azure-cli/azure/cli/command_modules/mysql/tests/latest/recordings/test_mysql_flexible_server_cross_region_replica_mgmt.yaml
@@ -4153,7 +4153,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000005?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000005?api-version=2024-05-01
   response:
     body:
       string: '{"name":"VNET000005","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000005","etag":"W/\"b64a9790-28e8-4f69-9fef-5b2b8284dd21\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"eee24458-c434-4d9c-8838-553db6f3cb33","addressSpace":{"addressPrefixes":["172.1.0.0/16"]},"privateEndpointVNetPolicies":"Disabled","subnets":[{"name":"SUBNET000006","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000005/subnets/SUBNET000006","etag":"W/\"b64a9790-28e8-4f69-9fef-5b2b8284dd21\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.1.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}],"virtualNetworkPeerings":[],"enableDdosProtection":false}}'
@@ -6086,7 +6086,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000005/subnets/SUBNET000006?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000005/subnets/SUBNET000006?api-version=2024-05-01
   response:
     body:
       string: '{"name":"SUBNET000006","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000005/subnets/SUBNET000006","etag":"W/\"b64a9790-28e8-4f69-9fef-5b2b8284dd21\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.1.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}'
@@ -8391,7 +8391,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/azuredbclirep2000004.private.mysql.database.azure.com?api-version=2024-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/azuredbclirep2000004.private.mysql.database.azure.com?api-version=2018-09-01
   response:
     body:
       string: '{"id":"\/subscriptions\/00000000-0000-0000-0000-000000000000\/resourceGroups\/clitest.rg000001\/providers\/Microsoft.Network\/privateDnsZones\/azuredbclirep2000004.private.mysql.database.azure.com","name":"azuredbclirep2000004.private.mysql.database.azure.com","type":"Microsoft.Network\/privateDnsZones","etag":"d2ef5a8b-9796-4f57-9669-267b10191557","location":"global","properties":{"internalId":"SW1tdXRhYmxlWm9uZUlkZW50aXR5O2VmZjU4ZGNmLWMyYTAtNDg5OS05MDg4LTNiZTYwMGZjNmJjOTsw","maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'

--- a/src/azure-cli/azure/cli/command_modules/mysql/tests/latest/recordings/test_mysql_flexible_server_existing_private_dns_zone.yaml
+++ b/src/azure-cli/azure/cli/command_modules/mysql/tests/latest/recordings/test_mysql_flexible_server_existing_private_dns_zone.yaml
@@ -2768,7 +2768,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet?api-version=2024-05-01
   response:
     body:
       string: '{"name":"servergrouptestvnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet","etag":"W/\"f0b4a7df-5391-4e92-a3bb-9a12c63a12f6\"","type":"Microsoft.Network/virtualNetworks","location":"northeurope","properties":{"provisioningState":"Succeeded","resourceGuid":"f6c1f008-6466-4c4f-8345-c651e982bc3e","addressSpace":{"addressPrefixes":["172.1.0.0/16"]},"privateEndpointVNetPolicies":"Disabled","subnets":[{"name":"servergrouptestsubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet/subnets/servergrouptestsubnet","etag":"W/\"f0b4a7df-5391-4e92-a3bb-9a12c63a12f6\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.1.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}],"virtualNetworkPeerings":[],"enableDdosProtection":false}}'
@@ -4751,7 +4751,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet/subnets/servergrouptestsubnet?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet/subnets/servergrouptestsubnet?api-version=2024-05-01
   response:
     body:
       string: '{"name":"servergrouptestsubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet/subnets/servergrouptestsubnet","etag":"W/\"f0b4a7df-5391-4e92-a3bb-9a12c63a12f6\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.1.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}'
@@ -6686,7 +6686,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet/subnets/servergrouptestsubnet?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet/subnets/servergrouptestsubnet?api-version=2024-05-01
   response:
     body:
       string: '{"name":"servergrouptestsubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet/subnets/servergrouptestsubnet","etag":"W/\"f0b4a7df-5391-4e92-a3bb-9a12c63a12f6\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.1.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}'
@@ -9275,7 +9275,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet?api-version=2024-05-01
   response:
     body:
       string: '{"name":"servergrouptestvnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet","etag":"W/\"a810c800-6618-40e3-8712-ca1beb86e928\"","type":"Microsoft.Network/virtualNetworks","location":"northeurope","properties":{"provisioningState":"Succeeded","resourceGuid":"f6c1f008-6466-4c4f-8345-c651e982bc3e","addressSpace":{"addressPrefixes":["172.1.0.0/16"]},"privateEndpointVNetPolicies":"Disabled","subnets":[{"name":"servergrouptestsubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet/subnets/servergrouptestsubnet","etag":"W/\"a810c800-6618-40e3-8712-ca1beb86e928\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.1.0.0/24","delegations":[{"name":"Microsoft.DBforMySQL/flexibleServers","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet/subnets/servergrouptestsubnet/delegations/Microsoft.DBforMySQL/flexibleServers","etag":"W/\"a810c800-6618-40e3-8712-ca1beb86e928\"","properties":{"provisioningState":"Succeeded","serviceName":"Microsoft.DBforMySQL/flexibleServers","actions":["Microsoft.Network/virtualNetworks/subnets/join/action"]},"type":"Microsoft.Network/virtualNetworks/subnets/delegations"}],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}],"virtualNetworkPeerings":[],"enableDdosProtection":false}}'
@@ -11258,7 +11258,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet/subnets/servergrouptestsubnet?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet/subnets/servergrouptestsubnet?api-version=2024-05-01
   response:
     body:
       string: '{"name":"servergrouptestsubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet/subnets/servergrouptestsubnet","etag":"W/\"a810c800-6618-40e3-8712-ca1beb86e928\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.1.0.0/24","delegations":[{"name":"Microsoft.DBforMySQL/flexibleServers","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet/subnets/servergrouptestsubnet/delegations/Microsoft.DBforMySQL/flexibleServers","etag":"W/\"a810c800-6618-40e3-8712-ca1beb86e928\"","properties":{"provisioningState":"Succeeded","serviceName":"Microsoft.DBforMySQL/flexibleServers","actions":["Microsoft.Network/virtualNetworks/subnets/join/action"]},"type":"Microsoft.Network/virtualNetworks/subnets/delegations"}],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}'
@@ -13193,7 +13193,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet/subnets/servergrouptestsubnet?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet/subnets/servergrouptestsubnet?api-version=2024-05-01
   response:
     body:
       string: '{"name":"servergrouptestsubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet/subnets/servergrouptestsubnet","etag":"W/\"a810c800-6618-40e3-8712-ca1beb86e928\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.1.0.0/24","delegations":[{"name":"Microsoft.DBforMySQL/flexibleServers","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet/subnets/servergrouptestsubnet/delegations/Microsoft.DBforMySQL/flexibleServers","etag":"W/\"a810c800-6618-40e3-8712-ca1beb86e928\"","properties":{"provisioningState":"Succeeded","serviceName":"Microsoft.DBforMySQL/flexibleServers","actions":["Microsoft.Network/virtualNetworks/subnets/join/action"]},"type":"Microsoft.Network/virtualNetworks/subnets/delegations"}],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}'
@@ -15816,7 +15816,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet?api-version=2024-05-01
   response:
     body:
       string: '{"name":"servergrouptestvnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet","etag":"W/\"a810c800-6618-40e3-8712-ca1beb86e928\"","type":"Microsoft.Network/virtualNetworks","location":"northeurope","properties":{"provisioningState":"Succeeded","resourceGuid":"f6c1f008-6466-4c4f-8345-c651e982bc3e","addressSpace":{"addressPrefixes":["172.1.0.0/16"]},"privateEndpointVNetPolicies":"Disabled","subnets":[{"name":"servergrouptestsubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet/subnets/servergrouptestsubnet","etag":"W/\"a810c800-6618-40e3-8712-ca1beb86e928\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.1.0.0/24","delegations":[{"name":"Microsoft.DBforMySQL/flexibleServers","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet/subnets/servergrouptestsubnet/delegations/Microsoft.DBforMySQL/flexibleServers","etag":"W/\"a810c800-6618-40e3-8712-ca1beb86e928\"","properties":{"provisioningState":"Succeeded","serviceName":"Microsoft.DBforMySQL/flexibleServers","actions":["Microsoft.Network/virtualNetworks/subnets/join/action"]},"type":"Microsoft.Network/virtualNetworks/subnets/delegations"}],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}],"virtualNetworkPeerings":[],"enableDdosProtection":false}}'
@@ -17799,7 +17799,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet/subnets/servergrouptestsubnet?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet/subnets/servergrouptestsubnet?api-version=2024-05-01
   response:
     body:
       string: '{"name":"servergrouptestsubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet/subnets/servergrouptestsubnet","etag":"W/\"a810c800-6618-40e3-8712-ca1beb86e928\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.1.0.0/24","delegations":[{"name":"Microsoft.DBforMySQL/flexibleServers","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet/subnets/servergrouptestsubnet/delegations/Microsoft.DBforMySQL/flexibleServers","etag":"W/\"a810c800-6618-40e3-8712-ca1beb86e928\"","properties":{"provisioningState":"Succeeded","serviceName":"Microsoft.DBforMySQL/flexibleServers","actions":["Microsoft.Network/virtualNetworks/subnets/join/action"]},"type":"Microsoft.Network/virtualNetworks/subnets/delegations"}],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}'
@@ -19734,7 +19734,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet/subnets/servergrouptestsubnet?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet/subnets/servergrouptestsubnet?api-version=2024-05-01
   response:
     body:
       string: '{"name":"servergrouptestsubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet/subnets/servergrouptestsubnet","etag":"W/\"a810c800-6618-40e3-8712-ca1beb86e928\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.1.0.0/24","delegations":[{"name":"Microsoft.DBforMySQL/flexibleServers","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet/subnets/servergrouptestsubnet/delegations/Microsoft.DBforMySQL/flexibleServers","etag":"W/\"a810c800-6618-40e3-8712-ca1beb86e928\"","properties":{"provisioningState":"Succeeded","serviceName":"Microsoft.DBforMySQL/flexibleServers","actions":["Microsoft.Network/virtualNetworks/subnets/join/action"]},"type":"Microsoft.Network/virtualNetworks/subnets/delegations"}],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}'
@@ -21821,7 +21821,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/clitestunlinked.mysql.database.azure.com?api-version=2024-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/clitestunlinked.mysql.database.azure.com?api-version=2018-09-01
   response:
     body:
       string: '{"id":"\/subscriptions\/00000000-0000-0000-0000-000000000000\/resourceGroups\/clitest.rg000001\/providers\/Microsoft.Network\/privateDnsZones\/clitestunlinked.mysql.database.azure.com","name":"clitestunlinked.mysql.database.azure.com","type":"Microsoft.Network\/privateDnsZones","etag":"a63210bc-fc42-4234-addc-82b47bbc27ce","location":"global","properties":{"internalId":"SW1tdXRhYmxlWm9uZUlkZW50aXR5OzBmNjhhZmRlLTFkZDEtNGY1OC1hNTBkLWFiZTJlNGM4YTZlMzsw","maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
@@ -25651,7 +25651,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002/providers/Microsoft.Network/virtualNetworks/vnetgrouptestvnet?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002/providers/Microsoft.Network/virtualNetworks/vnetgrouptestvnet?api-version=2024-05-01
   response:
     body:
       string: '{"name":"vnetgrouptestvnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Network/virtualNetworks/vnetgrouptestvnet","etag":"W/\"346d0869-21df-401d-aaa2-a431104dabf2\"","type":"Microsoft.Network/virtualNetworks","location":"northeurope","properties":{"provisioningState":"Succeeded","resourceGuid":"433c2934-f63f-4748-ac9b-40c81773abbc","addressSpace":{"addressPrefixes":["172.1.0.0/16"]},"privateEndpointVNetPolicies":"Disabled","subnets":[{"name":"vnetgrouptestsubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Network/virtualNetworks/vnetgrouptestvnet/subnets/vnetgrouptestsubnet","etag":"W/\"346d0869-21df-401d-aaa2-a431104dabf2\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.1.0.0/24","networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Network/networkSecurityGroups/NRMS-pjffyzvulpssivnetgrouptestvnet"},"delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}],"virtualNetworkPeerings":[],"enableDdosProtection":false}}'
@@ -27634,7 +27634,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002/providers/Microsoft.Network/virtualNetworks/vnetgrouptestvnet/subnets/vnetgrouptestsubnet?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002/providers/Microsoft.Network/virtualNetworks/vnetgrouptestvnet/subnets/vnetgrouptestsubnet?api-version=2024-05-01
   response:
     body:
       string: '{"name":"vnetgrouptestsubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Network/virtualNetworks/vnetgrouptestvnet/subnets/vnetgrouptestsubnet","etag":"W/\"346d0869-21df-401d-aaa2-a431104dabf2\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.1.0.0/24","networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Network/networkSecurityGroups/NRMS-pjffyzvulpssivnetgrouptestvnet"},"delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}'
@@ -29569,7 +29569,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002/providers/Microsoft.Network/virtualNetworks/vnetgrouptestvnet/subnets/vnetgrouptestsubnet?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002/providers/Microsoft.Network/virtualNetworks/vnetgrouptestvnet/subnets/vnetgrouptestsubnet?api-version=2024-05-01
   response:
     body:
       string: '{"name":"vnetgrouptestsubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Network/virtualNetworks/vnetgrouptestvnet/subnets/vnetgrouptestsubnet","etag":"W/\"346d0869-21df-401d-aaa2-a431104dabf2\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.1.0.0/24","networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Network/networkSecurityGroups/NRMS-pjffyzvulpssivnetgrouptestvnet"},"delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}'
@@ -31876,7 +31876,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/clitestvnetgroup.mysql.database.azure.com?api-version=2024-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/clitestvnetgroup.mysql.database.azure.com?api-version=2018-09-01
   response:
     body:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/privateDnsZones/clitestvnetgroup.mysql.database.azure.com''
@@ -33807,7 +33807,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002/providers/Microsoft.Network/privateDnsZones/clitestvnetgroup.mysql.database.azure.com?api-version=2024-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002/providers/Microsoft.Network/privateDnsZones/clitestvnetgroup.mysql.database.azure.com?api-version=2018-09-01
   response:
     body:
       string: '{"id":"\/subscriptions\/00000000-0000-0000-0000-000000000000\/resourceGroups\/clitest.rg000002\/providers\/Microsoft.Network\/privateDnsZones\/clitestvnetgroup.mysql.database.azure.com","name":"clitestvnetgroup.mysql.database.azure.com","type":"Microsoft.Network\/privateDnsZones","etag":"028bf1b8-e631-4b8d-b139-26fb04829a9b","location":"global","properties":{"internalId":"SW1tdXRhYmxlWm9uZUlkZW50aXR5O2RkNzhlNmUyLTFkYjktNDczOS1hMDI1LTZjMDE1ZjM0NTlmZDsw","maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":1,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'

--- a/src/azure-cli/azure/cli/command_modules/mysql/tests/latest/recordings/test_mysql_flexible_server_georestore_mgmt.yaml
+++ b/src/azure-cli/azure/cli/command_modules/mysql/tests/latest/recordings/test_mysql_flexible_server_georestore_mgmt.yaml
@@ -2138,7 +2138,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000010?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000010?api-version=2024-05-01
   response:
     body:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/virtualNetworks/VNET000010''
@@ -4280,7 +4280,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000010/subnets/SUBNET000011?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000010/subnets/SUBNET000011?api-version=2024-05-01
   response:
     body:
       string: '{"error":{"code":"NotFound","message":"Resource /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000010/subnets/SUBNET000011
@@ -6528,7 +6528,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/azuredbclitest-000002.private.mysql.database.azure.com?api-version=2024-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/azuredbclitest-000002.private.mysql.database.azure.com?api-version=2018-09-01
   response:
     body:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/privateDnsZones/azuredbclitest-000002.private.mysql.database.azure.com''
@@ -8459,7 +8459,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/azuredbclitest-000002.private.mysql.database.azure.com?api-version=2024-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/azuredbclitest-000002.private.mysql.database.azure.com?api-version=2018-09-01
   response:
     body:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/privateDnsZones/azuredbclitest-000002.private.mysql.database.azure.com''
@@ -13701,7 +13701,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000012?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000012?api-version=2024-05-01
   response:
     body:
       string: '{"name":"VNET000012","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000012","etag":"W/\"b9212859-d0a3-4b75-887e-a78ccc0065a2\"","type":"Microsoft.Network/virtualNetworks","location":"westeurope","properties":{"provisioningState":"Succeeded","resourceGuid":"b4b490d7-1e2b-4b13-985a-3f255278a1ce","addressSpace":{"addressPrefixes":["172.1.0.0/16"]},"privateEndpointVNetPolicies":"Disabled","subnets":[{"name":"SUBNET000013","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000012/subnets/SUBNET000013","etag":"W/\"b9212859-d0a3-4b75-887e-a78ccc0065a2\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.1.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}],"virtualNetworkPeerings":[],"enableDdosProtection":false}}'
@@ -15684,7 +15684,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000012/subnets/SUBNET000013?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000012/subnets/SUBNET000013?api-version=2024-05-01
   response:
     body:
       string: '{"name":"SUBNET000013","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000012/subnets/SUBNET000013","etag":"W/\"b9212859-d0a3-4b75-887e-a78ccc0065a2\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.1.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}'
@@ -17619,7 +17619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000012/subnets/SUBNET000013?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000012/subnets/SUBNET000013?api-version=2024-05-01
   response:
     body:
       string: '{"name":"SUBNET000013","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000012/subnets/SUBNET000013","etag":"W/\"b9212859-d0a3-4b75-887e-a78ccc0065a2\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.1.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}'
@@ -19924,7 +19924,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/azuredbclitest-000005.private.mysql.database.azure.com?api-version=2024-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/azuredbclitest-000005.private.mysql.database.azure.com?api-version=2018-09-01
   response:
     body:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/privateDnsZones/azuredbclitest-000005.private.mysql.database.azure.com''
@@ -21855,7 +21855,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/azuredbclitest-000005.private.mysql.database.azure.com?api-version=2024-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/azuredbclitest-000005.private.mysql.database.azure.com?api-version=2018-09-01
   response:
     body:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/privateDnsZones/azuredbclitest-000005.private.mysql.database.azure.com''
@@ -25716,7 +25716,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000014?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000014?api-version=2024-05-01
   response:
     body:
       string: '{"name":"VNET000014","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000014","etag":"W/\"41554329-66b7-4e50-a0eb-d62abf83dde5\"","type":"Microsoft.Network/virtualNetworks","location":"westeurope","properties":{"provisioningState":"Succeeded","resourceGuid":"c524bcca-fd24-4a7b-9194-ebf14e823e35","addressSpace":{"addressPrefixes":["172.1.0.0/16"]},"privateEndpointVNetPolicies":"Disabled","subnets":[{"name":"SUBNET000015","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000014/subnets/SUBNET000015","etag":"W/\"41554329-66b7-4e50-a0eb-d62abf83dde5\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.1.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}],"virtualNetworkPeerings":[],"enableDdosProtection":false}}'
@@ -27699,7 +27699,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000014/subnets/SUBNET000015?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000014/subnets/SUBNET000015?api-version=2024-05-01
   response:
     body:
       string: '{"name":"SUBNET000015","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000014/subnets/SUBNET000015","etag":"W/\"41554329-66b7-4e50-a0eb-d62abf83dde5\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.1.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}'
@@ -29634,7 +29634,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000014/subnets/SUBNET000015?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000014/subnets/SUBNET000015?api-version=2024-05-01
   response:
     body:
       string: '{"name":"SUBNET000015","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000014/subnets/SUBNET000015","etag":"W/\"41554329-66b7-4e50-a0eb-d62abf83dde5\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.1.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}'
@@ -31939,7 +31939,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/azuredbclitest-000006.private.mysql.database.azure.com?api-version=2024-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/azuredbclitest-000006.private.mysql.database.azure.com?api-version=2018-09-01
   response:
     body:
       string: '{"id":"\/subscriptions\/00000000-0000-0000-0000-000000000000\/resourceGroups\/clitest.rg000001\/providers\/Microsoft.Network\/privateDnsZones\/azuredbclitest-000006.private.mysql.database.azure.com","name":"azuredbclitest-000006.private.mysql.database.azure.com","type":"Microsoft.Network\/privateDnsZones","etag":"25855a8f-b3d4-4da7-a844-1bda36779422","location":"global","properties":{"internalId":"SW1tdXRhYmxlWm9uZUlkZW50aXR5O2VhMDY4NTM1LTc5ZDctNDg5MS1hYjY4LWZiMzg2OGM3NTFlOTsw","maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'

--- a/src/azure-cli/azure/cli/command_modules/mysql/tests/latest/recordings/test_mysql_flexible_server_new_private_dns_zone.yaml
+++ b/src/azure-cli/azure/cli/command_modules/mysql/tests/latest/recordings/test_mysql_flexible_server_new_private_dns_zone.yaml
@@ -2528,7 +2528,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/clitest-private-dns-zone-test-3.private.mysql.database.azure.com?api-version=2024-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/clitest-private-dns-zone-test-3.private.mysql.database.azure.com?api-version=2018-09-01
   response:
     body:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/privateDnsZones/clitest-private-dns-zone-test-3.private.mysql.database.azure.com''
@@ -4459,7 +4459,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/clitest-private-dns-zone-test-3.private.mysql.database.azure.com?api-version=2024-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/clitest-private-dns-zone-test-3.private.mysql.database.azure.com?api-version=2018-09-01
   response:
     body:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/privateDnsZones/clitest-private-dns-zone-test-3.private.mysql.database.azure.com''
@@ -6903,7 +6903,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002/providers/Microsoft.Network/privateDnsZones/clitest-private-dns-zone-test-4.private.mysql.database.azure.com?api-version=2024-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002/providers/Microsoft.Network/privateDnsZones/clitest-private-dns-zone-test-4.private.mysql.database.azure.com?api-version=2018-09-01
   response:
     body:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/privateDnsZones/clitest-private-dns-zone-test-4.private.mysql.database.azure.com''
@@ -8834,7 +8834,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002/providers/Microsoft.Network/privateDnsZones/clitest-private-dns-zone-test-4.private.mysql.database.azure.com?api-version=2024-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002/providers/Microsoft.Network/privateDnsZones/clitest-private-dns-zone-test-4.private.mysql.database.azure.com?api-version=2018-09-01
   response:
     body:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/privateDnsZones/clitest-private-dns-zone-test-4.private.mysql.database.azure.com''
@@ -11330,7 +11330,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/clitestdnszone1.private.mysql.database.azure.com?api-version=2024-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/clitestdnszone1.private.mysql.database.azure.com?api-version=2018-09-01
   response:
     body:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/privateDnsZones/clitestdnszone1.private.mysql.database.azure.com''
@@ -13261,7 +13261,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/clitestdnszone1.private.mysql.database.azure.com?api-version=2024-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/clitestdnszone1.private.mysql.database.azure.com?api-version=2018-09-01
   response:
     body:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/privateDnsZones/clitestdnszone1.private.mysql.database.azure.com''
@@ -15889,7 +15889,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002/providers/Microsoft.Network/virtualNetworks/vnetgrouptestvnet?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002/providers/Microsoft.Network/virtualNetworks/vnetgrouptestvnet?api-version=2024-05-01
   response:
     body:
       string: '{"name":"vnetgrouptestvnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Network/virtualNetworks/vnetgrouptestvnet","etag":"W/\"7f46e38a-1b13-4883-a179-9eac0960d6b8\"","type":"Microsoft.Network/virtualNetworks","location":"northeurope","properties":{"provisioningState":"Succeeded","resourceGuid":"c07d346d-59d2-4814-9ee0-ccfa31986302","addressSpace":{"addressPrefixes":["172.1.0.0/16"]},"privateEndpointVNetPolicies":"Disabled","subnets":[{"name":"vnetgrouptestsubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Network/virtualNetworks/vnetgrouptestvnet/subnets/vnetgrouptestsubnet","etag":"W/\"7f46e38a-1b13-4883-a179-9eac0960d6b8\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.1.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}],"virtualNetworkPeerings":[],"enableDdosProtection":false}}'
@@ -17872,7 +17872,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002/providers/Microsoft.Network/virtualNetworks/vnetgrouptestvnet/subnets/vnetgrouptestsubnet?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002/providers/Microsoft.Network/virtualNetworks/vnetgrouptestvnet/subnets/vnetgrouptestsubnet?api-version=2024-05-01
   response:
     body:
       string: '{"name":"vnetgrouptestsubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Network/virtualNetworks/vnetgrouptestvnet/subnets/vnetgrouptestsubnet","etag":"W/\"7f46e38a-1b13-4883-a179-9eac0960d6b8\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.1.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}'
@@ -19807,7 +19807,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002/providers/Microsoft.Network/virtualNetworks/vnetgrouptestvnet/subnets/vnetgrouptestsubnet?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002/providers/Microsoft.Network/virtualNetworks/vnetgrouptestvnet/subnets/vnetgrouptestsubnet?api-version=2024-05-01
   response:
     body:
       string: '{"name":"vnetgrouptestsubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Network/virtualNetworks/vnetgrouptestvnet/subnets/vnetgrouptestsubnet","etag":"W/\"7f46e38a-1b13-4883-a179-9eac0960d6b8\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.1.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}'
@@ -22156,7 +22156,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000003/providers/Microsoft.Network/privateDnsZones/clitestdnszone2.private.mysql.database.azure.com?api-version=2024-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000003/providers/Microsoft.Network/privateDnsZones/clitestdnszone2.private.mysql.database.azure.com?api-version=2018-09-01
   response:
     body:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/privateDnsZones/clitestdnszone2.private.mysql.database.azure.com''
@@ -25435,7 +25435,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet?api-version=2024-05-01
   response:
     body:
       string: '{"name":"servergrouptestvnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet","etag":"W/\"1a7c8229-4741-41fc-9a4b-aef6e5b968b5\"","type":"Microsoft.Network/virtualNetworks","location":"northeurope","properties":{"provisioningState":"Succeeded","resourceGuid":"cf3c5a39-3a59-4053-a36b-9406f267054b","addressSpace":{"addressPrefixes":["172.1.0.0/16"]},"privateEndpointVNetPolicies":"Disabled","subnets":[{"name":"servergrouptestsubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet/subnets/servergrouptestsubnet","etag":"W/\"1a7c8229-4741-41fc-9a4b-aef6e5b968b5\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.1.0.0/24","networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/NRMS-tt3x75dwad7j6servergrouptestvnet"},"delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}],"virtualNetworkPeerings":[],"enableDdosProtection":false}}'
@@ -27418,7 +27418,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet/subnets/servergrouptestsubnet?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet/subnets/servergrouptestsubnet?api-version=2024-05-01
   response:
     body:
       string: '{"name":"servergrouptestsubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet/subnets/servergrouptestsubnet","etag":"W/\"1a7c8229-4741-41fc-9a4b-aef6e5b968b5\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.1.0.0/24","networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/NRMS-tt3x75dwad7j6servergrouptestvnet"},"delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}'
@@ -29353,7 +29353,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet/subnets/servergrouptestsubnet?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet/subnets/servergrouptestsubnet?api-version=2024-05-01
   response:
     body:
       string: '{"name":"servergrouptestsubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/servergrouptestvnet/subnets/servergrouptestsubnet","etag":"W/\"1a7c8229-4741-41fc-9a4b-aef6e5b968b5\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.1.0.0/24","networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/NRMS-tt3x75dwad7j6servergrouptestvnet"},"delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}'
@@ -31704,7 +31704,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000003/providers/Microsoft.Network/privateDnsZones/clitestdnszone3.private.mysql.database.azure.com?api-version=2024-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000003/providers/Microsoft.Network/privateDnsZones/clitestdnszone3.private.mysql.database.azure.com?api-version=2018-09-01
   response:
     body:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/privateDnsZones/clitestdnszone3.private.mysql.database.azure.com''

--- a/src/azure-cli/azure/cli/command_modules/mysql/tests/latest/recordings/test_mysql_flexible_server_restore_mgmt.yaml
+++ b/src/azure-cli/azure/cli/command_modules/mysql/tests/latest/recordings/test_mysql_flexible_server_restore_mgmt.yaml
@@ -2138,7 +2138,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000008?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000008?api-version=2024-05-01
   response:
     body:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/virtualNetworks/VNET000008''
@@ -4230,7 +4230,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000008/subnets/SUBNET000009?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000008/subnets/SUBNET000009?api-version=2024-05-01
   response:
     body:
       string: '{"error":{"code":"NotFound","message":"Resource /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000008/subnets/SUBNET000009
@@ -6478,7 +6478,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/azuredbclitest-000002.private.mysql.database.azure.com?api-version=2024-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/azuredbclitest-000002.private.mysql.database.azure.com?api-version=2018-09-01
   response:
     body:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/privateDnsZones/azuredbclitest-000002.private.mysql.database.azure.com''
@@ -8409,7 +8409,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/azuredbclitest-000002.private.mysql.database.azure.com?api-version=2024-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/azuredbclitest-000002.private.mysql.database.azure.com?api-version=2018-09-01
   response:
     body:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/privateDnsZones/azuredbclitest-000002.private.mysql.database.azure.com''
@@ -13680,7 +13680,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000010?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000010?api-version=2024-05-01
   response:
     body:
       string: '{"name":"VNET000010","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000010","etag":"W/\"04a72005-0847-4c1b-8d5d-46f89532d77b\"","type":"Microsoft.Network/virtualNetworks","location":"northeurope","properties":{"provisioningState":"Succeeded","resourceGuid":"b61795c4-33b2-4c63-8c18-f94844690722","addressSpace":{"addressPrefixes":["172.1.0.0/16"]},"privateEndpointVNetPolicies":"Disabled","subnets":[{"name":"SUBNET000011","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000010/subnets/SUBNET000011","etag":"W/\"04a72005-0847-4c1b-8d5d-46f89532d77b\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.1.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}],"virtualNetworkPeerings":[],"enableDdosProtection":false}}'
@@ -15663,7 +15663,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000010/subnets/SUBNET000011?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000010/subnets/SUBNET000011?api-version=2024-05-01
   response:
     body:
       string: '{"name":"SUBNET000011","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000010/subnets/SUBNET000011","etag":"W/\"04a72005-0847-4c1b-8d5d-46f89532d77b\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.1.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}'
@@ -17598,7 +17598,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000010/subnets/SUBNET000011?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000010/subnets/SUBNET000011?api-version=2024-05-01
   response:
     body:
       string: '{"name":"SUBNET000011","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000010/subnets/SUBNET000011","etag":"W/\"04a72005-0847-4c1b-8d5d-46f89532d77b\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.1.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}'
@@ -19903,7 +19903,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/azuredbclitest-000004.private.mysql.database.azure.com?api-version=2024-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/azuredbclitest-000004.private.mysql.database.azure.com?api-version=2018-09-01
   response:
     body:
       string: '{"id":"\/subscriptions\/00000000-0000-0000-0000-000000000000\/resourceGroups\/clitest.rg000001\/providers\/Microsoft.Network\/privateDnsZones\/azuredbclitest-000004.private.mysql.database.azure.com","name":"azuredbclitest-000004.private.mysql.database.azure.com","type":"Microsoft.Network\/privateDnsZones","etag":"b393d11c-13a0-4249-a519-ff8f57a9c654","location":"global","properties":{"internalId":"SW1tdXRhYmxlWm9uZUlkZW50aXR5OzQ1YWEyYjI5LTJlYTYtNDJhNi1hZTBiLTUyOTUyNWUxODc2Mzsw","maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
@@ -23710,7 +23710,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000012?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000012?api-version=2024-05-01
   response:
     body:
       string: '{"name":"VNET000012","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000012","etag":"W/\"9fdaac78-abf5-4353-9150-ea3a3175aaeb\"","type":"Microsoft.Network/virtualNetworks","location":"northeurope","properties":{"provisioningState":"Succeeded","resourceGuid":"b4ec4baa-5241-436d-b1cc-65b296bd4ee0","addressSpace":{"addressPrefixes":["172.1.0.0/16"]},"privateEndpointVNetPolicies":"Disabled","subnets":[{"name":"SUBNET000013","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000012/subnets/SUBNET000013","etag":"W/\"9fdaac78-abf5-4353-9150-ea3a3175aaeb\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.1.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}],"virtualNetworkPeerings":[],"enableDdosProtection":false}}'
@@ -25693,7 +25693,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000012/subnets/SUBNET000013?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000012/subnets/SUBNET000013?api-version=2024-05-01
   response:
     body:
       string: '{"name":"SUBNET000013","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000012/subnets/SUBNET000013","etag":"W/\"9fdaac78-abf5-4353-9150-ea3a3175aaeb\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.1.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}'
@@ -27628,7 +27628,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000012/subnets/SUBNET000013?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000012/subnets/SUBNET000013?api-version=2024-05-01
   response:
     body:
       string: '{"name":"SUBNET000013","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000012/subnets/SUBNET000013","etag":"W/\"9fdaac78-abf5-4353-9150-ea3a3175aaeb\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.1.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}'
@@ -29933,7 +29933,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/azuredbclitest-000005.private.mysql.database.azure.com?api-version=2024-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/azuredbclitest-000005.private.mysql.database.azure.com?api-version=2018-09-01
   response:
     body:
       string: '{"id":"\/subscriptions\/00000000-0000-0000-0000-000000000000\/resourceGroups\/clitest.rg000001\/providers\/Microsoft.Network\/privateDnsZones\/azuredbclitest-000005.private.mysql.database.azure.com","name":"azuredbclitest-000005.private.mysql.database.azure.com","type":"Microsoft.Network\/privateDnsZones","etag":"7d9a2173-f6b9-40f1-9971-d7cc256b9fe7","location":"global","properties":{"internalId":"SW1tdXRhYmxlWm9uZUlkZW50aXR5Ozc3OTAwOGQ0LTdiNzItNGQ3My04ZjlmLTJkZThjMWU4YTY4MTsw","maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'

--- a/src/azure-cli/azure/cli/command_modules/mysql/tests/latest/recordings/test_mysql_flexible_server_upgrade_mgmt.yaml
+++ b/src/azure-cli/azure/cli/command_modules/mysql/tests/latest/recordings/test_mysql_flexible_server_upgrade_mgmt.yaml
@@ -2138,7 +2138,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000004?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000004?api-version=2024-05-01
   response:
     body:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/virtualNetworks/VNET000004''
@@ -4280,7 +4280,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000004/subnets/SUBNET000005?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000004/subnets/SUBNET000005?api-version=2024-05-01
   response:
     body:
       string: '{"error":{"code":"NotFound","message":"Resource /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNET000004/subnets/SUBNET000005
@@ -6528,7 +6528,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/azuredbclitest-000002.private.mysql.database.azure.com?api-version=2024-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/azuredbclitest-000002.private.mysql.database.azure.com?api-version=2018-09-01
   response:
     body:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/privateDnsZones/azuredbclitest-000002.private.mysql.database.azure.com''
@@ -8459,7 +8459,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/azuredbclitest-000002.private.mysql.database.azure.com?api-version=2024-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/azuredbclitest-000002.private.mysql.database.azure.com?api-version=2018-09-01
   response:
     body:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/privateDnsZones/azuredbclitest-000002.private.mysql.database.azure.com''

--- a/src/azure-cli/azure/cli/command_modules/mysql/tests/latest/recordings/test_mysql_flexible_server_vnet_mgmt_supplied_subnet_id_in_different_rg.yaml
+++ b/src/azure-cli/azure/cli/command_modules/mysql/tests/latest/recordings/test_mysql_flexible_server_vnet_mgmt_supplied_subnet_id_in_different_rg.yaml
@@ -2394,7 +2394,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitestvnet5?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitestvnet5?api-version=2024-05-01
   response:
     body:
       string: '{"name":"clitestvnet5","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitestvnet5","etag":"W/\"4a83c39b-cfd0-4237-a50a-d5e170b95978\"","type":"Microsoft.Network/virtualNetworks","location":"northeurope","properties":{"provisioningState":"Succeeded","resourceGuid":"90f148da-6090-42aa-9126-7564352e47d5","addressSpace":{"addressPrefixes":["10.10.0.0/16"]},"privateEndpointVNetPolicies":"Disabled","subnets":[{"name":"clitestsubnet5","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitestvnet5/subnets/clitestsubnet5","etag":"W/\"4a83c39b-cfd0-4237-a50a-d5e170b95978\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.10.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}],"virtualNetworkPeerings":[],"enableDdosProtection":false}}'
@@ -4377,7 +4377,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitestvnet5/subnets/clitestsubnet5?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitestvnet5/subnets/clitestsubnet5?api-version=2024-05-01
   response:
     body:
       string: '{"name":"clitestsubnet5","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitestvnet5/subnets/clitestsubnet5","etag":"W/\"4a83c39b-cfd0-4237-a50a-d5e170b95978\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.10.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}'
@@ -6312,7 +6312,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitestvnet5/subnets/clitestsubnet5?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitestvnet5/subnets/clitestsubnet5?api-version=2024-05-01
   response:
     body:
       string: '{"name":"clitestsubnet5","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitestvnet5/subnets/clitestsubnet5","etag":"W/\"4a83c39b-cfd0-4237-a50a-d5e170b95978\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.10.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}'
@@ -8617,7 +8617,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002/providers/Microsoft.Network/privateDnsZones/testdnszone5.private.mysql.database.azure.com?api-version=2024-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002/providers/Microsoft.Network/privateDnsZones/testdnszone5.private.mysql.database.azure.com?api-version=2018-09-01
   response:
     body:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/privateDnsZones/testdnszone5.private.mysql.database.azure.com''
@@ -10548,7 +10548,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/testdnszone5.private.mysql.database.azure.com?api-version=2024-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/testdnszone5.private.mysql.database.azure.com?api-version=2018-09-01
   response:
     body:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/privateDnsZones/testdnszone5.private.mysql.database.azure.com''

--- a/src/azure-cli/azure/cli/command_modules/mysql/tests/latest/recordings/test_mysql_flexible_server_vnet_mgmt_supplied_subnetid.yaml
+++ b/src/azure-cli/azure/cli/command_modules/mysql/tests/latest/recordings/test_mysql_flexible_server_vnet_mgmt_supplied_subnetid.yaml
@@ -2446,7 +2446,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/testvnet?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/testvnet?api-version=2024-05-01
   response:
     body:
       string: '{"name":"testvnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/testvnet","etag":"W/\"25e038c2-60d0-4d2e-a73a-24c9cb42d657\"","type":"Microsoft.Network/virtualNetworks","location":"northeurope","properties":{"provisioningState":"Succeeded","resourceGuid":"02e63094-10e9-431f-8165-0f1cd2445327","addressSpace":{"addressPrefixes":["172.1.0.0/16"]},"privateEndpointVNetPolicies":"Disabled","subnets":[{"name":"testsubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/testvnet/subnets/testsubnet","etag":"W/\"25e038c2-60d0-4d2e-a73a-24c9cb42d657\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.1.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}],"virtualNetworkPeerings":[],"enableDdosProtection":false}}'
@@ -4429,7 +4429,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/testvnet/subnets/testsubnet?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/testvnet/subnets/testsubnet?api-version=2024-05-01
   response:
     body:
       string: '{"name":"testsubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/testvnet/subnets/testsubnet","etag":"W/\"25e038c2-60d0-4d2e-a73a-24c9cb42d657\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.1.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}'
@@ -6364,7 +6364,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/testvnet/subnets/testsubnet?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/testvnet/subnets/testsubnet?api-version=2024-05-01
   response:
     body:
       string: '{"name":"testsubnet","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/testvnet/subnets/testsubnet","etag":"W/\"25e038c2-60d0-4d2e-a73a-24c9cb42d657\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.1.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled"},"type":"Microsoft.Network/virtualNetworks/subnets"}'
@@ -8669,7 +8669,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/testdnszone0.private.mysql.database.azure.com?api-version=2024-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/testdnszone0.private.mysql.database.azure.com?api-version=2018-09-01
   response:
     body:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/privateDnsZones/testdnszone0.private.mysql.database.azure.com''
@@ -10600,7 +10600,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/testdnszone0.private.mysql.database.azure.com?api-version=2024-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/testdnszone0.private.mysql.database.azure.com?api-version=2018-09-01
   response:
     body:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/privateDnsZones/testdnszone0.private.mysql.database.azure.com''

--- a/src/azure-cli/azure/cli/command_modules/mysql/tests/latest/recordings/test_mysql_flexible_server_vnet_mgmt_supplied_vname_and_subnetname.yaml
+++ b/src/azure-cli/azure/cli/command_modules/mysql/tests/latest/recordings/test_mysql_flexible_server_vnet_mgmt_supplied_vname_and_subnetname.yaml
@@ -2349,7 +2349,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitestvnet3?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitestvnet3?api-version=2024-05-01
   response:
     body:
       string: '{"name":"clitestvnet3","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitestvnet3","etag":"W/\"fa978544-fe89-4222-8905-d21cddb77eaf\"","type":"Microsoft.Network/virtualNetworks","location":"northeurope","properties":{"provisioningState":"Succeeded","resourceGuid":"85137aa5-176c-41cb-b006-70857fe92c81","addressSpace":{"addressPrefixes":["13.0.0.0/16"]},"privateEndpointVNetPolicies":"Disabled","subnets":[],"virtualNetworkPeerings":[],"enableDdosProtection":false}}'
@@ -4332,7 +4332,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitestvnet3/subnets/clitestsubnet3?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitestvnet3/subnets/clitestsubnet3?api-version=2024-05-01
   response:
     body:
       string: '{"error":{"code":"NotFound","message":"Resource /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitestvnet3/subnets/clitestsubnet3
@@ -6479,7 +6479,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitestvnet3/subnets/clitestsubnet3?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitestvnet3/subnets/clitestsubnet3?api-version=2024-05-01
   response:
     body:
       string: '{"error":{"code":"NotFound","message":"Resource /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitestvnet3/subnets/clitestsubnet3
@@ -8727,7 +8727,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/testdnszone3.private.mysql.database.azure.com?api-version=2024-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/testdnszone3.private.mysql.database.azure.com?api-version=2018-09-01
   response:
     body:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/privateDnsZones/testdnszone3.private.mysql.database.azure.com''
@@ -10658,7 +10658,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/testdnszone3.private.mysql.database.azure.com?api-version=2024-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/testdnszone3.private.mysql.database.azure.com?api-version=2018-09-01
   response:
     body:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/privateDnsZones/testdnszone3.private.mysql.database.azure.com''
@@ -13798,7 +13798,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitestvnet4?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitestvnet4?api-version=2024-05-01
   response:
     body:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/virtualNetworks/clitestvnet4''
@@ -15940,7 +15940,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitestvnet4/subnets/Subnetazuredbclitest-000003mysql?api-version=2025-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitestvnet4/subnets/Subnetazuredbclitest-000003mysql?api-version=2024-05-01
   response:
     body:
       string: '{"error":{"code":"NotFound","message":"Resource /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitestvnet4/subnets/Subnetazuredbclitest-000003mysql
@@ -18188,7 +18188,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/testdnszone4.private.mysql.database.azure.com?api-version=2024-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/testdnszone4.private.mysql.database.azure.com?api-version=2018-09-01
   response:
     body:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/privateDnsZones/testdnszone4.private.mysql.database.azure.com''
@@ -20119,7 +20119,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.81.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/testdnszone4.private.mysql.database.azure.com?api-version=2024-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Network/privateDnsZones/testdnszone4.private.mysql.database.azure.com?api-version=2018-09-01
   response:
     body:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/privateDnsZones/testdnszone4.private.mysql.database.azure.com''


### PR DESCRIPTION
**Related command**
```
az mysql flexible-server replica create
az mysql flexible-server create
az mysql flexible-server update
```
any path that resolves a --subnet / --vnet / --private-dns-zone)

**Description**<!--Mandatory-->
In regions where the Microsoft.Network/virtualNetworks RP has not yet rolled out its newest API version (e.g. UAE North, where the RP tops out at 2025-07-01 while the global newest is 2025-09-01), az mysql flexible-server commands that take an existing subnet fail with:

ERROR: Invalid Vnet. The vnet id of the subnet id your provided was not found.

Root cause: _resolve_api_version in mysql/_util.py picked the first non-preview entry from provider.resource_types[].api_versions, i.e. the RP's globally-newest version. ARM rolls API versions out per region, so the picked version is not yet enabled in UAE North. ARM returns 400 NoRegisteredProviderFound; the existence check treats that as "not found" and aborts with the misleading Invalid Vnet message.

Fix: prefer the RP-declared default_api_version (pinned by the RP to a broadly-supported stable version available in every region), and fall back to the previous api_versions[0] logic only when no default is declared. This matches the pattern already used by PostgreSQL flexible-server (postgresql/utils/_flexible_server_util.py::_resolve_api_version).

Effect: VNet/subnet/private-DNS-zone existence probes now succeed in regions like UAE North; no behavior change for regions/RPs that already work (they fall through to the existing logic).

**Testing Guide**
```
az mysql flexible-server replica create \
  --replica-name <replica-name> \
  --source-server <source-server> \
  --resource-group <rg> \
  --subscription <sub-id> \
  --location "UAE North" \
  --subnet /subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.Network/virtualNetworks/<vnet>/subnets/<subnet> \
  --private-dns-zone /subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.Network/privateDnsZones/<zone>.private.mysql.database.azure.com
```
**History Notes**

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
