### PR TITLE
[AKS] `az aks check-acr`: Support national/sovereign clouds that report cloud=AzureStackCloud

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -2252,6 +2252,21 @@ def aks_check_acr(cmd, client, resource_group_name, name, acr, node_name=None):
                         "args": ["-v6", acr],
                         "stdin": True,
                         "stdinOnce": True,
+                        # On national/sovereign clouds, node provisioning stamps
+                        # "cloud": "AzureStackCloud" in /etc/kubernetes/azure.json and
+                        # writes the cloud-specific endpoints to a companion
+                        # /etc/kubernetes/akscustom.json (a go-autorest environment file).
+                        # go-autorest's EnvironmentFromName only resolves AzureStackCloud
+                        # when AZURE_ENVIRONMENT_FILEPATH points at that file; otherwise
+                        # canipull aborts with "Unknown Azure cloud name: AzureStackCloud"
+                        # before running any MSI/ACR check. The env var is ignored on public
+                        # clouds (cloud != AzureStackCloud), so this is safe everywhere.
+                        "env": [
+                            {
+                                "name": "AZURE_ENVIRONMENT_FILEPATH",
+                                "value": "/etc/kubernetes/akscustom.json",
+                            }
+                        ],
                         "volumeMounts": [
                             {"name": "azurejson", "mountPath": "/etc/kubernetes"},
                             {"name": "sslcerts", "mountPath": "/etc/ssl/certs"},


### PR DESCRIPTION
**Related command**
`az aks check-acr`

**Description**
On AKS clusters in national/sovereign clouds (e.g. Bleu), node provisioning stamps `"cloud": "AzureStackCloud"` into `/etc/kubernetes/azure.json` (reusing the Stack identifier as a catch-all for non-public clouds) and writes the cloud-specific endpoints to a companion `/etc/kubernetes/akscustom.json` file (a go-autorest `azure.Environment` document).

`az aks check-acr` runs the `canipull` container, which calls go-autorest's `azure.EnvironmentFromName(cfg.Cloud)`. For `AzureStackCloud`, go-autorest only resolves the environment when `AZURE_ENVIRONMENT_FILEPATH` points at such a metadata file. Because the wrapper never set this env var, the very first step of the managed-identity / service-principal validation failed and the tool exited with `Unknown Azure cloud name: AzureStackCloud` — before any MSI / token / ACR check ran. DNS, CNAME and ACR location detection all succeeded; only the cloud-name resolution aborted. There was no flag or invocation to work around it, making the command unusable on every cluster in these clouds.

This change sets `AZURE_ENVIRONMENT_FILEPATH=/etc/kubernetes/akscustom.json` on the canipull container. The pod already hostPath-mounts the node's `/etc/kubernetes`, so the companion file is present, and go-autorest can build the environment from it. The same file is already consumed successfully by the in-cluster CSI node drivers on these nodes, confirming the schema and mechanism.

This is safe for public clouds: go-autorest ignores `AZURE_ENVIRONMENT_FILEPATH` unless the cloud name is `AzureStackCloud`, so AzureCloud / AzureChinaCloud / AzureUSGovernment clusters are unaffected.

Related issue: https://github.com/Azure/aks-canipull/issues/21

**Testing Guide**
On an AKS cluster in a sovereign cloud whose nodes report `"cloud": "AzureStackCloud"` in `/etc/kubernetes/azure.json` and ship `/etc/kubernetes/akscustom.json`:

```
az aks check-acr --name MyManagedCluster --resource-group MyResourceGroup --acr myacr.<sovereign-acr-suffix>
```

Before: fails with `Unknown Azure cloud name: AzureStackCloud`.
After: canipull proceeds past cloud resolution and performs the managed-identity / ACR pull checks.

Public-cloud clusters continue to work unchanged (the env var is ignored when the cloud is not `AzureStackCloud`).

**History Notes**
[AKS] `az aks check-acr`: Support national/sovereign clouds where nodes report `cloud=AzureStackCloud` by pointing canipull at the on-node `akscustom.json` environment file

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
