### PR TITLE
[App Service] `az webapp config ssl list`: List site-scoped certificates for Flex Consumption apps

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -6846,7 +6846,14 @@ def list_ssl_certs(cmd, resource_group_name, name=None):
     if name:
         raise ArgumentUsageError("--name is only supported for Flex Consumption function apps. "
                                  "For other app types, certificates are managed at the resource group level.")
-    return client.certificates.list_by_resource_group(resource_group_name)
+    # Resource-group-level listing. Classic certificates are managed at the resource group level,
+    # but certificates for Flex Consumption function apps are stored per-site and are not returned
+    # by certificates.list_by_resource_group. Include those so the listing is complete.
+    certs = list(client.certificates.list_by_resource_group(resource_group_name))
+    for app in client.web_apps.list_by_resource_group(resource_group_name):
+        if app.kind and 'functionapp' in app.kind and \n                is_flex_functionapp(cmd.cli_ctx, resource_group_name, app.name):
+            certs.extend(client.site_certificates.list(resource_group_name=resource_group_name, name=app.name))
+    return certs
 
 
 def show_ssl_cert(cmd, resource_group_name, certificate_name, name=None):

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -6846,12 +6846,13 @@ def list_ssl_certs(cmd, resource_group_name, name=None):
     if name:
         raise ArgumentUsageError("--name is only supported for Flex Consumption function apps. "
                                  "For other app types, certificates are managed at the resource group level.")
-    # Resource-group-level listing. Classic certificates are managed at the resource group level,
-    # but certificates for Flex Consumption function apps are stored per-site and are not returned
-    # by certificates.list_by_resource_group. Include those so the listing is complete.
+    # Resource-group-level listing returns classic certificates. Certificates for Flex Consumption
+    # function apps are stored per-site and are not returned by certificates.list_by_resource_group,
+    # so enumerate those as well to give a complete view.
     certs = list(client.certificates.list_by_resource_group(resource_group_name))
     for app in client.web_apps.list_by_resource_group(resource_group_name):
-        if app.kind and 'functionapp' in app.kind and \n                is_flex_functionapp(cmd.cli_ctx, resource_group_name, app.name):
+        if (app.kind and 'functionapp' in app.kind.lower()
+                and is_flex_functionapp(cmd.cli_ctx, resource_group_name, app.name)):
             certs.extend(client.site_certificates.list(resource_group_name=resource_group_name, name=app.name))
     return certs
 


### PR DESCRIPTION
### Description

`az webapp config ssl list --resource-group <rg>` (without `--name`) only enumerates classic resource-group-scoped certificates via `certificates.list_by_resource_group`. Certificates for Flex Consumption function apps are stored per-site as `Microsoft.Web/sites/{app}/certificates` and are only reachable through the `site_certificates` API, which `list_ssl_certs` queries solely when `--name` is supplied (and that argument is restricted to Flex apps). As a result a certificate that is imported and bound to a Flex Consumption function app does not appear in the resource-group-level listing at all, even though it exists and is in use.

This change makes the resource-group-level listing also enumerate the site-scoped certificates for any Flex Consumption function app in the resource group, so the output is complete.

### Testing

Reproduced by importing a Key Vault certificate to a Flex Consumption (FC1) function app: `az webapp config ssl list --resource-group <rg>` returned an empty list while the certificate was present (`Microsoft.Web/sites/{app}/certificates`) and bound. With this change the certificate is listed.

Draft pending changelog and test additions.