### PR TITLE
{App Service} `az functionapp function keys list`: Fix returning null values with azure-mgmt-web 11.0.0

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -11437,8 +11437,11 @@ def update_function_key(cmd, resource_group_name, name, function_name, key_name,
 def list_function_keys(cmd, resource_group_name, name, function_name, slot=None):
     client = web_client_factory(cmd.cli_ctx)
     if slot:
-        return client.web_apps.list_function_keys_slot(resource_group_name, name, function_name, slot)
-    return client.web_apps.list_function_keys(resource_group_name, name, function_name)
+        keys = client.web_apps.list_function_keys_slot(resource_group_name, name, function_name, slot)
+    else:
+        keys = client.web_apps.list_function_keys(resource_group_name, name, function_name)
+    # SDK may return .properties as None for flat dictionary responses; fall back to raw payload
+    return keys.properties if keys.properties is not None else dict(keys)
 
 
 def delete_function_key(cmd, resource_group_name, name, key_name, function_name=None, slot=None):

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands_thru_mock.py
@@ -17,7 +17,8 @@ from azure.cli.command_modules.appservice.custom import (
     remove_remote_build_app_settings,
     config_source_control,
     validate_app_settings_in_scm,
-    update_container_settings_functionapp)
+    update_container_settings_functionapp,
+    list_function_keys)
 from azure.cli.core.profiles import ResourceType
 from azure.cli.core.azclierror import (AzureInternalError, UnclassifiedUserFault)
 from azure.cli.core.azclierror import ResourceNotFoundError
@@ -849,3 +850,42 @@ class TestFunctionappMocked(unittest.TestCase):
 
         # assert
         self.assertEqual(matched.name, 'dotnet-isolated')
+
+    @mock.patch('azure.cli.command_modules.appservice.custom.web_client_factory', autospec=True)
+    def test_list_function_keys_unwraps_broken_string_dictionary(self, web_client_factory_mock):
+        # azure-mgmt-web 11.0.0 deserializes flat dictionary responses with .properties = None
+        from azure.mgmt.web import models as _models
+        from azure.mgmt.web._utils.model_base import _deserialize
+
+        broken = _deserialize(
+            _models.StringDictionary,
+            {'default': 'vvrX4LJY1JWbimFI28UM', 'myCustomKey': 'abc'})
+        self.assertIsNone(broken.properties)
+
+        cmd_mock = _get_test_cmd()
+        client_mock = mock.MagicMock()
+        client_mock.web_apps.list_function_keys.return_value = broken
+        web_client_factory_mock.return_value = client_mock
+
+        result = list_function_keys(cmd_mock, 'rg', 'app', 'httpget')
+
+        self.assertEqual(result, {'default': 'vvrX4LJY1JWbimFI28UM', 'myCustomKey': 'abc'})
+        client_mock.web_apps.list_function_keys.assert_called_once_with('rg', 'app', 'httpget')
+        client_mock.web_apps.list_function_keys_slot.assert_not_called()
+
+    @mock.patch('azure.cli.command_modules.appservice.custom.web_client_factory', autospec=True)
+    def test_list_function_keys_uses_properties_when_sdk_returns_enveloped_response(self, web_client_factory_mock):
+        # Prefers .properties when populated (forward-compatible with a future SDK fix)
+        fixed = mock.MagicMock()
+        fixed.properties = {'default': 'abc'}
+
+        cmd_mock = _get_test_cmd()
+        client_mock = mock.MagicMock()
+        client_mock.web_apps.list_function_keys_slot.return_value = fixed
+        web_client_factory_mock.return_value = client_mock
+
+        result = list_function_keys(cmd_mock, 'rg', 'app', 'httpget', slot='staging')
+
+        self.assertEqual(result, {'default': 'abc'})
+        client_mock.web_apps.list_function_keys_slot.assert_called_once_with('rg', 'app', 'httpget', 'staging')
+        client_mock.web_apps.list_function_keys.assert_not_called()


### PR DESCRIPTION
**Related command**
`az functionapp function keys list`

**Description**<!--Mandatory-->
`az functionapp function keys list` returns all-null fields (`id`, `kind`, `name`, `properties`, `type`) after the `azure-mgmt-web` 9.0.0 → 11.0.0 upgrade in #33341.

 **Root Cause**
 
 `azure-mgmt-web 11.0.0` regenerated `StringDictionary` with typespec-python. The new model sets `__flattened_items = [""]`, which fails to lift flat-at-root ARM responses (e.g. `{"default": "<key>"}`) into `.properties`. The raw payload is preserved in the model's `MutableMapping` backing store but `.properties` returns `None`.
 
 **Fix**
 
 In `list_function_keys`, fall back to `dict(keys)` when `keys.properties is None`. This is forward-compatible — if a future SDK release populates `.properties` correctly, that path is used instead.

**Testing Guide** 
 - Added 2 unit tests in `test_functionapp_commands_thru_mock.py`
 - Verified end-to-end against a live function app (before: all nulls, after: correct key values)
 - All 32 existing + new mock tests pass
 
 ```bash
 # List function keys (the broken command)
 az functionapp function keys list -g <resource-group> -n <functionapp-name> --function-name <function-name>
 
 # With slot
 az functionapp function keys list -g <resource-group> -n <functionapp-name> --function-name <function-name> --slot <slot-name>
 
 # Verify these still work (should be unaffected)
 az functionapp keys list -g <resource-group> -n <functionapp-name>
 az functionapp config appsettings list -g <resource-group> -n <functionapp-name>

Expected (before fix):

 {"id": null, "kind": null, "name": null, "properties": null, "type": null}

Expected (after fix):

 {"default": "<key-value>"}
```
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
