### PR TITLE
{CI} Fix macOS build: Use libexec/bin/python instead of libexec/bin/python3

### DIFF
--- a/.azure-pipelines/templates/macos/macos-build-jobs.yml
+++ b/.azure-pipelines/templates/macos/macos-build-jobs.yml
@@ -62,7 +62,7 @@ jobs:
       echo "Architecture: $(Architecture)"
       brew install python@${{ parameters.PythonVersion }}
       
-      PYTHON_PATH=$(brew --prefix python@${{ parameters.PythonVersion }})/libexec/bin/python3
+      PYTHON_PATH=$(brew --prefix python@${{ parameters.PythonVersion }})/libexec/bin/python
       echo "Python path: $PYTHON_PATH"
       $PYTHON_PATH --version
       
@@ -171,7 +171,7 @@ jobs:
         brew install python@${{ parameters.PythonVersion }}
       fi
 
-      AZ_PYTHON="$(brew --prefix python@${{ parameters.PythonVersion }})/libexec/bin/python3"
+      AZ_PYTHON="$(brew --prefix python@${{ parameters.PythonVersion }})/libexec/bin/python"
       export AZ_PYTHON
       
       echo "System architecture: $(uname -m)"

--- a/.azure-pipelines/templates/macos/macos-cask-generation-and-tests.yml
+++ b/.azure-pipelines/templates/macos/macos-cask-generation-and-tests.yml
@@ -302,7 +302,7 @@ jobs:
         brew install python@${{ parameters.PythonVersion }}
       fi
       
-      AZ_PYTHON="$(brew --prefix python@${{ parameters.PythonVersion }})/libexec/bin/python3"
+      AZ_PYTHON="$(brew --prefix python@${{ parameters.PythonVersion }})/libexec/bin/python"
       export AZ_PYTHON
       
       export AZ_DEBUG=1

--- a/.azure-pipelines/templates/macos/macos-sign-notarize-jobs.yml
+++ b/.azure-pipelines/templates/macos/macos-sign-notarize-jobs.yml
@@ -713,7 +713,7 @@ jobs:
       echo "=== Functional Test ==="
       # Test CLI
       if brew list python@${{ parameters.PythonVersion }} &>/dev/null; then
-        AZ_PYTHON="$(brew --prefix python@${{ parameters.PythonVersion }})/libexec/bin/python3"
+        AZ_PYTHON="$(brew --prefix python@${{ parameters.PythonVersion }})/libexec/bin/python"
         export AZ_PYTHON
         export AZ_DEBUG=1
         if "$TEST_DIR/bin/az" version 2>&1 | head -5; then

--- a/scripts/release/macos/build_binary_tar_gz.py
+++ b/scripts/release/macos/build_binary_tar_gz.py
@@ -138,8 +138,8 @@ def _load_template(path: Path) -> str:
 def find_homebrew_python() -> Path:
     """Find necessary Homebrew Python x.yz installation."""
     candidates = [
-        Path(f"/opt/homebrew/opt/python@{PYTHON_MAJOR_MINOR}/libexec/bin/python3"),
-        Path(f"/usr/local/opt/python@{PYTHON_MAJOR_MINOR}/libexec/bin/python3"),
+        Path(f"/opt/homebrew/opt/python@{PYTHON_MAJOR_MINOR}/libexec/bin/python"),
+        Path(f"/usr/local/opt/python@{PYTHON_MAJOR_MINOR}/libexec/bin/python"),
         Path(f"/opt/homebrew/bin/python{PYTHON_MAJOR_MINOR}"),
         Path(f"/usr/local/bin/python{PYTHON_MAJOR_MINOR}"),
     ]
@@ -157,7 +157,7 @@ def find_homebrew_python() -> Path:
             check=True,
         )
         prefix = Path(result.stdout.strip())
-        python_path = prefix / "libexec" / "bin" / "python3"
+        python_path = prefix / "libexec" / "bin" / "python"
         if python_path.exists() and _is_python_version(python_path, PYTHON_MAJOR_MINOR):
             print(f"Found Homebrew Python via brew --prefix: {python_path}")
             return python_path


### PR DESCRIPTION
## Problem
After bumping the embedded Python to 3.14, the macOS build pipeline fails at the `Install Homebrew Python` step:

```
Python path: /opt/homebrew/opt/python@3.14/libexec/bin/python3
.../python@3.14/libexec/bin/python3: No such file or directory
```

## Root cause
The Homebrew `python@X.Y` formula creates the **unversioned** `python` symlink in `libexec/bin` unconditionally, but creates the major-versioned `python3` symlink in `libexec/bin` **only for altinstalls** (i.e. when the formula is *not* Homebrew's current default `python3`):

```ruby
def altinstall? = name != Formula["python3"].name
...
{ "python" => "python#{version.major_minor}", ... }                        # unversioned, ALWAYS
  .merge(altinstall? ? { "python3" => "python#{version.major_minor}", ... } : {})   # python3, ONLY if altinstall?
```

`python@3.14` is currently Homebrew's **default** `python3` (`altinstall? == false`; it is installed as `/opt/homebrew/bin/python3`). For the default formula the real `python3` lives in `HOMEBREW_PREFIX/bin`, so no `python3` symlink is added under `libexec/bin` -- only the unversioned `python`. Hence `.../python@3.14/libexec/bin/python3` does not exist.

This is confirmed by the formulae caveats: 3.14 says `Python is installed as .../bin/python3` and lists only unversioned libexec symlinks (`python`, `pip`); 3.13 (the altinstall) says `.../bin/python3.13` and lists both `python` **and** `python3` in libexec. This is why the pipeline worked on 3.13 and broke after the bump to 3.14.

## Fix
Use the always-present unversioned `libexec/bin/python` symlink instead of `libexec/bin/python3`. This is robust regardless of which minor version is Homebrew's default `python3`.

## Files changed
- `.azure-pipelines/templates/macos/macos-build-jobs.yml` (2 occurrences)
- `.azure-pipelines/templates/macos/macos-cask-generation-and-tests.yml`
- `.azure-pipelines/templates/macos/macos-sign-notarize-jobs.yml`
- `scripts/release/macos/build_binary_tar_gz.py` (candidate list + `brew --prefix` fallback)
