### PR TITLE
[ACR] `az acr check-health`: Fix health check to use the correct MCR endpoint in sovereign clouds (USSec, USNat)

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/check_health.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/check_health.py
@@ -17,7 +17,12 @@ logger = get_logger(__name__)
 
 DOCKER_PULL_SUCCEEDED = "Downloaded newer image for {}"
 DOCKER_IMAGE_UP_TO_DATE = "Image is up to date for {}"
-IMAGE = "mcr.microsoft.com/mcr/hello-world:latest"
+_DEFAULT_MCR_HOST = "mcr.microsoft.com"
+_CLOUD_MCR_HOSTS = {
+    "ussec": "mcr.microsoft.scloud",
+    "usnat": "mcr.microsoft.eaglex.ic.gov",
+}
+_HEALTH_CHECK_IMAGE_PATH = "/mcr/hello-world:latest"
 FAQ_MESSAGE = "\nPlease refer to https://aka.ms/acr/health-check for more information."
 ERROR_MSG_DEEP_LINK = "\nPlease refer to https://aka.ms/acr/errors#{} for more information."
 MIN_HELM_VERSION = "2.11.0"
@@ -72,9 +77,16 @@ def _subprocess_communicate(command_parts, shell=False):
     return output, warning, stderr, succeeded
 
 
+def _get_health_check_image(cmd):
+    """Return the MCR hello-world image appropriate for the current cloud."""
+    cloud_name = cmd.cli_ctx.cloud.name.lower()
+    mcr_host = _CLOUD_MCR_HOSTS.get(cloud_name, _DEFAULT_MCR_HOST)
+    return mcr_host + _HEALTH_CHECK_IMAGE_PATH
+
+
 # Checks for the environment
 # Checks docker command, docker daemon, docker version and docker pull
-def _get_docker_status_and_version(ignore_errors, yes):
+def _get_docker_status_and_version(cmd, ignore_errors, yes):
     from ._errors import DOCKER_DAEMON_ERROR, DOCKER_PULL_ERROR, DOCKER_VERSION_ERROR
 
     # Docker command and docker daemon check
@@ -103,25 +115,26 @@ def _get_docker_status_and_version(ignore_errors, yes):
 
     # Docker pull check - only if docker daemon is available
     if docker_daemon_available:
+        image = _get_health_check_image(cmd)
         if not yes:
             from knack.prompting import prompt_y_n
-            confirmation = prompt_y_n("This will pull the image {}. Proceed?".format(IMAGE))
+            confirmation = prompt_y_n("This will pull the image {}. Proceed?".format(image))
             if not confirmation:
                 logger.warning("Skipping pull check.")
                 return
 
-        output, warning, stderr, succeeded = _subprocess_communicate([docker_command, "pull", IMAGE])
+        output, warning, stderr, succeeded = _subprocess_communicate([docker_command, "pull", image])
 
         if not succeeded:
             if stderr and DOCKER_PULL_WRONG_PLATFORM in stderr:
-                print_pass("Docker pull of '{}'".format(IMAGE))
-                logger.warning("Image '%s' can be pulled but cannot be used on this platform", IMAGE)
+                print_pass("Docker pull of '{}'".format(image))
+                logger.warning("Image '%s' can be pulled but cannot be used on this platform", image)
                 return
             _handle_error(DOCKER_PULL_ERROR.append_error_message(stderr), ignore_errors)
         else:
             if warning:
                 logger.warning(warning)
-            print_pass("Docker pull of '{}'".format(IMAGE))
+            print_pass("Docker pull of '{}'".format(image))
 
 
 # Get current CLI version
@@ -458,7 +471,7 @@ def acr_check_health(cmd,  # pylint: disable useless-return
     if in_cloud_console:
         logger.warning("Environment checks are not supported in Azure Cloud Shell.")
     else:
-        _get_docker_status_and_version(ignore_errors, yes)
+        _get_docker_status_and_version(cmd, ignore_errors, yes)
         _get_cli_version()
 
     _check_registry_health(cmd, registry_name, repository, ignore_errors)

--- a/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_check_health_cloud.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_check_health_cloud.py
@@ -1,0 +1,52 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import unittest
+from unittest import mock
+
+from azure.cli.command_modules.acr.check_health import _get_health_check_image
+
+
+class TestGetHealthCheckImage(unittest.TestCase):
+    """Unit tests for cloud-aware MCR image resolution in check-health."""
+
+    def _make_cmd(self, cloud_name):
+        cmd = mock.MagicMock()
+        cmd.cli_ctx.cloud.name = cloud_name
+        return cmd
+
+    def test_default_cloud(self):
+        cmd = self._make_cmd("AzureCloud")
+        self.assertEqual(_get_health_check_image(cmd), "mcr.microsoft.com/mcr/hello-world:latest")
+
+    def test_ussec_cloud(self):
+        cmd = self._make_cmd("USSec")
+        self.assertEqual(_get_health_check_image(cmd), "mcr.microsoft.scloud/mcr/hello-world:latest")
+
+    def test_usnat_cloud(self):
+        cmd = self._make_cmd("USNat")
+        self.assertEqual(_get_health_check_image(cmd), "mcr.microsoft.eaglex.ic.gov/mcr/hello-world:latest")
+
+    def test_ussec_case_insensitive(self):
+        cmd = self._make_cmd("ussec")
+        self.assertEqual(_get_health_check_image(cmd), "mcr.microsoft.scloud/mcr/hello-world:latest")
+
+    def test_usnat_case_insensitive(self):
+        cmd = self._make_cmd("USNAT")
+        self.assertEqual(_get_health_check_image(cmd), "mcr.microsoft.eaglex.ic.gov/mcr/hello-world:latest")
+
+    def test_azure_us_government(self):
+        # Fairfax uses the standard MCR endpoint
+        cmd = self._make_cmd("AzureUSGovernment")
+        self.assertEqual(_get_health_check_image(cmd), "mcr.microsoft.com/mcr/hello-world:latest")
+
+    def test_azure_china_cloud(self):
+        # China cloud uses the standard MCR endpoint
+        cmd = self._make_cmd("AzureChinaCloud")
+        self.assertEqual(_get_health_check_image(cmd), "mcr.microsoft.com/mcr/hello-world:latest")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Related command**
`az acr check-health`

**Description**

`az acr check-health` previously hardcoded the MCR image endpoint (mcr.microsoft.com) for the Docker pull health check. This fails in air-gapped sovereign clouds (USSec, USNat) where that endpoint is unreachable. This PR makes the health check cloud-aware by resolving the correct MCR host based on the active CLI cloud context:

 - USSec → mcr.microsoft.scloud
 - USNat → mcr.microsoft.eaglex.ic.gov
 - All other clouds → mcr.microsoft.com (default)

**Testing Guide**
Default cloud (AzureCloud) — uses mcr.microsoft.com
 `az acr check-health`

 Sovereign cloud — uses the mapped MCR host for the active cloud
 `az cloud set -n USSec`
 `az acr check-health`

Unit tests added in test_check_health_cloud.py covering all cloud mappings and case-insensitivity.

**History Notes**
[ACR] az acr check-health: Fix health check to use the correct MCR endpoint in sovereign clouds (USSec, USNat)

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
