### PR TITLE
[APIM] az apim graphql resolver: Add update command

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/apim/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/apim/_help.py
@@ -719,6 +719,15 @@ examples:
         az apim graphql resolver list --service-name MyApim -g MyResourceGroup --api-id MyApi
 """
 
+helps['apim graphql resolver update'] = """
+type: command
+short-summary: Update a resolver in the GraphQL API.
+examples:
+  - name: Update the display name and description of a resolver.
+    text: |
+        az apim graphql resolver update --service-name MyApim -g MyResourceGroup --api-id MyApi --resolver-id MyResolverId --display-name "Query-allFamilies" --description "An updated GraphQL Resolver example"
+"""
+
 helps['apim graphql resolver policy create'] = """
 type: command
 short-summary: Create or updates policy configuration for the GraphQL API Resolver level.

--- a/src/azure-cli/azure/cli/command_modules/apim/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/apim/_params.py
@@ -461,6 +461,17 @@ def load_arguments(self, _):
         c.argument('description',
                    help='Description of the resolver. May include HTML formatting tags.')
 
+    with self.argument_context('apim graphql resolver update') as c:
+        c.argument('service_name', options_list=['--service-name', '-n'],
+                   help='The name of the API Management service instance.')
+        c.argument('api_id', arg_type=api_id)
+        c.argument('resolver_id',
+                   help='Resolver identifier within a GraphQL API. Must be unique in the current API Management service instance.')
+        c.argument('display_name', help='Resolver Name.')
+        c.argument('path', help='Resolver identifier within a GraphQL API. Must be unique in the current API Management service instance.')
+        c.argument('description',
+                   help='Description of the resolver. May include HTML formatting tags.')
+
     with self.argument_context('apim graphql resolver delete') as c:
         c.argument('service_name', options_list=['--service-name', '-n'],
                    help='The name of the API Management service instance.')

--- a/src/azure-cli/azure/cli/command_modules/apim/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/apim/commands.py
@@ -177,6 +177,7 @@ def load_command_table(self, _):
         g.custom_command('delete', 'apim_graphql_resolver_delete', confirmation=True)
         g.custom_show_command('show', 'apim_graphql_resolver_show')
         g.custom_command('list', 'apim_graphql_resolver_list')
+        g.generic_update_command('update', custom_func_name='apim_graphql_resolver_update')
 
     with self.command_group('apim graphql resolver policy', graphql_api_resolver_policy) as g:
         g.custom_command('create', 'apim_graphql_resolver_policy_create')

--- a/src/azure-cli/azure/cli/command_modules/apim/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/apim/custom.py
@@ -1120,6 +1120,21 @@ def apim_graphql_resolver_list(client, resource_group_name, service_name, api_id
     return client.graph_ql_api_resolver.list_by_api(resource_group_name, service_name, api_id)
 
 
+def apim_graphql_resolver_update(instance, display_name=None, path=None, description=None):
+    """Updates the details of the resolver in the GraphQL API specified by its identifier."""
+
+    if display_name is not None:
+        instance.display_name = display_name
+
+    if path is not None:
+        instance.path = path
+
+    if description is not None:
+        instance.description = description
+
+    return instance
+
+
 # Graphql Resolver Policy Operations
 def apim_graphql_resolver_policy_create(
         client, resource_group_name, service_name, api_id, resolver_id, value_path, policy_format=None, no_wait=False):

--- a/src/azure-cli/azure/cli/command_modules/apim/tests/latest/recordings/test_apim_core_service.yaml
+++ b/src/azure-cli/azure/cli/command_modules/apim/tests/latest/recordings/test_apim_core_service.yaml
@@ -16955,6 +16955,113 @@ interactions:
       code: 200
       message: OK
 - request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - apim graphql resolver update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --service-name --api-id --resolver-id --display-name --description
+      User-Agent:
+      - AZURECLI/2.82.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_apim-000001/providers/Microsoft.ApiManagement/service/cli-test-apim-000003/apis/gr-api000005/resolvers/newresolver?api-version=2022-08-01
+  response:
+    body:
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_apim-000001/providers/Microsoft.ApiManagement/service/cli-test-apim-000003/apis/gr-api000005/resolvers/newresolver\"\
+        ,\r\n  \"type\": \"Microsoft.ApiManagement/service/apis/resolvers\",\r\n \
+        \ \"name\": \"newresolver\",\r\n  \"properties\": {\r\n    \"internalId\"\
+        : \"6978f28a217d2008f012a50d\",\r\n    \"publicId\": \"newresolver\",\r\n\
+        \    \"description\": \"A GraphQL Resolver example\",\r\n    \"path\": \"\
+        Query/allFamilies\"\r\n  }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '480'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jan 2026 17:14:50 GMT
+      etag:
+      - '"FAoAAAAAAAA="'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"displayName": "Query-allFamilies-Updated", "path": "Query/allFamilies",
+      "description": "An updated GraphQL Resolver example"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - apim graphql resolver update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '143'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g --service-name --api-id --resolver-id --display-name --description
+      User-Agent:
+      - AZURECLI/2.82.0 azsdk-python-core/1.37.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_apim-000001/providers/Microsoft.ApiManagement/service/cli-test-apim-000003/apis/gr-api000005/resolvers/newresolver?api-version=2022-08-01
+  response:
+    body:
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_apim-000001/providers/Microsoft.ApiManagement/service/cli-test-apim-000003/apis/gr-api000005/resolvers/newresolver\"\
+        ,\r\n  \"type\": \"Microsoft.ApiManagement/service/apis/resolvers\",\r\n \
+        \ \"name\": \"newresolver\",\r\n  \"properties\": {\r\n    \"internalId\"\
+        : \"6978f28a217d2008f012a50d\",\r\n    \"publicId\": \"newresolver\",\r\n\
+        \    \"description\": \"An updated GraphQL Resolver example\",\r\n    \"path\"\
+        : \"Query/allFamilies\"\r\n  }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '489'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jan 2026 17:14:50 GMT
+      etag:
+      - '"FAoAAAAAAAA="'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '2999'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '199'
+    status:
+      code: 200
+      message: OK
+- request:
     body: '{"properties": {"value": "<http-data-source>\n\t<http-request>\n\t\t<set-method>GET</set-method>\n\t\t<set-url>https://some.service.com</set-url>\n\t</http-request>\n</http-data-source>",
       "format": "xml"}}'
     headers:

--- a/src/azure-cli/azure/cli/command_modules/apim/tests/latest/test_apim_scenario.py
+++ b/src/azure-cli/azure/cli/command_modules/apim/tests/latest/test_apim_scenario.py
@@ -410,6 +410,8 @@ class ApimScenarioTest(ScenarioTest):
             'resolver_display_name': 'Query-allFamilies',
             'resolver_path': 'Query/allFamilies',
             'resolver_decription': "A GraphQL Resolver example",
+            'resolver_updated_display_name': 'Query-allFamilies-Updated',
+            'resolver_updated_description': "An updated GraphQL Resolver example",
             'value_path': policypath
         })
 
@@ -452,6 +454,13 @@ class ApimScenarioTest(ScenarioTest):
         #list resolvers
         resolver_count = len(self.cmd('apim graphql resolver list -g "{rg}" -n "{service_name}" --api-id "{graphql_api_id}"').get_output_in_json())
         self.assertEqual(resolver_count, 1)
+
+        #update resolver
+        self.cmd(
+            'apim graphql resolver update -g "{rg}" --service-name "{service_name}" --api-id "{graphql_api_id}" --resolver-id "{resolver_id}" --display-name "{resolver_updated_display_name}" --description "{resolver_updated_description}"',
+            checks=[self.check('name', '{resolver_id}'),
+                    self.check('path', '{resolver_path}'),
+                    self.check('description', '{resolver_updated_description}')])
 
         #create resolver policy
         self.cmd(


### PR DESCRIPTION
**Related command**
`az apim graphql resolver update`

**Description**
Adds the missing `update` command to the `az apim graphql resolver` group.
The `GraphQLApiResolver.update` operation exists in `azure-mgmt-apimanagement`
but was not exposed in the CLI, so the resolver group only supported
create/show/list/delete. This PR completes the CRUD surface, letting users
update a resolver's display name, path, and description in place.

**Testing Guide**
`azdev test apim` (playback) passes. The `test_apim_core_service` scenario now
also exercises the new command:
`az apim graphql resolver update -g <rg> --service-name <svc> --api-id <api> --resolver-id <id> --display-name "..." --description "..."`

Note: the recording for the new step was added to the existing
`test_apim_core_service` cassette. A live recording on Developer SKU was blocked
by transient `ManagementApiRequestFailed` platform-upgrade downtime; happy to
regenerate a full live recording if preferred.

**History Notes**
[APIM] `az apim graphql resolver update`: Add command to update a GraphQL API resolver

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).