### PR TITLE
{Extension} Report experimental status in extension listings

### DIFF
--- a/src/azure-cli-core/azure/cli/core/extension/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/extension/__init__.py
@@ -363,6 +363,10 @@ def is_preview_from_extension_meta(extension_meta):
             is_preview_from_semantic_version(extension_meta.get('version')))
 
 
+def is_experimental_from_extension_meta(extension_meta):
+    return bool(extension_meta.get(EXT_METADATA_ISEXPERIMENTAL, False))
+
+
 def is_preview_from_semantic_version(version):
     """
     pre = [a, b] -> preview

--- a/src/azure-cli-core/azure/cli/core/extension/operations.py
+++ b/src/azure-cli-core/azure/cli/core/extension/operations.py
@@ -20,6 +20,7 @@ from azure.cli.core import CommandIndex
 from azure.cli.core.util import CLIError, reload_module, rmtree_with_retry
 from azure.cli.core.extension import (extension_exists, build_extension_path, get_extensions, get_extension_modname,
                                       get_extension, ext_compat_with_cli, is_preview_from_extension_meta,
+                                      is_experimental_from_extension_meta,
                                       WheelExtension, DevExtension, ExtensionNotInstalledException, WHEEL_INFO_RE)
 from azure.cli.core.telemetry import set_extension_management_detail
 
@@ -466,7 +467,7 @@ def list_available_extensions(index_url=None, show_details=False, cli_ctx=None):
             'version': latest['metadata']['version'],
             'summary': latest['metadata']['summary'],
             'preview': is_preview_from_extension_meta(latest['metadata']),
-            'experimental': False,
+            'experimental': is_experimental_from_extension_meta(latest['metadata']),
             'installed': installed
         })
     return results
@@ -503,7 +504,7 @@ def list_versions(extension_name, index_url=None, cli_ctx=None):
             'name': extension_name,
             'version': version,
             'preview': is_preview_from_extension_meta(ext['metadata']),
-            'experimental': False,
+            'experimental': is_experimental_from_extension_meta(ext['metadata']),
             'installed': installed,
             'compatible': compatible
         })

--- a/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_extension_commands.py
+++ b/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_extension_commands.py
@@ -14,7 +14,7 @@ from azure.cli.core.util import CLIError
 from azure.cli.core.extension import get_extension, build_extension_path
 from azure.cli.core.extension.operations import (add_extension_to_path, list_extensions, add_extension,
                                                  show_extension, remove_extension, update_extension,
-                                                 list_available_extensions, OUT_KEY_NAME, OUT_KEY_VERSION,
+                                                 list_available_extensions, list_versions, OUT_KEY_NAME, OUT_KEY_VERSION,
                                                  OUT_KEY_METADATA, OUT_KEY_PATH)
 from azure.cli.core.extension._resolve import NoExtensionCandidatesError
 from azure.cli.core.mock import DummyCli
@@ -381,6 +381,31 @@ class TestExtensionCommands(unittest.TestCase):
             self.assertEqual(res[1]['summary'], 'my summary')
             self.assertEqual(res[1]['version'], '0.1.0')
             self.assertEqual(res[1]['preview'], True)
+            self.assertEqual(res[1]['experimental'], True)
+
+    def test_list_versions_preserves_experimental_status(self):
+        sample_index_extensions = {
+            'test_sample_extension': [
+                {
+                    'metadata': {
+                        'name': 'test_sample_extension',
+                        'summary': 'my summary',
+                        'version': '0.1.0'
+                    }
+                },
+                {
+                    'metadata': {
+                        'name': 'test_sample_extension',
+                        'summary': 'my summary',
+                        'version': '0.2.0',
+                        'azext.isExperimental': True
+                    }
+                }
+            ]
+        }
+        with mock.patch('azure.cli.core.extension.operations.get_index_extensions', return_value=sample_index_extensions):
+            res = list_versions('test_sample_extension', cli_ctx=self.cmd.cli_ctx)
+            self.assertEqual(res[0]['experimental'], False)
             self.assertEqual(res[1]['experimental'], True)
 
     def test_list_available_extensions_incompatible_cli_version(self):

--- a/src/azure-cli-core/azure/cli/core/tests/test_extension.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_extension.py
@@ -299,7 +299,7 @@ class TestExtensions(TestExtensionsBase):
             self.assertEqual(res[0]['summary'], 'AzureMachineLearningWorkspaces Extension')
             self.assertEqual(res[0]['version'], '2.0.0a1')
             self.assertEqual(res[0]['preview'], True)
-            self.assertEqual(res[0]['experimental'], False)
+            self.assertEqual(res[0]['experimental'], True)
             self.assertEqual(res[1]['name'], 'test_sample_extension1')
             self.assertEqual(res[1]['version'], '1.15.0')
             self.assertEqual(res[1]['preview'], True)


### PR DESCRIPTION
Fixes #32871

## Summary

This updates extension listing output so the `experimental` field reflects `azext.isExperimental` metadata instead of always returning `false`.

## Why

`az extension list-available` and `az extension list-versions` already expose an `experimental` field, but both paths hard-coded it to `false`. Extensions such as `cli-translator` can therefore be marked experimental in metadata and documentation while the CLI reports them as non-experimental.

## Changes

- Add `is_experimental_from_extension_meta` beside the existing preview metadata helper.
- Use it in `list_available_extensions` and `list_versions`.
- Update extension tests so explicit `azext.isExperimental` metadata is preserved in command output.

## Validation

- `.venv/bin/python -m pytest src/azure-cli-core/azure/cli/core/extension/tests/latest/test_extension_commands.py::TestExtensionCommands::test_list_available_extensions_no_show_details src/azure-cli-core/azure/cli/core/extension/tests/latest/test_extension_commands.py::TestExtensionCommands::test_list_versions_preserves_experimental_status -q`
- `.venv/bin/python -m pytest src/azure-cli-core/azure/cli/core/tests/test_extension.py::TestExtensions::test_list_available_extensions_preview_details -q`
- `git diff --check`