### PR TITLE
[Consumption] az consumption budget create: correct construction of API call when creating a budget

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/consumption/aaz/latest/consumption/budget/_create.py
+++ b/src/azure-cli/azure/cli/command_modules/consumption/aaz/latest/consumption/budget/_create.py
@@ -264,7 +264,7 @@ class Create(AAZCommand):
             if properties is not None:
                 properties.set_prop("amount", AAZFloatType, ".amount", typ_kwargs={"flags": {"required": True}})
                 properties.set_prop("category", AAZStrType, ".category", typ_kwargs={"flags": {"required": True}})
-                properties.set_prop("filters", AAZObjectType, ".filters")
+                properties.set_prop("filter", AAZObjectType, ".filters")
                 properties.set_prop("notifications", AAZDictType, ".notifications")
                 properties.set_prop("timeGrain", AAZStrType, ".time_grain", typ_kwargs={"flags": {"required": True}})
                 properties.set_prop("timePeriod", AAZObjectType, ".time_period", typ_kwargs={"flags": {"required": True}})


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az consumption budget create`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Previously, there was a bug in the creation of the API call, where the request body contained a `filters` field but the server expected `filter`. This meant that attempting to create a consumption budget via the CLI was not possible without manually using `az rest`. This pull request is a simple bug patch that corrects the construction of the API call to work as expected.

**Related issue**
 #29950 

**Testing Guide**
<!--Example commands with explanations.-->
`az consumption budget create --amount 10 --budget-name monthlyBudget --category cost --start-date 2026-06-01 --end-date 2027-01-01 --time-grain monthly`
`az consumption budget create --amount 10 --budget-name monthlyBudget --category cost --start-date 2026-06-01 --end-date 2027-01-01 --time-grain monthly --resource-group-filter <RG name>`
`az consumption budget create --amount 10 --budget-name monthlyBudget --category cost --start-date 2026-06-01 --end-date 2027-01-01 --time-grain monthly --resource-group-filter <RG name> --resource-filter <resource name>`
The above commands can be used to show case that the command now functions as expected with no filters, one filter, or multiple filters. 