### PR TITLE
[Resource] Fix #32786: `az bicep publish`: Correct placement of `--force` in help example

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_help.py
@@ -2427,7 +2427,7 @@ examples:
   - name: Publish a bicep file.
     text: az bicep publish --file {bicep_file} --target "br:{registry}/{module_path}:{tag}"
   - name: Publish a bicep file overwriting an existing tag.
-    text: az bicep publish --file {bicep_file} --target "br:{registry}/{module_path}:{tag} --force"
+    text: az bicep publish --file {bicep_file} --target "br:{registry}/{module_path}:{tag}" --force
   - name: Publish a bicep file with documentation uri.
     text: az bicep publish --file {bicep_file} --target "br:{registry}/{module_path}:{tag}" --documentation-uri {documentation_uri}
   - name: Publish a bicep file with documentation uri and include source code


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

## Summary
- Move `--force` outside the quoted `--target` value in the `az bicep publish` help example.
- This updates the Azure CLI source help so generated docs keep the corrected syntax.

Fixes #32786.
Follow-up to MicrosoftDocs/azure-docs-cli#6015, where the generated docs were corrected and maintainers noted the source should be updated here.

## Testing
- `rg -n "az bicep publish --file \{bicep_file\} --target" src\azure-cli\azure\cli\command_modules\resource\_help.py`
- `git diff --check`

## AI disclosure
This pull request was prepared with assistance from OpenAI Codex.