### PR TITLE
[Keyvault] aes key size support

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/keyvault/_transformers.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_transformers.py
@@ -101,6 +101,7 @@ def transform_key_list_output(result, **command_args):  # pylint: disable=unused
         k['attributes'] = key._attributes    # pylint: disable=protected-access
         k['kid'] = key.id
         k['name'] = key.name
+        k['keySize'] = key.key_size
         k['managed'] = key.managed
         k['tags'] = key.tags
         k['releasePolicy'] = key.release_policy
@@ -129,6 +130,7 @@ def transform_key_output(result, **command_args):
             'expires': result.properties.expires_on,
             'exportable': result.properties.exportable,
             'hsmPlatform': result.properties.hsm_platform,
+            'keySize': result.properties.key_size,
             'notBefore': result.properties.not_before,
             'recoverableDays': result.properties.recoverable_days,
             'recoveryLevel': result.properties.recovery_level,

--- a/src/azure-cli/azure/cli/command_modules/keyvault/tests/latest/test_transformers.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/tests/latest/test_transformers.py
@@ -1,0 +1,126 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import unittest
+
+from azure.keyvault.keys import JsonWebKey, KeyProperties, KeyVaultKey
+from azure.keyvault.keys._models import DeletedKey
+
+from azure.cli.command_modules.keyvault._transformers import (
+    transform_key_list_output,
+    transform_key_output,
+)
+
+
+class _Attrs:
+    def __init__(self, key_size=None):
+        self.enabled = True
+        self.not_before = None
+        self.expires = None
+        self.created = None
+        self.updated = None
+        self.recovery_level = "Recoverable"
+        self.recoverable_days = 7
+        self.exportable = False
+        self.hsm_platform = None
+        self.key_size = key_size
+
+
+def _kid(name):
+    return "https://example.vault.azure.net/keys/{}/abc".format(name)
+
+
+def _make_key_properties(name, key_size=None):
+    return KeyProperties(key_id=_kid(name), attributes=_Attrs(key_size=key_size))
+
+
+def _make_key(name, key_size=None, kty="oct"):
+    key = KeyVaultKey.__new__(KeyVaultKey)
+    key._properties = _make_key_properties(name, key_size=key_size)
+    key._key_material = JsonWebKey(kty=kty, key_ops=["encrypt", "decrypt"])
+    return key
+
+
+def _make_deleted_key(name, key_size=None, kty="oct"):
+    # DeletedKey.__init__ forwards to KeyVaultKey.__init__, which still
+    # requires the positional key_id arg; bypass with __new__.
+    deleted = DeletedKey.__new__(DeletedKey)
+    deleted._properties = _make_key_properties(name, key_size=key_size)
+    deleted._key_material = JsonWebKey(kty=kty)
+    deleted._deleted_date = None
+    deleted._recovery_id = "https://example.vault.azure.net/deletedkeys/{}".format(name)
+    deleted._scheduled_purge_date = None
+    return deleted
+
+
+class KeyVaultTransformersTests(unittest.TestCase):
+
+    def test_show_aes_key_surfaces_key_size(self):
+        out = transform_key_output(_make_key("aes-256", key_size=256, kty="oct"))
+
+        self.assertEqual(out["attributes"]["keySize"], 256)
+
+    def test_show_aes_hsm_key_surfaces_key_size(self):
+        out = transform_key_output(_make_key("aes-128", key_size=128, kty="oct-HSM"))
+
+        self.assertEqual(out["attributes"]["keySize"], 128)
+
+    def test_show_rsa_key_returns_none_key_size(self):
+        out = transform_key_output(_make_key("rsa", key_size=None, kty="RSA"))
+
+        self.assertIn("keySize", out["attributes"])
+        self.assertIsNone(out["attributes"]["keySize"])
+
+    def test_show_deleted_key_includes_key_size_and_deletion_fields(self):
+        out = transform_key_output(_make_deleted_key("deleted-aes", key_size=256))
+
+        self.assertEqual(out["attributes"]["keySize"], 256)
+        self.assertIn("deletedDate", out)
+        self.assertIn("scheduledPurgeDate", out)
+        self.assertTrue(out["recoveryId"].endswith("/deletedkeys/deleted-aes"))
+
+    def test_show_passes_through_unknown_types(self):
+        sentinel = {"already": "transformed"}
+
+        self.assertIs(transform_key_output(sentinel), sentinel)
+
+    def test_list_surfaces_key_size_per_item(self):
+        items = [
+            _make_key_properties("aes-256", key_size=256),
+            _make_key_properties("aes-128", key_size=128),
+            _make_key_properties("rsa", key_size=None),
+        ]
+
+        out = transform_key_list_output(items)
+
+        self.assertEqual([k["keySize"] for k in out], [256, 128, None])
+        self.assertEqual([k["name"] for k in out], ["aes-256", "aes-128", "rsa"])
+
+    def test_list_surfaces_key_size_for_deleted_entries(self):
+        items = [
+            _make_deleted_key("deleted-aes", key_size=256),
+            _make_key_properties("live-aes", key_size=128),
+        ]
+
+        out = transform_key_list_output(items)
+
+        self.assertEqual(out[0]["keySize"], 256)
+        self.assertIn("deletedDate", out[0])
+        self.assertIn("scheduledPurgeDate", out[0])
+        self.assertEqual(out[1]["keySize"], 128)
+        self.assertNotIn("deletedDate", out[1])
+
+    def test_list_empty_returns_input(self):
+        self.assertEqual(transform_key_list_output([]), [])
+        self.assertIsNone(transform_key_list_output(None))
+
+    def test_list_passes_through_non_key_properties(self):
+        original = [{"not": "a key"}]
+
+        self.assertIs(transform_key_list_output(original), original)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/azure-cli/azure/cli/command_modules/keyvault/tests/latest/test_transformers.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/tests/latest/test_transformers.py
@@ -5,8 +5,7 @@
 
 import unittest
 
-from azure.keyvault.keys import JsonWebKey, KeyProperties, KeyVaultKey
-from azure.keyvault.keys._models import DeletedKey
+from azure.keyvault.keys import DeletedKey, JsonWebKey, KeyProperties, KeyVaultKey
 
 from azure.cli.command_modules.keyvault._transformers import (
     transform_key_list_output,

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -14,7 +14,7 @@ azure-data-tables==12.4.0
 azure-datalake-store==1.0.1
 azure-keyvault-administration==4.4.0
 azure-keyvault-certificates==4.7.0
-azure-keyvault-keys==4.11.0
+azure-keyvault-keys==4.12.0b1
 azure-keyvault-secrets==4.7.0
 azure-keyvault-securitydomain==1.0.0b1
 azure-mgmt-advisor==9.0.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -14,7 +14,7 @@ azure-data-tables==12.4.0
 azure-datalake-store==1.0.1
 azure-keyvault-administration==4.4.0
 azure-keyvault-certificates==4.7.0
-azure-keyvault-keys==4.11.0
+azure-keyvault-keys==4.12.0b1
 azure-keyvault-secrets==4.7.0
 azure-keyvault-securitydomain==1.0.0b1
 azure-mgmt-advisor==9.0.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -14,7 +14,7 @@ azure-data-tables==12.4.0
 azure-datalake-store==1.0.1
 azure-keyvault-administration==4.4.0
 azure-keyvault-certificates==4.7.0
-azure-keyvault-keys==4.11.0
+azure-keyvault-keys==4.12.0b1
 azure-keyvault-secrets==4.7.0
 azure-keyvault-securitydomain==1.0.0b1
 azure-mgmt-advisor==9.0.0

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -61,7 +61,7 @@ DEPENDENCIES = [
     'azure-datalake-store~=1.0.1',
     'azure-keyvault-administration==4.4.0',
     'azure-keyvault-certificates==4.7.0',
-    'azure-keyvault-keys==4.11.0',
+    'azure-keyvault-keys==4.12.0b1',
     'azure-keyvault-secrets==4.7.0',
     'azure-keyvault-securitydomain==1.0.0b1',
     'azure-mgmt-advisor==9.0.0',


### PR DESCRIPTION
**Related command**
`az keyvault key show`
`az keyvault key list`

**Description**<!--Mandatory-->
Add AES key size support to Key Vault key output by surfacing `keySize` in the transformed results for `az keyvault key show` and `az keyvault key list`.

This PR:
- upgrades `azure-keyvault-keys` from `4.11.0` to `4.12.0b1` so AES key size is available from the SDK
- adds `keySize` to key output in `transform_key_output`
- adds `keySize` to list output in `transform_key_list_output`
- adds unit tests covering AES keys, AES-HSM keys, RSA keys, deleted keys, list output, and passthrough/empty input behavior

Effect:
- customers can see AES key size directly in CLI output for supported Key Vault keys
- non-AES keys continue to return `keySize` as `None` when not provided by the SDK
- deleted key output preserves existing deletion metadata while also surfacing `keySize`

**Testing Guide**
Run the new transformer unit tests:
`python -m pytest src/azure-cli/azure/cli/command_modules/keyvault/tests/latest/test_transformers.py`

Validate command output manually with AES keys:
- `az keyvault key show --vault-name <vault-name> --name <aes-key-name>`
  - verify `attributes.keySize` is present, for example `128` or `256`
- `az keyvault key list --vault-name <vault-name>`
  - verify each AES key item includes `keySize`
- `az keyvault key show --vault-name <vault-name> --name <rsa-key-name>`
  - verify `attributes.keySize` is present and remains `null`/`None` when the SDK does not provide a value

If available, also validate deleted key output:
- `az keyvault key show-deleted --vault-name <vault-name> --name <deleted-aes-key-name>`
  - verify deletion fields are preserved and `attributes.keySize` is included

**History Notes**
[Keyvault] `az keyvault key show/list`: Add AES key size to output

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).