### PR TITLE
[Core] az login: Add interactive browser authentication in GitHub Codespaces

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -169,12 +169,12 @@ class Profile:
                 logger.info('No web browser is available. Fall back to device code.')
                 use_device_code = True
 
-            if not use_device_code and is_github_codespaces():
-                logger.info('GitHub Codespaces is detected. Fall back to device code.')
-                use_device_code = True
-
             if use_device_code:
                 user_identity = identity.login_with_device_code(scopes=scopes, claims_challenge=claims_challenge)
+            elif is_github_codespaces():
+                logger.info('GitHub Codespaces is detected. Use Codespaces browser auth code flow.')
+                user_identity = identity.login_with_auth_code_for_codespaces(scopes=scopes,
+                                                                             claims_challenge=claims_challenge)
             else:
                 user_identity = identity.login_with_auth_code(scopes=scopes, claims_challenge=claims_challenge)
         else:

--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -192,7 +192,8 @@ class Identity:  # pylint: disable=too-many-instance-attributes
                 self.wfile.write(
                     b'<html><body><h2>Authentication complete.</h2>'
                     b'<p>You may close this tab and return to your terminal.</p></body></html>')
-                callbacks.put(params)
+                if 'code' in params or 'error' in params:
+                    callbacks.put(params)
 
             def log_message(self, fmt, *args):
                 pass
@@ -216,16 +217,17 @@ class Identity:  # pylint: disable=too-many-instance-attributes
         url = input('After signing in, press Enter to continue '
                     '(or paste the redirected URL if your browser shows a connection error): ').strip()
 
-        server.shutdown()
-
-        if url:
-            auth_response = _parse_codespaces_auth_response(url)
-        else:
-            try:
-                auth_response = callbacks.get(timeout=60)
-            except queue.Empty:
-                raise CLIError('Login timed out. Please try again.')
-
+        try:
+            if url:
+                auth_response = _parse_codespaces_auth_response(url)
+            else:
+                try:
+                    auth_response = callbacks.get(timeout=60)
+                except queue.Empty:
+                    raise CLIError('Login timed out. Please try again.')
+        finally:
+            server.shutdown()
+            server.server_close()
         result = self._msal_app.acquire_token_by_auth_code_flow(flow, auth_response, scopes=scopes)
         return check_result(result)
 
@@ -507,8 +509,8 @@ def _parse_codespaces_auth_response(redirected_url):
         description = params.get('error_description', [''])[0]
         raise CLIError('Authentication failed: {} {}'.format(params.get('error', [''])[0], description).strip())
 
-    if 'code' not in params:
-        raise CLIError('Redirected URL does not include an authorization code.')
+    if 'code' not in params or 'state' not in params:
+        raise CLIError('Redirected URL does not include required parameters "code" and "state".')
 
     return {k: v[0] for k, v in params.items() if v}
 

--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -197,7 +197,7 @@ class Identity:  # pylint: disable=too-many-instance-attributes
             def log_message(self, fmt, *args):
                 pass
 
-        server = http.server.HTTPServer(('', 0), _CallbackHandler)
+        server = http.server.HTTPServer(('localhost', 0), _CallbackHandler)
         port = server.server_address[1]
         threading.Thread(target=server.serve_forever, daemon=True).start()
 

--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -3,10 +3,14 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+import http.server
 import json
 import os
 import re
 import sys
+import threading
+import webbrowser
+from urllib.parse import parse_qs, urlparse
 
 from azure.cli.core._environment import get_config_dir
 from knack.log import get_logger
@@ -169,6 +173,60 @@ class Identity:  # pylint: disable=too-many-instance-attributes
             parent_window_handle=self._msal_app.CONSOLE_WINDOW_HANDLE, on_before_launching_ui=_prompt_launching_ui,
             enable_msa_passthrough=True,
             claims_challenge=claims_challenge)
+        return check_result(result)
+
+    def login_with_auth_code_for_codespaces(self, scopes, claims_challenge=None):
+        import queue
+        import warnings
+
+        callbacks = queue.Queue()
+
+        class _CallbackHandler(http.server.BaseHTTPRequestHandler):
+            def do_GET(self):
+                parsed = urlparse(self.path)
+                params = {k: v[0] for k, v in
+                          parse_qs(parsed.query, keep_blank_values=True).items() if v}
+                self.send_response(200)
+                self.send_header('Content-Type', 'text/html')
+                self.end_headers()
+                self.wfile.write(
+                    b'<html><body><h2>Authentication complete.</h2>'
+                    b'<p>You may close this tab and return to your terminal.</p></body></html>')
+                callbacks.put(params)
+
+            def log_message(self, fmt, *args):
+                pass
+
+        server = http.server.HTTPServer(('', 0), _CallbackHandler)
+        port = server.server_address[1]
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+
+        # response_mode='query' is intentional — we need the code in the URL for the paste fallback
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            flow = self._msal_app.initiate_auth_code_flow(
+                scopes, redirect_uri='http://localhost:{}'.format(port),
+                prompt='select_account', claims_challenge=claims_challenge,
+                response_mode='query')
+
+        input('Press Enter to open the browser for sign-in...')
+        webbrowser.open(flow['auth_uri'])
+        logger.warning("If the browser did not open, visit: %s", flow['auth_uri'])
+
+        url = input('After signing in, press Enter to continue '
+                    '(or paste the redirected URL if your browser shows a connection error): ').strip()
+
+        server.shutdown()
+
+        if url:
+            auth_response = _parse_codespaces_auth_response(url)
+        else:
+            try:
+                auth_response = callbacks.get(timeout=60)
+            except queue.Empty:
+                raise CLIError('Login timed out. Please try again.')
+
+        result = self._msal_app.acquire_token_by_auth_code_flow(flow, auth_response, scopes=scopes)
         return check_result(result)
 
     def login_with_device_code(self, scopes, claims_challenge=None):
@@ -436,6 +494,23 @@ def _try_remove(path):
         os.remove(path)
     except FileNotFoundError:
         pass
+
+
+def _parse_codespaces_auth_response(redirected_url):
+    if not redirected_url:
+        raise CLIError('No redirected URL was provided.')
+
+    parsed = urlparse(redirected_url)
+    params = parse_qs(parsed.query or '', keep_blank_values=True)
+
+    if 'error' in params:
+        description = params.get('error_description', [''])[0]
+        raise CLIError('Authentication failed: {} {}'.format(params.get('error', [''])[0], description).strip())
+
+    if 'code' not in params:
+        raise CLIError('Redirected URL does not include an authorization code.')
+
+    return {k: v[0] for k, v in params.items() if v}
 
 
 def get_environment_credential():

--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -192,8 +192,9 @@ class Identity:  # pylint: disable=too-many-instance-attributes
                 self.wfile.write(
                     b'<html><body><h2>Authentication complete.</h2>'
                     b'<p>You may close this tab and return to your terminal.</p></body></html>')
-                if 'code' in params or 'error' in params:
+                if ('code' in params and 'state' in params) or 'error' in params:
                     callbacks.put(params)
+                    threading.Thread(target=self.server.shutdown, daemon=True).start()
 
             def log_message(self, fmt, *args):
                 pass
@@ -222,9 +223,10 @@ class Identity:  # pylint: disable=too-many-instance-attributes
                 auth_response = _parse_codespaces_auth_response(url)
             else:
                 try:
-                    auth_response = callbacks.get(timeout=60)
+                    auth_response = callbacks.get(timeout=300)
                 except queue.Empty:
-                    raise CLIError('Login timed out. Please try again.')
+                    raise CLIError('Login timed out waiting for the redirected response. '
+                                   'Please try again, or paste the redirected URL.')
         finally:
             server.shutdown()
             server.server_close()
@@ -509,10 +511,13 @@ def _parse_codespaces_auth_response(redirected_url):
         description = params.get('error_description', [''])[0]
         raise CLIError('Authentication failed: {} {}'.format(params.get('error', [''])[0], description).strip())
 
-    if 'code' not in params or 'state' not in params:
+    code = params.get('code', [''])[0]
+    state = params.get('state', [''])[0]
+
+    if not code or not state:
         raise CLIError('Redirected URL does not include required parameters "code" and "state".')
 
-    return {k: v[0] for k, v in params.items() if v}
+    return {k: v[0] for k, v in params.items() if v and v[0] != ''}
 
 
 def get_environment_credential():

--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -15,6 +15,7 @@ from azure.cli.core._profile import (Profile, SubscriptionFinder, _attach_token_
                                       _transform_subscription_for_multiapi,
                                       _TENANT_LEVEL_ACCOUNT_NAME)
 from azure.cli.core.azclierror import AuthenticationError
+from azure.cli.core.auth.identity import _parse_codespaces_auth_response
 from azure.cli.core.auth.util import AccessToken
 from azure.cli.core.mock import DummyCli
 from azure.mgmt.resource.subscriptions.models import \
@@ -379,15 +380,13 @@ class TestProfile(unittest.TestCase):
 
     @mock.patch('azure.cli.core._profile.SubscriptionFinder._create_subscription_client', autospec=True)
     @mock.patch('azure.cli.core.auth.identity.Identity.get_user_credential', autospec=True)
-    @mock.patch('azure.cli.core.auth.identity.Identity.login_with_device_code', autospec=True)
+    @mock.patch('azure.cli.core.auth.identity.Identity.login_with_auth_code_for_codespaces', autospec=True)
     @mock.patch('azure.cli.core._profile.is_github_codespaces', autospec=True, return_value=True)
     @mock.patch('azure.cli.core._profile.can_launch_browser', autospec=True, return_value=True)
-    def test_login_fallback_to_device_code_github_codespaces(self, can_launch_browser_mock, is_github_codespaces_mock,
-                                                             login_with_device_code_mock, get_user_credential_mock,
-                                                             create_subscription_client_mock):
-        # GitHub Codespaces does support launching a browser (actually a new tab),
-        # so we mock can_launch_browser to True.
-        login_with_device_code_mock.return_value = self.user_identity_mock
+    def test_login_with_auth_code_github_codespaces(self, can_launch_browser_mock, is_github_codespaces_mock,
+                                                    login_with_auth_code_for_codespaces_mock,
+                                                    get_user_credential_mock, create_subscription_client_mock):
+        login_with_auth_code_for_codespaces_mock.return_value = self.user_identity_mock
 
         cli = DummyCli()
         mock_subscription_client = mock.MagicMock()
@@ -397,11 +396,60 @@ class TestProfile(unittest.TestCase):
 
         storage_mock = {'subscriptions': None}
         profile = Profile(cli_ctx=cli, storage=storage_mock)
-        subs = profile.login(True, None, None, False, None, use_device_code=True, allow_no_subscriptions=False)
+        subs = profile.login(True, None, None, False, None, use_device_code=False, allow_no_subscriptions=False)
 
         # assert
-        login_with_device_code_mock.assert_called_once()
+        login_with_auth_code_for_codespaces_mock.assert_called_once()
         self.assertEqual(self.subscription1_with_tenant_info_output, subs)
+
+    @mock.patch('azure.cli.core._profile.SubscriptionFinder._create_subscription_client', autospec=True)
+    @mock.patch('azure.cli.core.auth.identity.Identity.get_user_credential', autospec=True)
+    @mock.patch('azure.cli.core.auth.identity.Identity.login_with_device_code', autospec=True)
+    @mock.patch('azure.cli.core._profile.is_github_codespaces', autospec=True, return_value=True)
+    @mock.patch('azure.cli.core._profile.can_launch_browser', autospec=True, return_value=True)
+    def test_login_does_not_use_device_code_in_codespaces(self, can_launch_browser_mock,
+                                                          is_github_codespaces_mock,
+                                                          login_with_device_code_mock,
+                                                          get_user_credential_mock,
+                                                          create_subscription_client_mock):
+        """Codespaces detection must route to auth_code flow, not device code."""
+        cli = DummyCli()
+        mock_subscription_client = mock.MagicMock()
+        mock_subscription_client.tenants.list.return_value = [TenantStub(self.tenant_id)]
+        mock_subscription_client.subscriptions.list.return_value = [deepcopy(self.subscription1_raw)]
+        create_subscription_client_mock.return_value = mock_subscription_client
+
+        storage_mock = {'subscriptions': None}
+        profile = Profile(cli_ctx=cli, storage=storage_mock)
+        with mock.patch('azure.cli.core.auth.identity.Identity.login_with_auth_code_for_codespaces',
+                        autospec=True, return_value=self.user_identity_mock):
+            profile.login(True, None, None, False, None, use_device_code=False, allow_no_subscriptions=False)
+
+        login_with_device_code_mock.assert_not_called()
+
+    def test_parse_codespaces_auth_response_valid(self):
+        url = 'http://localhost:12345?code=abc123&state=xyz&session_state=ss'
+        result = _parse_codespaces_auth_response(url)
+        self.assertEqual('abc123', result['code'])
+        self.assertEqual('xyz', result['state'])
+
+    def test_parse_codespaces_auth_response_error(self):
+        url = 'http://localhost:12345?error=access_denied&error_description=User+cancelled'
+        from knack.util import CLIError
+        with self.assertRaises(CLIError) as ctx:
+            _parse_codespaces_auth_response(url)
+        self.assertIn('access_denied', str(ctx.exception))
+
+    def test_parse_codespaces_auth_response_missing_code(self):
+        url = 'http://localhost:12345?state=xyz'
+        from knack.util import CLIError
+        with self.assertRaises(CLIError):
+            _parse_codespaces_auth_response(url)
+
+    def test_parse_codespaces_auth_response_empty(self):
+        from knack.util import CLIError
+        with self.assertRaises(CLIError):
+            _parse_codespaces_auth_response('')
 
     @mock.patch('azure.cli.core._profile.SubscriptionFinder._create_subscription_client', autospec=True)
     @mock.patch('azure.cli.core.auth.identity.Identity.get_user_credential', autospec=True)


### PR DESCRIPTION
**Related command**
`az login`

**Description**<!--Mandatory-->
Improves the browser authentication experience in GitHub Codespaces by using an interactive auth code flow instead of falling back to device code. This should now match the normal / non-Codespaces experience for Desktop Codespaces, and adds a workaround for Codespaces Web that still allows non-device code (standard) auth.

**Problem:**
When running `az login` in a GitHub Codespace, the CLI falls back to device code flow because `localhost` in the browser refers to the user's local machine, not the container. This forces a two-step auth process (visit URL separately → enter code) and is inconsistent with the desktop experience.

**Solution:**
- Detect GitHub Codespaces and route to a new `login_with_auth_code_for_codespaces()` method instead of device code
- Start a local HTTP callback server on a random port using `http://localhost:PORT` as the redirect URI (already registered for the Azure CLI app)
- Desktop VS Code: Automatically captures the callback via port forwarding -- user presses Enter after signing in and the token is received and used.
- Web Codespaces: User copies the redirected URL from the browser address bar and pastes it (browser shows connection error as expected, due to the shared port not being on localhost)
- Uses PKCE auth code flow for both paths; no additional setup required

**Testing Guide**

- Desktop VS Code Codespace:
  - `az login`
  - Press Enter to open browser
  - Sign in to Azure
  - Press Enter to continue → automatic callback capture → success

- Web Codespace:
  - `az login`
  - Press Enter to open browser
  - Sign in to Azure
  - See "connection refused" → copy URL from address bar
  - Paste URL at prompt → success

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Core] az login: Use interactive browser auth code flow in GitHub Codespaces instead of device code

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).

Should fix https://github.com/Azure/azure-cli/issues/20315, https://github.com/Azure/azure-cli/issues/31703, https://github.com/Azure/azure-cli/issues/26556, https://github.com/Azure/azure-cli/issues/21025