### PR TITLE
[Ssh] `az ssh`: Restore explicit failure for managed identity and Cloud Shell SSH cert flows

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -441,6 +441,11 @@ class Profile:
     def get_msal_token(self, scopes, data):
         """Get VM SSH certificate. DO NOT use it for other purposes. To get an access token, use get_raw_token instead.
         """
+        account = self.get_subscription()
+        managed_identity_type, _ = Profile._parse_managed_identity_account(account)
+        if managed_identity_type or (in_cloud_console() and account[_USER_ENTITY].get(_CLOUD_SHELL_ID)):
+            raise AuthenticationError("VM SSH currently doesn't support managed identity or Cloud Shell.")
+
         credential, _, _ = self.get_login_credentials(sdk_credential=False)
         from .auth.constants import ACCESS_TOKEN
         certificate_string = credential.acquire_token(scopes, data=data)[ACCESS_TOKEN]

--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -12,8 +12,9 @@ from copy import deepcopy
 from unittest import mock
 
 from azure.cli.core._profile import (Profile, SubscriptionFinder, _attach_token_tenant,
-                                     _transform_subscription_for_multiapi,
-                                     _TENANT_LEVEL_ACCOUNT_NAME)
+                                      _transform_subscription_for_multiapi,
+                                      _TENANT_LEVEL_ACCOUNT_NAME)
+from azure.cli.core.azclierror import AuthenticationError
 from azure.cli.core.auth.util import AccessToken
 from azure.cli.core.mock import DummyCli
 from azure.mgmt.resource.subscriptions.models import \
@@ -1349,6 +1350,42 @@ class TestProfile(unittest.TestCase):
         assert result == (None, MOCK_ACCESS_TOKEN)
         assert credential_mock_temp.acquire_token_scopes == ['https://pas.windows.net/CheckMyAccess/Linux/.default']
         assert credential_mock_temp.acquire_token_data == MOCK_DATA
+
+    @mock.patch('azure.cli.core.auth.msal_credentials.ManagedIdentityCredential', ManagedIdentityCredentialStub)
+    def test_get_msal_token_mi_unsupported(self):
+        profile = Profile(cli_ctx=DummyCli(), storage={'subscriptions': None})
+        consolidated = profile._normalize_properties('systemAssignedIdentity',
+                                                     [deepcopy(self.test_mi_subscription)],
+                                                     True,
+                                                     assigned_identity_info='MSI')
+        profile._set_subscriptions(consolidated)
+
+        with self.assertRaisesRegex(AuthenticationError,
+                                    "VM SSH currently doesn't support managed identity or Cloud Shell."):
+            profile.get_msal_token(['https://pas.windows.net/CheckMyAccess/Linux/.default'],
+                                   {'token_type': 'ssh-cert'})
+
+    @mock.patch('azure.cli.core._profile.in_cloud_console', autospec=True)
+    @mock.patch('azure.cli.core.auth.msal_credentials.CloudShellCredential', autospec=True)
+    def test_get_msal_token_cloud_shell_unsupported(self, cloud_shell_credential_mock, mock_in_cloud_console):
+        mock_in_cloud_console.return_value = True
+        cloud_shell_credential_mock.return_value = CloudShellCredentialStub()
+
+        profile = Profile(cli_ctx=DummyCli(), storage={'subscriptions': None})
+        test_subscription_id = '12345678-1bf0-4dda-aec3-cb9272f09590'
+        test_tenant_id = '12345678-38d6-4fb2-bad9-b7b93a3e1234'
+        cloud_shell_subscription = SubscriptionStub('/subscriptions/' + test_subscription_id,
+                                                    self.display_name1, self.state1, test_tenant_id)
+        consolidated = profile._normalize_properties(self.user1,
+                                                     [cloud_shell_subscription],
+                                                     True)
+        consolidated[0]['user']['cloudShellID'] = True
+        profile._set_subscriptions(consolidated)
+
+        with self.assertRaisesRegex(AuthenticationError,
+                                    "VM SSH currently doesn't support managed identity or Cloud Shell."):
+            profile.get_msal_token(['https://pas.windows.net/CheckMyAccess/Linux/.default'],
+                                   {'token_type': 'ssh-cert'})
 
     @mock.patch('azure.cli.core.auth.identity.Identity.logout_service_principal')
     @mock.patch('azure.cli.core.auth.identity.Identity.logout_user')


### PR DESCRIPTION
**Related command**
`  az ssh vm -n <vm-name> -g <resource-group> `

**Description**
When a user is logged in with a managed identity or running in Cloud Shell, `get_msal_token()` attempts to acquire an SSH certificate. However, MSAL `ManagedIdentityClient.acquire_token_for_client()` does not accept the `data` parameter (containing `token_type: "ssh-cert"`, `req_cnf`, `key_id`), so the `data` kwarg is silently ignored and a regular access token is returned instead of an SSH certificate. This results in a malformed token being used as the certificate string.

The previous implementation had an explicit check that threw an error for managed identity accounts, but it was lost during a previous refactor.

This PR restores the guard in `get_msal_token()` to raise `AuthenticationError` early when the account is a managed identity or Cloud Shell, before reaching the broken code path.

Fix: https://github.com/Azure/azure-cli/issues/33171

**Testing Guide**
```sh
# Log in with managed identity, then attempt SSH — should get a clear error:
az login --identity
az ssh vm -n myVM -g myRG
# Expected: AuthenticationError: VM SSH currently doesn't support managed identity or Cloud Shell.

# Log in with a regular user account — SSH should work as before:
az login
az ssh vm -n myVM -g myRG
# Expected: SSH connection succeeds
```

**History Notes**
[Ssh] `az ssh`: Restore explicit failure for unsupported managed identity and Cloud Shell SSH cert flows

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).