### PR TITLE
[LTS] Bump embedded Python to 3.13.14 (CVE-2026-3087)

### DIFF
--- a/build_scripts/windows/scripts/build.cmd
+++ b/build_scripts/windows/scripts/build.cmd
@@ -30,7 +30,7 @@ if "%ARCH%"=="x86" (
     echo Please set ARCH to "x86" or "x64"
     goto ERROR
 )
-set PYTHON_VERSION=3.13.9
+set PYTHON_VERSION=3.13.14
 
 set WIX_DOWNLOAD_URL="https://azurecliprod.blob.core.windows.net/msi/wix310-binaries-mirror.zip"
 set PYTHON_DOWNLOAD_URL="https://www.python.org/ftp/python/%PYTHON_VERSION%/python-%PYTHON_VERSION%-embed-%PYTHON_ARCH%.zip"

--- a/scripts/release/debian/build.sh
+++ b/scripts/release/debian/build.sh
@@ -15,7 +15,7 @@ set -exv
 ls -Rl /mnt/artifacts
 
 WORKDIR=`cd $(dirname $0); cd ../../../; pwd`
-PYTHON_VERSION="3.13.9"
+PYTHON_VERSION="3.13.14"
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Update APT packages


### PR DESCRIPTION
### Description

Backports the CPython fix for **CVE-2026-3087** (GHSA-7r27-jhmm-vmp6) to the 2.66 LTS line by bumping the embedded Python from `3.13.9` to `3.13.14`.

CVE-2026-3087 is a Windows-only directory-traversal flaw in `shutil.unpack_archive()` for ZIP entries that carry a drive prefix (e.g. `C:\...`). The fix (gh-146581) first shipped in the CPython 3.13 line in **3.13.14**, so this is a clean in-LTS patch bump — no STS migration required.

Updated the two embedded-Python version pins:
- `build_scripts/windows/scripts/build.cmd`
- `scripts/release/debian/build.sh`

Advisory: https://github.com/advisories/GHSA-7r27-jhmm-vmp6