### PR TITLE
{Find} Migrate `az find` from Aladdin to MS Learn MCP approach

### DIFF
--- a/src/azure-cli-core/azure/cli/core/helpIndex.latest.json
+++ b/src/azure-cli-core/azure/cli/core/helpIndex.latest.json
@@ -378,7 +378,7 @@
         "tags": ""
       },
       "find": {
-        "summary": "Search Microsoft Learn for Azure CLI commands, examples, and related documentation.",
+        "summary": "I'm an AI assistant, my advice is based on Microsoft Learn documentation as well as the usage patterns of Azure CLI and Azure ARM users. Using me improves Azure products and documentation.",
         "tags": ""
       },
       "interactive": {

--- a/src/azure-cli-core/azure/cli/core/helpIndex.latest.json
+++ b/src/azure-cli-core/azure/cli/core/helpIndex.latest.json
@@ -378,7 +378,7 @@
         "tags": ""
       },
       "find": {
-        "summary": "I'm an AI robot, my advice is based on our Azure documentation as well as the usage patterns of Azure CLI and Azure ARM users. Using me improves Azure products and documentation.",
+        "summary": "Search Microsoft Learn for Azure CLI commands, examples, and related documentation.",
         "tags": ""
       },
       "interactive": {

--- a/src/azure-cli/azure/cli/command_modules/find/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/find/_help.py
@@ -9,7 +9,7 @@ from knack.help_files import helps  # pylint: disable=unused-import
 
 helps['find'] = """
 type: command
-short-summary: I'm an AI robot, my advice is based on our Azure documentation as well as the usage patterns of Azure CLI and Azure ARM users. Using me improves Azure products and documentation.
+short-summary: I'm an AI assistant, my advice is based on Microsoft Learn documentation as well as the usage patterns of Azure CLI and Azure ARM users. Using me improves Azure products and documentation.
 examples:
   - name: Give me any Azure CLI group and I’ll show the most popular commands within the group.
     text: |

--- a/src/azure-cli/azure/cli/command_modules/find/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/find/_help.py
@@ -11,10 +11,10 @@ helps['find'] = """
 type: command
 short-summary: I'm an AI assistant, my advice is based on Microsoft Learn documentation as well as the usage patterns of Azure CLI and Azure ARM users. Using me improves Azure products and documentation.
 examples:
-  - name: Give me any Azure CLI group and I’ll show the most popular commands within the group.
+  - name: Give me any Azure CLI group and I'll show the most popular commands within the group.
     text: |
         az find "az storage"
-  - name: Give me any Azure CLI command and I’ll show the most popular parameters and subcommands.
+  - name: Give me any Azure CLI command and I'll show the most popular parameters and subcommands.
     text: |
         az find "az monitor activity-log list"
   - name: You can also enter a search term, and I'll try to help find the best commands.

--- a/src/azure-cli/azure/cli/command_modules/find/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/find/custom.py
@@ -21,10 +21,371 @@ logger = get_logger(__name__)
 
 WAIT_MESSAGE = ['Finding examples...']
 
-EXTENSION_NAME = 'find'
-
+# Display limits
+MAX_DOC_RESULTS = 5
+MAX_CODE_RESULTS = 3
 
 Example = namedtuple("Example", "title snippet")
+
+
+class MCPClient:
+    """Lightweight MCP client for Microsoft Learn MCP Server.
+
+    Implements the minimum JSON-RPC 2.0 over Streamable HTTP protocol
+    needed for single-invocation tool calls (initialize → notify → tools/call).
+    """
+
+    MCP_ENDPOINT = "https://learn.microsoft.com/api/mcp"
+
+    def __init__(self, client_version=None):
+        self.session_id = None
+        self.client_version = client_version or str(parse(core_version))
+        self._headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream"
+        }
+        self._request_id = 0
+        self._add_telemetry_headers()
+
+    def _add_telemetry_headers(self):
+        """Add telemetry context as custom headers."""
+        # Used for DDOS protection and rate limiting
+        user_id = telemetry_core._get_installation_id()  # pylint: disable=protected-access
+        hashed_user_id = hashlib.sha256(user_id.encode('utf-8')).hexdigest()
+        self._headers["X-UserId"] = hashed_user_id
+
+        if telemetry_core.is_telemetry_enabled():
+            correlation_id = telemetry_core._session.correlation_id  # pylint: disable=protected-access
+            event_id = telemetry_core._session.event_id  # pylint: disable=protected-access
+            subscription_id = telemetry_core._get_azure_subscription_id()  # pylint: disable=protected-access
+
+            self._headers["X-CorrelationId"] = correlation_id
+            self._headers["X-EventId"] = event_id
+            if subscription_id is not None:
+                self._headers["X-SubscriptionId"] = subscription_id
+
+    def _next_id(self):
+        self._request_id += 1
+        return self._request_id
+
+    def initialize(self):
+        """Send initialize request and store session ID."""
+        body = {
+            "jsonrpc": "2.0",
+            "id": self._next_id(),
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "azure-cli-find",
+                    "version": self.client_version
+                }
+            }
+        }
+        resp = requests.post(self.MCP_ENDPOINT, json=body, headers=self._headers, timeout=10)
+        resp.raise_for_status()
+        self.session_id = resp.headers.get("mcp-session-id")
+        if self.session_id:
+            self._headers["mcp-session-id"] = self.session_id
+        return self._parse_sse(resp.text)
+
+    def notify_initialized(self):
+        """Send initialized notification to confirm client readiness."""
+        body = {"jsonrpc": "2.0", "method": "notifications/initialized"}
+        requests.post(self.MCP_ENDPOINT, json=body, headers=self._headers, timeout=10)
+
+    def call_tool(self, tool_name, arguments):
+        """Call an MCP tool and return parsed results.
+
+        Args:
+            tool_name: Name of the MCP tool (e.g., 'microsoft_docs_search').
+            arguments: Dict of tool arguments.
+
+        Returns:
+            Parsed JSON result from the tool's text content.
+        """
+        body = {
+            "jsonrpc": "2.0",
+            "id": self._next_id(),
+            "method": "tools/call",
+            "params": {
+                "name": tool_name,
+                "arguments": arguments
+            }
+        }
+        resp = requests.post(self.MCP_ENDPOINT, json=body, headers=self._headers, timeout=30)
+        resp.raise_for_status()
+        result = self._parse_sse(resp.text)
+        content_list = result.get("result", {}).get("content", [])
+        if content_list and content_list[0].get("text"):
+            return json.loads(content_list[0]["text"])
+        return {}
+
+    @staticmethod
+    def _parse_sse(text):
+        """Parse single-event SSE response.
+
+        The MCP server returns responses in SSE format with a single 'data:' event.
+        """
+        for line in text.split("\n"):
+            if line.startswith("data: "):
+                return json.loads(line[6:])
+        return {}
+
+
+def _extract_query_command(query):
+    """Extract the CLI command group/name from a query string.
+
+    Examples:
+        'az vm create' → 'az vm create'
+        'az vm' → 'az vm'
+        'vm create' → 'az vm create'
+        'deploy arm template' → None (not a CLI command pattern)
+
+    Returns:
+        Normalized command string or None if not a CLI command pattern.
+    """
+    query = query.strip().lower()
+    if query.startswith('az '):
+        return query
+    # If the query looks like a CLI subcommand (single words that could be a group)
+    parts = query.split()
+    if parts and not any(c in parts[0] for c in ' ./-'):
+        return 'az ' + query
+    return None
+
+
+def _is_cli_command_relevant(title, query):
+    """Check if a CLI command result title is relevant to the query.
+
+    For CLI command results (titles starting with 'az '), checks that
+    the result command shares the same command group as the query.
+
+    Examples (query='az vm create'):
+        'az vm create' → True (exact match)
+        'az vm run-command create' → True (same group)
+        'az lab vm create' → False (different group: 'lab' vs 'vm')
+        'az connectedvmware vm create' → False (different group)
+
+    Args:
+        title: The result title string.
+        query: The user's query string.
+
+    Returns:
+        True if the result is relevant, False otherwise.
+    """
+    title_lower = title.strip().lower()
+
+    # Only filter CLI command titles (starting with 'az ')
+    if not title_lower.startswith('az '):
+        return True
+
+    cmd = _extract_query_command(query)
+    if not cmd:
+        return True
+
+    # Extract the command group (first word after 'az')
+    cmd_parts = cmd.split()
+    if len(cmd_parts) < 2:
+        return True
+
+    query_group = cmd_parts[1]  # e.g., 'vm' from 'az vm create'
+
+    title_parts = title_lower.split()
+    if len(title_parts) < 2:
+        return True
+
+    title_group = title_parts[1]  # e.g., 'lab' from 'az lab vm create'
+
+    # The result's first command group must match the query's command group
+    return title_group == query_group
+
+
+def _filter_results(results, query):
+    """Filter MCP results for relevance to the query.
+
+    Removes CLI command results that belong to different command groups,
+    and filters out results whose titles have no meaningful word overlap
+    with the query (to discard noise from semantic search on gibberish queries).
+
+    Args:
+        results: List of MCP doc result dicts.
+        query: The user's query string.
+
+    Returns:
+        Filtered list of result dicts.
+    """
+    filtered = [r for r in results if _is_cli_command_relevant(r.get("title", ""), query)]
+
+    # For non-empty queries, check that at least some results are genuinely relevant
+    # by verifying word overlap between the query and result titles/content
+    query_words = _get_query_keywords(query)
+    if query_words:
+        filtered = [r for r in filtered if _has_keyword_overlap(r, query_words)]
+
+    return filtered
+
+
+def _get_query_keywords(query):
+    """Extract meaningful keywords from the query (words with 3+ chars, excluding 'az').
+
+    Args:
+        query: The user's query string.
+
+    Returns:
+        Set of lowercase keyword strings.
+    """
+    words = re.findall(r'[a-zA-Z]{3,}', query.lower())
+    stop_words = {'the', 'and', 'for', 'with', 'from', 'that', 'this', 'are', 'was', 'has', 'have'}
+    return {w for w in words if w != 'az' and w not in stop_words}
+
+
+def _has_keyword_overlap(result, query_words):
+    """Check if a result has meaningful keyword overlap with the query.
+
+    Args:
+        result: A doc result dict with 'title' and optionally 'content'.
+        query_words: Set of query keywords to match against.
+
+    Returns:
+        True if at least one query keyword appears in the result's title or content.
+    """
+    title = result.get("title", "").lower()
+    content = result.get("content", "").lower()[:500]  # Only check first 500 chars of content
+    combined = title + " " + content
+
+    return any(word in combined for word in query_words)
+
+
+def search_mslearn(query):
+    """Search Microsoft Learn via MCP for docs and code samples.
+
+    Calls two MCP tools:
+    1. microsoft_docs_search - for command reference and documentation
+    2. microsoft_code_sample_search - for runnable CLI examples
+
+    Args:
+        query: Search query string (e.g., 'az vm delete').
+
+    Returns:
+        Tuple of (docs_results, code_results) where each is a list of dicts.
+    """
+    client = MCPClient()
+
+    client.initialize()
+    client.notify_initialized()
+
+    docs_response = client.call_tool(
+        "microsoft_docs_search",
+        {"query": query}
+    )
+
+    code_response = client.call_tool(
+        "microsoft_code_sample_search",
+        {"query": query, "language": "azurecli"}
+    )
+
+    docs_results = docs_response.get("results", [])
+    code_results = code_response.get("results", [])
+
+    # Filter out irrelevant CLI commands (e.g., 'az lab vm' when searching 'az vm')
+    docs_results = _filter_results(docs_results, query)
+
+    # Filter code results by keyword overlap too
+    query_words = _get_query_keywords(query)
+    if query_words:
+        code_results = [r for r in code_results
+                        if any(word in (r.get("codeSnippet", "") + " " +
+                                        r.get("description", "")).lower()
+                               for word in query_words)]
+
+    return docs_results, code_results
+
+
+def _extract_summary(content):
+    """Extract a clean summary from MCP doc content.
+
+    MCP returns markdown content with headers. Extract the Summary section
+    or first meaningful paragraph.
+
+    Args:
+        content: Raw markdown content string.
+
+    Returns:
+        Clean summary string, max 150 chars.
+    """
+    if not content:
+        return ""
+
+    # Try to find a "### Summary" section
+    summary_match = re.search(r'###\s*Summary\s*\n(.+?)(?:\n###|\Z)', content, re.DOTALL)
+    if summary_match:
+        summary = summary_match.group(1).strip()
+        # Take first sentence/line
+        first_line = summary.split('\n')[0].strip()
+        if first_line:
+            return first_line[:150]
+
+    # Try first non-header, non-empty line
+    for line in content.split('\n'):
+        line = line.strip()
+        if line and not line.startswith('#') and not line.startswith('---'):
+            return line[:150]
+
+    return content[:150]
+
+
+def format_results(query, docs_results, code_results):
+    """Format and print search results to stdout.
+
+    Displays results in two sections:
+    1. Commands & Documentation - from microsoft_docs_search
+    2. Code Examples - from microsoft_code_sample_search
+
+    Args:
+        query: Original search query (for display).
+        docs_results: List of doc result dicts from MCP.
+        code_results: List of code sample dicts from MCP.
+    """
+    if not docs_results and not code_results:
+        print("\nSorry I am not able to help with [" + query + "]."
+              "\nTry typing the beginning of a command e.g. " + style_message('az vm') + ".", file=sys.stderr)
+        return
+
+    print("\nHere are the most common ways to use [" + query + "]: \n", file=sys.stderr)
+
+    if docs_results:
+        print(style_message(" Commands & Documentation"))
+        print("  " + "─" * 50)
+        for result in docs_results[:MAX_DOC_RESULTS]:
+            title = result.get("title", "")
+            content = result.get("content", "")
+            url = result.get("contentUrl", "")
+
+            summary = _extract_summary(content)
+
+            print(style_message("  " + title))
+            if summary:
+                print("  " + summary)
+            if url:
+                print("  " + url)
+            print()
+
+    if code_results:
+        print(style_message(" Code Examples"))
+        print("  " + "─" * 50)
+        for result in code_results[:MAX_CODE_RESULTS]:
+            snippet = result.get("codeSnippet", "")
+            url = result.get("link", "")
+
+            if snippet:
+                # Indent the code snippet
+                for line in snippet.strip().split('\n'):
+                    print("  " + line)
+            if url:
+                print("  Source: " + url)
+            print()
 
 
 def process_query(cli_term):
@@ -32,47 +393,47 @@ def process_query(cli_term):
         logger.error('Please provide a search term e.g. az find "vm"')
     else:
         print(random.choice(WAIT_MESSAGE), file=sys.stderr)
-        response = call_aladdin_service(cli_term)
 
-        if response.status_code != 200:
+        try:
+            docs_results, code_results = search_mslearn(cli_term)
+        except requests.exceptions.RequestException as ex:
+            logger.debug("MCP request failed: %s", ex)
             logger.error(
-                "The `az find` command has been retired. A new experience is being developed to replace it. "
-                "In the meantime, please use `az <command> --help` to explore commands and examples, "
-                "or visit https://aka.ms/cli_ref for reference documentation."
+                "Unable to search Microsoft Learn. Please check your network connection. "
+                "In the meantime, use `az <command> --help` or visit https://aka.ms/cli_ref."
             )
+            return
 
-        else:
-            if (platform.system() == 'Windows' and should_enable_styling()):
-                colorama.init(convert=True)
-            has_pruned_answer = False
-            answer_list = json.loads(response.content)
-            if not answer_list:
-                print("\nSorry I am not able to help with [" + cli_term + "]."
-                      "\nTry typing the beginning of a command e.g. " + style_message('az vm') + ".", file=sys.stderr)
-            else:
-                if answer_list[0]['source'] == 'pruned':
-                    has_pruned_answer = True
-                    answer_list.pop(0)
-                print("\nHere are the most common ways to use [" + cli_term + "]: \n", file=sys.stderr)
+        if platform.system() == 'Windows' and should_enable_styling():
+            colorama.init(convert=True)
 
-                for answer in answer_list:
-                    cleaned_answer = clean_from_http_answer(answer)
-                    print(style_message(cleaned_answer.title))
-                    print(cleaned_answer.snippet + '\n')
-                if has_pruned_answer:
-                    print(style_message("More commands and examples are available in the latest version of the CLI. "
-                                        "Please update for the best experience.\n"))
+        format_results(cli_term, docs_results, code_results)
+
     from azure.cli.core.util import show_updates_available
     show_updates_available()
 
 
 def get_generated_examples(cli_term):
-    examples = []
-    response = call_aladdin_service(cli_term)
+    """Get generated examples for a CLI term.
 
-    if response.status_code == 200:
-        for answer in json.loads(response.content):
-            examples.append(clean_from_http_answer(answer))
+    Returns list of Example namedtuples for backward compatibility.
+    """
+    examples = []
+    try:
+        docs_results, code_results = search_mslearn(cli_term)
+
+        for result in docs_results:
+            title = result.get("title", "")
+            summary = _extract_summary(result.get("content", ""))
+            examples.append(Example(title, summary))
+
+        for result in code_results:
+            snippet = result.get("codeSnippet", "")
+            desc = result.get("description", "")
+            examples.append(Example(desc[:100] if desc else "Example", snippet))
+
+    except requests.exceptions.RequestException:
+        pass
 
     return examples
 
@@ -94,59 +455,3 @@ def should_enable_styling():
     except AttributeError:
         pass
     return False
-
-
-def call_aladdin_service(query):
-    version = str(parse(core_version))
-    correlation_id = telemetry_core._session.correlation_id   # pylint: disable=protected-access
-    subscription_id = telemetry_core._get_azure_subscription_id()  # pylint: disable=protected-access
-    event_id = telemetry_core._session.event_id  # pylint: disable=protected-access
-
-    # Used for DDOS protection and rate limiting
-    user_id = telemetry_core._get_installation_id()  # pylint: disable=protected-access
-    hashed_user_id = hashlib.sha256(user_id.encode('utf-8')).hexdigest()
-
-    context = {
-        "versionNumber": version,
-    }
-
-    # Only pull in the contextual values if we have consent
-    if telemetry_core.is_telemetry_enabled():
-        context['correlationId'] = correlation_id
-
-    if telemetry_core.is_telemetry_enabled() and subscription_id is not None:
-        context['subscriptionId'] = subscription_id
-
-    if telemetry_core.is_telemetry_enabled():
-        context['eventId'] = event_id
-
-    api_url = 'https://app.aladdin.microsoft.com/api/v1.0/examples'
-    headers = {
-        'Content-Type': 'application/json',
-        'X-UserId': hashed_user_id
-    }
-
-    response = requests.get(
-        api_url,
-        params={
-            'query': query,
-            'clientType': 'AzureCli',
-            'context': json.dumps(context)
-        },
-        headers=headers)
-
-    return response
-
-
-def clean_from_http_answer(http_answer):
-    current_title = http_answer['title'].strip()
-    current_snippet = http_answer['snippet'].strip()
-    if current_title.startswith("az "):
-        current_title, current_snippet = current_snippet, current_title
-        current_title = current_title.split('\r\n')[0]
-    elif '```azurecli\r\n' in current_snippet:
-        start_index = current_snippet.index('```azurecli\r\n') + len('```azurecli\r\n')
-        current_snippet = current_snippet[start_index:]
-    current_snippet = current_snippet.replace('```', '').replace(current_title, '').strip()
-    current_snippet = re.sub(r'\[.*\]', '', current_snippet).strip()
-    return Example(current_title, current_snippet)

--- a/src/azure-cli/azure/cli/command_modules/find/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/find/custom.py
@@ -15,11 +15,12 @@ import colorama  # pylint: disable=import-error
 
 from azure.cli.core import telemetry as telemetry_core
 from azure.cli.core import __version__ as core_version
+from azure.cli.core.style import Style, format_styled_text
 from packaging.version import parse
 from knack.log import get_logger
 logger = get_logger(__name__)
 
-WAIT_MESSAGE = ['Finding examples...']
+WAIT_MESSAGE = ['Finding examples and documentation...']
 
 # Display limits
 MAX_DOC_RESULTS = 5
@@ -336,12 +337,127 @@ def _extract_summary(content):
     return content[:150]
 
 
+def _clean_title(title):
+    """Normalize a title into a real sentence.
+
+    Strips leading markdown header markers ('#') and ensures the title
+    ends with a sentence mark (period, question mark, or exclamation mark).
+
+    Args:
+        title: Raw title string.
+
+    Returns:
+        Cleaned title string, or empty string if no title.
+    """
+    if not title:
+        return ""
+
+    title = title.strip().lstrip('#').strip()
+    if title and title[-1] not in '.?!':
+        title += '.'
+    return title
+
+
+def _to_imperative(text):
+    """Convert a leading third-person-singular verb to imperative mood.
+
+    Examples:
+        'Deploys the template.' -> 'Deploy the template.'
+        'Creates a virtual machine.' -> 'Create a virtual machine.'
+        'Specifies the name.' -> 'Specify the name.'
+
+    Args:
+        text: A description sentence.
+
+    Returns:
+        The sentence with its first word converted to imperative mood.
+    """
+    if not text:
+        return text
+
+    first, _, rest = text.partition(' ')
+    lower = first.lower()
+    if lower.endswith('ies') and len(first) > 4:
+        first = first[:-3] + 'y'
+    elif lower.endswith('s') and not lower.endswith('ss'):
+        first = first[:-1]
+
+    return first + (' ' + rest if rest else '')
+
+
+def _extract_description(description):
+    """Extract the human-readable description from a code sample's metadata.
+
+    The MCP code sample 'description' field is a metadata blob such as:
+        'description: Deploys the ARM template ...\\nlanguage: azurecli\\n'
+    This extracts just the description text as a clean sentence.
+
+    Args:
+        description: Raw description metadata string.
+
+    Returns:
+        Cleaned description sentence, or 'Example.' as a fallback.
+    """
+    if description:
+        for line in description.split('\n'):
+            line = line.strip()
+            if line.lower().startswith('description:'):
+                return _clean_title(_to_imperative(line[len('description:'):].strip()))
+
+        # Fallback: first non-empty, non-metadata line
+        for line in description.split('\n'):
+            line = line.strip()
+            if line and not line.lower().startswith(('language:', 'package:')):
+                return _clean_title(_to_imperative(line))
+
+    return "Example."
+
+
+def _extract_command(snippet):
+    """Extract the `az` command block from a code snippet.
+
+    Returns the snippet lines starting from the first line that begins with
+    'az', preserving the server's original formatting. Stops at a blank line
+    that isn't a shell line-continuation, so a single example is returned.
+
+    Args:
+        snippet: Raw code snippet string.
+
+    Returns:
+        List of command lines (server formatting preserved), or empty list.
+    """
+    if not snippet:
+        return []
+
+    lines = snippet.split('\n')
+    start = next((i for i, line in enumerate(lines) if line.strip().startswith('az ')), None)
+    if start is None:
+        return []
+
+    # If the command block is indented, strip the leading indent of the first
+    # `az` line from every line, preserving relative indentation.
+    indent = len(lines[start]) - len(lines[start].lstrip())
+    result = []
+    for line in lines[start:]:
+        if not line.strip():
+            continue
+        # Remove up to `indent` leading whitespace chars, keeping deeper indents.
+        stripped = line
+        for _ in range(indent):
+            if stripped[:1] in (' ', '\t'):
+                stripped = stripped[1:]
+            else:
+                break
+        result.append(stripped.rstrip())
+    return result
+
+
 def format_results(query, docs_results, code_results):
     """Format and print search results to stdout.
 
     Displays results in two sections:
-    1. Commands & Documentation - from microsoft_docs_search
-    2. Code Examples - from microsoft_code_sample_search
+    1. Examples - from microsoft_code_sample_search (shown first)
+    2. Documentation - from microsoft_docs_search
 
     Args:
         query: Original search query (for display).
@@ -350,41 +466,45 @@ def format_results(query, docs_results, code_results):
     """
     if not docs_results and not code_results:
         print("\nSorry I am not able to help with [" + query + "]."
-              "\nTry typing the beginning of a command e.g. " + style_message('az vm') + ".", file=sys.stderr)
+              "\nTry typing the beginning of a command e.g., " + style_message('az vm') + ".", file=sys.stderr)
         return
 
-    print("\nHere are the most common ways to use [" + query + "]: \n", file=sys.stderr)
-
-    if docs_results:
-        print(style_message(" Commands & Documentation"))
-        print("  " + "─" * 50)
-        for result in docs_results[:MAX_DOC_RESULTS]:
-            title = result.get("title", "")
-            content = result.get("content", "")
-            url = result.get("contentUrl", "")
-
-            summary = _extract_summary(content)
-
-            print(style_message("  " + title))
-            if summary:
-                print("  " + summary)
-            if url:
-                print("  " + url)
-            print()
+    print("\nHere is what I found for [" + query + "]: \n", file=sys.stderr)
 
     if code_results:
-        print(style_message(" Code Examples"))
-        print("  " + "─" * 50)
+        examples = []
         for result in code_results[:MAX_CODE_RESULTS]:
-            snippet = result.get("codeSnippet", "")
-            url = result.get("link", "")
+            command_lines = _extract_command(result.get("codeSnippet", ""))
+            if not command_lines:
+                continue
+            examples.append((
+                _extract_description(result.get("description", "")),
+                command_lines,
+                result.get("link", "")
+            ))
 
-            if snippet:
-                # Indent the code snippet
-                for line in snippet.strip().split('\n'):
-                    print("  " + line)
+        if examples:
+            print("Examples")
+            for title, command_lines, url in examples:
+                print("    " + format_styled_text((Style.ACTION, title)))
+                for line in command_lines:
+                    print("    " + line)
+                if url:
+                    print("    " + format_styled_text((Style.SECONDARY, url)))
+                print()
+
+    if docs_results:
+        print("Documentation")
+        for result in docs_results[:MAX_DOC_RESULTS]:
+            title = _clean_title(result.get("title", ""))
+            summary = _extract_summary(result.get("content", ""))
+            url = result.get("contentUrl", "")
+
+            print("    " + format_styled_text((Style.ACTION, title)))
+            if summary:
+                print("    " + summary)
             if url:
-                print("  Source: " + url)
+                print("    " + format_styled_text((Style.SECONDARY, url)))
             print()
 
 
@@ -400,7 +520,8 @@ def process_query(cli_term):
             logger.debug("MCP request failed: %s", ex)
             logger.error(
                 "Unable to search Microsoft Learn. Please check your network connection. "
-                "In the meantime, use `az <command> --help` or visit https://aka.ms/cli_ref."
+                "In the meantime, please use `az <command> --help` to explore commands and examples, "
+                "or visit https://aka.ms/cli_ref for reference documentation."
             )
             return
 

--- a/src/azure-cli/azure/cli/command_modules/find/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/find/custom.py
@@ -46,24 +46,41 @@ class MCPClient:
             "Accept": "application/json, text/event-stream"
         }
         self._request_id = 0
-        self._add_telemetry_headers()
+        self._context = self._build_telemetry_context()
 
-    def _add_telemetry_headers(self):
-        """Add telemetry context as custom headers."""
+    def _build_telemetry_context(self):
+        """Build telemetry context sent alongside MCP requests.
+
+        Mirrors the dev branch behavior: the hashed installation id is always
+        sent as the ``X-UserId`` header (used for DDOS protection and rate
+        limiting), while the remaining contextual values are only included when
+        the user has consented to telemetry.
+        """
         # Used for DDOS protection and rate limiting
         user_id = telemetry_core._get_installation_id()  # pylint: disable=protected-access
         hashed_user_id = hashlib.sha256(user_id.encode('utf-8')).hexdigest()
         self._headers["X-UserId"] = hashed_user_id
 
+        context = {
+            "versionNumber": self.client_version,
+        }
+
+        # Only pull in the contextual values if we have consent
         if telemetry_core.is_telemetry_enabled():
             correlation_id = telemetry_core._session.correlation_id  # pylint: disable=protected-access
             event_id = telemetry_core._session.event_id  # pylint: disable=protected-access
             subscription_id = telemetry_core._get_azure_subscription_id()  # pylint: disable=protected-access
 
-            self._headers["X-CorrelationId"] = correlation_id
-            self._headers["X-EventId"] = event_id
+            context["correlationId"] = correlation_id
+            context["eventId"] = event_id
             if subscription_id is not None:
-                self._headers["X-SubscriptionId"] = subscription_id
+                context["subscriptionId"] = subscription_id
+
+        return context
+
+    @property
+    def _params(self):
+        return {"context": json.dumps(self._context)}
 
     def _next_id(self):
         self._request_id += 1
@@ -84,7 +101,7 @@ class MCPClient:
                 }
             }
         }
-        resp = requests.post(self.MCP_ENDPOINT, json=body, headers=self._headers, timeout=10)
+        resp = requests.post(self.MCP_ENDPOINT, json=body, headers=self._headers, params=self._params, timeout=10)
         resp.raise_for_status()
         self.session_id = resp.headers.get("mcp-session-id")
         if self.session_id:
@@ -94,7 +111,7 @@ class MCPClient:
     def notify_initialized(self):
         """Send initialized notification to confirm client readiness."""
         body = {"jsonrpc": "2.0", "method": "notifications/initialized"}
-        requests.post(self.MCP_ENDPOINT, json=body, headers=self._headers, timeout=10)
+        requests.post(self.MCP_ENDPOINT, json=body, headers=self._headers, params=self._params, timeout=10)
 
     def call_tool(self, tool_name, arguments):
         """Call an MCP tool and return parsed results.
@@ -115,7 +132,7 @@ class MCPClient:
                 "arguments": arguments
             }
         }
-        resp = requests.post(self.MCP_ENDPOINT, json=body, headers=self._headers, timeout=30)
+        resp = requests.post(self.MCP_ENDPOINT, json=body, headers=self._headers, params=self._params, timeout=30)
         resp.raise_for_status()
         result = self._parse_sse(resp.text)
         content_list = result.get("result", {}).get("content", [])

--- a/src/azure-cli/azure/cli/command_modules/find/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/find/custom.py
@@ -510,11 +510,11 @@ def format_results(query, docs_results, code_results):
                 break
 
         if examples:
-            print(format_styled_text((Style.IMPORTANT, "Examples")))
+            print("Examples")
             for title, command_lines, url in examples:
-                print("    " + format_styled_text((Style.ACTION, "> " + title)))
+                print(format_styled_text((Style.ACTION, "  - " + title)))
                 for line in command_lines:
-                    print("    " + format_styled_text((Style.HIGHLIGHT, line)))
+                    print("    " + line)
                 if url:
                     print("    " + format_styled_text((Style.SECONDARY, url)))
                 print()
@@ -538,9 +538,9 @@ def format_results(query, docs_results, code_results):
                 break
 
         if docs:
-            print(format_styled_text((Style.IMPORTANT, "Documentation")))
+            print("Documentation")
             for title, summary, url in docs:
-                print("    " + format_styled_text((Style.ACTION, "> " + title)))
+                print(format_styled_text((Style.ACTION, "  - " + title)))
                 if summary:
                     print("    " + summary)
                 if url:

--- a/src/azure-cli/azure/cli/command_modules/find/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/find/custom.py
@@ -510,11 +510,11 @@ def format_results(query, docs_results, code_results):
                 break
 
         if examples:
-            print("Examples")
+            print(format_styled_text((Style.IMPORTANT, "Examples")))
             for title, command_lines, url in examples:
-                print("    " + format_styled_text((Style.ACTION, title)))
+                print("    " + format_styled_text((Style.ACTION, "> " + title)))
                 for line in command_lines:
-                    print("    " + line)
+                    print("    " + format_styled_text((Style.HIGHLIGHT, line)))
                 if url:
                     print("    " + format_styled_text((Style.SECONDARY, url)))
                 print()
@@ -538,9 +538,9 @@ def format_results(query, docs_results, code_results):
                 break
 
         if docs:
-            print("Documentation")
+            print(format_styled_text((Style.IMPORTANT, "Documentation")))
             for title, summary, url in docs:
-                print("    " + format_styled_text((Style.ACTION, title)))
+                print("    " + format_styled_text((Style.ACTION, "> " + title)))
                 if summary:
                     print("    " + summary)
                 if url:

--- a/src/azure-cli/azure/cli/command_modules/find/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/find/custom.py
@@ -23,7 +23,7 @@ logger = get_logger(__name__)
 WAIT_MESSAGE = ['Finding examples and documentation...']
 
 # Display limits
-MAX_DOC_RESULTS = 5
+MAX_DOC_RESULTS = 2
 MAX_CODE_RESULTS = 3
 
 Example = namedtuple("Example", "title snippet")
@@ -473,15 +473,24 @@ def format_results(query, docs_results, code_results):
 
     if code_results:
         examples = []
-        for result in code_results[:MAX_CODE_RESULTS]:
+        seen_urls = set()
+        for result in code_results:
             command_lines = _extract_command(result.get("codeSnippet", ""))
             if not command_lines:
                 continue
+            url = result.get("link", "")
+            # Skip duplicate URLs, keeping only the first occurrence.
+            if url and url in seen_urls:
+                continue
+            if url:
+                seen_urls.add(url)
             examples.append((
                 _extract_description(result.get("description", "")),
                 command_lines,
-                result.get("link", "")
+                url
             ))
+            if len(examples) >= MAX_CODE_RESULTS:
+                break
 
         if examples:
             print("Examples")
@@ -494,18 +503,32 @@ def format_results(query, docs_results, code_results):
                 print()
 
     if docs_results:
-        print("Documentation")
-        for result in docs_results[:MAX_DOC_RESULTS]:
-            title = _clean_title(result.get("title", ""))
-            summary = _extract_summary(result.get("content", ""))
+        docs = []
+        seen_urls = set()
+        for result in docs_results:
             url = result.get("contentUrl", "")
-
-            print("    " + format_styled_text((Style.ACTION, title)))
-            if summary:
-                print("    " + summary)
+            # Skip duplicate URLs, keeping only the first occurrence.
+            if url and url in seen_urls:
+                continue
             if url:
-                print("    " + format_styled_text((Style.SECONDARY, url)))
-            print()
+                seen_urls.add(url)
+            docs.append((
+                _clean_title(result.get("title", "")),
+                _extract_summary(result.get("content", "")),
+                url
+            ))
+            if len(docs) >= MAX_DOC_RESULTS:
+                break
+
+        if docs:
+            print("Documentation")
+            for title, summary, url in docs:
+                print("    " + format_styled_text((Style.ACTION, title)))
+                if summary:
+                    print("    " + summary)
+                if url:
+                    print("    " + format_styled_text((Style.SECONDARY, url)))
+                print()
 
 
 def process_query(cli_term):

--- a/src/azure-cli/azure/cli/command_modules/find/tests/latest/test_find.py
+++ b/src/azure-cli/azure/cli/command_modules/find/tests/latest/test_find.py
@@ -149,31 +149,37 @@ class TestMCPClient(unittest.TestCase):
         self.assertEqual(body["params"]["name"], "microsoft_docs_search")
 
     @mock.patch('azure.cli.command_modules.find.custom.telemetry_core')
-    def test_telemetry_headers_enabled(self, mock_telemetry):
+    def test_telemetry_context_enabled(self, mock_telemetry):
         mock_telemetry._get_installation_id.return_value = "test-install-id"
         mock_telemetry.is_telemetry_enabled.return_value = True
         mock_telemetry._session.correlation_id = "corr-123"
         mock_telemetry._session.event_id = "evt-456"
         mock_telemetry._get_azure_subscription_id.return_value = "sub-789"
 
-        client = MCPClient()
+        client = MCPClient(client_version="2.60.0")
 
+        # Hashed installation id is always sent as a header for rate limiting.
         self.assertIn("X-UserId", client._headers)
-        self.assertEqual(client._headers["X-CorrelationId"], "corr-123")
-        self.assertEqual(client._headers["X-EventId"], "evt-456")
-        self.assertEqual(client._headers["X-SubscriptionId"], "sub-789")
+        # Contextual values are bundled into the context object when consented.
+        self.assertEqual(client._context["versionNumber"], "2.60.0")
+        self.assertEqual(client._context["correlationId"], "corr-123")
+        self.assertEqual(client._context["eventId"], "evt-456")
+        self.assertEqual(client._context["subscriptionId"], "sub-789")
+        self.assertEqual(json.loads(client._params["context"]), client._context)
 
     @mock.patch('azure.cli.command_modules.find.custom.telemetry_core')
-    def test_telemetry_headers_disabled(self, mock_telemetry):
+    def test_telemetry_context_disabled(self, mock_telemetry):
         mock_telemetry._get_installation_id.return_value = "test-install-id"
         mock_telemetry.is_telemetry_enabled.return_value = False
 
-        client = MCPClient()
+        client = MCPClient(client_version="2.60.0")
 
         self.assertIn("X-UserId", client._headers)
-        self.assertNotIn("X-CorrelationId", client._headers)
-        self.assertNotIn("X-EventId", client._headers)
-        self.assertNotIn("X-SubscriptionId", client._headers)
+        # Without consent only the version number is sent.
+        self.assertEqual(client._context["versionNumber"], "2.60.0")
+        self.assertNotIn("correlationId", client._context)
+        self.assertNotIn("eventId", client._context)
+        self.assertNotIn("subscriptionId", client._context)
 
     def test_parse_sse(self):
         sse_text = 'event: message\ndata: {"id": 1, "result": "ok"}\n\n'

--- a/src/azure-cli/azure/cli/command_modules/find/tests/latest/test_find.py
+++ b/src/azure-cli/azure/cli/command_modules/find/tests/latest/test_find.py
@@ -364,16 +364,51 @@ class TestFormatResults(unittest.TestCase):
     @mock.patch('azure.cli.command_modules.find.custom.should_enable_styling', return_value=False)
     @mock.patch('sys.stdout', new_callable=StringIO)
     def test_format_caps_results(self, mock_stdout, _):
-        # Create more results than the max
-        many_docs = [SAMPLE_DOC_RESULTS[0]] * (MAX_DOC_RESULTS + 5)
-        many_code = [SAMPLE_CODE_RESULTS[0]] * (MAX_CODE_RESULTS + 5)
+        # Create more (distinct-URL) results than the max.
+        many_docs = []
+        for i in range(MAX_DOC_RESULTS + 5):
+            doc = dict(SAMPLE_DOC_RESULTS[0])
+            doc["contentUrl"] = "https://learn.microsoft.com/doc/%d" % i
+            many_docs.append(doc)
+        many_code = []
+        for i in range(MAX_CODE_RESULTS + 5):
+            code = dict(SAMPLE_CODE_RESULTS[0])
+            code["link"] = "https://learn.microsoft.com/code/%d" % i
+            many_code.append(code)
         format_results("az vm", many_docs, many_code)
         output = mock_stdout.getvalue()
-        # Count occurrences of the contentUrl (unique per doc result printed)
-        doc_count = output.count(SAMPLE_DOC_RESULTS[0]["contentUrl"])
-        code_count = output.count("--force-deletion true")
+        # Count printed doc/code URLs to confirm the caps are enforced.
+        doc_count = output.count("https://learn.microsoft.com/doc/")
+        code_count = output.count("https://learn.microsoft.com/code/")
         self.assertEqual(doc_count, MAX_DOC_RESULTS)
         self.assertEqual(code_count, MAX_CODE_RESULTS)
+
+    @mock.patch('azure.cli.command_modules.find.custom.should_enable_styling', return_value=False)
+    @mock.patch('sys.stdout', new_callable=StringIO)
+    def test_format_dedupes_by_url(self, mock_stdout, _):
+        # Duplicate URLs should be collapsed (first kept), and later unique
+        # results used to fill up to the cap.
+        dup_doc = dict(SAMPLE_DOC_RESULTS[0])
+        extra_doc = dict(SAMPLE_DOC_RESULTS[1])
+        extra_doc["contentUrl"] = "https://learn.microsoft.com/doc/extra"
+        # With MAX_DOC_RESULTS == 2, the duplicate must be collapsed so the
+        # unique extra_doc fills the freed slot.
+        docs = [SAMPLE_DOC_RESULTS[0], dup_doc, extra_doc]
+
+        dup_code = dict(SAMPLE_CODE_RESULTS[0])
+        extra_code = dict(SAMPLE_CODE_RESULTS[1])
+        extra_code["link"] = "https://learn.microsoft.com/code/extra"
+        code = [SAMPLE_CODE_RESULTS[0], dup_code, SAMPLE_CODE_RESULTS[1], extra_code]
+
+        format_results("az vm", docs, code)
+        output = mock_stdout.getvalue()
+
+        # Each duplicated URL is printed only once.
+        self.assertEqual(output.count(SAMPLE_DOC_RESULTS[0]["contentUrl"]), 1)
+        self.assertEqual(output.count(SAMPLE_CODE_RESULTS[0]["link"]), 1)
+        # Caps are filled from the remaining unique results.
+        self.assertIn("https://learn.microsoft.com/doc/extra", output)
+        self.assertIn("https://learn.microsoft.com/code/extra", output)
 
 
 class TestProcessQuery(unittest.TestCase):

--- a/src/azure-cli/azure/cli/command_modules/find/tests/latest/test_find.py
+++ b/src/azure-cli/azure/cli/command_modules/find/tests/latest/test_find.py
@@ -336,11 +336,11 @@ class TestFormatResults(unittest.TestCase):
         format_results("az vm delete", SAMPLE_DOC_RESULTS, SAMPLE_CODE_RESULTS)
 
         output = mock_stdout.getvalue()
-        self.assertIn("Commands & Documentation", output)
+        self.assertIn("Documentation", output)
         self.assertIn("az vm delete", output)
         self.assertIn("Delete a virtual machine.", output)
         self.assertIn("learn.microsoft.com/cli/azure/vm", output)
-        self.assertIn("Code Examples", output)
+        self.assertIn("Examples", output)
         self.assertIn("--resource-group myResourceGroup", output)
         self.assertIn("--force-deletion true", output)
 
@@ -356,16 +356,16 @@ class TestFormatResults(unittest.TestCase):
     def test_format_docs_only(self, mock_stdout, _):
         format_results("az vm", SAMPLE_DOC_RESULTS, [])
         output = mock_stdout.getvalue()
-        self.assertIn("Commands & Documentation", output)
-        self.assertNotIn("Code Examples", output)
+        self.assertIn("Documentation", output)
+        self.assertNotIn("Examples", output)
 
     @mock.patch('azure.cli.command_modules.find.custom.should_enable_styling', return_value=False)
     @mock.patch('sys.stdout', new_callable=StringIO)
     def test_format_code_only(self, mock_stdout, _):
         format_results("az vm", [], SAMPLE_CODE_RESULTS)
         output = mock_stdout.getvalue()
-        self.assertNotIn("Commands & Documentation", output)
-        self.assertIn("Code Examples", output)
+        self.assertNotIn("Documentation", output)
+        self.assertIn("Examples", output)
 
     @mock.patch('azure.cli.command_modules.find.custom.should_enable_styling', return_value=False)
     @mock.patch('sys.stdout', new_callable=StringIO)

--- a/src/azure-cli/azure/cli/command_modules/find/tests/latest/test_find.py
+++ b/src/azure-cli/azure/cli/command_modules/find/tests/latest/test_find.py
@@ -6,76 +6,452 @@
 import json
 import unittest
 from unittest import mock
-import requests
+from io import StringIO
 
-from azure.cli.command_modules.find.custom import (Example, call_aladdin_service,
-                                                   get_generated_examples, clean_from_http_answer)
-
-
-def create_valid_http_response():
-    mock_response = requests.Response()
-    mock_response.status_code = 200
-    data = [{
-        'title': 'RunTestAutomation',
-        'snippet': 'az find'
-    }, {
-        'title': 'az test',
-        'snippet': 'The title'
-    }]
-    mock_response._content = json.dumps(data)
-    return mock_response
+from azure.cli.command_modules.find.custom import (
+    Example, MCPClient, search_mslearn, format_results,
+    get_generated_examples, process_query, _extract_summary,
+    _is_cli_command_relevant, _extract_query_command, _filter_results,
+    _get_query_keywords, _has_keyword_overlap,
+    MAX_DOC_RESULTS, MAX_CODE_RESULTS
+)
 
 
-def create_empty_http_response():
-    mock_response = requests.Response()
-    mock_response.status_code = 200
-    data = []
-    mock_response._content = json.dumps(data)
-    return mock_response
+def _make_sse_response(result_data, session_id="test-session-id"):
+    """Create a mock requests.Response with SSE-formatted MCP response."""
+    resp = mock.MagicMock()
+    resp.status_code = 200
+    resp.headers = {"mcp-session-id": session_id}
+    sse_data = json.dumps(result_data)
+    resp.text = f"event: message\ndata: {sse_data}\n\n"
+    resp.raise_for_status = mock.MagicMock()
+    return resp
 
 
-class FindCustomCommandTest(unittest.TestCase):
+def _make_init_response(session_id="test-session-id"):
+    """Create a mock initialize response."""
+    return _make_sse_response({
+        "result": {
+            "protocolVersion": "2025-03-26",
+            "serverInfo": {"name": "Microsoft Learn MCP Server", "version": "1.0.0"},
+            "capabilities": {"tools": {"listChanged": True}}
+        },
+        "id": 1,
+        "jsonrpc": "2.0"
+    }, session_id)
 
-    def test_call_aladdin_service(self):
-        mock_response = create_valid_http_response()
 
-        with mock.patch('requests.get', return_value=(mock_response)):
-            response = call_aladdin_service('RunTestAutomation')
-            self.assertEqual(200, response.status_code)
-            self.assertEqual(2, len(json.loads(response.content)))
+def _make_notify_response():
+    """Create a mock notify response (empty 200)."""
+    resp = mock.MagicMock()
+    resp.status_code = 200
+    resp.raise_for_status = mock.MagicMock()
+    return resp
 
-    def test_example_clean_from_http_answer(self):
-        cleaned_responses = []
-        mock_response = create_valid_http_response()
 
-        for response in json.loads(mock_response.content):
-            cleaned_responses.append(clean_from_http_answer(response))
+def _make_tool_response(results, request_id=2):
+    """Create a mock tool call response."""
+    inner_text = json.dumps({"results": results})
+    return _make_sse_response({
+        "result": {
+            "content": [{"type": "text", "text": inner_text}]
+        },
+        "id": request_id,
+        "jsonrpc": "2.0"
+    })
 
-        self.assertEqual('RunTestAutomation', cleaned_responses[0].title)
-        self.assertEqual('az find', cleaned_responses[0].snippet)
-        self.assertEqual('The title', cleaned_responses[1].title)
-        self.assertEqual('az test', cleaned_responses[1].snippet)
 
-    def test_get_generated_examples_full(self):
-        examples = []
-        mock_response = create_valid_http_response()
+SAMPLE_DOC_RESULTS = [
+    {
+        "title": "az vm delete",
+        "content": "### Command\naz vm delete\n\n### Summary\nDelete a virtual machine.\n\n### Optional Parameters\n--name\nName of the VM.",
+        "contentUrl": "https://learn.microsoft.com/cli/azure/vm?view=azure-cli-latest"
+    },
+    {
+        "title": "Delete a VM and attached resources",
+        "content": "# Delete a VM and attached resources\nYou can change the behavior when you delete a VM.",
+        "contentUrl": "https://learn.microsoft.com/azure/virtual-machines/delete"
+    }
+]
 
-        with mock.patch('requests.get', return_value=(mock_response)):
-            examples = get_generated_examples('RunTestAutomation')
+SAMPLE_CODE_RESULTS = [
+    {
+        "description": "Deletes an Azure virtual machine using force deletion.",
+        "codeSnippet": "az vm delete \\\n    --resource-group myResourceGroup \\\n    --name myVM \\\n    --force-deletion true",
+        "link": "https://learn.microsoft.com/azure/virtual-machines/delete#force-delete",
+        "language": "azurecli"
+    },
+    {
+        "description": "Deletes a virtual machine in Azure.",
+        "codeSnippet": "az vm delete \\\n --resource-group myResourceGroup \\\n --name myVM",
+        "link": "https://learn.microsoft.com/azure/aks/rdp#remove-rdp-access",
+        "language": "azurecli"
+    }
+]
 
-            self.assertEqual('RunTestAutomation', examples[0].title)
-            self.assertEqual('az find', examples[0].snippet)
-            self.assertEqual('The title', examples[1].title)
-            self.assertEqual('az test', examples[1].snippet)
 
-    def test_get_generated_examples_empty(self):
-        examples = []
-        mock_response = create_empty_http_response()
+class TestMCPClient(unittest.TestCase):
 
-        with mock.patch('requests.get', return_value=(mock_response)):
-            examples = get_generated_examples('RunTestAutomation')
+    @mock.patch('azure.cli.command_modules.find.custom.telemetry_core')
+    @mock.patch('requests.post')
+    def test_initialize(self, mock_post, mock_telemetry):
+        mock_telemetry._get_installation_id.return_value = "test-install-id"
+        mock_telemetry.is_telemetry_enabled.return_value = False
+        mock_post.return_value = _make_init_response("my-session-123")
 
-            self.assertEqual(0, len(examples))
+        client = MCPClient(client_version="2.60.0")
+        result = client.initialize()
+
+        self.assertEqual(client.session_id, "my-session-123")
+        self.assertEqual(client._headers["mcp-session-id"], "my-session-123")
+        self.assertEqual(result["result"]["serverInfo"]["name"], "Microsoft Learn MCP Server")
+
+        # Verify the POST was made correctly
+        call_args = mock_post.call_args
+        body = call_args[1]["json"]
+        self.assertEqual(body["method"], "initialize")
+        self.assertEqual(body["params"]["clientInfo"]["name"], "azure-cli-find")
+        self.assertEqual(body["params"]["clientInfo"]["version"], "2.60.0")
+
+    @mock.patch('azure.cli.command_modules.find.custom.telemetry_core')
+    @mock.patch('requests.post')
+    def test_notify_initialized(self, mock_post, mock_telemetry):
+        mock_telemetry._get_installation_id.return_value = "test-install-id"
+        mock_telemetry.is_telemetry_enabled.return_value = False
+        mock_post.return_value = _make_notify_response()
+
+        client = MCPClient()
+        client.session_id = "test-session"
+        client._headers["mcp-session-id"] = "test-session"
+        client.notify_initialized()
+
+        call_args = mock_post.call_args
+        body = call_args[1]["json"]
+        self.assertEqual(body["method"], "notifications/initialized")
+
+    @mock.patch('azure.cli.command_modules.find.custom.telemetry_core')
+    @mock.patch('requests.post')
+    def test_call_tool(self, mock_post, mock_telemetry):
+        mock_telemetry._get_installation_id.return_value = "test-install-id"
+        mock_telemetry.is_telemetry_enabled.return_value = False
+        mock_post.return_value = _make_tool_response(SAMPLE_DOC_RESULTS)
+
+        client = MCPClient()
+        client.session_id = "test-session"
+        result = client.call_tool("microsoft_docs_search", {"query": "az vm delete"})
+
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["title"], "az vm delete")
+
+        call_args = mock_post.call_args
+        body = call_args[1]["json"]
+        self.assertEqual(body["method"], "tools/call")
+        self.assertEqual(body["params"]["name"], "microsoft_docs_search")
+
+    @mock.patch('azure.cli.command_modules.find.custom.telemetry_core')
+    def test_telemetry_headers_enabled(self, mock_telemetry):
+        mock_telemetry._get_installation_id.return_value = "test-install-id"
+        mock_telemetry.is_telemetry_enabled.return_value = True
+        mock_telemetry._session.correlation_id = "corr-123"
+        mock_telemetry._session.event_id = "evt-456"
+        mock_telemetry._get_azure_subscription_id.return_value = "sub-789"
+
+        client = MCPClient()
+
+        self.assertIn("X-UserId", client._headers)
+        self.assertEqual(client._headers["X-CorrelationId"], "corr-123")
+        self.assertEqual(client._headers["X-EventId"], "evt-456")
+        self.assertEqual(client._headers["X-SubscriptionId"], "sub-789")
+
+    @mock.patch('azure.cli.command_modules.find.custom.telemetry_core')
+    def test_telemetry_headers_disabled(self, mock_telemetry):
+        mock_telemetry._get_installation_id.return_value = "test-install-id"
+        mock_telemetry.is_telemetry_enabled.return_value = False
+
+        client = MCPClient()
+
+        self.assertIn("X-UserId", client._headers)
+        self.assertNotIn("X-CorrelationId", client._headers)
+        self.assertNotIn("X-EventId", client._headers)
+        self.assertNotIn("X-SubscriptionId", client._headers)
+
+    def test_parse_sse(self):
+        sse_text = 'event: message\ndata: {"id": 1, "result": "ok"}\n\n'
+        result = MCPClient._parse_sse(sse_text)
+        self.assertEqual(result["result"], "ok")
+
+    def test_parse_sse_empty(self):
+        result = MCPClient._parse_sse("no data here")
+        self.assertEqual(result, {})
+
+
+class TestExtractSummary(unittest.TestCase):
+
+    def test_extract_summary_from_markdown(self):
+        content = "### Command\naz vm delete\n\n### Summary\nDelete a virtual machine.\n\n### Parameters\n--name"
+        summary = _extract_summary(content)
+        self.assertEqual(summary, "Delete a virtual machine.")
+
+    def test_extract_summary_no_summary_section(self):
+        content = "# Delete a VM\nYou can change the behavior when deleting a VM."
+        summary = _extract_summary(content)
+        self.assertEqual(summary, "You can change the behavior when deleting a VM.")
+
+    def test_extract_summary_empty(self):
+        self.assertEqual(_extract_summary(""), "")
+        self.assertEqual(_extract_summary(None), "")
+
+    def test_extract_summary_truncates(self):
+        long_content = "A" * 200
+        summary = _extract_summary(long_content)
+        self.assertEqual(len(summary), 150)
+
+
+class TestRelevanceFiltering(unittest.TestCase):
+
+    def test_extract_query_command_with_az_prefix(self):
+        self.assertEqual(_extract_query_command("az vm create"), "az vm create")
+        self.assertEqual(_extract_query_command("az storage blob"), "az storage blob")
+
+    def test_extract_query_command_without_az_prefix(self):
+        self.assertEqual(_extract_query_command("vm create"), "az vm create")
+        self.assertEqual(_extract_query_command("vm"), "az vm")
+
+    def test_extract_query_command_non_cli(self):
+        # Free-text queries get 'az' prepended but won't match real CLI groups,
+        # so filtering still works correctly (non-matching titles pass through)
+        result = _extract_query_command("deploy arm template")
+        self.assertEqual(result, "az deploy arm template")
+
+    def test_is_relevant_exact_match(self):
+        self.assertTrue(_is_cli_command_relevant("az vm create", "az vm create"))
+
+    def test_is_relevant_parent_group(self):
+        self.assertTrue(_is_cli_command_relevant("az vm", "az vm create"))
+
+    def test_is_relevant_subcommand(self):
+        self.assertTrue(_is_cli_command_relevant("az vm run-command create", "az vm create"))
+
+    def test_is_relevant_different_group(self):
+        self.assertFalse(_is_cli_command_relevant("az lab vm create", "az vm create"))
+        self.assertFalse(_is_cli_command_relevant("az connectedvmware vm create", "az vm create"))
+        self.assertFalse(_is_cli_command_relevant("az scvmm vm create", "az vm create"))
+        self.assertFalse(_is_cli_command_relevant("az sql vm create", "az vm create"))
+        self.assertFalse(_is_cli_command_relevant("az networkcloud virtualmachine create", "az vm create"))
+
+    def test_is_relevant_non_cli_title(self):
+        # Non-CLI titles (docs, tutorials) are always relevant
+        self.assertTrue(_is_cli_command_relevant("Create a virtual machine", "az vm create"))
+        self.assertTrue(_is_cli_command_relevant("Delete a VM and attached resources", "az vm delete"))
+
+    def test_filter_results(self):
+        results = [
+            {"title": "az vm create", "content": "Create VM", "contentUrl": "url1"},
+            {"title": "az lab vm create", "content": "Lab VM", "contentUrl": "url2"},
+            {"title": "az connectedvmware vm create", "content": "Connected VM", "contentUrl": "url3"},
+            {"title": "Create a virtual machine", "content": "Tutorial about VM creation", "contentUrl": "url4"},
+        ]
+        filtered = _filter_results(results, "az vm create")
+        titles = [r["title"] for r in filtered]
+        self.assertIn("az vm create", titles)
+        self.assertIn("Create a virtual machine", titles)
+        self.assertNotIn("az lab vm create", titles)
+        self.assertNotIn("az connectedvmware vm create", titles)
+
+    def test_filter_results_gibberish_query(self):
+        """Gibberish queries should return no results when nothing matches."""
+        results = [
+            {"title": "Albanian Keyboard", "content": "KLID: 0000041C", "contentUrl": "url1"},
+            {"title": "ADLaM Keyboard", "content": "KLID: 00140C00", "contentUrl": "url2"},
+            {"title": "!asd", "content": "debugger extension", "contentUrl": "url3"},
+        ]
+        filtered = _filter_results(results, "alskdn1k2lenasd")
+        self.assertEqual(len(filtered), 0)
+
+    def test_get_query_keywords(self):
+        self.assertEqual(_get_query_keywords("az vm create"), {"create"})  # 'az' excluded, 'vm' < 3 chars
+        self.assertEqual(_get_query_keywords("az storage blob list"), {"storage", "blob", "list"})
+        self.assertEqual(_get_query_keywords("deploy arm template"), {"deploy", "arm", "template"})
+
+    def test_has_keyword_overlap_match(self):
+        result = {"title": "az vm create", "content": "Create a virtual machine"}
+        self.assertTrue(_has_keyword_overlap(result, {"create"}))
+
+    def test_has_keyword_overlap_no_match(self):
+        result = {"title": "Albanian Keyboard", "content": "KLID code"}
+        self.assertFalse(_has_keyword_overlap(result, {"alskdn1k2lenasd"}))
+
+
+class TestSearchMslearn(unittest.TestCase):
+
+    @mock.patch('azure.cli.command_modules.find.custom.telemetry_core')
+    @mock.patch('requests.post')
+    def test_search_returns_docs_and_code(self, mock_post, mock_telemetry):
+        mock_telemetry._get_installation_id.return_value = "test-install-id"
+        mock_telemetry.is_telemetry_enabled.return_value = False
+
+        mock_post.side_effect = [
+            _make_init_response(),
+            _make_notify_response(),
+            _make_tool_response(SAMPLE_DOC_RESULTS),
+            _make_tool_response(SAMPLE_CODE_RESULTS),
+        ]
+
+        docs, code = search_mslearn("az vm delete")
+
+        self.assertEqual(len(docs), 2)
+        self.assertEqual(len(code), 2)
+        self.assertEqual(docs[0]["title"], "az vm delete")
+        self.assertIn("codeSnippet", code[0])
+
+    @mock.patch('azure.cli.command_modules.find.custom.telemetry_core')
+    @mock.patch('requests.post')
+    def test_search_empty_results(self, mock_post, mock_telemetry):
+        mock_telemetry._get_installation_id.return_value = "test-install-id"
+        mock_telemetry.is_telemetry_enabled.return_value = False
+
+        mock_post.side_effect = [
+            _make_init_response(),
+            _make_notify_response(),
+            _make_tool_response([]),
+            _make_tool_response([]),
+        ]
+
+        docs, code = search_mslearn("xyznonexistent")
+        self.assertEqual(len(docs), 0)
+        self.assertEqual(len(code), 0)
+
+
+class TestFormatResults(unittest.TestCase):
+
+    @mock.patch('azure.cli.command_modules.find.custom.should_enable_styling', return_value=False)
+    @mock.patch('sys.stdout', new_callable=StringIO)
+    def test_format_with_results(self, mock_stdout, _):
+        format_results("az vm delete", SAMPLE_DOC_RESULTS, SAMPLE_CODE_RESULTS)
+
+        output = mock_stdout.getvalue()
+        self.assertIn("Commands & Documentation", output)
+        self.assertIn("az vm delete", output)
+        self.assertIn("Delete a virtual machine.", output)
+        self.assertIn("learn.microsoft.com/cli/azure/vm", output)
+        self.assertIn("Code Examples", output)
+        self.assertIn("--resource-group myResourceGroup", output)
+        self.assertIn("--force-deletion true", output)
+
+    @mock.patch('azure.cli.command_modules.find.custom.should_enable_styling', return_value=False)
+    @mock.patch('sys.stderr', new_callable=StringIO)
+    def test_format_empty_results(self, mock_stderr, _):
+        format_results("xyznonexistent", [], [])
+        output = mock_stderr.getvalue()
+        self.assertIn("Sorry I am not able to help with", output)
+
+    @mock.patch('azure.cli.command_modules.find.custom.should_enable_styling', return_value=False)
+    @mock.patch('sys.stdout', new_callable=StringIO)
+    def test_format_docs_only(self, mock_stdout, _):
+        format_results("az vm", SAMPLE_DOC_RESULTS, [])
+        output = mock_stdout.getvalue()
+        self.assertIn("Commands & Documentation", output)
+        self.assertNotIn("Code Examples", output)
+
+    @mock.patch('azure.cli.command_modules.find.custom.should_enable_styling', return_value=False)
+    @mock.patch('sys.stdout', new_callable=StringIO)
+    def test_format_code_only(self, mock_stdout, _):
+        format_results("az vm", [], SAMPLE_CODE_RESULTS)
+        output = mock_stdout.getvalue()
+        self.assertNotIn("Commands & Documentation", output)
+        self.assertIn("Code Examples", output)
+
+    @mock.patch('azure.cli.command_modules.find.custom.should_enable_styling', return_value=False)
+    @mock.patch('sys.stdout', new_callable=StringIO)
+    def test_format_caps_results(self, mock_stdout, _):
+        # Create more results than the max
+        many_docs = [SAMPLE_DOC_RESULTS[0]] * (MAX_DOC_RESULTS + 5)
+        many_code = [SAMPLE_CODE_RESULTS[0]] * (MAX_CODE_RESULTS + 5)
+        format_results("az vm", many_docs, many_code)
+        output = mock_stdout.getvalue()
+        # Count occurrences of the contentUrl (unique per doc result printed)
+        doc_count = output.count(SAMPLE_DOC_RESULTS[0]["contentUrl"])
+        code_count = output.count("--force-deletion true")
+        self.assertEqual(doc_count, MAX_DOC_RESULTS)
+        self.assertEqual(code_count, MAX_CODE_RESULTS)
+
+
+class TestProcessQuery(unittest.TestCase):
+
+    @mock.patch('azure.cli.command_modules.find.custom.telemetry_core')
+    @mock.patch('azure.cli.command_modules.find.custom.show_updates_available', create=True)
+    @mock.patch('requests.post')
+    @mock.patch('sys.stdout', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
+    def test_process_query_success(self, mock_stderr, mock_stdout, mock_post, _, mock_telemetry):
+        mock_telemetry._get_installation_id.return_value = "test-install-id"
+        mock_telemetry.is_telemetry_enabled.return_value = False
+
+        mock_post.side_effect = [
+            _make_init_response(),
+            _make_notify_response(),
+            _make_tool_response(SAMPLE_DOC_RESULTS),
+            _make_tool_response(SAMPLE_CODE_RESULTS),
+        ]
+
+        with mock.patch('azure.cli.command_modules.find.custom.should_enable_styling', return_value=False):
+            process_query("az vm delete")
+
+        output = mock_stdout.getvalue()
+        self.assertIn("az vm delete", output)
+
+    @mock.patch('azure.cli.command_modules.find.custom.telemetry_core')
+    @mock.patch('azure.cli.command_modules.find.custom.show_updates_available', create=True)
+    @mock.patch('requests.post')
+    def test_process_query_network_error(self, mock_post, _, mock_telemetry):
+        mock_telemetry._get_installation_id.return_value = "test-install-id"
+        mock_telemetry.is_telemetry_enabled.return_value = False
+
+        import requests as req
+        mock_post.side_effect = req.exceptions.ConnectionError("Connection failed")
+
+        # Should not raise
+        process_query("az vm delete")
+
+    @mock.patch('azure.cli.command_modules.find.custom.show_updates_available', create=True)
+    def test_process_query_empty_term(self, _):
+        # Should not raise, just log error
+        process_query(None)
+
+
+class TestGetGeneratedExamples(unittest.TestCase):
+
+    @mock.patch('azure.cli.command_modules.find.custom.telemetry_core')
+    @mock.patch('requests.post')
+    def test_get_generated_examples(self, mock_post, mock_telemetry):
+        mock_telemetry._get_installation_id.return_value = "test-install-id"
+        mock_telemetry.is_telemetry_enabled.return_value = False
+
+        mock_post.side_effect = [
+            _make_init_response(),
+            _make_notify_response(),
+            _make_tool_response(SAMPLE_DOC_RESULTS),
+            _make_tool_response(SAMPLE_CODE_RESULTS),
+        ]
+
+        examples = get_generated_examples("az vm delete")
+
+        self.assertGreater(len(examples), 0)
+        # Should return Example namedtuples
+        self.assertIsInstance(examples[0], Example)
+        self.assertEqual(examples[0].title, "az vm delete")
+
+    @mock.patch('azure.cli.command_modules.find.custom.telemetry_core')
+    @mock.patch('requests.post')
+    def test_get_generated_examples_network_error(self, mock_post, mock_telemetry):
+        mock_telemetry._get_installation_id.return_value = "test-install-id"
+        mock_telemetry.is_telemetry_enabled.return_value = False
+
+        import requests as req
+        mock_post.side_effect = req.exceptions.ConnectionError("fail")
+
+        examples = get_generated_examples("az vm delete")
+        self.assertEqual(len(examples), 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Related command**
`az find`

**Description**
The Aladdin service (app.aladdin.microsoft.com) is being retired. This PR migrates the `az find` command backend to the Microsoft Learn MCP Server (learn.microsoft.com/api/mcp), restoring search functionality with improved result quality.

resolve: https://github.com/Azure/CLIPS/issues/24

**Testing Guide**
`python -m pytest src\azure-cli\azure\cli\command_modules\find\tests\latest\test_find.py -v`

**History Notes**

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
