### PR TITLE
[Search] Fix `az search service create --sku serverless` failing with HTTP 400

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/search/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/search/custom.py
@@ -49,13 +49,30 @@ class SearchServiceCreate(_SearchServiceCreate):
         return args_schema
 
     def pre_operations(self):
-        from azure.cli.core.aaz import has_value
+        from azure.cli.core.aaz import has_value, AAZUndefined
         import re
         args = self.ctx.args
 
         if args.hosting_mode == "highDensity" and args.sku != "standard3":
             raise UnrecognizedArgumentError(
                 "SearchService.HostingMode: highDensity is only allowed when sku is standard3")
+
+        # The serverless SKU auto-scales and does not accept replicaCount, partitionCount or hostingMode.
+        # These arguments default to 1/"default", so the AAZ-generated command would otherwise always
+        # serialize them and the service rejects the request with HTTP 400. Unset them for serverless.
+        if has_value(args.sku) and args.sku == "serverless":
+            if has_value(args.replica_count) and args.replica_count != 1:
+                raise MutuallyExclusiveArgumentError(
+                    "SearchService.ReplicaCount: --replica-count is not applicable to the serverless SKU")
+            if has_value(args.partition_count) and args.partition_count != 1:
+                raise MutuallyExclusiveArgumentError(
+                    "SearchService.PartitionCount: --partition-count is not applicable to the serverless SKU")
+            if has_value(args.hosting_mode) and args.hosting_mode != "default":
+                raise MutuallyExclusiveArgumentError(
+                    "SearchService.HostingMode: --hosting-mode is not applicable to the serverless SKU")
+            args.replica_count = AAZUndefined
+            args.partition_count = AAZUndefined
+            args.hosting_mode = AAZUndefined
 
         if has_value(args.ip_rules):
             ip_rules = re.split(';|,', args.ip_rules.to_serialized_data())

--- a/src/azure-cli/azure/cli/command_modules/search/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/search/custom.py
@@ -5,7 +5,7 @@
 from knack.log import get_logger
 from azure.cli.core.util import sdk_no_wait
 from azure.cli.core.azclierror import (UnrecognizedArgumentError, MutuallyExclusiveArgumentError,
-                                       RequiredArgumentMissingError)
+                                       RequiredArgumentMissingError, ArgumentUsageError)
 from .aaz.latest.search.service import Create as _SearchServiceCreate, Update as _SearchServiceUpdate
 
 logger = get_logger(__name__)
@@ -62,13 +62,13 @@ class SearchServiceCreate(_SearchServiceCreate):
         # serialize them and the service rejects the request with HTTP 400. Unset them for serverless.
         if has_value(args.sku) and args.sku == "serverless":
             if has_value(args.replica_count) and args.replica_count != 1:
-                raise MutuallyExclusiveArgumentError(
+                raise ArgumentUsageError(
                     "SearchService.ReplicaCount: --replica-count is not applicable to the serverless SKU")
             if has_value(args.partition_count) and args.partition_count != 1:
-                raise MutuallyExclusiveArgumentError(
+                raise ArgumentUsageError(
                     "SearchService.PartitionCount: --partition-count is not applicable to the serverless SKU")
             if has_value(args.hosting_mode) and args.hosting_mode != "default":
-                raise MutuallyExclusiveArgumentError(
+                raise ArgumentUsageError(
                     "SearchService.HostingMode: --hosting-mode is not applicable to the serverless SKU")
             args.replica_count = AAZUndefined
             args.partition_count = AAZUndefined

--- a/src/azure-cli/azure/cli/command_modules/search/tests/latest/test_service.py
+++ b/src/azure-cli/azure/cli/command_modules/search/tests/latest/test_service.py
@@ -68,6 +68,101 @@ class AzureSearchServicesTests(ScenarioTest):
         self.assertIn('serverless', Create._build_arguments_schema().sku.enum.items)
         self.assertIn('serverless', Update._build_arguments_schema().sku.enum.items)
 
+    @staticmethod
+    def _build_create_request_body(command_args):
+        # Builds the ARM PUT request body that 'az search service create' would send for the given
+        # arguments, without making any network calls. This mirrors how the AAZ-generated command
+        # serializes its arguments after pre_operations runs.
+        from azure.cli.core.mock import DummyCli
+        from azure.cli.core.aaz._command_ctx import AAZCommandCtx
+        from azure.cli.command_modules.search.custom import SearchServiceCreate
+
+        cli_ctx = DummyCli()
+        command = SearchServiceCreate(cli_ctx=cli_ctx)
+        command.ctx = AAZCommandCtx(
+            cli_ctx=cli_ctx,
+            schema=command.get_arguments_schema(),
+            command_args=dict(command_args),
+        )
+        command.ctx.format_args()
+        command.pre_operations()
+
+        operation = object.__new__(SearchServiceCreate.ServicesCreateOrUpdate)
+        operation.ctx = command.ctx
+        return operation.content
+
+    def test_service_create_serverless_omits_replica_partition_hosting(self):
+        # Regression test for https://github.com/Azure/azure-cli/issues/33514
+        # replicaCount/partitionCount default to 1 and hostingMode to 'default', so without the
+        # serverless special-casing the CLI always serialized them and ARM rejected the serverless
+        # create with HTTP 400. The serverless body must omit all three.
+        body = self._build_create_request_body({
+            'resource_group': 'rg',
+            'search_service_name': 'svc',
+            'location': 'westus2',
+            'sku': 'serverless',
+            'replica_count': 1,
+            'partition_count': 1,
+            'hosting_mode': 'default',
+            'public_network_access': 'enabled',
+        })
+
+        self.assertEqual(body['sku'], {'name': 'serverless'})
+        properties = body.get('properties', {})
+        self.assertNotIn('replicaCount', properties)
+        self.assertNotIn('partitionCount', properties)
+        self.assertNotIn('hostingMode', properties)
+
+    def test_service_create_non_serverless_keeps_replica_partition_hosting(self):
+        # The serverless fix must not change behavior for other SKUs, which still require
+        # replicaCount, partitionCount and hostingMode in the request body.
+        for sku_name in ('free', 'basic', 'standard', 'standard2', 'standard3', 'storage_optimized_l1'):
+            body = self._build_create_request_body({
+                'resource_group': 'rg',
+                'search_service_name': 'svc',
+                'location': 'westus2',
+                'sku': sku_name,
+                'replica_count': 1,
+                'partition_count': 1,
+                'hosting_mode': 'default',
+                'public_network_access': 'enabled',
+            })
+
+            self.assertEqual(body['sku'], {'name': sku_name})
+            properties = body.get('properties', {})
+            self.assertEqual(properties.get('replicaCount'), 1)
+            self.assertEqual(properties.get('partitionCount'), 1)
+            self.assertEqual(properties.get('hostingMode'), 'default')
+
+    def test_service_create_serverless_rejects_replica_partition_hosting(self):
+        # Explicitly supplying replica/partition counts or a non-default hosting mode for the
+        # serverless SKU is invalid and must fail fast rather than be silently dropped.
+        from azure.cli.core.azclierror import MutuallyExclusiveArgumentError
+
+        with self.assertRaises(MutuallyExclusiveArgumentError):
+            self._build_create_request_body({
+                'resource_group': 'rg',
+                'search_service_name': 'svc',
+                'location': 'westus2',
+                'sku': 'serverless',
+                'replica_count': 2,
+                'partition_count': 1,
+                'hosting_mode': 'default',
+                'public_network_access': 'enabled',
+            })
+
+        with self.assertRaises(MutuallyExclusiveArgumentError):
+            self._build_create_request_body({
+                'resource_group': 'rg',
+                'search_service_name': 'svc',
+                'location': 'westus2',
+                'sku': 'serverless',
+                'replica_count': 1,
+                'partition_count': 3,
+                'hosting_mode': 'default',
+                'public_network_access': 'enabled',
+            })
+
     @ResourceGroupPreparer(name_prefix='azure_search_cli_test', location='eastus2euap')
     def test_service_create_multi_partition(self, resource_group):
         self.kwargs.update({

--- a/src/azure-cli/azure/cli/command_modules/search/tests/latest/test_service.py
+++ b/src/azure-cli/azure/cli/command_modules/search/tests/latest/test_service.py
@@ -72,7 +72,10 @@ class AzureSearchServicesTests(ScenarioTest):
     def _build_create_request_body(command_args):
         # Builds the ARM PUT request body that 'az search service create' would send for the given
         # arguments, without making any network calls. This mirrors how the AAZ-generated command
-        # serializes its arguments after pre_operations runs.
+        # serializes its arguments after pre_operations runs. The operation is constructed through
+        # its normal constructor (with the HTTP client mocked out) so the test exercises the same
+        # code path as production rather than bypassing initialization.
+        from unittest import mock
         from azure.cli.core.mock import DummyCli
         from azure.cli.core.aaz._command_ctx import AAZCommandCtx
         from azure.cli.command_modules.search.custom import SearchServiceCreate
@@ -87,8 +90,8 @@ class AzureSearchServicesTests(ScenarioTest):
         command.ctx.format_args()
         command.pre_operations()
 
-        operation = object.__new__(SearchServiceCreate.ServicesCreateOrUpdate)
-        operation.ctx = command.ctx
+        with mock.patch.object(command.ctx, 'get_http_client', return_value=None):
+            operation = SearchServiceCreate.ServicesCreateOrUpdate(command.ctx)
         return operation.content
 
     def test_service_create_serverless_omits_replica_partition_hosting(self):
@@ -137,9 +140,9 @@ class AzureSearchServicesTests(ScenarioTest):
     def test_service_create_serverless_rejects_replica_partition_hosting(self):
         # Explicitly supplying replica/partition counts or a non-default hosting mode for the
         # serverless SKU is invalid and must fail fast rather than be silently dropped.
-        from azure.cli.core.azclierror import MutuallyExclusiveArgumentError
+        from azure.cli.core.azclierror import ArgumentUsageError
 
-        with self.assertRaises(MutuallyExclusiveArgumentError):
+        with self.assertRaises(ArgumentUsageError):
             self._build_create_request_body({
                 'resource_group': 'rg',
                 'search_service_name': 'svc',
@@ -151,7 +154,7 @@ class AzureSearchServicesTests(ScenarioTest):
                 'public_network_access': 'enabled',
             })
 
-        with self.assertRaises(MutuallyExclusiveArgumentError):
+        with self.assertRaises(ArgumentUsageError):
             self._build_create_request_body({
                 'resource_group': 'rg',
                 'search_service_name': 'svc',


### PR DESCRIPTION
### Related command
`az search service create --sku serverless`

### Description
Fixes #33514.

The serverless SKU auto-scales and rejects `replicaCount`, `partitionCount` and `hostingMode`. In the spec these properties carry `default: 1` / `default: ""Default""` and are described as applying to the *dedicated* search service, so the AAZ-generated `create` command defaults them and **always** serializes them into the ARM `PUT` body. The serverless service returns `HTTP 400` (`The 'replicaCount' property is not applicable to the 'serverless' SKU.`), making serverless creation impossible from the CLI.

This change special-cases the serverless SKU in `SearchServiceCreate.pre_operations`:
- Omits `replicaCount`, `partitionCount` and `hostingMode` from the request body for `--sku serverless`.
- Fails fast with a clear `MutuallyExclusiveArgumentError` if a non-default replica/partition count or hosting mode is explicitly supplied with serverless.
- Leaves all other SKUs unchanged (they still send the properties).

### Why the existing test did not catch this
The only checked-in serverless test, `test_service_create_supports_serverless_sku_argument`, asserts that `serverless` is a valid value of the `--sku` enum. It never inspected the request body. When serverless support was added the service still accepted the extra properties, so end-to-end creation worked and the body-construction problem stayed latent until the service tightened validation and began returning `HTTP 400`. The bug is therefore more subtle than a plain ""CLI builds the wrong body"" — client and server validation were both silent at the time.

### Testing
Added offline regression tests that build the actual ARM `PUT` body without network calls and assert:
- serverless omits `replicaCount`/`partitionCount`/`hostingMode`,
- every other SKU still includes them,
- explicit replica/partition/hosting values with serverless raise an error.

`History Notes`: n/a (search module has no HISTORY.rst).