### PR TITLE
{AKS} Set principalType when creating role assignments

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_roleassignments.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_roleassignments.py
@@ -100,6 +100,14 @@ def add_role_assignment_executor(cmd, role, assignee, resource_group_name=None,
 
 def add_role_assignment(cmd, role, service_principal_msi_id, is_service_principal=True,
                         delay=2, scope=None, assignee_principal_type=None):
+    # Every caller of add_role_assignment targets either a service principal or a managed
+    # identity, both of which are represented as a ServicePrincipal in Microsoft Entra ID.
+    # Explicitly setting the principal type lets the Authorization RP skip the Entra ID
+    # existence check, which avoids PrincipalNotFound failures caused by replication delay
+    # for freshly created identities.
+    if assignee_principal_type is None:
+        assignee_principal_type = "ServicePrincipal"
+
     # AAD can have delays in propagating data, so sleep and retry
     hook = cmd.cli_ctx.get_progress_controller(True)
     hook.add(message="Waiting for AAD role to propagate", value=0, total_val=1.0)

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -8356,12 +8356,16 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
             except Exception as e:  # pylint: disable=broad-except
                 logger.warning("Could not get signed in user: %s", str(e))
             else:
+                # signed_in_user_get() calls Graph /me, which only succeeds for a delegated
+                # (interactive) user; service principal / managed identity logins raise GraphError
+                # and are handled by the except branch above. So the assignee here is always a User.
                 self.context.external_functions.add_role_assignment_executor(  # type: ignore # pylint: disable=protected-access
                     self.cmd,
                     "Azure Kubernetes Service RBAC Cluster Admin",
                     user["id"],
                     scope=cluster.id,
                     resolve_assignee=False,
+                    assignee_principal_type="User",
                 )
 
     def put_mc(self, mc: ManagedCluster) -> ManagedCluster:


### PR DESCRIPTION
**Related command**
`az aks create`, `az aks update`, `az aks nodepool add` (and any AKS command that creates role assignments, e.g. `--attach-acr`, app routing, kubelet identity, Automatic SKU cluster-admin grant)

**Description**
AKS commands create a number of role assignments on behalf of the user (attach-acr, app routing DNS zone / key vault, VNet subnet, kubelet identity, Automatic SKU cluster-admin, etc.). Until now these assignments were created without specifying the `principalType` in the request body, except for `--attach-acr` when the user explicitly passed `--assignee-principal-type`.

When `principalType` is omitted, the Authorization RP performs an existence check against Microsoft Entra ID for the principal. For freshly created identities (e.g. a just-provisioned managed identity), Entra ID replication delay can cause this check to fail with `PrincipalNotFound`, leading to flaky cluster create/update operations that have to be retried.

This PR sets `principalType` explicitly for the role assignments created by AKS:

- `add_role_assignment` now defaults `principalType` to `ServicePrincipal`. Every internal caller targets either a service principal or a managed identity, both of which are represented as a `ServicePrincipal` in Microsoft Entra ID. The explicit value lets the Authorization RP skip the Entra ID existence check.
- The Automatic SKU cluster-admin grant to the signed-in user now passes `principalType=User`. This path resolves the assignee via Microsoft Graph `/me`, which only succeeds for a delegated (interactive) user, so the principal is always a `User`.

A user-supplied `--assignee-principal-type` continues to take precedence and is unaffected.

**Testing Guide**
- `az aks create -g <rg> -n <name> --attach-acr <acr>` against a brand-new managed identity / ACR and confirm the role assignment succeeds without `PrincipalNotFound` retries.
- `az aks create -g <rg> -n <name> --sku automatic` as an interactive user and confirm the cluster-admin role assignment is created with `principalType=User`.
- Existing acs unit tests for role assignment continue to pass.

**History Notes**
[AKS] `az aks create/update`: Set `principalType` when creating role assignments to avoid `PrincipalNotFound` failures caused by Microsoft Entra ID replication delay
