### PR TITLE
{Compute} `az vm/vmss create`: Fix `--os-type` auto value assignment and resolve API calling redundancy

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_validators.py
@@ -653,10 +653,7 @@ def _validate_vm_create_storage_profile(cmd, namespace, for_scale_set=False):
         image = _show_vm_image(cmd, namespace)
 
         os_system = image.get('osDiskImage', {}).get('operatingSystem', '')
-        if 'windows' in os_system.lower():
-            namespace.os_type = 'windows'
-        else:
-            namespace.os_type = 'linux'
+        namespace.os_type = os_system.lower()
 
     if getattr(namespace, 'source_snapshots_or_disks', None) and \
             getattr(namespace, 'source_snapshots_or_disks_size_gb', None):

--- a/src/azure-cli/azure/cli/command_modules/vm/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_validators.py
@@ -319,24 +319,27 @@ def _parse_image_argument(cmd, namespace):
         raise CLIError(err)
 
 
+def _show_vm_image(cmd, namespace):
+    from .aaz.latest.vm.image import Show as VMImageShow
+    image_version = namespace.os_version
+    if namespace.os_version.lower() == 'latest':
+        image_version = _get_latest_image_version_by_aaz(cmd.cli_ctx, namespace.location, namespace.os_publisher,
+                                                         namespace.os_offer, namespace.os_sku)
+
+    command_args = {
+        'location': namespace.location,
+        'offer': namespace.os_offer,
+        'publisher': namespace.os_publisher,
+        'sku': namespace.os_sku,
+        'version': image_version,
+    }
+
+    return VMImageShow(cli_ctx=cmd.cli_ctx)(command_args=command_args)
+
+
 def _get_image_plan_info_if_exists(cmd, namespace):
     try:
-        from .aaz.latest.vm.image import Show as VmImageShow
-        if namespace.os_version.lower() == 'latest':
-            image_version = _get_latest_image_version_by_aaz(cmd.cli_ctx, namespace.location, namespace.os_publisher,
-                                                             namespace.os_offer, namespace.os_sku)
-        else:
-            image_version = namespace.os_version
-
-        command_args = {
-            'location': namespace.location,
-            'offer': namespace.os_offer,
-            'publisher': namespace.os_publisher,
-            'sku': namespace.os_sku,
-            'version': image_version,
-        }
-        image = VmImageShow(cli_ctx=cmd.cli_ctx)(command_args=command_args)
-
+        image = _show_vm_image(cmd, namespace)
         return image.get('plan')
     except ResourceNotFoundError as ex:
         logger.warning("Querying the image of '%s' failed for an error '%s'. Configuring plan settings "
@@ -643,7 +646,13 @@ def _validate_vm_create_storage_profile(cmd, namespace, for_scale_set=False):
                 'when "--security-type" is "ConfidentialVM" and "--enable-vtpm" is True')
 
     if not namespace.os_type:
-        namespace.os_type = 'windows' if 'windows' in namespace.os_offer.lower() else 'linux'
+        image = _show_vm_image(cmd, namespace)
+
+        os_system = image.get('osDiskImage', {}).get('operatingSystem', '')
+        if 'windows' in os_system.lower():
+            namespace.os_type = 'windows'
+        else:
+            namespace.os_type = 'linux'
 
     if getattr(namespace, 'source_snapshots_or_disks', None) and \
             getattr(namespace, 'source_snapshots_or_disks_size_gb', None):
@@ -1499,20 +1508,7 @@ def _validate_generation_version_and_trusted_launch(cmd, namespace):
             return
 
         if image_type == 'urn':
-            from .aaz.latest.vm.image import Show as VmImageShow
-            os_version = namespace.os_version
-            if os_version.lower() == 'latest':
-                os_version = _get_latest_image_version_by_aaz(cmd.cli_ctx, namespace.location, namespace.os_publisher,
-                                                              namespace.os_offer, namespace.os_sku)
-
-            command_args = {
-                'location': namespace.location,
-                'offer': namespace.os_offer,
-                'publisher': namespace.os_publisher,
-                'sku': namespace.os_sku,
-                'version': os_version
-            }
-            vm_image_info = VmImageShow(cli_ctx=cmd.cli_ctx)(command_args=command_args)
+            vm_image_info = _show_vm_image(cmd, namespace)
 
             if vm_image_info.get('imageDeprecationStatus', {}).get('imageState') == 'ScheduledForDeprecation':
                 from datetime import datetime

--- a/src/azure-cli/azure/cli/command_modules/vm/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_validators.py
@@ -320,6 +320,9 @@ def _parse_image_argument(cmd, namespace):
 
 
 def _show_vm_image(cmd, namespace):
+    if getattr(namespace, '_vm_image_info', None):
+        return namespace._vm_image_info
+
     from .aaz.latest.vm.image import Show as VMImageShow
     image_version = namespace.os_version
     if namespace.os_version.lower() == 'latest':
@@ -334,7 +337,8 @@ def _show_vm_image(cmd, namespace):
         'version': image_version,
     }
 
-    return VMImageShow(cli_ctx=cmd.cli_ctx)(command_args=command_args)
+    namespace._vm_image_info = VMImageShow(cli_ctx=cmd.cli_ctx)(command_args=command_args)
+    return namespace._vm_image_info
 
 
 def _get_image_plan_info_if_exists(cmd, namespace):

--- a/src/azure-cli/azure/cli/command_modules/vm/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_validators.py
@@ -320,8 +320,8 @@ def _parse_image_argument(cmd, namespace):
 
 
 def _show_vm_image(cmd, namespace):
-    if hasattr(namespace, '_vm_image_info'):
-        return namespace._vm_image_info
+    if hasattr(namespace, 'vm_image_info_cache'):
+        return namespace.vm_image_info_cache
 
     from .aaz.latest.vm.image import Show as VMImageShow
     image_version = namespace.os_version
@@ -337,8 +337,8 @@ def _show_vm_image(cmd, namespace):
         'version': image_version,
     }
 
-    namespace._vm_image_info = VMImageShow(cli_ctx=cmd.cli_ctx)(command_args=command_args)
-    return namespace._vm_image_info
+    namespace.vm_image_info_cache = VMImageShow(cli_ctx=cmd.cli_ctx)(command_args=command_args)
+    return namespace.vm_image_info_cache
 
 
 def _get_image_plan_info_if_exists(cmd, namespace):

--- a/src/azure-cli/azure/cli/command_modules/vm/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_validators.py
@@ -319,9 +319,10 @@ def _parse_image_argument(cmd, namespace):
         raise CLIError(err)
 
 
+# pylint: disable=protected-access
 def _show_vm_image(cmd, namespace):
-    if hasattr(namespace, 'vm_image_info_cache'):
-        return namespace.vm_image_info_cache
+    if hasattr(namespace, '_vm_image_info_cache'):
+        return namespace._vm_image_info_cache
 
     from .aaz.latest.vm.image import Show as VMImageShow
     image_version = namespace.os_version
@@ -337,8 +338,8 @@ def _show_vm_image(cmd, namespace):
         'version': image_version,
     }
 
-    namespace.vm_image_info_cache = VMImageShow(cli_ctx=cmd.cli_ctx)(command_args=command_args)
-    return namespace.vm_image_info_cache
+    namespace._vm_image_info_cache = VMImageShow(cli_ctx=cmd.cli_ctx)(command_args=command_args)
+    return namespace._vm_image_info_cache
 
 
 def _get_image_plan_info_if_exists(cmd, namespace):

--- a/src/azure-cli/azure/cli/command_modules/vm/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_validators.py
@@ -320,7 +320,7 @@ def _parse_image_argument(cmd, namespace):
 
 
 def _show_vm_image(cmd, namespace):
-    if getattr(namespace, '_vm_image_info', None):
+    if hasattr(namespace, '_vm_image_info'):
         return namespace._vm_image_info
 
     from .aaz.latest.vm.image import Show as VMImageShow


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az vm create`
`az vmss create`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Issue: When `--os-type` is not provided, `--os_type` in `vm/ vmss create` command is automatically assigned based on value from `namespace.os_offer`, which is unreliable.

Solution: Queries the image via `vm image show` API `/subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/publishers/{publisherName}/artifacttypes/vmimage/offers/{offer}/skus/{skus}/versions/{version}` and reads the value of `osDiskImage.operatingSystem` field to set `--os-type`.

Issue: There are a redundant of calling of `vm image show` API, 2 times in total before this change.

Solution: I have extracted it into a single `_show_vm_image()` helper function and cache collected image value on the namespace, so the same image is being fetch once instead of multiple times.


**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
