### PR TITLE
{Core} Validate endpoint origin to prevent access token leakage

### DIFF
--- a/src/azure-cli-core/azure/cli/core/aaz/_arg_fmt.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_arg_fmt.py
@@ -765,13 +765,12 @@ class AAZPaginationTokenArgFormat(AAZBaseArgFormat):
                 raise AAZInvalidArgValueError("`next_link` or `offset` doesn't exist.")
 
             # `next_link` is a URL that the next page request is sent to with an Azure access token.
-            # Validate it shares the same origin as the trusted ARM endpoint to prevent the token
-            # from being sent to an attacker-controlled host such as
+            # Validate it shares the same origin as a trusted endpoint of the active cloud to prevent
+            # the token from being sent to an attacker-controlled host such as
             # `https://management.azure.com.attacker`.
             if next_link is not None:
-                from azure.cli.core.util import is_same_origin
-                resource_manager = ctx.cli_ctx.cloud.endpoints.resource_manager
-                if not is_same_origin(next_link, resource_manager):
+                from azure.cli.core.util import is_trusted_cloud_endpoint
+                if not is_trusted_cloud_endpoint(next_link, ctx.cli_ctx):
                     raise AAZInvalidArgValueError("`next_link` '{}' is not a valid endpoint.".format(next_link))
 
         assert isinstance(value, AAZSimpleValue)

--- a/src/azure-cli-core/azure/cli/core/aaz/_arg_fmt.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_arg_fmt.py
@@ -760,9 +760,19 @@ class AAZPaginationTokenArgFormat(AAZBaseArgFormat):
                 raise AAZInvalidArgValueError("Decoded object is not a dictionary.")
 
             try:
-                _, _ = obj["next_link"], obj["offset"]
+                next_link, _ = obj["next_link"], obj["offset"]
             except KeyError:
                 raise AAZInvalidArgValueError("`next_link` or `offset` doesn't exist.")
+
+            # `next_link` is a URL that the next page request is sent to with an Azure access token.
+            # Validate it shares the same origin as the trusted ARM endpoint to prevent the token
+            # from being sent to an attacker-controlled host such as
+            # `https://management.azure.com.attacker`.
+            if next_link is not None:
+                from azure.cli.core.util import is_same_origin
+                resource_manager = ctx.cli_ctx.cloud.endpoints.resource_manager
+                if not is_same_origin(next_link, resource_manager):
+                    raise AAZInvalidArgValueError("`next_link` '{}' is not a valid endpoint.".format(next_link))
 
         assert isinstance(value, AAZSimpleValue)
         data = value._data

--- a/src/azure-cli-core/azure/cli/core/tests/test_aaz_arg_fmt.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_aaz_arg_fmt.py
@@ -847,6 +847,13 @@ class TestAAZArgBaseFmt(unittest.TestCase):
 
         self.assertEqual(args.to_serialized_data(), {"token": base64.b64decode(data).decode("utf-8")})
 
+        # next_link pointing to a trusted data-plane endpoint, e.g., Microsoft Graph is accepted
+        dataplane_next_link = "https://graph.microsoft.com/v1.0/users?$skiptoken=abc"
+        data = _encode({"next_link": dataplane_next_link, "offset": 0})
+        args = self.format_arg(schema, {"token": data})
+
+        self.assertEqual(args.to_serialized_data(), {"token": base64.b64decode(data).decode("utf-8")})
+
         # next_link pointing to a lookalike host must be rejected (prefix-matching attack)
         spoofed_next_link = "https://management.azure.com.attacker/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2025-09-01"
         data = _encode({"next_link": spoofed_next_link, "offset": 0})

--- a/src/azure-cli-core/azure/cli/core/tests/test_aaz_arg_fmt.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_aaz_arg_fmt.py
@@ -836,3 +836,30 @@ class TestAAZArgBaseFmt(unittest.TestCase):
         with self.assertRaises(azclierror.InvalidArgumentValueError) as e:
             self.format_arg(schema, {"token": data})
         self.assertEqual(str(e.exception), "InvalidArgumentValue: --next-token: `next_link` or `offset` doesn't exist.")
+
+        def _encode(obj):
+            return base64.b64encode(json.dumps(obj).encode("utf-8")).decode("utf-8")
+
+        # next_link pointing to the trusted ARM endpoint is accepted
+        valid_next_link = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2025-09-01"
+        data = _encode({"next_link": valid_next_link, "offset": 0})
+        args = self.format_arg(schema, {"token": data})
+
+        self.assertEqual(args.to_serialized_data(), {"token": base64.b64decode(data).decode("utf-8")})
+
+        # next_link pointing to a lookalike host must be rejected (prefix-matching attack)
+        spoofed_next_link = "https://management.azure.com.attacker/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2025-09-01"
+        data = _encode({"next_link": spoofed_next_link, "offset": 0})
+        with self.assertRaises(azclierror.InvalidArgumentValueError) as e:
+            self.format_arg(schema, {"token": data})
+
+        self.assertEqual(str(e.exception), "InvalidArgumentValue: --next-token: `next_link` '{}' is not a valid endpoint.".format(spoofed_next_link))
+
+        # next_link using a userinfo trick where the real host is the attacker must be rejected
+        userinfo_next_link = "https://management.azure.com@attacker/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2025-09-01"
+        data = _encode({"next_link": userinfo_next_link, "offset": 0})
+        with self.assertRaises(azclierror.InvalidArgumentValueError) as e:
+            self.format_arg(schema, {"token": data})
+
+        self.assertEqual(str(e.exception), "InvalidArgumentValue: --next-token: `next_link` '{}' is not a valid endpoint.".format(userinfo_next_link))
+

--- a/src/azure-cli-core/azure/cli/core/tests/test_util.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_util.py
@@ -17,7 +17,7 @@ from azure.cli.core.util import \
     (get_file_json, truncate_text, shell_safe_json_parse, b64_to_hex, hash_string, random_string,
      open_page_in_browser, can_launch_browser, handle_exception, ConfiguredDefaultSetter, send_raw_request,
      should_disable_connection_verify, parse_proxy_resource_id, get_az_user_agent, get_az_rest_user_agent,
-    _get_parent_proc_name, is_wsl, run_cmd, run_az_cmd, roughly_parse_command)
+    _get_parent_proc_name, is_wsl, run_cmd, run_az_cmd, roughly_parse_command, is_same_origin)
 from azure.cli.core.mock import DummyCli
 
 
@@ -374,6 +374,17 @@ class TestUtils(unittest.TestCase):
         request = send_mock.call_args[0][1]
         self.assertEqual(request.url, 'https://management.azure.com:443/subscriptions/00000001-0000-0000-0000-000000000000/resourcegroups/02?api-version=2019-07-01')
 
+        # Test lookalike host is NOT mistaken for the trusted ARM endpoint via prefix matching.
+        # The access token must NOT be attached to an attacker-controlled origin.
+        for spoofed_host in ['https://management.azure.com.attacker', 'https://management.azure.com@attacker']:
+            spoofed_url = spoofed_host + arm_resource_id
+            get_raw_token_mock.reset_mock()
+            send_raw_request(cli_ctx, 'GET', spoofed_url, generated_client_request_id_name=None)
+            get_raw_token_mock.assert_not_called()
+            request = send_mock.call_args[0][1]
+
+            self.assertNotIn('Authorization', request.headers)
+
         # Test non-ARM APIs
 
         # Test AD Graph API https://graph.windows.net/
@@ -399,6 +410,35 @@ class TestUtils(unittest.TestCase):
             get_raw_token_mock.assert_called_with(mock.ANY, test_arm_active_directory_resource_id, subscription=subscription_id)
             request = send_mock.call_args[0][1]
             self.assertEqual(request.headers['User-Agent'], get_az_rest_user_agent() + ' env-ua ARG-UA')
+
+    def test_is_same_origin(self):
+        endpoint = 'https://management.azure.com/'
+
+        # Same origin
+        self.assertTrue(is_same_origin('https://management.azure.com/subscriptions/01?api-version=2025-09-01', endpoint))
+        self.assertTrue(is_same_origin('https://management.azure.com', endpoint))
+        # Case-insensitive scheme and host
+        self.assertTrue(is_same_origin('HTTPS://Management.Azure.Com/path', endpoint))
+        # Default port is equivalent to an omitted port
+        self.assertTrue(is_same_origin('https://management.azure.com:443/path', endpoint))
+        self.assertTrue(is_same_origin('https://management.azure.com/path', 'https://management.azure.com:443/'))
+
+        # Prefix-matching attack: lookalike host must NOT match
+        self.assertFalse(is_same_origin('https://management.azure.com.attacker/path', endpoint))
+        self.assertFalse(is_same_origin('https://management.azure.com.attacker', endpoint))
+        # Userinfo trick: real host is the attacker
+        self.assertFalse(is_same_origin('https://management.azure.com@attacker/path', endpoint))
+        # Different scheme
+        self.assertFalse(is_same_origin('http://management.azure.com/path', endpoint))
+        # Different port
+        self.assertFalse(is_same_origin('https://management.azure.com:8443/path', endpoint))
+        # Different host
+        self.assertFalse(is_same_origin('https://graph.microsoft.com/path', endpoint))
+
+        # Malformed / non-URL inputs
+        self.assertFalse(is_same_origin('not a url', endpoint))
+        self.assertFalse(is_same_origin('', endpoint))
+        self.assertFalse(is_same_origin('https://management.azure.com/path', 'not a url'))
 
     @mock.patch("psutil.Process")
     def test_get_parent_proc_name(self, mock_process_type):

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -1041,10 +1041,10 @@ def send_raw_request(cli_ctx, method, url, headers=None, uri_parameters=None,  #
     if not skip_authorization_header and url.lower().startswith('https://'):
         # Prepare `resource` for `get_raw_token`
         if not resource:
-            # If url starts with ARM endpoint, like `https://management.azure.com/`,
+            # If url's origin matches the ARM endpoint, like `https://management.azure.com/`,
             # use `active_directory_resource_id` for resource, like `https://management.core.windows.net/`.
             # This follows the same behavior as `azure.cli.core.commands.client_factory._get_mgmt_service_client`
-            if url.lower().startswith(endpoints.resource_manager.rstrip('/')):
+            if is_same_origin(url, endpoints.resource_manager):
                 resource = endpoints.active_directory_resource_id
             else:
                 from azure.cli.core.cloud import CloudEndpointNotSetException
@@ -1053,7 +1053,7 @@ def send_raw_request(cli_ctx, method, url, headers=None, uri_parameters=None,  #
                         value = getattr(endpoints, p)
                     except CloudEndpointNotSetException:
                         continue
-                    if isinstance(value, str) and url.lower().startswith(value.lower()):
+                    if isinstance(value, str) and is_same_origin(url, value):
                         resource = value
                         break
         if resource:
@@ -1063,7 +1063,7 @@ def send_raw_request(cli_ctx, method, url, headers=None, uri_parameters=None,  #
             # TODO: In the future when multi-tenant subscription is supported, we won't be able to uniquely identify
             #   the token from subscription anymore.
             token_subscription = None
-            if url.lower().startswith(endpoints.resource_manager.rstrip('/')):
+            if is_same_origin(url, endpoints.resource_manager):
                 token_subscription = _extract_subscription_id(url)
             if token_subscription:
                 logger.debug('Retrieving token for resource %s, subscription %s', resource, token_subscription)
@@ -1208,6 +1208,53 @@ def urlretrieve(url):
     from urllib.request import urlopen
     req = urlopen(url, context=_ssl_context())
     return req.read()
+
+
+def is_same_origin(url, endpoint):
+    """Check whether ``url`` and ``endpoint`` share the same origin (scheme + host + port).
+
+    This performs an exact origin comparison rather than substring or prefix matching, so a
+    malicious host such as ``https://management.azure.com.attacker`` is not mistaken for
+    the trusted endpoint ``https://management.azure.com``. It is intended for validating that a
+    URL points to a trusted endpoint before sensitive data (e.g., an Azure access token) is sent
+    to it.
+
+    :param url: The URL to validate, e.g., ``https://management.azure.com/subscriptions/...``.
+    :param endpoint: The trusted endpoint to validate against, e.g., ``https://management.azure.com/``.
+    :return: ``True`` if both share the same origin, otherwise ``False``.
+    :rtype: bool
+    """
+    from urllib.parse import urlparse
+    try:
+        url_parts = urlparse(url)
+        endpoint_parts = urlparse(endpoint)
+
+    except ValueError:
+        return False
+
+    # Require a real host on both sides to avoid false positives against non-URL endpoint values.
+    # `hostname` (rather than `netloc`) is used so that userinfo tricks like
+    # `https://management.azure.com@attacker` resolve to the actual host `attacker`.
+    if not url_parts.hostname or not endpoint_parts.hostname:
+        return False
+
+    def _effective_port(parts):
+        # Treat a missing port as the scheme's default port so that, e.g.,
+        # `https://management.azure.com:443/` and `https://management.azure.com/` are equivalent.
+        if parts.port is not None:
+            return parts.port
+
+        return {'http': 80, 'https': 443}.get(parts.scheme.lower())
+
+    try:
+        if _effective_port(url_parts) != _effective_port(endpoint_parts):
+            return False
+
+    except ValueError:
+        return False
+
+    return (url_parts.scheme.lower() == endpoint_parts.scheme.lower() and
+            url_parts.hostname.lower() == endpoint_parts.hostname.lower())
 
 
 def parse_proxy_resource_id(rid):

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -1217,11 +1217,15 @@ def is_same_origin(url, endpoint):
     :rtype: bool
     """
     from urllib.parse import urlparse
+
+    if not isinstance(url, str) or not isinstance(endpoint, str):
+        return False
+
     try:
         url_parts = urlparse(url)
         endpoint_parts = urlparse(endpoint)
 
-    except ValueError:
+    except (TypeError, ValueError):
         return False
 
     # Require a real host on both sides to avoid false positives against non-URL endpoint values.

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -1047,15 +1047,7 @@ def send_raw_request(cli_ctx, method, url, headers=None, uri_parameters=None,  #
             if is_same_origin(url, endpoints.resource_manager):
                 resource = endpoints.active_directory_resource_id
             else:
-                from azure.cli.core.cloud import CloudEndpointNotSetException
-                for p in [x for x in dir(endpoints) if not x.startswith('_')]:
-                    try:
-                        value = getattr(endpoints, p)
-                    except CloudEndpointNotSetException:
-                        continue
-                    if isinstance(value, str) and is_same_origin(url, value):
-                        resource = value
-                        break
+                resource = match_cloud_endpoint(url, cli_ctx)
         if resource:
             # Prepare `subscription` for `get_raw_token`
             # If this is an ARM request, try to extract subscription ID from the URL.
@@ -1255,6 +1247,41 @@ def is_same_origin(url, endpoint):
 
     return (url_parts.scheme.lower() == endpoint_parts.scheme.lower() and
             url_parts.hostname.lower() == endpoint_parts.hostname.lower())
+
+
+def match_cloud_endpoint(url, cli_ctx):
+    """Return the active cloud endpoint that shares the same origin as ``url``.
+
+    :param url: The URL to match, e.g., ``https://management.azure.com/subscriptions/...``.
+    :param cli_ctx: The CLI context whose active cloud's endpoints are treated as trusted.
+    :return: The matching endpoint value, or ``None`` if no endpoint shares ``url``'s origin.
+    :rtype: str or None
+    """
+    from azure.cli.core.cloud import CloudEndpointNotSetException
+
+    endpoints = cli_ctx.cloud.endpoints
+    for p in [x for x in dir(endpoints) if not x.startswith('_')]:
+        try:
+            value = getattr(endpoints, p)
+
+        except CloudEndpointNotSetException:
+            continue
+
+        if isinstance(value, str) and is_same_origin(url, value):
+            return value
+
+    return None
+
+
+def is_trusted_cloud_endpoint(url, cli_ctx):
+    """Check whether ``url`` shares the same origin as any endpoint of the active cloud.
+
+    :param url: The URL to validate, e.g., ``https://management.azure.com/subscriptions/...``.
+    :param cli_ctx: The CLI context whose active cloud's endpoints are treated as trusted.
+    :return: ``True`` if ``url`` shares the same origin as any cloud endpoint, otherwise ``False``.
+    :rtype: bool
+    """
+    return match_cloud_endpoint(url, cli_ctx) is not None
 
 
 def parse_proxy_resource_id(rid):


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Problem:
Azure CLI used str.startswith() to check whether a URL targets a trusted Azure endpoint before attaching an access token. A lookalike host like `https://management.azure.com.attacker` could match `https://management.azure.com` via prefix matching, causing the token to be sent to an attacker-controlled origin.

Fix:
Added is_same_origin(url, endpoint) in `util.py` that does exact origin comparison (scheme + host + port), handling default ports and userinfo (user@host) tricks. Applied it to:
- send_raw_request (az rest) — replaces the startswith() checks.
- AAZ pagination next_link — validates the URL against the ARM endpoint before reuse.

Tests:
Added coverage for is_same_origin, the az rest token-leak scenario, and the AAZ next_link validation, including lookalike-host and userinfo spoofing cases.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
