### PR TITLE
docs: clarify --resource argument examples for az rest (#31473)

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/util/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/util/_help.py
@@ -14,7 +14,8 @@ long-summary: >
     This command automatically authenticates using the logged-in credential: If Authorization header is not set, it
     attaches header `Authorization: Bearer <token>`, where `<token>` is retrieved from AAD. The target resource of the
     token is derived from --url if --url starts with an endpoint from `az cloud show --query endpoints`. You may also
-    use --resource for a custom resource (e.g., `https://graph.microsoft.com` for Microsoft Graph or `499b84ac-1321-427f-aa17-267ca6975798` for Azure DevOps).
+    use --resource for a custom resource. Examples include `https://graph.microsoft.com` for
+    Microsoft Graph or `499b84ac-1321-427f-aa17-267ca6975798` for Azure DevOps.
 
 
     If Content-Type header is not set and --body is a valid JSON string, Content-Type header will default to

--- a/src/azure-cli/azure/cli/command_modules/util/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/util/_help.py
@@ -14,7 +14,7 @@ long-summary: >
     This command automatically authenticates using the logged-in credential: If Authorization header is not set, it
     attaches header `Authorization: Bearer <token>`, where `<token>` is retrieved from AAD. The target resource of the
     token is derived from --url if --url starts with an endpoint from `az cloud show --query endpoints`. You may also
-    use --resource for a custom resource.
+    use --resource for a custom resource (e.g., `https://graph.microsoft.com` for Microsoft Graph or `499b84ac-1321-427f-aa17-267ca6975798` for Azure DevOps).
 
 
     If Content-Type header is not set and --body is a valid JSON string, Content-Type header will default to


### PR DESCRIPTION
**Related command**
`az rest`

**Description**
Fixes #31473. 
Updated the `long-summary` help text for the `--resource` argument in the `az rest` command. Added explicit examples of custom resources (Microsoft Graph and Azure DevOps) to clarify the expected input format based on user feedback.

**Testing Guide**
Run `az rest -h` to verify the updated `--resource` description is formatted correctly.

**History Notes**
[Core] `az rest`: Clarified `--resource` argument examples in help text

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).