### PR TITLE
{CI} Add Azure Pipeline to trigger reference docs CI

### DIFF
--- a/.azure-pipelines/trigger-reference-docs-ci.yml
+++ b/.azure-pipelines/trigger-reference-docs-ci.yml
@@ -1,0 +1,58 @@
+name: Azure CLI Trigger Reference Docs CI
+
+trigger:
+  branches:
+    include:
+    - release
+    - release-lts-*
+    - test-release-*
+
+pr: none
+
+resources:
+- repo: self
+
+variables:
+- template: ${{ variables.Pipeline.Workspace }}/.azure-pipelines/templates/variables.yml
+# - group: '<docs-reference-variable-group>'  # provides ADO_DocsReference_Organization / _Project / _Latest_Pipeline_ID / _LTS_Pipeline_ID / _ServiceConnection
+
+jobs:
+- job: TriggerReferenceDocsCI
+  displayName: 'Queue Microsoft Learn Docs Reference CI'
+  condition: or(eq(variables['Build.SourceBranchName'], 'release'), startsWith(variables['Build.SourceBranchName'], 'release-lts-'), startsWith(variables['Build.SourceBranchName'], 'test-release-'))
+  pool:
+    name: ${{ variables.ubuntu_pool }}
+  steps:
+  - checkout: none
+  - task: AzureCLI@2
+    displayName: 'Queue docs reference pipeline'
+    inputs:
+      azureSubscription: $(ADO_DocsReference_ServiceConnection)
+      scriptType: pscore
+      scriptLocation: inlineScript
+      inlineScript: |
+        $organization = $env:AdoOrg
+        $project = $env:AdoProject
+        $thisRepoLink = $env:ThisRepoLink
+        $thisRunLink = $env:ThisRunLink
+        $triggerBranch = $env:ReleaseBranch
+        $definitionId = $triggerBranch -like 'release-lts-*' ? $env:AdoLtsPipelineId : $env:AdoLatestPipelineId
+        $variables = @("triggerBranch=$triggerBranch", "triggerFromRepo=$thisRepoLink", "triggerByPipeline=$thisRunLink")
+
+        $output = az pipelines build queue --definition-id $definitionId --project $project --organization $organization --variables @variables | ConvertFrom-Json -AsHashtable
+        if ($? -eq $false)
+        {
+            $pipelineDefinitionLink = $organization + [uri]::EscapeDataString($project) + "/_build?definitionId=$definitionId"
+            Write-Error "Failed to queue the pipeline run for $pipelineDefinitionLink, please check above error message."
+        }
+        $runId = $output.id
+        $runLink = $organization + [uri]::EscapeDataString($project) + "/_build/results?buildId=$runId"
+        Write-Host "Triggered reference pipeline run, for details please check: $runLink"
+    env:
+      AdoOrg: $(ADO_DocsReference_Organization)
+      AdoProject: $(ADO_DocsReference_Project)
+      AdoLatestPipelineId: $(ADO_DocsReference_Latest_Pipeline_ID)
+      AdoLtsPipelineId: $(ADO_DocsReference_LTS_Pipeline_ID)
+      ReleaseBranch: $(Build.SourceBranchName)
+      ThisRepoLink: $(Build.Repository.Uri)
+      ThisRunLink: $(System.CollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)

--- a/.azure-pipelines/trigger-reference-docs-ci.yml
+++ b/.azure-pipelines/trigger-reference-docs-ci.yml
@@ -40,10 +40,10 @@ jobs:
         $variables = @("triggerBranch=$triggerBranch", "triggerFromRepo=$thisRepoLink", "triggerByPipeline=$thisRunLink")
 
         $output = az pipelines build queue --definition-id $definitionId --project $project --organization $organization --variables @variables | ConvertFrom-Json -AsHashtable
-        if ($? -eq $false)
+        if ($LASTEXITCODE -ne 0)
         {
             $pipelineDefinitionLink = $organization + [uri]::EscapeDataString($project) + "/_build?definitionId=$definitionId"
-            Write-Error "Failed to queue the pipeline run for $pipelineDefinitionLink, please check above error message."
+            throw "Failed to queue the pipeline run for $pipelineDefinitionLink, please check above error message."
         }
         $runId = $output.id
         $runLink = $organization + [uri]::EscapeDataString($project) + "/_build/results?buildId=$runId"


### PR DESCRIPTION
### What
Adds `.azure-pipelines/trigger-reference-docs-ci.yml`, an internal Azure Pipeline that queues the Microsoft Learn docs reference CI pipeline when Azure CLI releases — the same job the existing GitHub Action `.github/workflows/TriggerReferenceDocsCI.yml` does today, but authenticating with an Azure DevOps service connection (Workload Identity Federation) instead of a federated GitHub login.

### Why
The federated credential the GitHub Action relies on is being retired, so the trigger logic is moving into an internal Azure Pipeline.

### How it works
- Triggers on pushes to `release`, `release-lts-*`, and `test-release-*` (the last is for the team to test in isolation). A job `condition` further restricts execution to those branches, so a stray manual run on any other branch is skipped.
- The released branch is read automatically from `Build.SourceBranchName` — no manual parameter to fill.
- Routing: `release-lts-*` → the LTS docs pipeline; everything else (`release`, `test-release-*`) → the normal (latest) docs pipeline.
- Authenticates via the ADO service connection and queues the target pipeline with `az pipelines build queue`, passing the branch through to the downstream pipeline.

### The GitHub Action is intentionally kept
`TriggerReferenceDocsCI.yml` stays in place as a safety net and will be disabled once the new pipeline is validated. The `trigger:` here only takes effect once the pipeline is registered in ADO, so merging this file is inert until then.

### Follow-ups before it goes live
- Create the WIF service connection, authorize it for this pipeline, and provide its name as `ADO_DocsReference_ServiceConnection`.
- Provide `ADO_DocsReference_Organization`, `ADO_DocsReference_Project`, `ADO_DocsReference_Latest_Pipeline_ID`, `ADO_DocsReference_LTS_Pipeline_ID` via a variable group (uncomment the `- group:` line) or pipeline variables.
- Register the pipeline in ADO and confirm the `azure-devops` CLI extension is available on the agent pool.
- Validate via a `test-release-*` branch, then disable the GitHub Action.
