### PR TITLE
{Backup} Add CRR config entries for Delos cloud regions

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/backup/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom.py
@@ -71,6 +71,8 @@ secondary_region_map = {
     "chinanorth": "chinaeast",
     "chinanorth2": "chinaeast2",
     "chinanorth3": "chinaeast3",
+    "deloscloudgermanycentral": "deloscloudgermanynorth",
+    "deloscloudgermanynorth": "deloscloudgermanycentral",
     "eastasia": "southeastasia",
     "eastus": "westus",
     "eastus2": "centralus",


### PR DESCRIPTION
**Related command**
az backup

**Description**
Adding CRR (Cross Region Restore) config entries for Delos cloud regions (deloscloudgermanycentral <-> deloscloudgermanynorth), similar to the Bleu cloud CRR support added in PR #32425.

**Testing Guide**
N/A - config-only change adding region pair mapping.

**History Notes**

[Backup] `az backup`: Add CRR config entries for Delos cloud regions

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).