### PR TITLE
{Packaging} Decouple extension metadata from wheel==0.30.0 and cap setuptools<81

### DIFF
--- a/.azure-pipelines/templates/azdev_setup.yml
+++ b/.azure-pipelines/templates/azdev_setup.yml
@@ -15,7 +15,10 @@ steps:
       python -m venv env
       chmod +x env/bin/activate
       . env/bin/activate
-      python -m pip install -U pip
+      # Cap setuptools<81 to match the CLI build (81 drops setup.py --dry-run,
+      # 82 removes pkg_resources) so `azdev setup` builds under a supported
+      # setuptools regardless of what the agent image ships.
+      python -m pip install -U pip "setuptools<81"
       # azdev 0.2.11b1 decouples extension metadata generation from wheel==0.30.0
       # (see Azure/azure-cli-extensions#7740). It is not on PyPI yet, so install it
       # pinned to the azure-cli-dev-tools#549 merge commit (0.2.11b1) for a

--- a/.azure-pipelines/templates/azdev_setup.yml
+++ b/.azure-pipelines/templates/azdev_setup.yml
@@ -16,7 +16,12 @@ steps:
       chmod +x env/bin/activate
       . env/bin/activate
       python -m pip install -U pip
-      pip install azdev
+      # azdev 0.2.11b1 decouples extension metadata generation from wheel==0.30.0
+      # (see Azure/azure-cli-extensions#7740). It is not on PyPI yet, so install it
+      # pinned to the azure-cli-dev-tools#549 merge commit (0.2.11b1) for a
+      # reproducible build. Switch this to `pip install --upgrade "azdev==0.2.11b1"`
+      # once the pre-release is published to PyPI.
+      pip install --upgrade "git+https://github.com/Azure/azure-cli-dev-tools.git@49390f30c6a822620d2fbdf88889c4445d22666f#egg=azdev"
       azdev --version
 
       if [ -z "$CLI_EXT_REPO_PATH" ]; then

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -560,7 +560,7 @@ jobs:
     displayName: 'Use Python $(python.version)'
     inputs:
       versionSpec: '$(python.version)'
-  - bash: pip install --upgrade pip wheel setuptools
+  - bash: pip install --upgrade pip wheel "setuptools<81"
     displayName: 'Install pip and wheel'
   - bash: ./scripts/ci/test_profile_integration.sh
     displayName: 'Run Integration Test against Profiles'
@@ -581,7 +581,7 @@ jobs:
     displayName: 'Use Python $(python.version)'
     inputs:
       versionSpec: '$(python.version)'
-  - bash: pip install --upgrade pip wheel setuptools
+  - bash: pip install --upgrade pip wheel "setuptools<81"
     displayName: 'Install pip and wheel setuptools'
   - bash: ./scripts/ci/test_extensions.sh
     displayName: 'Load extensions'
@@ -1251,7 +1251,6 @@ jobs:
       cd ..
       git clone --depth 1 -b main https://github.com/Azure/azure-cli-extensions.git ./azure-cli-extensions
       azdev extension repo add ./azure-cli-extensions
-      pip install setuptools==70.0.0 wheel==0.30.0
       azdev extension add "*"
       pip install msrestazure markupsafe==2.0.1
       # Some extension will change the dependence, so run `azdev setup` again after all extensions installed.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 # basic
-setuptools>=65.5.1
+# Cap setuptools<81: newer setuptools breaks the CLI's setup.py-based builds
+# (81 removes setup.py --dry-run and changes distutils command signatures;
+# 82 removes pkg_resources). Pin to the last 80.x line.
+setuptools>=65.5.1,<81
 pip>=9.0.1

--- a/scripts/release/debian/build.sh
+++ b/scripts/release/debian/build.sh
@@ -37,7 +37,8 @@ $PYTHON_SRC_DIR/*/configure --srcdir $PYTHON_SRC_DIR/* --prefix $WORKDIR/python_
 make
 make install
 
-$WORKDIR/python_env/bin/python3 -m pip install --upgrade pip setuptools
+# Cap setuptools<81: 81 removes setup.py --dry-run and changes distutils command signatures (82 removes pkg_resources); the CLI build relies on setup.py.
+$WORKDIR/python_env/bin/python3 -m pip install --upgrade pip "setuptools<81"
 
 export PATH=$PATH:$WORKDIR/python_env/bin
 

--- a/scripts/release/homebrew/docker/requirements.txt
+++ b/scripts/release/homebrew/docker/requirements.txt
@@ -1,6 +1,7 @@
-# Pin setuptools<82 because homebrew-pypi-poet (abandoned since 2018) uses pkg_resources
-# which was removed in setuptools 82+. See https://github.com/Azure/azure-cli/issues/32800
-setuptools<82
+# Pin setuptools<81 to stay aligned with the CLI-wide cap: homebrew-pypi-poet
+# (abandoned since 2018) uses pkg_resources, which was removed in setuptools 82+,
+# and 81 changes setup.py/distutils behavior. See https://github.com/Azure/azure-cli/issues/32800
+setuptools<81
 homebrew-pypi-poet~=0.10.0
 jinja2~=3.1.6
 requests>=2.20.0

--- a/scripts/release/pypi/build.sh
+++ b/scripts/release/pypi/build.sh
@@ -17,7 +17,8 @@ echo "Branch $branch"
 echo "Search setup files from `pwd`."
 python --version
 
-pip install -U pip setuptools wheel
+# Cap setuptools<81: 81 removes setup.py --dry-run and changes distutils command signatures (82 removes pkg_resources); `python setup.py bdist_wheel` below relies on setup.py.
+pip install -U pip "setuptools<81" wheel
 pip list
 
 script_dir=`cd $(dirname $BASH_SOURCE[0]); pwd`

--- a/scripts/release/rpm/test_azurelinux_in_docker.sh
+++ b/scripts/release/rpm/test_azurelinux_in_docker.sh
@@ -14,7 +14,8 @@ time az self-test
 time az --version
 
 cd /azure-cli/
-python -m pip install --upgrade setuptools
+# Cap setuptools<81: 81 removes setup.py --dry-run and changes distutils command signatures (82 removes pkg_resources); build.sh relies on setup.py.
+python -m pip install --upgrade "setuptools<81"
 ./scripts/ci/build.sh
 
 # From Fedora36, when using `pip install --prefix` with root privileges, the package is installed into `{prefix}/local/lib`.

--- a/scripts/release/rpm/test_rpm_in_docker.sh
+++ b/scripts/release/rpm/test_rpm_in_docker.sh
@@ -15,7 +15,8 @@ time az self-test
 time az --version
 
 cd /azure-cli/
-python -m pip install --upgrade pip setuptools
+# Cap setuptools<81: 81 removes setup.py --dry-run and changes distutils command signatures (82 removes pkg_resources); build.sh relies on setup.py.
+python -m pip install --upgrade pip "setuptools<81"
 ./scripts/ci/build.sh
 
 # From Fedora36, when using `pip install --prefix` with root privileges, the package is installed into `{prefix}/local/lib`.

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -59,7 +59,10 @@ DEPENDENCIES = [
     'msal[broker]==1.36.0; sys_platform == "win32"',
     'msal==1.36.0; sys_platform != "win32"',
     'packaging>=20.9',
-    'pkginfo>=1.5.0.1',
+    # pkginfo>=1.12.0 reads the spec-defined wheel METADATA / unpacked .dist-info
+    # layout produced by modern wheel/setuptools (no metadata.json). Required so
+    # WheelExtension.get_metadata works without the legacy wheel==0.30.0 artifact.
+    'pkginfo>=1.12.0',
     # psutil can't install on cygwin: https://github.com/Azure/azure-cli/issues/9399
     'psutil>=5.9; sys_platform != "cygwin"',
     'PyJWT>=2.1.0',

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -117,7 +117,7 @@ oauthlib==3.2.2
 packaging==25.0
 paramiko==3.5.0
 pbr==7.0.3
-pkginfo==1.8.2
+pkginfo==1.12.1.2
 portalocker==3.2.0
 psutil==6.1.0
 pycomposefile==0.0.34

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -118,7 +118,7 @@ oauthlib==3.2.2
 packaging==25.0
 paramiko==3.5.0
 pbr==7.0.3
-pkginfo==1.8.2
+pkginfo==1.12.1.2
 portalocker==3.2.0
 psutil==6.1.0
 pycomposefile==0.0.34

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -117,7 +117,7 @@ oauthlib==3.2.2
 packaging==25.0
 paramiko==3.5.0
 pbr==7.0.3
-pkginfo==1.8.2
+pkginfo==1.12.1.2
 portalocker==3.2.0
 psutil==6.1.0
 pycomposefile==0.0.34

--- a/tools/automation/verify/default_modules.py
+++ b/tools/automation/verify/default_modules.py
@@ -25,9 +25,13 @@ def get_cli_dependencies(build_folder):
     # ``metadata.json`` artifact, which only ``wheel==0.30.0`` writes into
     # ``.dist-info/`` (removed in wheel>=0.31.0, see pypa/wheel#195). This lets
     # the CLI wheel be built with any modern wheel/setuptools version.
+    # ``requires_dist`` entries are full PEP 508 strings (e.g. ``azure-cli-foo==1.2.3``
+    # or with markers); normalize them to bare distribution names so callers can
+    # compare against module names directly.
     from pkginfo import Wheel
+    from packaging.requirements import Requirement
     print('Load metadata from {}'.format(azure_cli_wheel))
-    return list(Wheel(azure_cli_wheel).requires_dist or [])
+    return [Requirement(r).name for r in (Wheel(azure_cli_wheel).requires_dist or [])]
 
 
 def verify_default_modules(args):

--- a/tools/automation/verify/default_modules.py
+++ b/tools/automation/verify/default_modules.py
@@ -7,9 +7,6 @@
 
 import os
 import sys
-import json
-import tempfile
-import zipfile
 import glob
 
 from automation.utilities.path import (get_repo_root, get_command_modules_paths)
@@ -23,17 +20,14 @@ def get_cli_dependencies(build_folder):
     azure_cli_wheel = glob.glob(build_folder.rstrip('/') + '/azure_cli-*.whl')[0]
     print('Explore wheel file {}.'.format(azure_cli_wheel))
 
-    tmp_dir = tempfile.mkdtemp()
-
-    zip_ref = zipfile.ZipFile(azure_cli_wheel, 'r')
-    zip_ref.extractall(tmp_dir)
-    zip_ref.close()
-
-    dist_info_dir = [f for f in os.listdir(tmp_dir) if f.endswith('.dist-info')][0]
-    whl_metadata_filepath = os.path.join(tmp_dir, dist_info_dir, 'metadata.json')
-    with open(whl_metadata_filepath) as f:
-        print('Load metadata file from {}'.format(whl_metadata_filepath))
-        return json.load(f)['run_requires'][0]['requires']
+    # Read the run-time dependencies (``Requires-Dist``) straight from the spec
+    # defined wheel ``METADATA`` via ``pkginfo`` instead of the legacy
+    # ``metadata.json`` artifact, which only ``wheel==0.30.0`` writes into
+    # ``.dist-info/`` (removed in wheel>=0.31.0, see pypa/wheel#195). This lets
+    # the CLI wheel be built with any modern wheel/setuptools version.
+    from pkginfo import Wheel
+    print('Load metadata from {}'.format(azure_cli_wheel))
+    return list(Wheel(azure_cli_wheel).requires_dist or [])
 
 
 def verify_default_modules(args):


### PR DESCRIPTION
## Related command
`az extension add`, `az extension show`, `az extension list`, `az extension remove`, `az extension update` (extension metadata reading); CI: `azdev extension build/update-index/publish`

## Description
Azure CLI has been stuck on `wheel==0.30.0` because the extension loader and CI relied on the `metadata.json` file that only wheel 0.30.0 writes into `.dist-info/` (removed in wheel 0.31.0,  pypa/wheel#195). azdev 0.2.11b1 (Azure/azure-cli-dev-tools#549) now generates that metadata itself via `pkginfo`, so the `wheel==0.30.0` / `setuptools==70.0.0` pins are no longer needed.

This PR removes those pins from azure-cli and aligns the toolchain:
- `tools/automation/verify/default_modules.py`: read the CLI wheel's run-time dependencies from the spec-defined `METADATA` (`Requires-Dist`) via `pkginfo`, instead of the removed metadata.json.
- `azure-pipelines.yml` / `.azure-pipelines/templates/azdev_setup.yml`: drop `pip install setuptools==70.0.0 wheel==0.30.0` and install azdev pinned to the [#549](https://github.com/Azure/azure-cli-dev-tools/pull/549) commit (0.2.11b1) until it is published to PyPI.
- Cap setuptools<81 across requirements.txt, CI, and the release build scripts. 81 removes `setup.py --dry-run` and changes distutils command signatures; 82 removes pkg_resources, the CLI build still relies on setup.py.
- `azure-cli-core`: require `pkginfo>=1.12.0` (frozen requirements bumped to 1.12.1.2) so `WheelExtension.get_metadata` reads the modern unpacked `.dist-info`/METADATA layout without `metadata.json`.

Companion work: Azure/azure-cli-dev-tools#549 (merged) and the matching azure-cli-extensions PR.
Related: Azure/azure-cli-extensions#7740

## Testing Guide
- Extension metadata unit tests pass for every layout (wheel 0.30.0 with `metadata.json`, wheel 0.31.0+ without, and the dev/source path):
  `pytest src/azure-cli-core/azure/cli/core/extension/tests/latest/test_wheel_type_extension.py src/azure-cli-core/azure/cli/core/extension/tests/latest/test_dev_type_extension.py`
- Build the CLI wheel with a modern, unpinned toolchain and confirm `verify_default_modules` still resolves the dependency list.
- `az extension add/show/list/remove` against an extension built by the decoupled azdev.
