### PR TITLE
{NetAppFiles} Fix test_volume_create_with_cmk recording: align identity api-version to 2025-05-31-preview

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/netappfiles/tests/latest/recordings/test_volume_create_with_cmk.yaml
+++ b/src/azure-cli/azure/cli/command_modules/netappfiles/tests/latest/recordings/test_volume_create_with_cmk.yaml
@@ -603,7 +603,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.86.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_netappfiles_test_volume_000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cli-id-000005?api-version=2024-11-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_netappfiles_test_volume_000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cli-id-000005?api-version=2025-05-31-preview
   response:
     body:
       string: '{"location":"westus","tags":{"CreatedOnDate":"2026-05-15T15:50:26.4100215Z"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_netappfiles_test_volume_000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cli-id-000005","name":"cli-id-000005","type":"Microsoft.ManagedIdentity/userAssignedIdentities","properties":{"isolationScope":"None","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","principalId":"bb7fd67c-33cb-4248-8096-e098f8145da5","clientId":"9c289b0d-b3a6-4f87-8ab9-1e34ee3a34a2"}}'


### PR DESCRIPTION
### Description

Fixes a broken playback test on dev caused by a semantic merge conflict between two PRs that merged the same day:

- **#32214** ([Identity] az identity create/update) bumped `az identity` to `api-version=2025-05-31-preview` and bulk-updated the request URIs in existing recordings.
- **#33387** ({NetAppFiles} pool size enhancement) introduced a new recording `test_volume_create_with_cmk.yaml` whose identity-create request was recorded at the old `api-version=2024-11-30`.

Because both merged concurrently, #32214's bulk find-and-replace never touched the new netappfiles cassette, so on `dev` the live request (`2025-05-31-preview`) no longer matches the recorded request (`2024-11-30`), producing:

`vcr.errors.CannotOverwriteExistingCassetteException`

This PR aligns the recorded `userAssignedIdentities` PUT request URI to `2025-05-31-preview`, matching the current `az identity` api-version (same mechanical change #32214 applied to all other affected cassettes).

### Testing
- Single-line recording change; full validation via CI.