### PR TITLE
[Network] Fix #33520: `az network vpn-connection create`: `--shared-key` is optional with certificate-based authentication

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_validators.py
@@ -668,7 +668,7 @@ def process_vpn_connection_create_namespace(cmd, namespace):
 
     _normalize_shared_key_fields(namespace)
 
-    if (namespace.local_gateway2 or namespace.vnet_gateway2) and not namespace.shared_key:
+    if (namespace.local_gateway2 or namespace.vnet_gateway2) and not namespace.shared_key and auth != 'certificate':
         raise CLIError('--shared-key is required for VNET-to-VNET or Site-to-Site connections.')
 
     if namespace.express_route_circuit2 and namespace.shared_key:

--- a/src/azure-cli/azure/cli/command_modules/network/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_validators.py
@@ -668,7 +668,8 @@ def process_vpn_connection_create_namespace(cmd, namespace):
 
     _normalize_shared_key_fields(namespace)
 
-    if (namespace.local_gateway2 or namespace.vnet_gateway2) and not namespace.shared_key and auth != 'certificate':
+    has_gateway = any([namespace.local_gateway2, namespace.vnet_gateway2])
+    if has_gateway and not (namespace.shared_key or auth == 'certificate'):
         raise CLIError('--shared-key is required for VNET-to-VNET or Site-to-Site connections.')
 
     if namespace.express_route_circuit2 and namespace.shared_key:

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_unit_tests.py
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_unit_tests.py
@@ -77,5 +77,53 @@ class TestNetworkUnitTests(unittest.TestCase):
         self.assertEqual(result[1].value, 'noodle')
 
 
+class TestVpnConnectionCertAuthNoSharedKey(unittest.TestCase):
+    """Unit test to verify that --shared-key is not required when --auth-type Certificate is used."""
+
+    def _build_namespace(self, auth_type=None, shared_key=None):
+        namespace = mock.MagicMock()
+        namespace.resource_group_name = 'test-rg'
+        namespace.vnet_gateway1 = ('/subscriptions/00000000-0000-0000-0000-000000000000/'
+                                   'resourceGroups/test-rg/providers/Microsoft.Network/'
+                                   'virtualNetworkGateways/gw1')
+        namespace.local_gateway2 = ('/subscriptions/00000000-0000-0000-0000-000000000000/'
+                                    'resourceGroups/test-rg/providers/Microsoft.Network/'
+                                    'localNetworkGateways/lgw2')
+        namespace.vnet_gateway2 = None
+        namespace.express_route_circuit2 = None
+        namespace.shared_key = shared_key
+        namespace.shared_key_keyvault_id = None
+        namespace.auth_type = auth_type
+        namespace.tags = None
+        namespace.location = 'eastus'
+        return namespace
+
+    def test_cert_auth_without_shared_key_should_not_raise(self):
+        """--auth-type Certificate should not require --shared-key."""
+        from azure.cli.command_modules.network._validators import process_vpn_connection_create_namespace
+
+        cmd = mock.MagicMock()
+        namespace = self._build_namespace(auth_type='Certificate', shared_key=None)
+
+        try:
+            process_vpn_connection_create_namespace(cmd, namespace)
+        except CLIError as e:
+            if '--shared-key is required' in str(e):
+                self.fail(
+                    'Raised CLIError for missing --shared-key even though '
+                    '--auth-type Certificate was specified.')
+
+    def test_no_shared_key_without_cert_auth_should_raise(self):
+        """without --auth-type Certificate, missing --shared-key must raise CLIError."""
+        from azure.cli.command_modules.network._validators import process_vpn_connection_create_namespace
+
+        cmd = mock.MagicMock()
+        namespace = self._build_namespace(auth_type=None, shared_key=None)
+
+        with self.assertRaises(CLIError) as ctx:
+            process_vpn_connection_create_namespace(cmd, namespace)
+        self.assertIn('--shared-key is required', str(ctx.exception))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Related command**
`az network vpn-connection create`

**Description**
When creating a VPN connection with `--auth-type Certificate`, the validator incorrectly raises `CLIError: --shared-key is required for VNET-to-VNET or Site-to-Site connections` even though certificate-based authentication does not require a shared key.

The fix adds `and auth != 'certificate'` to the shared-key requirement check so it is skipped when `--auth-type Certificate` is specified.

Fix: https://github.com/Azure/azure-cli/issues/33520

**Testing Guide**
```sh
# This command previously failed with "--shared-key is required" error, now works:
az network vpn-connection create -g myRG -n myConn \
    --vnet-gateway1 myGateway \
    --local-gateway2 myLocalGW \
    --auth-type Certificate \
    --cert-auth "<cert-auth-json>"

# Expected: CLIError: --shared-key is required for VNET-to-VNET or Site-to-Site connections:
az network vpn-connection create -g myRG -n myConn \
    --vnet-gateway1 myGateway \
    --local-gateway2 myLocalGW
```

**History Notes**
[Network] `az network vpn-connection create`: Fix `--shared-key` incorrectly required when `--auth-type Certificate` is used

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
