### PR TITLE
{Docs} remove outdated info from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 [![Python](https://img.shields.io/pypi/pyversions/azure-cli.svg?maxAge=2592000)](https://pypi.python.org/pypi/azure-cli)
 [![Build Status](https://dev.azure.com/azure-sdk/public/_apis/build/status/cli/Azure.azure-cli?branchName=dev)](https://dev.azure.com/azure-sdk/public/_build/latest?definitionId=246&branchName=dev)
-[![Slack](https://img.shields.io/badge/Slack-azurecli.slack.com-blue.svg)](https://azurecli.slack.com)
 
-A great cloud needs great tools; we're excited to introduce *Azure CLI*, our next generation multi-platform command line experience for Azure.
+A great cloud needs great tools; we're excited to introduce *Azure CLI*, our cross-platform command line experience for Azure.
 
 Take a test run now from [Azure Cloud Shell](https://portal.azure.com/#cloudshell)!
 
@@ -153,7 +152,6 @@ You can download the latest builds by following the links below:
 |:-----------------:|:-------------------------------------------|
 |        MSI        | https://aka.ms/InstallAzureCliWindowsEdge  |
 | Homebrew Formula  | https://aka.ms/InstallAzureCliHomebrewEdge |
-| Ubuntu Bionic Deb | https://aka.ms/InstallAzureCliBionicEdge   |
 | Ubuntu Focal Deb  | https://aka.ms/InstallAzureCliFocalEdge    |
 | Ubuntu Jammy Deb  | https://aka.ms/InstallAzureCliJammyEdge    |
 |      RPM el8      | https://aka.ms/InstallAzureCliRpmEl8Edge   |
@@ -174,7 +172,7 @@ You can install the edge build on Ubuntu Jammy with the following command:
 curl --location --silent --output azure-cli_jammy.deb https://aka.ms/InstallAzureCliJammyEdge && dpkg -i azure-cli_jammy.deb
 ```
 
-And install the edge build with rpm package on RHEL 8 or CentOS Stream 8:
+And install the edge build with rpm package on RHEL 8:
 
 ```bash
 dnf install -y $(curl --location --silent --output /dev/null --write-out %{url_effective} https://aka.ms/InstallAzureCliRpmEl8Edge)


### PR DESCRIPTION
**Related command**

N/A — documentation only (top-level `README.md`), not tied to any `az` command.

**Description**

This PR removes a few pieces of outdated information from the top-level `README.md`:

- **Remove the deprecated Slack badge** — `azurecli.slack.com` is no longer an actively maintained / officially supported community channel.
- **Drop the dated `next generation` wording** — the Python `az` CLI has been *the* standard Azure CLI for years; `cross-platform` describes it accurately without the legacy framing.
- **Remove the Ubuntu Bionic (18.04) edge-build row** — Ubuntu 18.04 reached end of standard support in April 2023.
- **Drop `or CentOS Stream 8` from the RPM edge-build instructions** — CentOS Stream 8 reached EOL on 2024-05-31. RHEL 8 remains supported (the official install docs still ship the el8 RPM), so it is kept.

No functional changes — documentation only (`1 file changed, +2 -4`).

**Testing Guide**

N/A — README-only change, no commands affected.

**History Notes**

N/A — not customer-facing (documentation cleanup). Component is tagged with braces in the title to skip history-note generation.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md). (N/A — no command changes.)

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md). (N/A — no code changes.)