### PR TITLE
{CI} Fix homebrew formula test by stripping `no_autobump!` in local tap

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -679,6 +679,10 @@ jobs:
       git config --global user.name "Your Name"
       brew tap-new dev/azure-cli
       cp $SYSTEM_ARTIFACTSDIRECTORY/homebrew/azure-cli.rb $(brew --repository)/Library/Taps/dev/homebrew-azure-cli/Formula/
+      # `no_autobump!` is carried over from the upstream homebrew-core formula but is only
+      # allowed in official Homebrew taps. Remove it so the formula can be installed from
+      # this local dev tap. It must remain in the released formula, so we only strip it here.
+      sed -i '' '/no_autobump!/d' $(brew --repository)/Library/Taps/dev/homebrew-azure-cli/Formula/azure-cli.rb
       brew install --build-from-source dev/homebrew-azure-cli/azure-cli
       
       echo == Az Version ==


### PR DESCRIPTION
## Description

The `Test Homebrew Formula` CI job started failing with:

```
Error: dev/azure-cli/azure-cli: no_autobump! can only be used in official Homebrew taps.
```

### Root cause

The formula generator (`scripts/release/homebrew/docker/formula_generate.py`) builds `azure-cli.rb` by downloading the latest upstream `homebrew-core` formula and patching it (version/url/sha/deps). The upstream formula now contains:

```ruby
no_autobump! because: :bumped_by_upstream
```

`no_autobump!` tells Homebrew''s autobump bot not to auto-bump azure-cli (the Azure CLI team submits full updates itself, since each release also needs the entire dependency `resource` list regenerated).

This line had been carried into our generated formula harmlessly for a while. The failure was triggered by an **external Homebrew change**, not by any recent commit in this repo:

- **[Homebrew/brew#21982](https://github.com/Homebrew/brew/pull/21982)** — *"cask: restrict `no_autobump!` usage to official Homebrew taps"* — merged **2026-04-21** (commit `b72c12f`). It added a guard to `formula.rb`/`cask/dsl.rb`:

  ```ruby
  raise ArgumentError, "no_autobump! can only be used in official Homebrew taps." if tap && !tap.official?
  ```

  Before this PR, `no_autobump!` was accepted in any tap (it resolved a long-standing TODO). After the CI image picked up a Homebrew version containing it, the previously-tolerated directive started raising an error.

Our CI test installs the generated formula into a **local dummy tap** (`dev/azure-cli`), which is not official, so Homebrew now rejects it.

> Note: a GitHub search for this exact error returns only 2 PRs — Homebrew/brew#21982 (which introduced the check) and this one. The failing pattern (generate a formula from a homebrew-core copy, then install it from a local tap) is uncommon, so few projects hit it.

### Fix

Strip the `no_autobump!` line **only from the test copy** placed in the local dev tap, right before `brew install`. The directive must remain in the released formula (which is submitted to the official `homebrew-core` tap), so the generator and the published artifact are left untouched. If upstream later removes the line, the `sed` becomes a harmless no-op.
