### PR TITLE
{ACR}: Re-enable test_acr_connectedregistry_dedicated_endpoint_not_enabled

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_connectedregistry_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_connectedregistry_commands.py
@@ -4,7 +4,6 @@
 # --------------------------------------------------------------------------------------------
 
 from azure.cli.testsdk import ScenarioTest, StorageAccountPreparer, ResourceGroupPreparer, record_only
-from azure.cli.testsdk.scenario_tests import live_only
 from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 
 
@@ -171,7 +170,6 @@ class AcrConnectedRegistryCommandsTests(ScenarioTest):
         # Delete registry
         self.cmd('acr delete -n {registry_name} -g {rg} -y')
 
-    @live_only()
     @ResourceGroupPreparer()
     @AllowLargeResponse(size_kb=99999)
     def test_acr_connectedregistry_dedicated_endpoint_not_enabled(self, resource_group, resource_group_location):


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
N/A - test infrastructure only.

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
PR #33060 added `@live_only()` to skip this test in replay mode after the SDK split in PR #33017 converted `RegistriesOperations.update` into an async LRO (begin_update). The caller in connected_registry.py kept using the returned poller as a finished result, so the cassette stopped matching real traffic.

PR #33040 already shipped the real fix on dev: it wraps `acr_update_set` in `LongRunningOperation(cmd.cli_ctx)(...)` and refreshes the cassette with the LRO polling interactions. The test passes in replay mode against current dev (verified locally).

This change drops the now-unnecessary @live_only() decorator and its unused import.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
