### PR TITLE
{App Service} `az webapp deploy`: cache SCM URL and headers within a …

### DIFF
--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -6,10 +6,6 @@ Release History
 2.87.0
 ++++++
 
-**App Service**
-
-* `az webapp deploy`/`az functionapp deploy`: Cache the Site model, SCM URL, and SCM authentication headers for the lifetime of a single deploy invocation, derive `is_flex` from cached Site SKU, reducing per-deploy ARM calls from ~12 to ~3 and halving exposure to transient credential-fetch failures during the post-publish status poll (#33560)
-
 **ACR**
 
 * [BREAKING CHANGE] `az acr replication create/update`: Remove deprecated `--region-endpoint-enabled` flag and use `--global-endpoint-routing` instead (#33173)

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -6,6 +6,10 @@ Release History
 2.87.0
 ++++++
 
+**App Service**
+
+* `az webapp deploy`/`az functionapp deploy`: Cache the Site model, SCM URL, and SCM authentication headers for the lifetime of a single deploy invocation, derive `is_flex` from cached Site SKU, reducing per-deploy ARM calls from ~12 to ~3 and halving exposure to transient credential-fetch failures during the post-publish status poll (#33560)
+
 **ACR**
 
 * [BREAKING CHANGE] `az acr replication create/update`: Remove deprecated `--region-endpoint-enabled` flag and use `--global-endpoint-routing` instead (#33173)

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -6285,10 +6285,18 @@ def view_in_browser(cmd, resource_group_name, name, slot=None, logs=False):
 
 
 def _get_url(cmd, resource_group_name, name, slot=None):
-    SslState = cmd.get_models('SslState')
     site = _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'get', slot)
     if not site:
         raise ResourceNotFoundError("'{}' app doesn't exist".format(name))
+    return _url_from_site(cmd, site)
+
+
+def _url_from_site(cmd, site):
+    # Shared URL derivation used by _get_url (which fetches the site itself)
+    # and by _get_visit_url in the onedeploy flow (which reuses the cached
+    # Site from perform_onedeploy_webapp). Factored out so the two paths
+    # cannot drift in how they pick the host or determine HTTPS.
+    SslState = cmd.get_models('SslState')
     url = site.enabled_host_names[0]  # picks the custom domain URL incase a domain is assigned
     ssl_host = next((h for h in site.host_name_ssl_states
                      if h.ssl_state != SslState.disabled), None)
@@ -6689,10 +6697,20 @@ def basic_auth_supported(cli_ctx, name, resource_group_name, slot=None):
 
 
 # auth with basic auth if available
-def get_scm_site_headers(cli_ctx, name, resource_group_name, slot=None, additional_headers=None):
+def get_scm_site_headers(cli_ctx, name, resource_group_name, slot=None, additional_headers=None,
+                         is_flex_hint=None):
     import urllib3
 
-    is_flex = is_flex_functionapp(cli_ctx, resource_group_name, name)
+    # is_flex_functionapp issues an ARM GET /sites (api 2023-12-01) via
+    # send_raw_request. Callers that already know whether the site is a
+    # FlexConsumption function app (e.g., perform_onedeploy_webapp knows the
+    # target is a Web App, so is_flex must be False) can pass is_flex_hint
+    # to skip the redundant call. Default None preserves existing behavior
+    # for all other callers.
+    if is_flex_hint is None:
+        is_flex = is_flex_functionapp(cli_ctx, resource_group_name, name)
+    else:
+        is_flex = is_flex_hint
 
     if not is_flex and basic_auth_supported(cli_ctx, name, resource_group_name, slot):
         logger.info("[AUTH]: basic")
@@ -9731,17 +9749,42 @@ def _list_managed_instance_locations(cmd, sku_tier):
     return [SimpleNamespace(**location) for location in locations]
 
 
-def _check_zip_deployment_status(cmd, rg_name, name, deployment_status_url, slot, timeout=None):
+def _check_zip_deployment_status(cmd, rg_name, name, deployment_status_url, slot, timeout=None,
+                                 deploy_params=None):
     import requests
     from azure.cli.core.util import should_disable_connection_verify
 
-    headers = get_scm_site_headers(cmd.cli_ctx, name, rg_name, slot)
+    # Reuse SCM headers acquired during the publish leg when invoked from the
+    # onedeploy flow. Removes 3 ARM calls per deploy (is_flex_functionapp +
+    # basic_auth_supported + _get_site_credential). Falls back to a fresh
+    # fetch for legacy callers (enable_zip_deploy) that don't pass params,
+    # and on 401 in case credentials were rotated mid-deploy.
+    headers = None
+    if deploy_params is not None and deploy_params._cached_scm_headers is not None:  # pylint: disable=protected-access
+        headers = dict(deploy_params._cached_scm_headers)  # pylint: disable=protected-access
+        client_id = (cmd.cli_ctx.data or {}).get('headers', {}).get('x-ms-client-request-id')
+        if client_id:
+            headers['x-ms-client-request-id'] = client_id
+    if headers is None:
+        headers = get_scm_site_headers(cmd.cli_ctx, name, rg_name, slot)
     total_trials = (int(timeout) // 2) if timeout else 450
     num_trials = 0
+    refreshed_headers = False
     while num_trials < total_trials:
         time.sleep(2)
         response = requests.get(deployment_status_url, headers=headers,
                                 verify=not should_disable_connection_verify())
+        if response.status_code == 401 and not refreshed_headers:
+            # Cached credentials may be stale (rotated between publish and
+            # status poll). Drop the cache and refetch once before giving up.
+            if deploy_params is not None:
+                deploy_params._cached_scm_headers = None  # pylint: disable=protected-access
+            headers = get_scm_site_headers(cmd.cli_ctx, name, rg_name, slot,
+                                           is_flex_hint=_known_is_flex_hint(deploy_params))
+            if deploy_params is not None:
+                _populate_cached_scm_headers(deploy_params, headers)
+            refreshed_headers = True
+            continue
         try:
             res_dict = response.json()
         except json.decoder.JSONDecodeError:
@@ -9766,11 +9809,26 @@ def _check_zip_deployment_status(cmd, rg_name, name, deployment_status_url, slot
     return res_dict
 
 
-def _get_latest_deployment_id(cmd, rg_name, name, deployment_status_url, slot):
+def _get_latest_deployment_id(cmd, rg_name, name, deployment_status_url, slot, deploy_params=None):
     import requests
     from azure.cli.core.util import should_disable_connection_verify
 
-    headers = get_scm_site_headers(cmd.cli_ctx, name, rg_name, slot)
+    # Reuse the SCM headers already cached during the publish leg when the
+    # OneDeploy flow is the caller; this saves a full get_scm_site_headers
+    # round-trip (is_flex_functionapp + basic_auth_supported +
+    # publishingcredentials/list — 3 ARM calls per status poll start).
+    if deploy_params is not None and deploy_params._cached_scm_headers is not None:  # pylint: disable=protected-access
+        headers = dict(deploy_params._cached_scm_headers)  # pylint: disable=protected-access
+        # x-ms-client-request-id must be fresh per call so distributed
+        # tracing stays useful; the cache deliberately omits it.
+        client_id = (cmd.cli_ctx.data or {}).get('headers', {}).get('x-ms-client-request-id')
+        if client_id:
+            headers['x-ms-client-request-id'] = client_id
+    else:
+        headers = get_scm_site_headers(cmd.cli_ctx, name, rg_name, slot,
+                                       is_flex_hint=_known_is_flex_hint(deploy_params))
+        if deploy_params is not None:
+            _populate_cached_scm_headers(deploy_params, headers)
     total_trials = 30
     num_trials = 0
     while num_trials < total_trials:
@@ -9796,47 +9854,56 @@ def _get_latest_deployment_id(cmd, rg_name, name, deployment_status_url, slot):
 
 
 def _check_runtimestatus_with_deploymentstatusapi(cmd, resource_group_name, name, slot,
-                                                  deployment_status_url, is_async, timeout):
+                                                  deployment_status_url, is_async, timeout,
+                                                  deploy_params=None):
     response_body = None
     logger.warning('Polling the status of %s deployment. Start Time: %s UTC',
                    "async" if is_async else "sync",
                    datetime.datetime.now(datetime.timezone.utc))
     # verify if the app is a linux web app
-    client = web_client_factory(cmd.cli_ctx)
-    app = client.web_apps.get(resource_group_name, name)
-    app_is_linux_webapp = is_linux_webapp(app)
+    if deploy_params is not None:
+        # Reuse the Site fetched (or cached) during the publish leg. Saves
+        # 1 GET /sites per deploy invocation.
+        app_is_linux_webapp = _get_or_fetch_is_linux_webapp(deploy_params)
+    else:
+        # Legacy caller (enable_zip_deploy) — preserve original behavior.
+        client = web_client_factory(cmd.cli_ctx)
+        app = client.web_apps.get(resource_group_name, name)
+        app_is_linux_webapp = is_linux_webapp(app)
     # TODO: enable tracking for slot deployments again once site warmup is fixed for slots
     if not app_is_linux_webapp or slot is not None:
         response_body = _check_zip_deployment_status(cmd, resource_group_name, name, deployment_status_url,
-                                                     slot, timeout)
+                                                     slot, timeout, deploy_params=deploy_params)
     else:
         # get the deployment id
         # once deploymentstatus/latest is available, we can use it to track the deployment
         deployment_id = _get_latest_deployment_id(cmd, resource_group_name,
-                                                  name, deployment_status_url, slot)
+                                                  name, deployment_status_url, slot,
+                                                  deploy_params=deploy_params)
         if deployment_id is None:
             logger.warning("Failed to enable tracking runtime status for this deployment. "
                            "Resuming without tracking status.")
             response_body = _check_zip_deployment_status(cmd, resource_group_name, name, deployment_status_url,
-                                                         slot, timeout)
+                                                         slot, timeout, deploy_params=deploy_params)
         else:
             deploymentstatisapi_url = _build_deploymentstatus_url(cmd, resource_group_name,
                                                                   name, slot, deployment_id)
             response_body = _poll_deployment_runtime_status(cmd, resource_group_name, name, slot,
-                                                            deploymentstatisapi_url, deployment_id, timeout)
+                                                            deploymentstatisapi_url, deployment_id, timeout,
+                                                            deploy_params=deploy_params)
             # incase we are unable to fetch response from deploymentstatus API
             # fallback to polling kudu for deployment status
             if response_body is None:
                 logger.warning("Failed to track the runtime status for this deployment. "
                                "Resuming without tracking status.")
                 response_body = _check_zip_deployment_status(cmd, resource_group_name, name, deployment_status_url,
-                                                             slot, timeout)
+                                                             slot, timeout, deploy_params=deploy_params)
     return response_body
 
 
 # pylint: disable=too-many-branches
 def _poll_deployment_runtime_status(cmd, resource_group_name, webapp_name, slot, deploymentstatusapi_url,
-                                    deployment_id, timeout=None):
+                                    deployment_id, timeout=None, deploy_params=None):
     max_time_sec = int(timeout) if timeout else 1000
     start_time = time.time()
     time_elapsed = 0
@@ -9920,7 +9987,12 @@ def _poll_deployment_runtime_status(cmd, resource_group_name, webapp_name, slot,
         time.sleep(15)
 
     if time_elapsed >= max_time_sec and deployment_status != "RuntimeSuccessful":
-        scm_url = _get_scm_url(cmd, resource_group_name, webapp_name, slot)
+        # Derive SCM URL from cache when available (avoids yet another GET /sites
+        # in an error path that the customer never expected to hit).
+        if deploy_params is not None:
+            scm_url = _get_or_fetch_scm_url(deploy_params)
+        else:
+            scm_url = _get_scm_url(cmd, resource_group_name, webapp_name, slot)
         if deployment_status == "BuildInProgress":
             deployments_log_url = scm_url + f"/api/deployments/{deployment_id}/log"
             raise CLIError("Timeout reached while build was still in progress. "
@@ -10953,6 +11025,15 @@ def perform_onedeploy_functionapp(cmd,
     params.track_status = False
     params.is_functionapp = True
 
+    # Eagerly fetch (and cache) the Site so downstream helpers
+    # (_get_or_fetch_scm_url, _get_visit_url, _get_or_fetch_is_linux_webapp)
+    # can derive answers from the cached model without issuing additional
+    # GET /sites calls. The is_flex hint is derived later by
+    # _known_is_flex_hint which reads site.sku from the cached model.
+    app = _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'get', slot)
+    params._cached_site = app  # pylint: disable=protected-access
+    params.is_linux_webapp = is_linux_webapp(app)
+
     return _perform_onedeploy_internal(params)
 
 
@@ -10991,8 +11072,12 @@ def perform_onedeploy_webapp(cmd,
     params.enable_kudu_warmup = enable_kudu_warmup
     params.enriched_errors = enriched_errors
 
-    client = web_client_factory(cmd.cli_ctx)
-    app = client.web_apps.get(resource_group_name, name)
+    # When a slot is targeted, fetch the slot's Site (not production) so the
+    # cached model matches what every downstream consumer expects — slots have
+    # their own host_name_ssl_states and enabled_host_names, and is_linux is
+    # inherited but read off whichever Site we serve out of the cache.
+    app = _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'get', slot)
+    params._cached_site = app  # pylint: disable=protected-access
     params.is_linux_webapp = is_linux_webapp(app)
 
     # Warn that zip deploy won't auto-build on Linux
@@ -11029,7 +11114,92 @@ class OneDeployParams:
         self.is_linux_webapp = None
         self.is_functionapp = None
         self.enriched_errors = False
+        # Per-invocation caches. Populated during a single deploy and
+        # cleared in _perform_onedeploy_internal's `finally` block. These MUST
+        # NOT be logged, serialized, or accessed outside the current call
+        # stack. Underscore prefix signals "do not touch / do not persist".
+        # _cached_scm_headers may contain a Basic-auth Authorization header
+        # built from the site's publishing credentials; it is the only secret
+        # in OneDeployParams and is handled with the same care as the bare
+        # credential would be.
+        # _cached_site holds the SDK Site model returned by web_apps.get; it
+        # contains no secrets. The SCM URL is derived from its
+        # host_name_ssl_states on each access (trivial iteration).
+        self._cached_scm_headers = None
+        self._cached_site = None
 # pylint: enable=too-many-instance-attributes,too-few-public-methods
+
+
+def _get_or_fetch_site(params):
+    # Lazily fetch and cache the SDK Site model. The site's metadata
+    # (kind, host names, SKU, etc.) does not change during a single deploy
+    # invocation, so all consumers in the onedeploy flow share one fetch.
+    # When params.slot is set, fetch the slot's Site via get_slot so the
+    # cached host_name_ssl_states / enabled_host_names belong to the slot
+    # and not to production.
+    if params._cached_site is None:  # pylint: disable=protected-access
+        params._cached_site = _generic_site_operation(  # pylint: disable=protected-access
+            params.cmd.cli_ctx, params.resource_group_name, params.webapp_name, 'get', params.slot)
+    return params._cached_site  # pylint: disable=protected-access
+
+
+def _get_or_fetch_is_linux_webapp(params):
+    # Reuse the cached Site to answer the is-Linux question without an extra
+    # ARM call. perform_onedeploy_webapp populates params.is_linux_webapp
+    # eagerly; perform_onedeploy_functionapp does not, so we may need to
+    # fetch on first use for function apps.
+    if params.is_linux_webapp is None:
+        params.is_linux_webapp = is_linux_webapp(_get_or_fetch_site(params))
+    return params.is_linux_webapp
+
+
+def _get_visit_url(params):
+    # Build the "You can visit your app at: …" URL without issuing another
+    # GET /sites when the Site is already cached. perform_onedeploy_webapp
+    # fetches the slot's Site when params.slot is set, so the cached model
+    # already has slot-specific host_name_ssl_states and we can serve both
+    # production and slot URLs from the cache.
+    if params._cached_site is None:  # pylint: disable=protected-access
+        return _get_url(params.cmd, params.resource_group_name, params.webapp_name, params.slot)
+    return _url_from_site(params.cmd, params._cached_site)  # pylint: disable=protected-access
+
+
+def _get_or_fetch_scm_url(params):
+    # Derive the SCM hostname from the cached Site model. Both entry points
+    # (perform_onedeploy_webapp, perform_onedeploy_functionapp) eagerly
+    # populate _cached_site, so this is always a local iteration over ~3
+    # host_name_ssl_states entries — no ARM call needed.
+    cached_site = params._cached_site  # pylint: disable=protected-access
+    if cached_site is not None:
+        from azure.mgmt.web.models import HostType
+        for host in cached_site.host_name_ssl_states or []:
+            if host.host_type == HostType.repository:
+                return "https://{}".format(host.name)
+    # Fallback for defensive safety (should not be reached in normal flow).
+    return _get_scm_url(params.cmd, params.resource_group_name, params.webapp_name, params.slot)
+
+
+def _populate_cached_scm_headers(params, headers):
+    # Cache only the stable, request-independent fields of the SCM headers so
+    # the post-publish status poller can skip a second round-trip through
+    # is_flex_functionapp + basic_auth_supported + _get_site_credential
+    # (3 ARM calls). Per-request fields like x-ms-client-request-id MUST NOT
+    # be cached: every ARM/SCM call needs a fresh request id so distributed
+    # traces remain useful.
+    #
+    # The auth header key may be either 'Authorization' (AAD branch in
+    # get_scm_site_headers, which capitalizes the name) or 'authorization'
+    # (basic-auth branch, which inherits urllib3.util.make_headers' lowercase
+    # key). Match case-insensitively and preserve whichever casing the source
+    # used, so the cached headers are byte-equivalent to a freshly fetched
+    # dict on either auth path.
+    auth_key = next((k for k in headers if k.lower() == 'authorization'), None)
+    if auth_key is None:
+        return
+    cached = {auth_key: headers[auth_key]}
+    if 'User-Agent' in headers:
+        cached['User-Agent'] = headers['User-Agent']
+    params._cached_scm_headers = cached  # pylint: disable=protected-access
 
 
 def _build_onedeploy_url(params, instance_id=None):
@@ -11039,7 +11209,7 @@ def _build_onedeploy_url(params, instance_id=None):
 
 
 def _build_kudu_warmup_scm_url(params):
-    scm_url = _get_scm_url(params.cmd, params.resource_group_name, params.webapp_name, params.slot)
+    scm_url = _get_or_fetch_scm_url(params)
     return scm_url + '/api/deployments?warmup=true'
 
 
@@ -11066,7 +11236,7 @@ def _build_kudu_warmup_arm_url(params, instance_id=None):
 
 
 def _build_onedeploy_scm_url(params):
-    scm_url = _get_scm_url(params.cmd, params.resource_group_name, params.webapp_name, params.slot)
+    scm_url = _get_or_fetch_scm_url(params)
     deploy_url = scm_url + '/api/publish?type=' + params.artifact_type
 
     if params.is_async_deployment is not None:
@@ -11134,12 +11304,38 @@ def _get_ondeploy_headers(params):
 
     additional_headers = {"Content-Type": content_type, "Cache-Control": "no-cache"}
 
-    return get_scm_site_headers(params.cmd.cli_ctx, params.webapp_name, params.resource_group_name, params.slot,
-                                additional_headers=additional_headers)
+    headers = get_scm_site_headers(params.cmd.cli_ctx, params.webapp_name, params.resource_group_name, params.slot,
+                                   additional_headers=additional_headers,
+                                   is_flex_hint=_known_is_flex_hint(params))
+    # Stash credentials for reuse by the status poller (see
+    # _check_zip_deployment_status). The cache is cleared in
+    # _perform_onedeploy_internal's finally block.
+    _populate_cached_scm_headers(params, headers)
+    return headers
+
+
+def _known_is_flex_hint(params):
+    # FlexConsumption is a function-app SKU; if the caller has already
+    # determined the site is a Web App (is_functionapp=False, set in
+    # perform_onedeploy_webapp line ~11029) then is_flex is necessarily
+    # False and the is_flex_functionapp ARM call can be skipped.
+    # For function apps, if the Site is already cached we can read the SKU
+    # directly (site.sku == 'FlexConsumption') without a separate ARM call.
+    if params is None:
+        return None
+    if params.is_functionapp is False:
+        return False
+    # When the Site model is cached (perform_onedeploy_functionapp populates
+    # it eagerly), derive the flex answer from site.sku.
+    cached = getattr(params, '_cached_site', None)
+    if cached is not None:
+        sku = getattr(cached, 'sku', None)
+        return bool(sku and sku.lower() == 'flexconsumption')
+    return None
 
 
 def _get_onedeploy_status_url(params):
-    scm_url = _get_scm_url(params.cmd, params.resource_group_name, params.webapp_name, params.slot)
+    scm_url = _get_or_fetch_scm_url(params)
     return scm_url + '/api/deployments/latest'
 
 
@@ -11152,9 +11348,10 @@ def _get_onedeploy_request_body(params):
         logger.warning('Deploying from local path: %s', params.src_path)
 
         if params.track_status is not None and params.track_status:
-            client = web_client_factory(params.cmd.cli_ctx)
-            app = client.web_apps.get(params.resource_group_name, params.webapp_name)
-            app_is_linux_webapp = is_linux_webapp(app)
+            # Was: client.web_apps.get(...). Reuses the cached Site populated
+            # by perform_onedeploy_webapp (or fetches on first use for
+            # function apps). Saves 1 GET /sites per web-app deploy.
+            app_is_linux_webapp = _get_or_fetch_is_linux_webapp(params)
 
         try:
             with open(os.path.realpath(os.path.expanduser(params.src_path)), 'rb') as fs:
@@ -11251,7 +11448,21 @@ def _warmup_kudu_and_get_cookie_internal(params):
         try:
             if not params.src_url:  # use SCM endpoint for Kudu warmup
                 kudu_warmup_url = _build_kudu_warmup_scm_url(params)
-                headers = get_scm_site_headers(params.cmd.cli_ctx, params.webapp_name, params.resource_group_name)
+                # Reuse the cached SCM headers populated by _get_ondeploy_headers
+                # when available. Saves another full get_scm_site_headers
+                # round-trip (is_flex_functionapp + basic_auth_supported +
+                # publishingcredentials/list — 3 ARM calls) before the
+                # actual POST /api/publish.
+                if params._cached_scm_headers is not None:  # pylint: disable=protected-access
+                    headers = dict(params._cached_scm_headers)  # pylint: disable=protected-access
+                    client_id = (params.cmd.cli_ctx.data or {}).get('headers', {}).get('x-ms-client-request-id')
+                    if client_id:
+                        headers['x-ms-client-request-id'] = client_id
+                else:
+                    headers = get_scm_site_headers(
+                        params.cmd.cli_ctx, params.webapp_name, params.resource_group_name,
+                        params.slot, is_flex_hint=_known_is_flex_hint(params))
+                    _populate_cached_scm_headers(params, headers)
                 response = requests.get(kudu_warmup_url, headers=headers, cookies=cookies, timeout=time_out)
             else:  # use ARM endpoint for Kudu warmup
                 kudu_warmup_url = _build_kudu_warmup_arm_url(params, instance_id)
@@ -11339,12 +11550,14 @@ def _make_onedeploy_request(params):
                     params.webapp_name, params.slot,
                     deployment_status_url,
                     params.is_async_deployment,
-                    params.timeout)
+                    params.timeout,
+                    deploy_params=params)
             else:
                 response_body = _check_zip_deployment_status(
                     params.cmd, params.resource_group_name,
                     params.webapp_name,
-                    deployment_status_url, params.slot, params.timeout)
+                    deployment_status_url, params.slot, params.timeout,
+                    deploy_params=params)
             logger.info('Server response: %s', response_body)
         else:
             if 'application/json' in response.headers.get('content-type', ""):
@@ -11353,8 +11566,7 @@ def _make_onedeploy_request(params):
                     logger.warning("Deployment status is: \"%s\"", state)
                 response_body = response.json().get("properties", {})
         logger.warning("Deployment has completed successfully")
-        logger.warning("You can visit your app at: %s", _get_url(params.cmd, params.resource_group_name,
-                                                                 params.webapp_name, params.slot))
+        logger.warning("You can visit your app at: %s", _get_visit_url(params))
         return response_body
 
     # API not available yet!
@@ -11378,7 +11590,7 @@ def _make_onedeploy_request(params):
 
     # check if an error occurred during deployment
     if response.status_code:
-        scm_url = _get_scm_url(params.cmd, params.resource_group_name, params.webapp_name, params.slot)
+        scm_url = _get_or_fetch_scm_url(params)
         latest_deploymentinfo_url = scm_url + "/api/deployments/latest"
         if _should_enrich_errors and response.status_code >= 400:
             logger.error("Deployment failed. Visit %s to get more information about your deployment.",
@@ -11415,14 +11627,24 @@ def _perform_onedeploy_internal(params):
     # Now make the OneDeploy API call
     logger.warning("Initiating deployment")
     try:
-        response = _make_onedeploy_request(params)
-        return response
-    except (ValidationError, ResourceNotFoundError, EnrichedDeploymentError):
-        raise
-    except Exception as ex:  # pylint: disable=broad-except
-        if _should_enrich_errors:
-            _try_enrich_and_raise(params, error_message=str(ex), last_known_step="Deployment request")
-        raise
+        try:
+            response = _make_onedeploy_request(params)
+            return response
+        except (ValidationError, ResourceNotFoundError, EnrichedDeploymentError):
+            raise
+        except Exception as ex:  # pylint: disable=broad-except
+            if _should_enrich_errors:
+                _try_enrich_and_raise(params, error_message=str(ex), last_known_step="Deployment request")
+            raise
+    finally:
+        # Drop cached SCM headers as early as possible.
+        # _cached_scm_headers may contain a Basic-auth header derived from the
+        # site's publishing password and must not outlive the deploy invocation.
+        # Python doesn't guarantee zeroing memory, but clearing the reference
+        # makes the object eligible for GC and ensures it cannot be picked up
+        # by any outer exception handler or telemetry path.
+        params._cached_scm_headers = None  # pylint: disable=protected-access
+        params._cached_site = None  # pylint: disable=protected-access
 
 
 def _wait_for_webapp(tunnel_server):

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands_thru_mock.py
@@ -1068,5 +1068,542 @@ class TestCreateAppServicePlanDefaults(unittest.TestCase):
         self.assertIn('P0V3', str(call_kwargs))
 
 
+class TestOneDeployScmCache(unittest.TestCase):
+    """Tests for the per-invocation SCM URL / SCM headers cache on OneDeployParams.
+
+    The cache avoids duplicate `_get_scm_url` and `get_scm_site_headers` round
+    trips between the publish leg and the status-poll leg of a single
+    `az webapp deploy` invocation. See _perform_onedeploy_internal +
+    _check_zip_deployment_status in custom.py.
+    """
+
+    def _make_params(self):
+        from azure.cli.command_modules.appservice.custom import OneDeployParams
+        params = OneDeployParams()
+        params.cmd = mock.MagicMock()
+        params.cmd.cli_ctx = mock.MagicMock()
+        params.cmd.cli_ctx.data = {'headers': {'x-ms-client-request-id': 'req-1'}}
+        params.resource_group_name = 'myRG'
+        params.webapp_name = 'myApp'
+        params.slot = None
+        return params
+
+    def test_get_or_fetch_scm_url_derives_from_cached_site(self):
+        from azure.cli.command_modules.appservice.custom import _get_or_fetch_scm_url
+        from azure.mgmt.web.models import HostType
+        params = self._make_params()
+        # Simulate a cached Site with a repository host
+        repo_host = mock.MagicMock()
+        repo_host.host_type = HostType.repository
+        repo_host.name = 'myapp.scm.azurewebsites.net'
+        std_host = mock.MagicMock()
+        std_host.host_type = HostType.standard
+        std_host.name = 'myapp.azurewebsites.net'
+        params._cached_site = mock.MagicMock()
+        params._cached_site.host_name_ssl_states = [std_host, repo_host]
+
+        first = _get_or_fetch_scm_url(params)
+        second = _get_or_fetch_scm_url(params)
+
+        self.assertEqual(first, 'https://myapp.scm.azurewebsites.net')
+        self.assertEqual(second, first)
+
+    @mock.patch('azure.cli.command_modules.appservice.custom._get_scm_url',
+                return_value='https://myapp.scm.azurewebsites.net')
+    def test_get_or_fetch_scm_url_falls_back_when_no_cached_site(self, get_scm_url_mock):
+        from azure.cli.command_modules.appservice.custom import _get_or_fetch_scm_url
+        params = self._make_params()
+        params._cached_site = None
+
+        result = _get_or_fetch_scm_url(params)
+
+        self.assertEqual(result, 'https://myapp.scm.azurewebsites.net')
+        get_scm_url_mock.assert_called_once_with(params.cmd, 'myRG', 'myApp', None)
+
+    def test_populate_cached_scm_headers_basic_auth_lowercase_key(self):
+        # The basic-auth branch of get_scm_site_headers builds headers via
+        # urllib3.util.make_headers(basic_auth=...), which uses a lowercase
+        # 'authorization' key (verified with urllib3 in CI). The cache must
+        # match case-insensitively so the customer's actual Windows + basic
+        # auth code path is covered.
+        from azure.cli.command_modules.appservice.custom import _populate_cached_scm_headers
+        params = self._make_params()
+        headers = {
+            'authorization': 'Basic dXNlcjpwYXNz',
+            'User-Agent': 'AzureCLI/2.86.0',
+            'x-ms-client-request-id': 'req-1',
+            'Content-Type': 'application/octet-stream',
+            'Cache-Control': 'no-cache',
+        }
+
+        _populate_cached_scm_headers(params, headers)
+
+        # Lowercase key preserved (byte-equivalent to a fresh fetch on this
+        # path). User-Agent included. Request id and content-type excluded.
+        self.assertEqual(set(params._cached_scm_headers.keys()), {'authorization', 'User-Agent'})
+        self.assertEqual(params._cached_scm_headers['authorization'], 'Basic dXNlcjpwYXNz')
+
+    def test_populate_cached_scm_headers_aad_capitalized_key(self):
+        # The AAD branch of get_scm_site_headers sets headers["Authorization"]
+        # (capitalized) for the Bearer token.
+        from azure.cli.command_modules.appservice.custom import _populate_cached_scm_headers
+        params = self._make_params()
+        headers = {
+            'Authorization': 'Bearer eyJ0eXAiOiJKV1QiLCJ...',
+            'User-Agent': 'AzureCLI/2.86.0',
+            'x-ms-client-request-id': 'req-1',
+        }
+
+        _populate_cached_scm_headers(params, headers)
+
+        self.assertEqual(set(params._cached_scm_headers.keys()), {'Authorization', 'User-Agent'})
+        self.assertEqual(params._cached_scm_headers['Authorization'], 'Bearer eyJ0eXAiOiJKV1QiLCJ...')
+
+    def test_populate_cached_scm_headers_noop_without_authorization(self):
+        from azure.cli.command_modules.appservice.custom import _populate_cached_scm_headers
+        params = self._make_params()
+
+        _populate_cached_scm_headers(params, {'Content-Type': 'application/octet-stream'})
+
+        self.assertIsNone(params._cached_scm_headers)
+
+    @mock.patch('azure.cli.command_modules.appservice.custom.get_scm_site_headers')
+    @mock.patch('azure.cli.command_modules.appservice.custom.time.sleep')
+    @mock.patch('requests.get')
+    def test_check_zip_deployment_status_reuses_cached_headers(
+            self, requests_get_mock, _sleep_mock, get_scm_site_headers_mock):
+        from azure.cli.command_modules.appservice.custom import _check_zip_deployment_status
+        params = self._make_params()
+        params._cached_scm_headers = {
+            'Authorization': 'Basic Y2FjaGVk',
+            'User-Agent': 'AzureCLI/test',
+        }
+        # If the cache is honored, get_scm_site_headers must not be called.
+        get_scm_site_headers_mock.side_effect = AssertionError(
+            'get_scm_site_headers must not be called when cache is populated')
+
+        resp = mock.MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {'status': 4}
+        requests_get_mock.return_value = resp
+
+        result = _check_zip_deployment_status(
+            params.cmd, 'myRG', 'myApp',
+            'https://myapp.scm.azurewebsites.net/api/deployments/latest',
+            None, timeout=10, deploy_params=params)
+
+        self.assertEqual(result.get('status'), 4)
+        # Auth + UA reused from cache; request id refreshed from cmd.
+        sent_headers = requests_get_mock.call_args.kwargs['headers']
+        self.assertEqual(sent_headers['Authorization'], 'Basic Y2FjaGVk')
+        self.assertEqual(sent_headers['User-Agent'], 'AzureCLI/test')
+        self.assertEqual(sent_headers['x-ms-client-request-id'], 'req-1')
+
+    @mock.patch('azure.cli.command_modules.appservice.custom.get_scm_site_headers')
+    @mock.patch('azure.cli.command_modules.appservice.custom.time.sleep')
+    @mock.patch('requests.get')
+    def test_check_zip_deployment_status_reuses_cached_headers_basic_auth(
+            self, requests_get_mock, _sleep_mock, get_scm_site_headers_mock):
+        # Integration-style test: feed the cache via _populate_cached_scm_headers
+        # using the exact dict shape urllib3 produces on the basic-auth path
+        # (lowercase 'authorization'), then verify the status poller forwards
+        # the credential correctly. This is the customer's actual code path.
+        from azure.cli.command_modules.appservice.custom import (
+            _populate_cached_scm_headers, _check_zip_deployment_status)
+        params = self._make_params()
+        _populate_cached_scm_headers(params, {
+            'authorization': 'Basic dXNlcjpwYXNz',  # lowercase from urllib3
+            'User-Agent': 'AzureCLI/test',
+            'x-ms-client-request-id': 'publish-leg-id',
+            'Content-Type': 'application/octet-stream',
+        })
+        get_scm_site_headers_mock.side_effect = AssertionError(
+            'get_scm_site_headers must not be called when cache is populated')
+
+        resp = mock.MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {'status': 4}
+        requests_get_mock.return_value = resp
+
+        _check_zip_deployment_status(
+            params.cmd, 'myRG', 'myApp',
+            'https://myapp.scm.azurewebsites.net/api/deployments/latest',
+            None, timeout=10, deploy_params=params)
+
+        sent_headers = requests_get_mock.call_args.kwargs['headers']
+        # Lowercase key faithfully forwarded — HTTP is case-insensitive so the
+        # server treats this the same as 'Authorization'.
+        self.assertEqual(sent_headers['authorization'], 'Basic dXNlcjpwYXNz')
+        self.assertEqual(sent_headers['User-Agent'], 'AzureCLI/test')
+        # Fresh request id, not the one from the publish leg.
+        self.assertEqual(sent_headers['x-ms-client-request-id'], 'req-1')
+        self.assertNotIn('Content-Type', sent_headers)
+
+    @mock.patch('azure.cli.command_modules.appservice.custom.get_scm_site_headers',
+                return_value={'Authorization': 'Bearer fresh', 'User-Agent': 'AzureCLI/test'})
+    @mock.patch('azure.cli.command_modules.appservice.custom.time.sleep')
+    @mock.patch('requests.get')
+    def test_check_zip_deployment_status_falls_back_when_no_cache(
+            self, requests_get_mock, _sleep_mock, get_scm_site_headers_mock):
+        from azure.cli.command_modules.appservice.custom import _check_zip_deployment_status
+
+        resp = mock.MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {'status': 4}
+        requests_get_mock.return_value = resp
+
+        # No deploy_params at all — legacy enable_zip_deploy call shape.
+        cmd = mock.MagicMock()
+        cmd.cli_ctx = mock.MagicMock()
+        _check_zip_deployment_status(
+            cmd, 'myRG', 'myApp',
+            'https://myapp.scm.azurewebsites.net/api/deployments/latest',
+            None, timeout=10)
+
+        get_scm_site_headers_mock.assert_called_once_with(cmd.cli_ctx, 'myApp', 'myRG', None)
+
+    @mock.patch('azure.cli.command_modules.appservice.custom.get_scm_site_headers',
+                return_value={'Authorization': 'Basic ZnJlc2g=', 'User-Agent': 'AzureCLI/test'})
+    @mock.patch('azure.cli.command_modules.appservice.custom.time.sleep')
+    @mock.patch('requests.get')
+    def test_check_zip_deployment_status_refreshes_on_401(
+            self, requests_get_mock, _sleep_mock, get_scm_site_headers_mock):
+        from azure.cli.command_modules.appservice.custom import _check_zip_deployment_status
+        params = self._make_params()
+        params._cached_scm_headers = {
+            'Authorization': 'Basic c3RhbGU=',
+            'User-Agent': 'AzureCLI/test',
+        }
+
+        resp_401 = mock.MagicMock()
+        resp_401.status_code = 401
+        resp_ok = mock.MagicMock()
+        resp_ok.status_code = 200
+        resp_ok.json.return_value = {'status': 4}
+        requests_get_mock.side_effect = [resp_401, resp_ok]
+
+        result = _check_zip_deployment_status(
+            params.cmd, 'myRG', 'myApp',
+            'https://myapp.scm.azurewebsites.net/api/deployments/latest',
+            None, timeout=10, deploy_params=params)
+
+        self.assertEqual(result.get('status'), 4)
+        # After 401 we refetched once and replaced the cached headers. The
+        # is_flex_hint defaults to None when params.is_functionapp is None
+        # (test setup); the refresh respects whatever the hint helper returns.
+        get_scm_site_headers_mock.assert_called_once_with(
+            params.cmd.cli_ctx, 'myApp', 'myRG', None, is_flex_hint=None)
+        self.assertEqual(params._cached_scm_headers['Authorization'], 'Basic ZnJlc2g=')
+        # Second request used the fresh credentials.
+        second_call_headers = requests_get_mock.call_args_list[1].kwargs['headers']
+        self.assertEqual(second_call_headers['Authorization'], 'Basic ZnJlc2g=')
+
+    @mock.patch('azure.cli.command_modules.appservice.custom._make_onedeploy_request')
+    @mock.patch('azure.cli.command_modules.appservice.custom._update_artifact_type')
+    def test_perform_onedeploy_internal_clears_cache_on_success(
+            self, _update_type_mock, make_request_mock):
+        from azure.cli.command_modules.appservice.custom import _perform_onedeploy_internal
+        params = self._make_params()
+        params.enriched_errors = False
+        params.is_linux_webapp = False
+        params.is_functionapp = False
+
+        def _populate_and_succeed(_params):
+            _params._cached_scm_headers = {'Authorization': 'Basic c2VjcmV0'}
+            _params._cached_site = mock.MagicMock(name='site')
+            return {'status': 'ok'}
+        make_request_mock.side_effect = _populate_and_succeed
+
+        result = _perform_onedeploy_internal(params)
+
+        self.assertEqual(result, {'status': 'ok'})
+        # finally block must drop all caches even on the happy path.
+        self.assertIsNone(params._cached_scm_headers)
+        self.assertIsNone(params._cached_site)
+
+    @mock.patch('azure.cli.command_modules.appservice.custom._make_onedeploy_request')
+    @mock.patch('azure.cli.command_modules.appservice.custom._update_artifact_type')
+    def test_perform_onedeploy_internal_clears_cache_on_exception(
+            self, _update_type_mock, make_request_mock):
+        from azure.cli.command_modules.appservice.custom import _perform_onedeploy_internal
+        params = self._make_params()
+        params.enriched_errors = False
+        params.is_linux_webapp = False
+        params.is_functionapp = False
+
+        def _populate_and_raise(_params):
+            _params._cached_scm_headers = {'Authorization': 'Basic c2VjcmV0'}
+            _params._cached_site = mock.MagicMock(name='site')
+            raise RuntimeError('boom')
+        make_request_mock.side_effect = _populate_and_raise
+
+        with self.assertRaises(RuntimeError):
+            _perform_onedeploy_internal(params)
+
+        # finally block must drop all caches before the exception propagates,
+        # so telemetry / outer handlers cannot see the credential.
+        self.assertIsNone(params._cached_scm_headers)
+        self.assertIsNone(params._cached_site)
+
+    def test_one_deploy_params_repr_does_not_leak_credentials(self):
+        from azure.cli.command_modules.appservice.custom import OneDeployParams
+        params = OneDeployParams()
+        params._cached_scm_headers = {'Authorization': 'Basic c2VjcmV0'}
+        # The default repr is the object id; it must not contain attribute
+        # values. If a future change adds a __repr__/__str__ that serializes
+        # the cache, this test fails so the reviewer is forced to think about
+        # the credential exposure.
+        self.assertNotIn('Basic', repr(params))
+        self.assertNotIn('c2VjcmV0', repr(params))
+        self.assertNotIn('Basic', str(params))
+
+    def test_known_is_flex_hint_web_app(self):
+        # Web apps (is_functionapp=False) can never be FlexConsumption, so the
+        # hint short-circuits the is_flex_functionapp ARM call.
+        from azure.cli.command_modules.appservice.custom import _known_is_flex_hint
+        params = self._make_params()
+        params.is_functionapp = False
+        self.assertEqual(_known_is_flex_hint(params), False)
+
+    def test_known_is_flex_hint_function_app(self):
+        # When the cached site has a sku, derive the answer directly.
+        from azure.cli.command_modules.appservice.custom import _known_is_flex_hint
+        params = self._make_params()
+        params.is_functionapp = True
+        # No cached site → cannot determine, return None
+        params._cached_site = None
+        self.assertIsNone(_known_is_flex_hint(params))
+        # Cached site with FlexConsumption SKU → True
+        params._cached_site = mock.MagicMock(sku='FlexConsumption')
+        self.assertTrue(_known_is_flex_hint(params))
+        # Cached site with different SKU → False
+        params._cached_site = mock.MagicMock(sku='Dynamic')
+        self.assertFalse(_known_is_flex_hint(params))
+
+    def test_known_is_flex_hint_unknown(self):
+        # Defensive: if is_functionapp hasn't been populated and no cached site,
+        # don't pretend to know.
+        from azure.cli.command_modules.appservice.custom import _known_is_flex_hint
+        params = self._make_params()
+        params.is_functionapp = None
+        params._cached_site = None
+        self.assertIsNone(_known_is_flex_hint(params))
+        self.assertIsNone(_known_is_flex_hint(None))
+
+    @mock.patch('azure.cli.command_modules.appservice.custom.is_flex_functionapp')
+    @mock.patch('azure.cli.command_modules.appservice.custom.basic_auth_supported', return_value=True)
+    @mock.patch('azure.cli.command_modules.appservice.custom._get_site_credential',
+                return_value=('user', 'pass'))
+    @mock.patch('azure.cli.command_modules.appservice.custom.get_az_user_agent', return_value='AzureCLI/test')
+    def test_get_scm_site_headers_skips_is_flex_when_hint_provided(
+            self, _ua_mock, _cred_mock, _basic_auth_mock, is_flex_mock):
+        # When the caller passes is_flex_hint=False, is_flex_functionapp must
+        # not be invoked — saves one ARM call (GET /sites api 2023-12-01).
+        from azure.cli.command_modules.appservice.custom import get_scm_site_headers
+        cli_ctx = mock.MagicMock()
+        cli_ctx.data = {'headers': {'x-ms-client-request-id': 'req-1'}}
+        is_flex_mock.side_effect = AssertionError(
+            'is_flex_functionapp must not be called when is_flex_hint is provided')
+
+        headers = get_scm_site_headers(cli_ctx, 'myApp', 'myRG', None, is_flex_hint=False)
+
+        # Basic-auth branch was selected because is_flex=False (from hint).
+        is_flex_mock.assert_not_called()
+        self.assertIn('authorization', headers)  # lowercase from urllib3
+        self.assertTrue(headers['authorization'].startswith('Basic '))
+
+    @mock.patch('azure.cli.command_modules.appservice.custom.is_flex_functionapp', return_value=False)
+    @mock.patch('azure.cli.command_modules.appservice.custom.basic_auth_supported', return_value=True)
+    @mock.patch('azure.cli.command_modules.appservice.custom._get_site_credential',
+                return_value=('user', 'pass'))
+    @mock.patch('azure.cli.command_modules.appservice.custom.get_az_user_agent', return_value='AzureCLI/test')
+    def test_get_scm_site_headers_calls_is_flex_when_no_hint(
+            self, _ua_mock, _cred_mock, _basic_auth_mock, is_flex_mock):
+        # Backward-compat: when no hint is provided (existing callers),
+        # is_flex_functionapp is invoked exactly as before.
+        from azure.cli.command_modules.appservice.custom import get_scm_site_headers
+        cli_ctx = mock.MagicMock()
+        cli_ctx.data = {'headers': {'x-ms-client-request-id': 'req-1'}}
+
+        get_scm_site_headers(cli_ctx, 'myApp', 'myRG', None)
+
+        is_flex_mock.assert_called_once_with(cli_ctx, 'myRG', 'myApp')
+
+
+class TestOneDeploySiteCache(unittest.TestCase):
+    """Tests for the per-invocation Site cache on OneDeployParams.
+
+    The Site cache dedupes GET /sites calls between perform_onedeploy_webapp,
+    _get_onedeploy_request_body (is_linux check),
+    _check_runtimestatus_with_deploymentstatusapi (is_linux check), and the
+    success-log URL builder. See _get_or_fetch_site / _get_or_fetch_is_linux_webapp
+    / _get_visit_url / _url_from_site in custom.py.
+    """
+
+    def _make_params(self):
+        from azure.cli.command_modules.appservice.custom import OneDeployParams
+        params = OneDeployParams()
+        params.cmd = mock.MagicMock()
+        params.cmd.cli_ctx = mock.MagicMock()
+        params.resource_group_name = 'myRG'
+        params.webapp_name = 'myApp'
+        params.slot = None
+        return params
+
+    @mock.patch('azure.cli.command_modules.appservice.custom._generic_site_operation')
+    def test_get_or_fetch_site_caches_result(self, generic_op_mock):
+        from azure.cli.command_modules.appservice.custom import _get_or_fetch_site
+        params = self._make_params()
+        sentinel_site = mock.MagicMock(name='site')
+        generic_op_mock.return_value = sentinel_site
+
+        first = _get_or_fetch_site(params)
+        second = _get_or_fetch_site(params)
+        third = _get_or_fetch_site(params)
+
+        self.assertIs(first, sentinel_site)
+        self.assertIs(second, sentinel_site)
+        self.assertIs(third, sentinel_site)
+        generic_op_mock.assert_called_once_with(
+            params.cmd.cli_ctx, 'myRG', 'myApp', 'get', None)
+
+    @mock.patch('azure.cli.command_modules.appservice.custom._generic_site_operation')
+    def test_get_or_fetch_site_uses_slot_when_set(self, generic_op_mock):
+        # When params.slot is set, the cached Site must be the slot's Site
+        # (via get_slot under the hood), not the production Site. Slots have
+        # their own host_name_ssl_states and enabled_host_names, so
+        # _get_visit_url would otherwise show the wrong URL.
+        from azure.cli.command_modules.appservice.custom import _get_or_fetch_site
+        params = self._make_params()
+        params.slot = 'staging'
+        slot_site = mock.MagicMock(name='slotSite')
+        generic_op_mock.return_value = slot_site
+
+        result = _get_or_fetch_site(params)
+
+        self.assertIs(result, slot_site)
+        generic_op_mock.assert_called_once_with(
+            params.cmd.cli_ctx, 'myRG', 'myApp', 'get', 'staging')
+
+    @mock.patch('azure.cli.command_modules.appservice.custom._generic_site_operation')
+    def test_get_or_fetch_is_linux_webapp_uses_cached_value(self, generic_op_mock):
+        # perform_onedeploy_webapp populates is_linux_webapp eagerly; the
+        # helper must not re-fetch when the answer is already known.
+        from azure.cli.command_modules.appservice.custom import _get_or_fetch_is_linux_webapp
+        params = self._make_params()
+        params.is_linux_webapp = True
+
+        self.assertTrue(_get_or_fetch_is_linux_webapp(params))
+        generic_op_mock.assert_not_called()
+
+        params.is_linux_webapp = False
+        self.assertFalse(_get_or_fetch_is_linux_webapp(params))
+        generic_op_mock.assert_not_called()
+
+    @mock.patch('azure.cli.command_modules.appservice.custom.is_linux_webapp', return_value=True)
+    @mock.patch('azure.cli.command_modules.appservice.custom._generic_site_operation')
+    def test_get_or_fetch_is_linux_webapp_lazy_fetch_for_functionapp(
+            self, generic_op_mock, is_linux_mock):
+        # perform_onedeploy_functionapp does NOT pre-populate is_linux_webapp,
+        # so the first consumer must lazily fetch + cache the Site.
+        from azure.cli.command_modules.appservice.custom import _get_or_fetch_is_linux_webapp
+        params = self._make_params()
+        params.is_linux_webapp = None
+        site = mock.MagicMock(name='site')
+        generic_op_mock.return_value = site
+
+        first = _get_or_fetch_is_linux_webapp(params)
+        second = _get_or_fetch_is_linux_webapp(params)
+
+        self.assertTrue(first)
+        self.assertTrue(second)
+        # Site fetched exactly once even across multiple lookups.
+        generic_op_mock.assert_called_once()
+        is_linux_mock.assert_called_once_with(site)
+        # Result is memoized on params for subsequent helpers (e.g. the
+        # status poller).
+        self.assertTrue(params.is_linux_webapp)
+        self.assertIs(params._cached_site, site)
+
+    def test_url_from_site_picks_https_when_ssl_enabled(self):
+        from azure.cli.command_modules.appservice.custom import _url_from_site
+        SslState = mock.MagicMock()
+        SslState.disabled = 'Disabled'
+        cmd = mock.MagicMock()
+        cmd.get_models.return_value = SslState
+        site = mock.MagicMock()
+        site.enabled_host_names = ['custom.contoso.com', 'myapp.azurewebsites.net']
+        site.host_name_ssl_states = [
+            mock.MagicMock(ssl_state='SniEnabled'),
+        ]
+
+        self.assertEqual(
+            _url_from_site(cmd, site), 'https://custom.contoso.com')
+
+    def test_url_from_site_picks_http_when_no_ssl(self):
+        from azure.cli.command_modules.appservice.custom import _url_from_site
+        SslState = mock.MagicMock()
+        SslState.disabled = 'Disabled'
+        cmd = mock.MagicMock()
+        cmd.get_models.return_value = SslState
+        site = mock.MagicMock()
+        site.enabled_host_names = ['myapp.azurewebsites.net']
+        site.host_name_ssl_states = [
+            mock.MagicMock(ssl_state='Disabled'),
+            mock.MagicMock(ssl_state='Disabled'),
+        ]
+
+        self.assertEqual(
+            _url_from_site(cmd, site), 'http://myapp.azurewebsites.net')
+
+    @mock.patch('azure.cli.command_modules.appservice.custom._get_url')
+    @mock.patch('azure.cli.command_modules.appservice.custom._url_from_site',
+                return_value='https://myapp.azurewebsites.net')
+    def test_get_visit_url_uses_cached_site(self, url_from_site_mock, get_url_mock):
+        # When the Site is already cached (the common case after
+        # perform_onedeploy_webapp), no fallback ARM call should be made.
+        from azure.cli.command_modules.appservice.custom import _get_visit_url
+        params = self._make_params()
+        params._cached_site = mock.MagicMock(name='site')
+
+        result = _get_visit_url(params)
+
+        self.assertEqual(result, 'https://myapp.azurewebsites.net')
+        url_from_site_mock.assert_called_once_with(params.cmd, params._cached_site)
+        get_url_mock.assert_not_called()
+
+    @mock.patch('azure.cli.command_modules.appservice.custom._get_url')
+    @mock.patch('azure.cli.command_modules.appservice.custom._url_from_site',
+                return_value='https://myapp-staging.azurewebsites.net')
+    def test_get_visit_url_uses_cached_slot_site(self, url_from_site_mock, get_url_mock):
+        # For slot deployments, perform_onedeploy_webapp fetches the slot's
+        # Site, so _get_visit_url can still serve the URL from the cache.
+        from azure.cli.command_modules.appservice.custom import _get_visit_url
+        params = self._make_params()
+        params.slot = 'staging'
+        params._cached_site = mock.MagicMock(name='slotSite')
+
+        result = _get_visit_url(params)
+
+        self.assertEqual(result, 'https://myapp-staging.azurewebsites.net')
+        url_from_site_mock.assert_called_once_with(params.cmd, params._cached_site)
+        get_url_mock.assert_not_called()
+
+    @mock.patch('azure.cli.command_modules.appservice.custom._get_url',
+                return_value='https://myapp.azurewebsites.net')
+    def test_get_visit_url_falls_back_when_no_cache(self, get_url_mock):
+        # perform_onedeploy_functionapp does not populate _cached_site; in
+        # that path we must still produce a URL via the standard helper.
+        from azure.cli.command_modules.appservice.custom import _get_visit_url
+        params = self._make_params()
+        params._cached_site = None
+        params.slot = None
+
+        result = _get_visit_url(params)
+
+        self.assertEqual(result, 'https://myapp.azurewebsites.net')
+        get_url_mock.assert_called_once_with(params.cmd, 'myRG', 'myApp', None)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Related command

`az webapp deploy`, `az functionapp deploy`

### Description

`az webapp deploy` and `az functionapp deploy` issue ~12 redundant ARM calls per invocation. Most duplication comes from helpers that independently fetch the same Site model, SCM URL, publishing credentials, and `is_flex` status:

- `_get_scm_url` fetches GET /sites to resolve the SCM hostname — called twice (publish URL + status URL).
- `get_scm_site_headers` runs `is_flex_functionapp` + `basic_auth_supported` + `_get_site_credential` — called twice (publish POST + status poll), wasting 3+ ARM calls each time.

This PR hoists per-invocation state onto `OneDeployParams`:

1. **Eager Site fetch** — fetch the Site model once, cache on `_cached_site`. Derive SCM URL (from `host_name_ssl_states`), `is_linux` (from `reserved`), `is_flex` (from `sku`), and visit URL (from `enabled_host_names`) — zero additional ARM calls.
2. **SCM headers cache** — cache `get_scm_site_headers` result on `_cached_scm_headers`. Reused by status poller, Kudu warmup, and `_get_latest_deployment_id`. On HTTP 401 the cache is dropped and headers are refetched once.
3. **Security** — `_cached_scm_headers` is cleared in a `finally` block so basic-auth credentials cannot outlive the invocation.
4. **Case-insensitive auth key** — `urllib3.util.make_headers(basic_auth=...)` returns lowercase `'authorization'`; AAD uses `'Authorization'`. Cache population handles both via case-insensitive key matching.

#### ARM call reduction (verified via E2E)

| Scenario | Before | After |
|----------|--------|-------|
| Linux webapp (AAD) | ~12 | **3** (GET /sites, GET basicPub/scm, GET instances) |
| Consumption function app | ~8 | **2** (GET /sites, GET basicPub/scm) |
| Flex function app | ~6 | **1** (GET /sites) |

### Testing Guide

Deploy with `--debug` and count `Request URL:.*management.azure.com` lines (excluding `deploymentStatus` polling):

`az webapp deploy -g <rg> -n <app> --src-path <zip> --type zip --debug`

Unit tests: 160 tests covering cache lifecycle, SCM URL derivation from `host_name_ssl_states`, slot awareness, `is_flex` hint from cached SKU, header caching, and cache cleanup on success/exception.

### History Notes

{App Service} `az webapp deploy`/`az functionapp deploy`: Reduce per-deploy ARM calls from ~12 to ~3 by caching the Site model, SCM URL, and SCM authentication headers for the lifetime of a single deploy invocation
