### PR TITLE
[Network] `az network private-endpoint-connection`: Add provider `Microsoft.HorizonDB/clusters`

### DIFF
--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -79,6 +79,7 @@ Release History
 * `az network vnet create/update`: Add `--summarized-gateway-prefixes` to support summarized gateway prefixes (#33241)
 * `az network application-gateway ssl-cert create/update`: Add `--hsm` to support Managed HSM (#33353)
 * `az network virtual-network-appliance create/update`: Add `--private-ip-address-version` to support private ip address version (#33315)
+* `az network private-link-resource`, `az network private-endpoint-connection`: Add support for HorizonDB clusters
 
 **PostgreSQL**
 

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -79,6 +79,7 @@ Release History
 * `az network vnet create/update`: Add `--summarized-gateway-prefixes` to support summarized gateway prefixes (#33241)
 * `az network application-gateway ssl-cert create/update`: Add `--hsm` to support Managed HSM (#33353)
 * `az network virtual-network-appliance create/update`: Add `--private-ip-address-version` to support private ip address version (#33315)
+
 **PostgreSQL**
 
 * [BREAKING CHANGE] `az postgres flexible-server create/update`: Remove `--high-availability` for preferred argument `--zonal-resiliency` (#33300)

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -79,7 +79,7 @@ Release History
 * `az network vnet create/update`: Add `--summarized-gateway-prefixes` to support summarized gateway prefixes (#33241)
 * `az network application-gateway ssl-cert create/update`: Add `--hsm` to support Managed HSM (#33353)
 * `az network virtual-network-appliance create/update`: Add `--private-ip-address-version` to support private ip address version (#33315)
-* `az network private-link-resource`, `az network private-endpoint-connection`: Add support for HorizonDB clusters
+* `az network private-link-resource`, `az network private-endpoint-connection`: Add support for HorizonDB clusters (#33644)
 
 **PostgreSQL**
 

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -79,8 +79,6 @@ Release History
 * `az network vnet create/update`: Add `--summarized-gateway-prefixes` to support summarized gateway prefixes (#33241)
 * `az network application-gateway ssl-cert create/update`: Add `--hsm` to support Managed HSM (#33353)
 * `az network virtual-network-appliance create/update`: Add `--private-ip-address-version` to support private ip address version (#33315)
-* `az network private-link-resource`, `az network private-endpoint-connection`: Add support for HorizonDB clusters (#33644)
-
 **PostgreSQL**
 
 * [BREAKING CHANGE] `az postgres flexible-server create/update`: Remove `--high-availability` for preferred argument `--zonal-resiliency` (#33300)

--- a/src/azure-cli/azure/cli/command_modules/network/private_link_resource_and_endpoint_connections/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/private_link_resource_and_endpoint_connections/custom.py
@@ -46,6 +46,7 @@ def register_providers():
     _register_one_provider("Microsoft.EventHub/namespaces", "2021-06-01-preview", True)
     _register_one_provider('Microsoft.HardwareSecurityModules/cloudHsmClusters', '2022-08-31-preview', True)
     _register_one_provider("Microsoft.HDInsight/clusters", '2018-06-01-preview', True)
+    _register_one_provider('Microsoft.HorizonDB/clusters', '2026-01-20-preview', True)
     _register_one_provider("Microsoft.HybridCompute/privateLinkScopes", '2021-05-20', True)
     _register_one_provider("Microsoft.HealthcareApis/services", "2020-03-30", True)
     _register_one_provider("Microsoft.HealthDataAiservices/deidservices", "2024-09-20", True)

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_private_endpoint_connection_horizondb_cluster.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_private_endpoint_connection_horizondb_cluster.yaml
@@ -1,0 +1,2090 @@
+interactions:
+- request:
+    body: '{"location": "uksouth", "properties": {"addressSpace": {"addressPrefixes":
+      ["10.0.0.0/16"]}, "enableDdosProtection": false, "enableVmProtection": false,
+      "subnets": [{"name": "cli-subnet-000004", "properties": {"addressPrefix": "10.0.0.0/24"}}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '245'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -n -g -l --subnet-name
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.Network/virtualNetworks/cli-vnet-000003?api-version=2025-07-01
+  response:
+    body:
+      string: '{"name":"cli-vnet-000003","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.Network/virtualNetworks/cli-vnet-000003","etag":"W/\"e3d18fe4-e8dd-41b1-8cef-061f5f5d3ae1\"","type":"Microsoft.Network/virtualNetworks","location":"uksouth","properties":{"provisioningState":"Updating","resourceGuid":"3bdec717-b3dc-41e1-a59c-fb60ef7dc941","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"privateEndpointVNetPolicies":"Disabled","subnets":[{"name":"cli-subnet-000004","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.Network/virtualNetworks/cli-vnet-000003/subnets/cli-subnet-000004","etag":"W/\"e3d18fe4-e8dd-41b1-8cef-061f5f5d3ae1\"","properties":{"provisioningState":"Updating","addressPrefix":"10.0.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled","defaultOutboundAccess":false},"type":"Microsoft.Network/virtualNetworks/subnets"}],"virtualNetworkPeerings":[],"enableDdosProtection":false}}'
+    headers:
+      azure-asyncnotification:
+      - Enabled
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/uksouth/operations/bc6151fc-4718-4eaa-a399-de9976463c6b?api-version=2025-07-01&t=639179045580542231&c=MIIHkTCCBnmgAwIBAgIRAIphu0X3wTKY-ML3gzs6k8owDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgRVVTMiBDQSAwMTAeFw0yNjA0MDUxOTUxNDZaFw0yNjEwMDEwMTUxNDZaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnR-Iz8Fgy9ddzo1kN9_c9HX8fqbMo-rawsyhsE9PSveyJv-L6NSkYs-1wxuKxocBLyNq8Jah1OkhbHL2yHbaT2kH5ZLNyn03w4Fn5lmjGi0KRYdPQwRIoK_PTIYI3maaXA7Kya68KMyhJgqlwqg9IsBK3Dq2D3vr1XP-PogUr3cssjfqfW_pVnR8bWGDNVCFKHbZbXMBWTNpAW91fHtf-4ojMqnePnvHVqONRoxeIQxsLtx3bQSh4Hw2QF_n1pMCUJ52n2c3_kjlULgAIesOTCdL9Pqul7Qby0zkLW0k9ppiEtPlfX0NNTyex0tR5-UE6EfjaiZZq9c_3Er-iDFcyQIDAQABo4IEjjCCBIowgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQU3jhSRQ1zlQcx7waACuHPEhCucfswHwYDVR0jBBgwFoAU_Ow-26p8H4IeBbihBvlD5wKzCrkwggGuBgNVHR8EggGlMIIBoTBooGagZIZiaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzMvY3VycmVudC5jcmwwaqBooGaGZGh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzMvY3VycmVudC5jcmwwWaBXoFWGU2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NybHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS8zL2N1cnJlbnQuY3JsMG6gbKBqhmhodHRwOi8vY2NtZWVhc3R1czJwa2kuZWFzdHVzMi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVlYXN0dXMyaWNhMDEvMy9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAnTNmUYMgtA5djeWjFRnP8bzb2RSij05KzI6-zmrz8PwFhloqF_K-ppJyIpYnHi-6ahqLnr9NDS-inELxBS21PcqBnDx4YKiKbvb4iFBRzM1_p-Qs_Ohg8kxB7_s3yJJ42MBeISb04d8hwwG0Hzy6JDsvrcnavrUJxzl7SoGQI3cdVs3L3rOxBKrmixXdFJBIOLZeN8ZRU9cs7iMLzt3XqSfAQv2DpEbhLst8W5F29nJyo_XsgU4CHTh6VDbniACMzAYRvF-MXIf2gLnjEuX4FhnaYly_84KVjx8sr1f0nqFtfDL6X6yYAtrzSZb5lv2fBipHiLwLRt3loXadj5jPy&s=jErmKnYUJKdwsoUYXUBxZfbDI9yO3x2MTzimml0aEMv-tIqSolqmzQY3Oc-SIwxTpSZuwZpNIOLQ1q1WPohRdZiSwQQkA0m63syao83F4ttkCSM-DVYU-X8hI_YW8WFrDQ9vd5rQXlJRhojQoJ8ZkvzfNEIWnSaAuBEH7KEbqNJIFqTmpCWomU0eS8QDqbZnFn6LdqUUXDfOd-LC2vnMmKbk2BgB7R3OLBXVFjzIee1-tPZp1kE2vQG0cQLzSr5XOJEU6BOSDSW4OT6eA-Kg2WOXwb2j02R-Dx2tY_qM6aXy2KfFRKNj-0T6O2LIizWm8zRo4uoM9gGg1bRO9Rd0vA&h=z1Y3zvZtl5IkNymxM54crz40-B27Bg68USHY1-4V7S4
+      cache-control:
+      - no-cache
+      content-length:
+      - '1080'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:29:17 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 4c3b2e6e-c355-4d75-bd5b-63a41845a169
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f91ea4c1-3a04-4ea9-87a6-1c146cca75ee/uksouth/c1fea55d-9283-4450-93be-e7d0406f8378
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '11999'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '799'
+      x-ms-throttle-levels:
+      - operationRatePct=0.1, operationConcurrencyPct=0.3, subscriptionWriteRatePct=0.5,
+        etc
+      x-msedge-ref:
+      - 'Ref A: 7C36CBCB832A4E6DBF196FC86A25E10E Ref B: AMS231032607047 Ref C: 2026-06-24T13:29:16Z'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -l --subnet-name
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/uksouth/operations/bc6151fc-4718-4eaa-a399-de9976463c6b?api-version=2025-07-01&t=639179045580542231&c=MIIHkTCCBnmgAwIBAgIRAIphu0X3wTKY-ML3gzs6k8owDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgRVVTMiBDQSAwMTAeFw0yNjA0MDUxOTUxNDZaFw0yNjEwMDEwMTUxNDZaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnR-Iz8Fgy9ddzo1kN9_c9HX8fqbMo-rawsyhsE9PSveyJv-L6NSkYs-1wxuKxocBLyNq8Jah1OkhbHL2yHbaT2kH5ZLNyn03w4Fn5lmjGi0KRYdPQwRIoK_PTIYI3maaXA7Kya68KMyhJgqlwqg9IsBK3Dq2D3vr1XP-PogUr3cssjfqfW_pVnR8bWGDNVCFKHbZbXMBWTNpAW91fHtf-4ojMqnePnvHVqONRoxeIQxsLtx3bQSh4Hw2QF_n1pMCUJ52n2c3_kjlULgAIesOTCdL9Pqul7Qby0zkLW0k9ppiEtPlfX0NNTyex0tR5-UE6EfjaiZZq9c_3Er-iDFcyQIDAQABo4IEjjCCBIowgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQU3jhSRQ1zlQcx7waACuHPEhCucfswHwYDVR0jBBgwFoAU_Ow-26p8H4IeBbihBvlD5wKzCrkwggGuBgNVHR8EggGlMIIBoTBooGagZIZiaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzMvY3VycmVudC5jcmwwaqBooGaGZGh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzMvY3VycmVudC5jcmwwWaBXoFWGU2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NybHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS8zL2N1cnJlbnQuY3JsMG6gbKBqhmhodHRwOi8vY2NtZWVhc3R1czJwa2kuZWFzdHVzMi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVlYXN0dXMyaWNhMDEvMy9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAnTNmUYMgtA5djeWjFRnP8bzb2RSij05KzI6-zmrz8PwFhloqF_K-ppJyIpYnHi-6ahqLnr9NDS-inELxBS21PcqBnDx4YKiKbvb4iFBRzM1_p-Qs_Ohg8kxB7_s3yJJ42MBeISb04d8hwwG0Hzy6JDsvrcnavrUJxzl7SoGQI3cdVs3L3rOxBKrmixXdFJBIOLZeN8ZRU9cs7iMLzt3XqSfAQv2DpEbhLst8W5F29nJyo_XsgU4CHTh6VDbniACMzAYRvF-MXIf2gLnjEuX4FhnaYly_84KVjx8sr1f0nqFtfDL6X6yYAtrzSZb5lv2fBipHiLwLRt3loXadj5jPy&s=jErmKnYUJKdwsoUYXUBxZfbDI9yO3x2MTzimml0aEMv-tIqSolqmzQY3Oc-SIwxTpSZuwZpNIOLQ1q1WPohRdZiSwQQkA0m63syao83F4ttkCSM-DVYU-X8hI_YW8WFrDQ9vd5rQXlJRhojQoJ8ZkvzfNEIWnSaAuBEH7KEbqNJIFqTmpCWomU0eS8QDqbZnFn6LdqUUXDfOd-LC2vnMmKbk2BgB7R3OLBXVFjzIee1-tPZp1kE2vQG0cQLzSr5XOJEU6BOSDSW4OT6eA-Kg2WOXwb2j02R-Dx2tY_qM6aXy2KfFRKNj-0T6O2LIizWm8zRo4uoM9gGg1bRO9Rd0vA&h=z1Y3zvZtl5IkNymxM54crz40-B27Bg68USHY1-4V7S4
+  response:
+    body:
+      string: '{"status":"InProgress"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '23'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:29:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - cf1fd1c4-f08f-42b9-92c5-48c1f265a94b
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f91ea4c1-3a04-4ea9-87a6-1c146cca75ee/westeurope/58906075-2aec-4dc2-9ac2-0771ad1eaa0e
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-ms-throttle-levels:
+      - operationConcurrencyPct=0.5, etc
+      x-msedge-ref:
+      - 'Ref A: A8D367DBDDCC47F98575CA86FAD9F77B Ref B: DUB601080511029 Ref C: 2026-06-24T13:29:18Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -l --subnet-name
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/uksouth/operations/bc6151fc-4718-4eaa-a399-de9976463c6b?api-version=2025-07-01&t=639179045580542231&c=MIIHkTCCBnmgAwIBAgIRAIphu0X3wTKY-ML3gzs6k8owDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgRVVTMiBDQSAwMTAeFw0yNjA0MDUxOTUxNDZaFw0yNjEwMDEwMTUxNDZaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnR-Iz8Fgy9ddzo1kN9_c9HX8fqbMo-rawsyhsE9PSveyJv-L6NSkYs-1wxuKxocBLyNq8Jah1OkhbHL2yHbaT2kH5ZLNyn03w4Fn5lmjGi0KRYdPQwRIoK_PTIYI3maaXA7Kya68KMyhJgqlwqg9IsBK3Dq2D3vr1XP-PogUr3cssjfqfW_pVnR8bWGDNVCFKHbZbXMBWTNpAW91fHtf-4ojMqnePnvHVqONRoxeIQxsLtx3bQSh4Hw2QF_n1pMCUJ52n2c3_kjlULgAIesOTCdL9Pqul7Qby0zkLW0k9ppiEtPlfX0NNTyex0tR5-UE6EfjaiZZq9c_3Er-iDFcyQIDAQABo4IEjjCCBIowgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQU3jhSRQ1zlQcx7waACuHPEhCucfswHwYDVR0jBBgwFoAU_Ow-26p8H4IeBbihBvlD5wKzCrkwggGuBgNVHR8EggGlMIIBoTBooGagZIZiaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzMvY3VycmVudC5jcmwwaqBooGaGZGh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzMvY3VycmVudC5jcmwwWaBXoFWGU2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NybHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS8zL2N1cnJlbnQuY3JsMG6gbKBqhmhodHRwOi8vY2NtZWVhc3R1czJwa2kuZWFzdHVzMi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVlYXN0dXMyaWNhMDEvMy9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAnTNmUYMgtA5djeWjFRnP8bzb2RSij05KzI6-zmrz8PwFhloqF_K-ppJyIpYnHi-6ahqLnr9NDS-inELxBS21PcqBnDx4YKiKbvb4iFBRzM1_p-Qs_Ohg8kxB7_s3yJJ42MBeISb04d8hwwG0Hzy6JDsvrcnavrUJxzl7SoGQI3cdVs3L3rOxBKrmixXdFJBIOLZeN8ZRU9cs7iMLzt3XqSfAQv2DpEbhLst8W5F29nJyo_XsgU4CHTh6VDbniACMzAYRvF-MXIf2gLnjEuX4FhnaYly_84KVjx8sr1f0nqFtfDL6X6yYAtrzSZb5lv2fBipHiLwLRt3loXadj5jPy&s=jErmKnYUJKdwsoUYXUBxZfbDI9yO3x2MTzimml0aEMv-tIqSolqmzQY3Oc-SIwxTpSZuwZpNIOLQ1q1WPohRdZiSwQQkA0m63syao83F4ttkCSM-DVYU-X8hI_YW8WFrDQ9vd5rQXlJRhojQoJ8ZkvzfNEIWnSaAuBEH7KEbqNJIFqTmpCWomU0eS8QDqbZnFn6LdqUUXDfOd-LC2vnMmKbk2BgB7R3OLBXVFjzIee1-tPZp1kE2vQG0cQLzSr5XOJEU6BOSDSW4OT6eA-Kg2WOXwb2j02R-Dx2tY_qM6aXy2KfFRKNj-0T6O2LIizWm8zRo4uoM9gGg1bRO9Rd0vA&h=z1Y3zvZtl5IkNymxM54crz40-B27Bg68USHY1-4V7S4
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:29:29 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 5c6c4f1c-519c-4207-8ee6-808da107ba27
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f91ea4c1-3a04-4ea9-87a6-1c146cca75ee/westeurope/3d3d0464-c7a8-446f-955e-ba663249b759
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-ms-throttle-levels:
+      - operationConcurrencyPct=0.5, subscriptionReadRatePct=0.1, etc
+      x-msedge-ref:
+      - 'Ref A: F46D3ABF66DE419EA51F7C9F86357343 Ref B: AMS231032608053 Ref C: 2026-06-24T13:29:29Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -l --subnet-name
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.Network/virtualNetworks/cli-vnet-000003?api-version=2025-07-01
+  response:
+    body:
+      string: '{"name":"cli-vnet-000003","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.Network/virtualNetworks/cli-vnet-000003","etag":"W/\"68fef896-7ea1-49ca-b6bf-18e490370690\"","type":"Microsoft.Network/virtualNetworks","location":"uksouth","properties":{"provisioningState":"Succeeded","resourceGuid":"3bdec717-b3dc-41e1-a59c-fb60ef7dc941","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"privateEndpointVNetPolicies":"Disabled","subnets":[{"name":"cli-subnet-000004","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.Network/virtualNetworks/cli-vnet-000003/subnets/cli-subnet-000004","etag":"W/\"68fef896-7ea1-49ca-b6bf-18e490370690\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled","defaultOutboundAccess":false},"type":"Microsoft.Network/virtualNetworks/subnets"}],"virtualNetworkPeerings":[],"enableDdosProtection":false}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1082'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:29:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 3e8546d5-86ac-4fdd-bb4a-071ad4e3b764
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-ms-throttle-levels:
+      - operationRatePct=0.2, operationConcurrencyPct=2.0, subscriptionReadRatePct=0.1,
+        etc
+      x-msedge-ref:
+      - 'Ref A: 29ABDA6C85174A63BC5AB030A3CEF6D1 Ref B: AMS231022012049 Ref C: 2026-06-24T13:29:30Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet subnet update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n --vnet-name -g --disable-private-endpoint-network-policies
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.Network/virtualNetworks/cli-vnet-000003/subnets/cli-subnet-000004?api-version=2024-07-01
+  response:
+    body:
+      string: '{"name":"cli-subnet-000004","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.Network/virtualNetworks/cli-vnet-000003/subnets/cli-subnet-000004","etag":"W/\"68fef896-7ea1-49ca-b6bf-18e490370690\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled","defaultOutboundAccess":false},"type":"Microsoft.Network/virtualNetworks/subnets"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '524'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:29:31 GMT
+      etag:
+      - W/"68fef896-7ea1-49ca-b6bf-18e490370690"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 5f0cd7bb-0572-4eca-89df-04f7266e4550
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f91ea4c1-3a04-4ea9-87a6-1c146cca75ee/uksouth/26c6f53b-4d03-4051-a536-f827a9864991
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-ms-throttle-levels:
+      - operationConcurrencyPct=0.5, subscriptionReadRatePct=0.1, etc
+      x-msedge-ref:
+      - 'Ref A: C211AECCAB1242C2A6D1C21D7C2B243D Ref B: AMS231020615023 Ref C: 2026-06-24T13:29:31Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.Network/virtualNetworks/cli-vnet-000003/subnets/cli-subnet-000004",
+      "name": "cli-subnet-000004", "properties": {"addressPrefix": "10.0.0.0/24",
+      "defaultOutboundAccess": false, "delegations": [], "privateEndpointNetworkPolicies":
+      "Disabled", "privateLinkServiceNetworkPolicies": "Enabled"}, "type": "Microsoft.Network/virtualNetworks/subnets"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet subnet update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '456'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -n --vnet-name -g --disable-private-endpoint-network-policies
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.Network/virtualNetworks/cli-vnet-000003/subnets/cli-subnet-000004?api-version=2024-07-01
+  response:
+    body:
+      string: '{"name":"cli-subnet-000004","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.Network/virtualNetworks/cli-vnet-000003/subnets/cli-subnet-000004","etag":"W/\"d9129fb5-013e-4d13-9f69-a85932806e41\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled","defaultOutboundAccess":false},"type":"Microsoft.Network/virtualNetworks/subnets"}'
+    headers:
+      azure-asyncnotification:
+      - Enabled
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/uksouth/operations/d2b44bb3-f962-4ea9-b2e0-64fa9bdad288?api-version=2024-07-01&t=639179045732913212&c=MIIHkTCCBnmgAwIBAgIRAIphu0X3wTKY-ML3gzs6k8owDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgRVVTMiBDQSAwMTAeFw0yNjA0MDUxOTUxNDZaFw0yNjEwMDEwMTUxNDZaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnR-Iz8Fgy9ddzo1kN9_c9HX8fqbMo-rawsyhsE9PSveyJv-L6NSkYs-1wxuKxocBLyNq8Jah1OkhbHL2yHbaT2kH5ZLNyn03w4Fn5lmjGi0KRYdPQwRIoK_PTIYI3maaXA7Kya68KMyhJgqlwqg9IsBK3Dq2D3vr1XP-PogUr3cssjfqfW_pVnR8bWGDNVCFKHbZbXMBWTNpAW91fHtf-4ojMqnePnvHVqONRoxeIQxsLtx3bQSh4Hw2QF_n1pMCUJ52n2c3_kjlULgAIesOTCdL9Pqul7Qby0zkLW0k9ppiEtPlfX0NNTyex0tR5-UE6EfjaiZZq9c_3Er-iDFcyQIDAQABo4IEjjCCBIowgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQU3jhSRQ1zlQcx7waACuHPEhCucfswHwYDVR0jBBgwFoAU_Ow-26p8H4IeBbihBvlD5wKzCrkwggGuBgNVHR8EggGlMIIBoTBooGagZIZiaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzMvY3VycmVudC5jcmwwaqBooGaGZGh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzMvY3VycmVudC5jcmwwWaBXoFWGU2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NybHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS8zL2N1cnJlbnQuY3JsMG6gbKBqhmhodHRwOi8vY2NtZWVhc3R1czJwa2kuZWFzdHVzMi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVlYXN0dXMyaWNhMDEvMy9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAnTNmUYMgtA5djeWjFRnP8bzb2RSij05KzI6-zmrz8PwFhloqF_K-ppJyIpYnHi-6ahqLnr9NDS-inELxBS21PcqBnDx4YKiKbvb4iFBRzM1_p-Qs_Ohg8kxB7_s3yJJ42MBeISb04d8hwwG0Hzy6JDsvrcnavrUJxzl7SoGQI3cdVs3L3rOxBKrmixXdFJBIOLZeN8ZRU9cs7iMLzt3XqSfAQv2DpEbhLst8W5F29nJyo_XsgU4CHTh6VDbniACMzAYRvF-MXIf2gLnjEuX4FhnaYly_84KVjx8sr1f0nqFtfDL6X6yYAtrzSZb5lv2fBipHiLwLRt3loXadj5jPy&s=T6Iqnea2ilA-krkoQttBS_kguCo8jtVOD-MFoN3Fluhg13h8yXHwRAbGIAwCTK8JxitUvbgwQZ_C4Na-zfIo9Czt0qao6BvVPG06Hws0LH57-MBKciDaZZZCRp07hEeVtGuwvpU4QZoBQVindzZLtRWU82Ltsta0dgUtyUA44YpIrASp1QEjNsUk0VAXXqfODOqpGDGznbixhlOR8ofQGapVcE7RDD71xSL-wYCYmDfBQ_ryzRTgaa3zTk1cLJtID7E9wF-8HptJ9fvBsH8LRZoIHSd7-9kYtCJJl1N3nR8qUMc0FNxMZoYOwwdY8jb4a4-c-fIhULASK5Ymw1Xoaw&h=Ia3AZfeUdnvC883vIk8X7QfbVS-7TVJvX1zQP--7VoM
+      cache-control:
+      - no-cache
+      content-length:
+      - '524'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:29:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 5ea4a88a-0a80-443a-ae33-ca746a881dfa
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f91ea4c1-3a04-4ea9-87a6-1c146cca75ee/uksouth/d833a68a-1fa6-42b5-b799-5598c1351916
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '11999'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '799'
+      x-ms-throttle-levels:
+      - operationRatePct=0.1, operationConcurrencyPct=0.3, subscriptionWriteRatePct=0.6,
+        etc
+      x-msedge-ref:
+      - 'Ref A: 581E3FEC46F3444AA36531FC74D6CDC2 Ref B: AMS231032607017 Ref C: 2026-06-24T13:29:32Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet subnet update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n --vnet-name -g --disable-private-endpoint-network-policies
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/uksouth/operations/d2b44bb3-f962-4ea9-b2e0-64fa9bdad288?api-version=2024-07-01&t=639179045732913212&c=MIIHkTCCBnmgAwIBAgIRAIphu0X3wTKY-ML3gzs6k8owDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgRVVTMiBDQSAwMTAeFw0yNjA0MDUxOTUxNDZaFw0yNjEwMDEwMTUxNDZaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnR-Iz8Fgy9ddzo1kN9_c9HX8fqbMo-rawsyhsE9PSveyJv-L6NSkYs-1wxuKxocBLyNq8Jah1OkhbHL2yHbaT2kH5ZLNyn03w4Fn5lmjGi0KRYdPQwRIoK_PTIYI3maaXA7Kya68KMyhJgqlwqg9IsBK3Dq2D3vr1XP-PogUr3cssjfqfW_pVnR8bWGDNVCFKHbZbXMBWTNpAW91fHtf-4ojMqnePnvHVqONRoxeIQxsLtx3bQSh4Hw2QF_n1pMCUJ52n2c3_kjlULgAIesOTCdL9Pqul7Qby0zkLW0k9ppiEtPlfX0NNTyex0tR5-UE6EfjaiZZq9c_3Er-iDFcyQIDAQABo4IEjjCCBIowgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQU3jhSRQ1zlQcx7waACuHPEhCucfswHwYDVR0jBBgwFoAU_Ow-26p8H4IeBbihBvlD5wKzCrkwggGuBgNVHR8EggGlMIIBoTBooGagZIZiaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzMvY3VycmVudC5jcmwwaqBooGaGZGh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzMvY3VycmVudC5jcmwwWaBXoFWGU2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NybHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS8zL2N1cnJlbnQuY3JsMG6gbKBqhmhodHRwOi8vY2NtZWVhc3R1czJwa2kuZWFzdHVzMi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVlYXN0dXMyaWNhMDEvMy9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAnTNmUYMgtA5djeWjFRnP8bzb2RSij05KzI6-zmrz8PwFhloqF_K-ppJyIpYnHi-6ahqLnr9NDS-inELxBS21PcqBnDx4YKiKbvb4iFBRzM1_p-Qs_Ohg8kxB7_s3yJJ42MBeISb04d8hwwG0Hzy6JDsvrcnavrUJxzl7SoGQI3cdVs3L3rOxBKrmixXdFJBIOLZeN8ZRU9cs7iMLzt3XqSfAQv2DpEbhLst8W5F29nJyo_XsgU4CHTh6VDbniACMzAYRvF-MXIf2gLnjEuX4FhnaYly_84KVjx8sr1f0nqFtfDL6X6yYAtrzSZb5lv2fBipHiLwLRt3loXadj5jPy&s=T6Iqnea2ilA-krkoQttBS_kguCo8jtVOD-MFoN3Fluhg13h8yXHwRAbGIAwCTK8JxitUvbgwQZ_C4Na-zfIo9Czt0qao6BvVPG06Hws0LH57-MBKciDaZZZCRp07hEeVtGuwvpU4QZoBQVindzZLtRWU82Ltsta0dgUtyUA44YpIrASp1QEjNsUk0VAXXqfODOqpGDGznbixhlOR8ofQGapVcE7RDD71xSL-wYCYmDfBQ_ryzRTgaa3zTk1cLJtID7E9wF-8HptJ9fvBsH8LRZoIHSd7-9kYtCJJl1N3nR8qUMc0FNxMZoYOwwdY8jb4a4-c-fIhULASK5Ymw1Xoaw&h=Ia3AZfeUdnvC883vIk8X7QfbVS-7TVJvX1zQP--7VoM
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:29:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 3d68074e-18c5-45ed-948b-9a71919a69ca
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f91ea4c1-3a04-4ea9-87a6-1c146cca75ee/westeurope/71ce94ea-ed35-45e9-a08e-fb142b417988
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-ms-throttle-levels:
+      - operationConcurrencyPct=0.5, subscriptionReadRatePct=0.1, etc
+      x-msedge-ref:
+      - 'Ref A: C1E1E874C8E64BD79E5662A112D10FD1 Ref B: AMS231020614017 Ref C: 2026-06-24T13:29:33Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet subnet update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n --vnet-name -g --disable-private-endpoint-network-policies
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.Network/virtualNetworks/cli-vnet-000003/subnets/cli-subnet-000004?api-version=2024-07-01
+  response:
+    body:
+      string: '{"name":"cli-subnet-000004","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.Network/virtualNetworks/cli-vnet-000003/subnets/cli-subnet-000004","etag":"W/\"d9129fb5-013e-4d13-9f69-a85932806e41\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24","delegations":[],"privateEndpointNetworkPolicies":"Disabled","privateLinkServiceNetworkPolicies":"Enabled","defaultOutboundAccess":false},"type":"Microsoft.Network/virtualNetworks/subnets"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '524'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:29:34 GMT
+      etag:
+      - W/"d9129fb5-013e-4d13-9f69-a85932806e41"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - b3a21f9f-9722-4e5f-9c6f-dda3ae6f3865
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f91ea4c1-3a04-4ea9-87a6-1c146cca75ee/westeurope/f2870848-e359-4c25-8580-bd3f5e3b32e0
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-ms-throttle-levels:
+      - operationConcurrencyPct=0.5, subscriptionReadRatePct=0.2, etc
+      x-msedge-ref:
+      - 'Ref A: 73735BB0A85A4DBE8A5DEE43A96F978A Ref B: DUB601080514052 Ref C: 2026-06-24T13:29:34Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "uksouth", "properties": {"createMode": "Default", "version":
+      "17", "administratorLogin": "admin123", "administratorLoginPassword": "aBcD1234!@#$",
+      "vCores": 2, "replicaCount": 1, "network": {"publicNetworkAccess": "Enabled"},
+      "highAvailability": {"mode": "Disabled"}, "aiModelManagement": 1}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '306'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - --method --headers --url --body
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"properties":{"createMode":"Default","version":"17","zonePlacementPolicy":"BestEffort","replicaCount":null,"vCores":2,"provisioningState":"Provisioning"},"location":"uksouth","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.HorizonDb/locations/uksouth/azureAsyncOperation/0511a4e9-73ca-4167-9afa-c4795235fea4?api-version=2026-01-20-preview&t=639179045786361870&c=MIIHlTCCBn2gAwIBAgIRANClaz6RLmreUbR9r6zb9WMwDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgV1VTMiBDQSAwMTAeFw0yNjA0MTAwODE5MzhaFw0yNjEwMDUxNDE5MzhaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3E1D6z1LouZ_KTbiqwoLegZPXxfJtAxSDEzNd5eYoT9Z0mkVt2msmJzCj13_5ZeNe1Zc3emsD0Nva_lxqQqpnd8AFotdRR7SW2RoZL6e0AggjtVdUxBw3arEEVPONhRCC4X4NVXP3cSjKZjoedb5vjiI7gzkBBWu_gld6jaW4bNj5MMfx0_PNVx65CAOf2YmGYzF7zv4k3cn5-QHu9FINZ2XuhjINP6EvIDSw6H-2qVAnJw-mNb5e2KonH1tYO7nlEsUCon2rz_d7bnJURgwh_6MZ5tSOhlvvnEM1BnC_4jnVBCpBhgt-GLaYNMWZfQnMLxuc13rgCkS5b0JKPbMDQIDAQABo4IEkjCCBI4wgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQUz6DzOu55HJGf5hqPqj6oUQtuHzkwHwYDVR0jBBgwFoAUrONy-gOyc549lcjvh1uu3Ruh7WgwggGyBgNVHR8EggGpMIIBpTBpoGegZYZjaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzc5L2N1cnJlbnQuY3JsMGugaaBnhmVodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NybHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS83OS9jdXJyZW50LmNybDBaoFigVoZUaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzc5L2N1cnJlbnQuY3JsMG-gbaBrhmlodHRwOi8vY2NtZXdlc3R1czJwa2kud2VzdHVzMi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWV3ZXN0dXMyaWNhMDEvNzkvY3VycmVudC5jcmwwggG3BggrBgEFBQcBAQSCAakwggGlMGwGCCsGAQUFBzAChmBodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwbgYIKwYBBQUHMAKGYmh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY2FjZXJ0cy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxL2NlcnQuY2VyMF0GCCsGAQUFBzAChlFodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwZgYIKwYBBQUHMAKGWmh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMTANBgkqhkiG9w0BAQsFAAOCAQEAnQMBcxghl--qhJL4CBD2951WWIqzswBZahCpYCb1uYtvUonEYArDTouihm73A1IMaA1hcof6i4mp4wlOCbJrwBz1o25Urh_E8AVOA1ylZkmsFxeAwRIXEH-HiAwvFsqrylOhL0jJvIDFa0jzjJTNlv5SkoW9fTaN0E16t8hjXVNvgecuZ56mGRaJku-UCWENmbdnq7Tn6ZMhxkpcUo1uXlbRbIWmSrnwBkZu9y949y3djVawgkZL3OzGb25vkxffx3kdRijKTXY3VNuHj9KRJ2mrrPHhFcw867D13Sc9-DVYBiHYW8bb-kvv1J7UCuJTE1jqyfCNTREat4NXicrPcg&s=m0iXpnQcFcivDq3O5YNKfqKrAqfweplFDPfdd1DkaS77aIPp0kC2txg4yR2P_c0IzuvgJXWlfHJ8Vxsvd_8W0GLknrHLyMuKOWqUlYUWitEnsd-HZHc4pmlv0-dPlkUf-HZ9e7ntjuuxtkDGHrRtiYjlMQSKyYcQTwIndMqGFOIBqO12eUljE0cVobh02vNayVhIHsn82_oCJkqxEnjDr4k0uzwS6MihJQQbffoAipfG5g3N5TvJcbMMUzSICAF3eu3kHAHJkJzX4Qnccfk4RaQtKcQQAKLJyGlbHio_TgJmz1CbddYM3LnRIGEUdVKSyHP6I86AQTOt99Se07bdog&h=lOk9QxyrlwBjKbfugm-9czXWz1v5Ai0fOfdZwqZj3kU
+      cache-control:
+      - no-cache
+      content-length:
+      - '383'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:29:37 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.HorizonDb/locations/uksouth/operationResults/0511a4e9-73ca-4167-9afa-c4795235fea4?api-version=2026-01-20-preview&t=639179045786361870&c=MIIHlTCCBn2gAwIBAgIRANClaz6RLmreUbR9r6zb9WMwDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgV1VTMiBDQSAwMTAeFw0yNjA0MTAwODE5MzhaFw0yNjEwMDUxNDE5MzhaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3E1D6z1LouZ_KTbiqwoLegZPXxfJtAxSDEzNd5eYoT9Z0mkVt2msmJzCj13_5ZeNe1Zc3emsD0Nva_lxqQqpnd8AFotdRR7SW2RoZL6e0AggjtVdUxBw3arEEVPONhRCC4X4NVXP3cSjKZjoedb5vjiI7gzkBBWu_gld6jaW4bNj5MMfx0_PNVx65CAOf2YmGYzF7zv4k3cn5-QHu9FINZ2XuhjINP6EvIDSw6H-2qVAnJw-mNb5e2KonH1tYO7nlEsUCon2rz_d7bnJURgwh_6MZ5tSOhlvvnEM1BnC_4jnVBCpBhgt-GLaYNMWZfQnMLxuc13rgCkS5b0JKPbMDQIDAQABo4IEkjCCBI4wgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQUz6DzOu55HJGf5hqPqj6oUQtuHzkwHwYDVR0jBBgwFoAUrONy-gOyc549lcjvh1uu3Ruh7WgwggGyBgNVHR8EggGpMIIBpTBpoGegZYZjaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzc5L2N1cnJlbnQuY3JsMGugaaBnhmVodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NybHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS83OS9jdXJyZW50LmNybDBaoFigVoZUaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzc5L2N1cnJlbnQuY3JsMG-gbaBrhmlodHRwOi8vY2NtZXdlc3R1czJwa2kud2VzdHVzMi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWV3ZXN0dXMyaWNhMDEvNzkvY3VycmVudC5jcmwwggG3BggrBgEFBQcBAQSCAakwggGlMGwGCCsGAQUFBzAChmBodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwbgYIKwYBBQUHMAKGYmh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY2FjZXJ0cy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxL2NlcnQuY2VyMF0GCCsGAQUFBzAChlFodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwZgYIKwYBBQUHMAKGWmh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMTANBgkqhkiG9w0BAQsFAAOCAQEAnQMBcxghl--qhJL4CBD2951WWIqzswBZahCpYCb1uYtvUonEYArDTouihm73A1IMaA1hcof6i4mp4wlOCbJrwBz1o25Urh_E8AVOA1ylZkmsFxeAwRIXEH-HiAwvFsqrylOhL0jJvIDFa0jzjJTNlv5SkoW9fTaN0E16t8hjXVNvgecuZ56mGRaJku-UCWENmbdnq7Tn6ZMhxkpcUo1uXlbRbIWmSrnwBkZu9y949y3djVawgkZL3OzGb25vkxffx3kdRijKTXY3VNuHj9KRJ2mrrPHhFcw867D13Sc9-DVYBiHYW8bb-kvv1J7UCuJTE1jqyfCNTREat4NXicrPcg&s=3AbsYeimbUhDk8LrgiLTb2Ik6srgUgvchXAoHT_iyive-d47ShNDOHFKOHOR-_Dv_VMZ-e84rujsYBqmUdmccK4ozaUsLozg3byj6KlT4qdHgoaFJ5NWJVTZyjQkYWaNfmeUAIT8WkcScfb8kganiGKxGk1gJgYaTHrqrAIaGvn8yjSAAb1CmEY2VhUFDjShlzHRr4CCCQa9CNu89HkOTqfnIcvYAfy3Mn9LzoKiOfhzktSFMAhGHj-CjjrKJPRfqzY9adBdngmicD0bb2Ew8c0fwL-ntlfd8Fum6vKKpRvM8cIrGAzawcyGbaU20_4KUDrZtjnMyVudJQuOQSNRxg&h=Brw9tJBlz-Hvn4dAPc8ELXQFSUSHgPbwl8amecUSECs
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f91ea4c1-3a04-4ea9-87a6-1c146cca75ee/westeurope/e20411c8-bcc9-4a7b-afc6-e7a68b5138df
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '11999'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 77A171C9504A4CAAABC6B88CDAB1DE4D Ref B: DUB241062310036 Ref C: 2026-06-24T13:29:36Z'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --method --url
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.aa04bff73d82.uksouth.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.aa04bff73d82.ro.uksouth.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"uksouth","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:29:48 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: EE64A63CD6A244F7B1F4613BF20215EC Ref B: AMS231032607031 Ref C: 2026-06-24T13:29:49Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --method --url
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.aa04bff73d82.uksouth.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.aa04bff73d82.ro.uksouth.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"uksouth","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:30:49 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 5C5BD52601194A3B822D1E8961D82CE5 Ref B: AMS231022012033 Ref C: 2026-06-24T13:30:50Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --method --url
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.aa04bff73d82.uksouth.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.aa04bff73d82.ro.uksouth.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"uksouth","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:31:50 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 9AFEEB91626243E5AABD701761F8FE60 Ref B: DUB601080511029 Ref C: 2026-06-24T13:31:51Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --method --url
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.aa04bff73d82.uksouth.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.aa04bff73d82.ro.uksouth.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"uksouth","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:32:51 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 172E36EE89DE47C08B42F75E9E13C297 Ref B: AMS231032609051 Ref C: 2026-06-24T13:32:52Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --method --url
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.aa04bff73d82.uksouth.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.aa04bff73d82.ro.uksouth.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"uksouth","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:33:52 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 5AF50A09DB1C4B0E95AE8A48C2B68BBA Ref B: AMS231032607049 Ref C: 2026-06-24T13:33:52Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --method --url
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.aa04bff73d82.uksouth.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.aa04bff73d82.ro.uksouth.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"uksouth","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:34:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: DE9EF721FC0A439FA27FF19389E74B64 Ref B: AMS231020512011 Ref C: 2026-06-24T13:34:53Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --method --url
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.aa04bff73d82.uksouth.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.aa04bff73d82.ro.uksouth.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"uksouth","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:35:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 67DDAE70D838421382FD4843B6628CFE Ref B: AMS231032609027 Ref C: 2026-06-24T13:35:54Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --method --url
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.aa04bff73d82.uksouth.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.aa04bff73d82.ro.uksouth.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"uksouth","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:36:55 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 29BDFAE7B2B449D1B681602BD2F08218 Ref B: AMS231020614031 Ref C: 2026-06-24T13:36:55Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --method --url
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.aa04bff73d82.uksouth.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.aa04bff73d82.ro.uksouth.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"uksouth","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:37:56 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 978508FE46A949B1A0A16501D7C701A9 Ref B: AMS231020615051 Ref C: 2026-06-24T13:37:56Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --method --url
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.aa04bff73d82.uksouth.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.aa04bff73d82.ro.uksouth.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"uksouth","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:38:57 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: A3E0A323A26347EFA4DB7C83EB069092 Ref B: DUB241062309031 Ref C: 2026-06-24T13:38:57Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --method --url
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.aa04bff73d82.uksouth.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":1,"vCores":2,"readonlyEndpoint":"clitest000002.aa04bff73d82.ro.uksouth.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"uksouth","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:39:59 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: D3B8A68AFA2B49C3A9228F1B12E858A2 Ref B: AMS231032609053 Ref C: 2026-06-24T13:39:59Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --method --url
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.aa04bff73d82.uksouth.horizondb.azure.com","version":"17","state":"Succeeded","zonePlacementPolicy":"BestEffort","replicaCount":1,"vCores":2,"readonlyEndpoint":"clitest000002.aa04bff73d82.ro.uksouth.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled","parameterGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/parameterGroups/default_pg17","syncStatus":"InSync"}},"location":"uksouth","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '784'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:40:59 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 65FD412CBBB3496E97C622519FA61C0F Ref B: AMS231020614053 Ref C: 2026-06-24T13:40:59Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-link-resource list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002/privateLinkResources?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"value":[{"properties":{"groupId":"DefaultPool","requiredMembers":["rw","ro"],"requiredZoneNames":["privatelink.horizondb.azure.com"]},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002/privateLinkResources/DefaultPool","name":"DefaultPool","type":"Microsoft.HorizonDb/clusters/privateLinkResources"}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '397'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:41:00 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f91ea4c1-3a04-4ea9-87a6-1c146cca75ee/uksouth/096b0790-fb23-4d31-aeda-bcbf9b7044d1
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: ADA79D387FD84384937224DCD76D8664 Ref B: AMS231020615051 Ref C: 2026-06-24T13:41:00Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-endpoint create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --vnet-name --subnet --connection-name --private-connection-resource-id
+        --group-id --manual-request
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001?api-version=2024-11-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001","name":"cli_test_hdb000001","type":"Microsoft.Resources/resourceGroups","location":"uksouth","tags":{"product":"azurecli","cause":"automation","test":"test_private_endpoint_connection_horizondb_cluster","date":"2026-06-24T13:29:13Z","module":"network"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '394'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:41:01 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 0021A886DFFA4E17B6616A58B57F0859 Ref B: AMS231020614033 Ref C: 2026-06-24T13:41:01Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "uksouth", "properties": {"ipVersionType": "IPv4", "manualPrivateLinkServiceConnections":
+      [{"name": "cli-pec-000006", "properties": {"groupIds": ["DefaultPool"], "privateLinkServiceId":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002"}}],
+      "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.Network/virtualNetworks/cli-vnet-000003/subnets/cli-subnet-000004"}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-endpoint create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '537'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -n --vnet-name --subnet --connection-name --private-connection-resource-id
+        --group-id --manual-request
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.Network/privateEndpoints/cli-pe-000005?api-version=2025-05-01
+  response:
+    body:
+      string: '{"name":"cli-pe-000005","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.Network/privateEndpoints/cli-pe-000005","etag":"W/\"edf8d13b-da1f-44e1-92e0-b9c9c4806716\"","type":"Microsoft.Network/privateEndpoints","location":"uksouth","properties":{"provisioningState":"Updating","resourceGuid":"287fadd1-2d62-42c3-ae45-0370d0eec481","privateLinkServiceConnections":[],"manualPrivateLinkServiceConnections":[{"name":"cli-pec-000006","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.Network/privateEndpoints/cli-pe-000005/manualPrivateLinkServiceConnections/cli-pec-000006","etag":"W/\"edf8d13b-da1f-44e1-92e0-b9c9c4806716\"","properties":{"provisioningState":"Succeeded","privateLinkServiceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002","groupIds":["DefaultPool"],"privateLinkServiceConnectionState":{"status":"Pending","description":"Awaiting
+        Approval","actionsRequired":"None"}},"type":"Microsoft.Network/privateEndpoints/manualPrivateLinkServiceConnections"}],"customNetworkInterfaceName":"","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.Network/virtualNetworks/cli-vnet-000003/subnets/cli-subnet-000004"},"ipConfigurations":[],"networkInterfaces":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.Network/networkInterfaces/cli-pe-000005.nic.81f53206-03a8-416f-9bbd-b82e10546e65"}],"customDnsConfigs":[],"ipVersionType":"IPv4"}}'
+    headers:
+      azure-asyncnotification:
+      - Enabled
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/uksouth/operations/4fae731b-39a8-4e86-8693-82e72ccd7874?api-version=2025-05-01&t=639179052630805337&c=MIIHkTCCBnmgAwIBAgIRAIphu0X3wTKY-ML3gzs6k8owDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgRVVTMiBDQSAwMTAeFw0yNjA0MDUxOTUxNDZaFw0yNjEwMDEwMTUxNDZaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnR-Iz8Fgy9ddzo1kN9_c9HX8fqbMo-rawsyhsE9PSveyJv-L6NSkYs-1wxuKxocBLyNq8Jah1OkhbHL2yHbaT2kH5ZLNyn03w4Fn5lmjGi0KRYdPQwRIoK_PTIYI3maaXA7Kya68KMyhJgqlwqg9IsBK3Dq2D3vr1XP-PogUr3cssjfqfW_pVnR8bWGDNVCFKHbZbXMBWTNpAW91fHtf-4ojMqnePnvHVqONRoxeIQxsLtx3bQSh4Hw2QF_n1pMCUJ52n2c3_kjlULgAIesOTCdL9Pqul7Qby0zkLW0k9ppiEtPlfX0NNTyex0tR5-UE6EfjaiZZq9c_3Er-iDFcyQIDAQABo4IEjjCCBIowgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQU3jhSRQ1zlQcx7waACuHPEhCucfswHwYDVR0jBBgwFoAU_Ow-26p8H4IeBbihBvlD5wKzCrkwggGuBgNVHR8EggGlMIIBoTBooGagZIZiaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzMvY3VycmVudC5jcmwwaqBooGaGZGh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzMvY3VycmVudC5jcmwwWaBXoFWGU2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NybHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS8zL2N1cnJlbnQuY3JsMG6gbKBqhmhodHRwOi8vY2NtZWVhc3R1czJwa2kuZWFzdHVzMi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVlYXN0dXMyaWNhMDEvMy9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAnTNmUYMgtA5djeWjFRnP8bzb2RSij05KzI6-zmrz8PwFhloqF_K-ppJyIpYnHi-6ahqLnr9NDS-inELxBS21PcqBnDx4YKiKbvb4iFBRzM1_p-Qs_Ohg8kxB7_s3yJJ42MBeISb04d8hwwG0Hzy6JDsvrcnavrUJxzl7SoGQI3cdVs3L3rOxBKrmixXdFJBIOLZeN8ZRU9cs7iMLzt3XqSfAQv2DpEbhLst8W5F29nJyo_XsgU4CHTh6VDbniACMzAYRvF-MXIf2gLnjEuX4FhnaYly_84KVjx8sr1f0nqFtfDL6X6yYAtrzSZb5lv2fBipHiLwLRt3loXadj5jPy&s=eWTv4hGo-0PFoo1KoRoDw0GP3oFMvGx0mLQBxxN-zaTUczoVpvc-nWoK5hMrcd03r1bfoxycWmRbzjWcvCyHBNPjEc74s1fVkjRnT62nb88J5duiqkog3cxu6W0j1py8QA5JnpUb-dd0kPhmUNS9PVNDiMHnOSVRuJVp8I3ZNjeYGnVmsoOs6dAiYa4F93y-aqfGzT6wyJBE25FI0WVeOJROMm9pJ-8epcLU80_wHx4iWY6vK31OZGKs5FkQ-H0LKKVpLWWbKWJPjYHoe4T7sZ_ui8zmWuIbGVxHSk3xtrkTTFnxOVDRhaeAq30IJrqXZlglNC_5TO1_Orz6y3LOmg&h=S1uL9cpV4G7dpAROAtENeLahjI0qsTW4bjVLWbKacdI
+      cache-control:
+      - no-cache
+      content-length:
+      - '1690'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:41:02 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 8c82593c-bcbd-42fb-8a4a-26ac9d31f765
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f91ea4c1-3a04-4ea9-87a6-1c146cca75ee/uksouth/ba5d33e9-7906-4b71-a862-601ce424459c
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '11999'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '799'
+      x-ms-throttle-levels:
+      - operationRatePct=0.1, operationConcurrencyPct=0.3, subscriptionWriteRatePct=0.5,
+        etc
+      x-msedge-ref:
+      - 'Ref A: 95275D9D91D245E49321DF810A43CE23 Ref B: AMS231022012007 Ref C: 2026-06-24T13:41:02Z'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-endpoint create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --vnet-name --subnet --connection-name --private-connection-resource-id
+        --group-id --manual-request
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/uksouth/operations/4fae731b-39a8-4e86-8693-82e72ccd7874?api-version=2025-05-01&t=639179052630805337&c=MIIHkTCCBnmgAwIBAgIRAIphu0X3wTKY-ML3gzs6k8owDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgRVVTMiBDQSAwMTAeFw0yNjA0MDUxOTUxNDZaFw0yNjEwMDEwMTUxNDZaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnR-Iz8Fgy9ddzo1kN9_c9HX8fqbMo-rawsyhsE9PSveyJv-L6NSkYs-1wxuKxocBLyNq8Jah1OkhbHL2yHbaT2kH5ZLNyn03w4Fn5lmjGi0KRYdPQwRIoK_PTIYI3maaXA7Kya68KMyhJgqlwqg9IsBK3Dq2D3vr1XP-PogUr3cssjfqfW_pVnR8bWGDNVCFKHbZbXMBWTNpAW91fHtf-4ojMqnePnvHVqONRoxeIQxsLtx3bQSh4Hw2QF_n1pMCUJ52n2c3_kjlULgAIesOTCdL9Pqul7Qby0zkLW0k9ppiEtPlfX0NNTyex0tR5-UE6EfjaiZZq9c_3Er-iDFcyQIDAQABo4IEjjCCBIowgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQU3jhSRQ1zlQcx7waACuHPEhCucfswHwYDVR0jBBgwFoAU_Ow-26p8H4IeBbihBvlD5wKzCrkwggGuBgNVHR8EggGlMIIBoTBooGagZIZiaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzMvY3VycmVudC5jcmwwaqBooGaGZGh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzMvY3VycmVudC5jcmwwWaBXoFWGU2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NybHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS8zL2N1cnJlbnQuY3JsMG6gbKBqhmhodHRwOi8vY2NtZWVhc3R1czJwa2kuZWFzdHVzMi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVlYXN0dXMyaWNhMDEvMy9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAnTNmUYMgtA5djeWjFRnP8bzb2RSij05KzI6-zmrz8PwFhloqF_K-ppJyIpYnHi-6ahqLnr9NDS-inELxBS21PcqBnDx4YKiKbvb4iFBRzM1_p-Qs_Ohg8kxB7_s3yJJ42MBeISb04d8hwwG0Hzy6JDsvrcnavrUJxzl7SoGQI3cdVs3L3rOxBKrmixXdFJBIOLZeN8ZRU9cs7iMLzt3XqSfAQv2DpEbhLst8W5F29nJyo_XsgU4CHTh6VDbniACMzAYRvF-MXIf2gLnjEuX4FhnaYly_84KVjx8sr1f0nqFtfDL6X6yYAtrzSZb5lv2fBipHiLwLRt3loXadj5jPy&s=eWTv4hGo-0PFoo1KoRoDw0GP3oFMvGx0mLQBxxN-zaTUczoVpvc-nWoK5hMrcd03r1bfoxycWmRbzjWcvCyHBNPjEc74s1fVkjRnT62nb88J5duiqkog3cxu6W0j1py8QA5JnpUb-dd0kPhmUNS9PVNDiMHnOSVRuJVp8I3ZNjeYGnVmsoOs6dAiYa4F93y-aqfGzT6wyJBE25FI0WVeOJROMm9pJ-8epcLU80_wHx4iWY6vK31OZGKs5FkQ-H0LKKVpLWWbKWJPjYHoe4T7sZ_ui8zmWuIbGVxHSk3xtrkTTFnxOVDRhaeAq30IJrqXZlglNC_5TO1_Orz6y3LOmg&h=S1uL9cpV4G7dpAROAtENeLahjI0qsTW4bjVLWbKacdI
+  response:
+    body:
+      string: '{"status":"InProgress"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '23'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:41:04 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 43bcc849-4834-4589-802f-fa659ee6b2a1
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f91ea4c1-3a04-4ea9-87a6-1c146cca75ee/westeurope/036757f9-1ae6-4424-a81c-31f9bff90816
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-ms-throttle-levels:
+      - operationConcurrencyPct=0.5, subscriptionReadRatePct=1.2, etc
+      x-msedge-ref:
+      - 'Ref A: E536C7B290524753BBD2A9C1CA2F4752 Ref B: AMS231032607007 Ref C: 2026-06-24T13:41:03Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-endpoint create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --vnet-name --subnet --connection-name --private-connection-resource-id
+        --group-id --manual-request
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/uksouth/operations/4fae731b-39a8-4e86-8693-82e72ccd7874?api-version=2025-05-01&t=639179052630805337&c=MIIHkTCCBnmgAwIBAgIRAIphu0X3wTKY-ML3gzs6k8owDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgRVVTMiBDQSAwMTAeFw0yNjA0MDUxOTUxNDZaFw0yNjEwMDEwMTUxNDZaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnR-Iz8Fgy9ddzo1kN9_c9HX8fqbMo-rawsyhsE9PSveyJv-L6NSkYs-1wxuKxocBLyNq8Jah1OkhbHL2yHbaT2kH5ZLNyn03w4Fn5lmjGi0KRYdPQwRIoK_PTIYI3maaXA7Kya68KMyhJgqlwqg9IsBK3Dq2D3vr1XP-PogUr3cssjfqfW_pVnR8bWGDNVCFKHbZbXMBWTNpAW91fHtf-4ojMqnePnvHVqONRoxeIQxsLtx3bQSh4Hw2QF_n1pMCUJ52n2c3_kjlULgAIesOTCdL9Pqul7Qby0zkLW0k9ppiEtPlfX0NNTyex0tR5-UE6EfjaiZZq9c_3Er-iDFcyQIDAQABo4IEjjCCBIowgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQU3jhSRQ1zlQcx7waACuHPEhCucfswHwYDVR0jBBgwFoAU_Ow-26p8H4IeBbihBvlD5wKzCrkwggGuBgNVHR8EggGlMIIBoTBooGagZIZiaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzMvY3VycmVudC5jcmwwaqBooGaGZGh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzMvY3VycmVudC5jcmwwWaBXoFWGU2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NybHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS8zL2N1cnJlbnQuY3JsMG6gbKBqhmhodHRwOi8vY2NtZWVhc3R1czJwa2kuZWFzdHVzMi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVlYXN0dXMyaWNhMDEvMy9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAnTNmUYMgtA5djeWjFRnP8bzb2RSij05KzI6-zmrz8PwFhloqF_K-ppJyIpYnHi-6ahqLnr9NDS-inELxBS21PcqBnDx4YKiKbvb4iFBRzM1_p-Qs_Ohg8kxB7_s3yJJ42MBeISb04d8hwwG0Hzy6JDsvrcnavrUJxzl7SoGQI3cdVs3L3rOxBKrmixXdFJBIOLZeN8ZRU9cs7iMLzt3XqSfAQv2DpEbhLst8W5F29nJyo_XsgU4CHTh6VDbniACMzAYRvF-MXIf2gLnjEuX4FhnaYly_84KVjx8sr1f0nqFtfDL6X6yYAtrzSZb5lv2fBipHiLwLRt3loXadj5jPy&s=eWTv4hGo-0PFoo1KoRoDw0GP3oFMvGx0mLQBxxN-zaTUczoVpvc-nWoK5hMrcd03r1bfoxycWmRbzjWcvCyHBNPjEc74s1fVkjRnT62nb88J5duiqkog3cxu6W0j1py8QA5JnpUb-dd0kPhmUNS9PVNDiMHnOSVRuJVp8I3ZNjeYGnVmsoOs6dAiYa4F93y-aqfGzT6wyJBE25FI0WVeOJROMm9pJ-8epcLU80_wHx4iWY6vK31OZGKs5FkQ-H0LKKVpLWWbKWJPjYHoe4T7sZ_ui8zmWuIbGVxHSk3xtrkTTFnxOVDRhaeAq30IJrqXZlglNC_5TO1_Orz6y3LOmg&h=S1uL9cpV4G7dpAROAtENeLahjI0qsTW4bjVLWbKacdI
+  response:
+    body:
+      string: '{"status":"InProgress"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '23'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:41:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 20136db2-b915-46a9-9800-26f511123092
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f91ea4c1-3a04-4ea9-87a6-1c146cca75ee/westeurope/2e6da54d-a0b6-4444-b7ba-1530d1213338
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-ms-throttle-levels:
+      - operationConcurrencyPct=0.5, subscriptionReadRatePct=1.3, etc
+      x-msedge-ref:
+      - 'Ref A: D0C86960FCE549E9A7D8739BD11D549D Ref B: AMS231032608035 Ref C: 2026-06-24T13:41:14Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-endpoint create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --vnet-name --subnet --connection-name --private-connection-resource-id
+        --group-id --manual-request
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/uksouth/operations/4fae731b-39a8-4e86-8693-82e72ccd7874?api-version=2025-05-01&t=639179052630805337&c=MIIHkTCCBnmgAwIBAgIRAIphu0X3wTKY-ML3gzs6k8owDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgRVVTMiBDQSAwMTAeFw0yNjA0MDUxOTUxNDZaFw0yNjEwMDEwMTUxNDZaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnR-Iz8Fgy9ddzo1kN9_c9HX8fqbMo-rawsyhsE9PSveyJv-L6NSkYs-1wxuKxocBLyNq8Jah1OkhbHL2yHbaT2kH5ZLNyn03w4Fn5lmjGi0KRYdPQwRIoK_PTIYI3maaXA7Kya68KMyhJgqlwqg9IsBK3Dq2D3vr1XP-PogUr3cssjfqfW_pVnR8bWGDNVCFKHbZbXMBWTNpAW91fHtf-4ojMqnePnvHVqONRoxeIQxsLtx3bQSh4Hw2QF_n1pMCUJ52n2c3_kjlULgAIesOTCdL9Pqul7Qby0zkLW0k9ppiEtPlfX0NNTyex0tR5-UE6EfjaiZZq9c_3Er-iDFcyQIDAQABo4IEjjCCBIowgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQU3jhSRQ1zlQcx7waACuHPEhCucfswHwYDVR0jBBgwFoAU_Ow-26p8H4IeBbihBvlD5wKzCrkwggGuBgNVHR8EggGlMIIBoTBooGagZIZiaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzMvY3VycmVudC5jcmwwaqBooGaGZGh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzMvY3VycmVudC5jcmwwWaBXoFWGU2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NybHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS8zL2N1cnJlbnQuY3JsMG6gbKBqhmhodHRwOi8vY2NtZWVhc3R1czJwa2kuZWFzdHVzMi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVlYXN0dXMyaWNhMDEvMy9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAnTNmUYMgtA5djeWjFRnP8bzb2RSij05KzI6-zmrz8PwFhloqF_K-ppJyIpYnHi-6ahqLnr9NDS-inELxBS21PcqBnDx4YKiKbvb4iFBRzM1_p-Qs_Ohg8kxB7_s3yJJ42MBeISb04d8hwwG0Hzy6JDsvrcnavrUJxzl7SoGQI3cdVs3L3rOxBKrmixXdFJBIOLZeN8ZRU9cs7iMLzt3XqSfAQv2DpEbhLst8W5F29nJyo_XsgU4CHTh6VDbniACMzAYRvF-MXIf2gLnjEuX4FhnaYly_84KVjx8sr1f0nqFtfDL6X6yYAtrzSZb5lv2fBipHiLwLRt3loXadj5jPy&s=eWTv4hGo-0PFoo1KoRoDw0GP3oFMvGx0mLQBxxN-zaTUczoVpvc-nWoK5hMrcd03r1bfoxycWmRbzjWcvCyHBNPjEc74s1fVkjRnT62nb88J5duiqkog3cxu6W0j1py8QA5JnpUb-dd0kPhmUNS9PVNDiMHnOSVRuJVp8I3ZNjeYGnVmsoOs6dAiYa4F93y-aqfGzT6wyJBE25FI0WVeOJROMm9pJ-8epcLU80_wHx4iWY6vK31OZGKs5FkQ-H0LKKVpLWWbKWJPjYHoe4T7sZ_ui8zmWuIbGVxHSk3xtrkTTFnxOVDRhaeAq30IJrqXZlglNC_5TO1_Orz6y3LOmg&h=S1uL9cpV4G7dpAROAtENeLahjI0qsTW4bjVLWbKacdI
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:41:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 1ade9a12-77e6-4ed9-9d7a-bebfaabf6daf
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f91ea4c1-3a04-4ea9-87a6-1c146cca75ee/westeurope/329d07b4-aa97-4627-bbbb-1aabb5c2e0ee
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-ms-throttle-levels:
+      - operationConcurrencyPct=0.5, subscriptionReadRatePct=1.3, etc
+      x-msedge-ref:
+      - 'Ref A: 798B4231533E4B1DA3C1EED7BF75C389 Ref B: DUB241062309025 Ref C: 2026-06-24T13:41:36Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-endpoint create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --vnet-name --subnet --connection-name --private-connection-resource-id
+        --group-id --manual-request
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.Network/privateEndpoints/cli-pe-000005?api-version=2025-05-01
+  response:
+    body:
+      string: '{"name":"cli-pe-000005","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.Network/privateEndpoints/cli-pe-000005","etag":"W/\"ba7569f3-244e-4e91-872e-b112283f2634\"","type":"Microsoft.Network/privateEndpoints","location":"uksouth","properties":{"provisioningState":"Succeeded","resourceGuid":"287fadd1-2d62-42c3-ae45-0370d0eec481","privateLinkServiceConnections":[],"manualPrivateLinkServiceConnections":[{"name":"cli-pec-000006","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.Network/privateEndpoints/cli-pe-000005/manualPrivateLinkServiceConnections/cli-pec-000006","etag":"W/\"ba7569f3-244e-4e91-872e-b112283f2634\"","properties":{"provisioningState":"Succeeded","privateLinkServiceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002","groupIds":["DefaultPool"],"privateLinkServiceConnectionState":{"status":"Pending","description":"Pending","actionsRequired":""}},"type":"Microsoft.Network/privateEndpoints/manualPrivateLinkServiceConnections"}],"customNetworkInterfaceName":"","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.Network/virtualNetworks/cli-vnet-000003/subnets/cli-subnet-000004"},"ipConfigurations":[],"networkInterfaces":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.Network/networkInterfaces/cli-pe-000005.nic.81f53206-03a8-416f-9bbd-b82e10546e65"}],"customDnsConfigs":[],"ipVersionType":"IPv4"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1677'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:41:37 GMT
+      etag:
+      - W/"ba7569f3-244e-4e91-872e-b112283f2634"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - d256047e-17b0-440a-9f5b-0036c88b8ace
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-ms-throttle-levels:
+      - operationConcurrencyPct=0.5, subscriptionReadRatePct=1.3, etc
+      x-msedge-ref:
+      - 'Ref A: 7A3F8D953B4B44BBA89E1EFF6FDDF748 Ref B: AMS231020512009 Ref C: 2026-06-24T13:41:37Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-endpoint-connection list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002/privateEndpointConnections?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"value":[{"properties":{"privateEndpoint":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.Network/privateEndpoints/cli-pe-000005"},"privateLinkServiceConnectionState":{"status":"Pending","description":"Pending","actionsRequired":"None"},"groupIds":["DefaultPool"],"provisioningState":"Succeeded"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002/privateEndpointConnections/cli-pe-000005.aef49504-3255-4a18-8565-980afd6da26e","name":"cli-pe-000005.aef49504-3255-4a18-8565-980afd6da26e","type":"Microsoft.HorizonDb/clusters/privateEndpointConnections"}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '714'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:41:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f91ea4c1-3a04-4ea9-87a6-1c146cca75ee/uksouth/c99b1c41-3924-4c9f-b3fc-1d50e32becfa
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: DEFA3FDF59EC45958777DD93E207C4ED Ref B: DUB241062309040 Ref C: 2026-06-24T13:41:38Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-endpoint-connection show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002/privateEndpointConnections/cli-pe-000005.aef49504-3255-4a18-8565-980afd6da26e?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"properties":{"privateEndpoint":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.Network/privateEndpoints/cli-pe-000005"},"privateLinkServiceConnectionState":{"status":"Pending","description":"Pending","actionsRequired":"None"},"groupIds":["DefaultPool"],"provisioningState":"Succeeded"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002/privateEndpointConnections/cli-pe-000005.aef49504-3255-4a18-8565-980afd6da26e","name":"cli-pe-000005.aef49504-3255-4a18-8565-980afd6da26e","type":"Microsoft.HorizonDb/clusters/privateEndpointConnections"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '702'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:41:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f91ea4c1-3a04-4ea9-87a6-1c146cca75ee/uksouth/ef3f272c-3ca6-4bb3-ab36-fa8c47559a7b
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 025CCE4E8BC34C06868BA2AAE8037D38 Ref B: DUB601080513031 Ref C: 2026-06-24T13:41:39Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-endpoint-connection show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-name -n -g --type
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002/privateEndpointConnections/cli-pe-000005.aef49504-3255-4a18-8565-980afd6da26e?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"properties":{"privateEndpoint":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.Network/privateEndpoints/cli-pe-000005"},"privateLinkServiceConnectionState":{"status":"Pending","description":"Pending","actionsRequired":"None"},"groupIds":["DefaultPool"],"provisioningState":"Succeeded"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002/privateEndpointConnections/cli-pe-000005.aef49504-3255-4a18-8565-980afd6da26e","name":"cli-pe-000005.aef49504-3255-4a18-8565-980afd6da26e","type":"Microsoft.HorizonDb/clusters/privateEndpointConnections"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '702'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:41:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f91ea4c1-3a04-4ea9-87a6-1c146cca75ee/uksouth/854a88b1-b8f0-48af-8428-d5876a5745a0
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 56C1042DAECB4D46B5E795F13F5872D5 Ref B: AMS231020512009 Ref C: 2026-06-24T13:41:40Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-endpoint-connection approve
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-name --resource-group --name --type --description
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002/privateEndpointConnections/cli-pe-000005.aef49504-3255-4a18-8565-980afd6da26e?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"properties":{"privateEndpoint":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.Network/privateEndpoints/cli-pe-000005"},"privateLinkServiceConnectionState":{"status":"Pending","description":"Pending","actionsRequired":"None"},"groupIds":["DefaultPool"],"provisioningState":"Succeeded"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002/privateEndpointConnections/cli-pe-000005.aef49504-3255-4a18-8565-980afd6da26e","name":"cli-pe-000005.aef49504-3255-4a18-8565-980afd6da26e","type":"Microsoft.HorizonDb/clusters/privateEndpointConnections"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '702'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:41:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f91ea4c1-3a04-4ea9-87a6-1c146cca75ee/uksouth/96f78dd0-7347-46bf-b913-f97645536b7b
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 7ACEF461355143B1823E216CE4B27CF9 Ref B: AMS231032608011 Ref C: 2026-06-24T13:41:40Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"privateEndpoint": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.Network/privateEndpoints/cli-pe-000005"},
+      "privateLinkServiceConnectionState": {"status": "Approved", "description": "Approved.",
+      "actionsRequired": "None"}, "groupIds": ["DefaultPool"], "provisioningState":
+      "Succeeded"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002/privateEndpointConnections/cli-pe-000005.aef49504-3255-4a18-8565-980afd6da26e",
+      "name": "cli-pe-000005.aef49504-3255-4a18-8565-980afd6da26e", "type": "Microsoft.HorizonDb/clusters/privateEndpointConnections"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-endpoint-connection approve
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '725'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - --resource-name --resource-group --name --type --description
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002/privateEndpointConnections/cli-pe-000005.aef49504-3255-4a18-8565-980afd6da26e?api-version=2026-01-20-preview
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.HorizonDb/locations/uksouth/azureAsyncOperation/52241996-539a-48f8-9b0e-1b2a0bf9d412?api-version=2026-01-20-preview&t=639179053020858850&c=MIIHkTCCBnmgAwIBAgIRAIphu0X3wTKY-ML3gzs6k8owDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgRVVTMiBDQSAwMTAeFw0yNjA0MDUxOTUxNDZaFw0yNjEwMDEwMTUxNDZaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnR-Iz8Fgy9ddzo1kN9_c9HX8fqbMo-rawsyhsE9PSveyJv-L6NSkYs-1wxuKxocBLyNq8Jah1OkhbHL2yHbaT2kH5ZLNyn03w4Fn5lmjGi0KRYdPQwRIoK_PTIYI3maaXA7Kya68KMyhJgqlwqg9IsBK3Dq2D3vr1XP-PogUr3cssjfqfW_pVnR8bWGDNVCFKHbZbXMBWTNpAW91fHtf-4ojMqnePnvHVqONRoxeIQxsLtx3bQSh4Hw2QF_n1pMCUJ52n2c3_kjlULgAIesOTCdL9Pqul7Qby0zkLW0k9ppiEtPlfX0NNTyex0tR5-UE6EfjaiZZq9c_3Er-iDFcyQIDAQABo4IEjjCCBIowgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQU3jhSRQ1zlQcx7waACuHPEhCucfswHwYDVR0jBBgwFoAU_Ow-26p8H4IeBbihBvlD5wKzCrkwggGuBgNVHR8EggGlMIIBoTBooGagZIZiaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzMvY3VycmVudC5jcmwwaqBooGaGZGh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzMvY3VycmVudC5jcmwwWaBXoFWGU2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NybHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS8zL2N1cnJlbnQuY3JsMG6gbKBqhmhodHRwOi8vY2NtZWVhc3R1czJwa2kuZWFzdHVzMi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVlYXN0dXMyaWNhMDEvMy9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAnTNmUYMgtA5djeWjFRnP8bzb2RSij05KzI6-zmrz8PwFhloqF_K-ppJyIpYnHi-6ahqLnr9NDS-inELxBS21PcqBnDx4YKiKbvb4iFBRzM1_p-Qs_Ohg8kxB7_s3yJJ42MBeISb04d8hwwG0Hzy6JDsvrcnavrUJxzl7SoGQI3cdVs3L3rOxBKrmixXdFJBIOLZeN8ZRU9cs7iMLzt3XqSfAQv2DpEbhLst8W5F29nJyo_XsgU4CHTh6VDbniACMzAYRvF-MXIf2gLnjEuX4FhnaYly_84KVjx8sr1f0nqFtfDL6X6yYAtrzSZb5lv2fBipHiLwLRt3loXadj5jPy&s=hWRTJSsSWBGsGd0a5KKH_76fjycbseUha8neFSS2jXVa1v58X-gpJX4YwThuBttvUx_twxXS-rfhOxgwUIQa8g5bsq-Ur2q-MPLyLFcuS3pYt3fXGJE_shhN3tq1GwzXzBtwVj97-hx6elaNWBULPHNl5MMpeogegqfVSTPLT4VblfLVeeZg1eBTl-aVeJQ33ZexHS3XhdOFbmPhbgBK9D9LXZPQEwUT3Dzf-QHyPZTL8h3oRpy_h8zN7XXmB5_lMu82nkqsLyRaxbXoiL4BY_3VHrMw4SKvwfFBBUuGsB0sB_p14LbTGokzAz27qbeUR3cXcgaXFz2aCMhtfmm_yw&h=98gHt-gM9Y7O3kPNV0W35qFP5brJFwBb3aICuwgbf0I
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Wed, 24 Jun 2026 13:41:41 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.HorizonDb/locations/uksouth/operationResults/52241996-539a-48f8-9b0e-1b2a0bf9d412?api-version=2026-01-20-preview&t=639179053021015072&c=MIIHkTCCBnmgAwIBAgIRAIphu0X3wTKY-ML3gzs6k8owDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgRVVTMiBDQSAwMTAeFw0yNjA0MDUxOTUxNDZaFw0yNjEwMDEwMTUxNDZaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnR-Iz8Fgy9ddzo1kN9_c9HX8fqbMo-rawsyhsE9PSveyJv-L6NSkYs-1wxuKxocBLyNq8Jah1OkhbHL2yHbaT2kH5ZLNyn03w4Fn5lmjGi0KRYdPQwRIoK_PTIYI3maaXA7Kya68KMyhJgqlwqg9IsBK3Dq2D3vr1XP-PogUr3cssjfqfW_pVnR8bWGDNVCFKHbZbXMBWTNpAW91fHtf-4ojMqnePnvHVqONRoxeIQxsLtx3bQSh4Hw2QF_n1pMCUJ52n2c3_kjlULgAIesOTCdL9Pqul7Qby0zkLW0k9ppiEtPlfX0NNTyex0tR5-UE6EfjaiZZq9c_3Er-iDFcyQIDAQABo4IEjjCCBIowgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQU3jhSRQ1zlQcx7waACuHPEhCucfswHwYDVR0jBBgwFoAU_Ow-26p8H4IeBbihBvlD5wKzCrkwggGuBgNVHR8EggGlMIIBoTBooGagZIZiaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzMvY3VycmVudC5jcmwwaqBooGaGZGh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzMvY3VycmVudC5jcmwwWaBXoFWGU2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NybHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS8zL2N1cnJlbnQuY3JsMG6gbKBqhmhodHRwOi8vY2NtZWVhc3R1czJwa2kuZWFzdHVzMi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVlYXN0dXMyaWNhMDEvMy9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAnTNmUYMgtA5djeWjFRnP8bzb2RSij05KzI6-zmrz8PwFhloqF_K-ppJyIpYnHi-6ahqLnr9NDS-inELxBS21PcqBnDx4YKiKbvb4iFBRzM1_p-Qs_Ohg8kxB7_s3yJJ42MBeISb04d8hwwG0Hzy6JDsvrcnavrUJxzl7SoGQI3cdVs3L3rOxBKrmixXdFJBIOLZeN8ZRU9cs7iMLzt3XqSfAQv2DpEbhLst8W5F29nJyo_XsgU4CHTh6VDbniACMzAYRvF-MXIf2gLnjEuX4FhnaYly_84KVjx8sr1f0nqFtfDL6X6yYAtrzSZb5lv2fBipHiLwLRt3loXadj5jPy&s=L1-wOHNLwvr18aFNusZ35RmkTF3mcUXKl6cdwgqzps8GLM5iwxjQGSM3aK6cdSIAJhEEJKTXn5ngkgaZLyBUXdL6i9hwrwoUBMk3oEqILfg7P5_Nl8XToNLknET-1dkGhgUeTmJYIF5X1hgiPQ8OVRAKLxUqKT9OmYaSqZrgEbXgrVomALeksx9YjdG_SgOOfjmqG31zElrO78UgtWU16MCNcS9NhMphabCFZy0PuGXxZSakbIjUBGY3l5vCppY8tWyHbpgYYWyblZr6cubCtRdKureOqWTyZnJDgpwioqZKJFwryAT2zh0TiR7w8bFdPMFqIVpb11Wqah6QQb1B5A&h=DT5upnlQgA3H93Oiq6HtnB5jKNELU5MyFjQebV4ZV6A
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f91ea4c1-3a04-4ea9-87a6-1c146cca75ee/uksouth/e350f3af-2c30-4dce-9190-ea94436a5596
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '11999'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: AC1538092F964CADB10D8CA10F5E6620 Ref B: DUB601080514031 Ref C: 2026-06-24T13:41:41Z'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-endpoint-connection approve
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-name --resource-group --name --type --description
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002/privateEndpointConnections/cli-pe-000005.aef49504-3255-4a18-8565-980afd6da26e?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"properties":{"privateEndpoint":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.Network/privateEndpoints/cli-pe-000005"},"privateLinkServiceConnectionState":{"status":"Pending","description":"Pending","actionsRequired":"None"},"groupIds":["DefaultPool"],"provisioningState":"Updating"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002/privateEndpointConnections/cli-pe-000005.aef49504-3255-4a18-8565-980afd6da26e","name":"cli-pe-000005.aef49504-3255-4a18-8565-980afd6da26e","type":"Microsoft.HorizonDb/clusters/privateEndpointConnections"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '701'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:41:52 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f91ea4c1-3a04-4ea9-87a6-1c146cca75ee/uksouth/b3d19693-e827-4769-8ec9-e299f459ad24
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 7EBBC37BBDF94B06A652222EE211D8D4 Ref B: AMS231020512039 Ref C: 2026-06-24T13:41:52Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-endpoint-connection approve
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-name --resource-group --name --type --description
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002/privateEndpointConnections/cli-pe-000005.aef49504-3255-4a18-8565-980afd6da26e?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"properties":{"privateEndpoint":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.Network/privateEndpoints/cli-pe-000005"},"privateLinkServiceConnectionState":{"status":"Approved","description":"Approved.","actionsRequired":"None"},"groupIds":["DefaultPool"],"provisioningState":"Succeeded"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002/privateEndpointConnections/cli-pe-000005.aef49504-3255-4a18-8565-980afd6da26e","name":"cli-pe-000005.aef49504-3255-4a18-8565-980afd6da26e","type":"Microsoft.HorizonDb/clusters/privateEndpointConnections"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '705'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:42:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f91ea4c1-3a04-4ea9-87a6-1c146cca75ee/uksouth/bd809ac9-53a0-4be4-97ac-87071b1e0be4
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: A6525B96E1534FD48F14B19108359E86 Ref B: AMS231020512021 Ref C: 2026-06-24T13:42:03Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-endpoint-connection reject
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id --description
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002/privateEndpointConnections/cli-pe-000005.aef49504-3255-4a18-8565-980afd6da26e?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"properties":{"privateEndpoint":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.Network/privateEndpoints/cli-pe-000005"},"privateLinkServiceConnectionState":{"status":"Approved","description":"Approved.","actionsRequired":"None"},"groupIds":["DefaultPool"],"provisioningState":"Succeeded"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002/privateEndpointConnections/cli-pe-000005.aef49504-3255-4a18-8565-980afd6da26e","name":"cli-pe-000005.aef49504-3255-4a18-8565-980afd6da26e","type":"Microsoft.HorizonDb/clusters/privateEndpointConnections"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '705'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:42:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f91ea4c1-3a04-4ea9-87a6-1c146cca75ee/uksouth/580477e8-724d-4bfa-9287-d330ac56460c
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 147CF90A2D7E4F2DA563AE2A56FDDF78 Ref B: DUB241062310060 Ref C: 2026-06-24T13:42:04Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"privateEndpoint": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.Network/privateEndpoints/cli-pe-000005"},
+      "privateLinkServiceConnectionState": {"status": "Rejected", "description": "Rejected.",
+      "actionsRequired": "None"}, "groupIds": ["DefaultPool"], "provisioningState":
+      "Succeeded"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002/privateEndpointConnections/cli-pe-000005.aef49504-3255-4a18-8565-980afd6da26e",
+      "name": "cli-pe-000005.aef49504-3255-4a18-8565-980afd6da26e", "type": "Microsoft.HorizonDb/clusters/privateEndpointConnections"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-endpoint-connection reject
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '725'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - --id --description
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002/privateEndpointConnections/cli-pe-000005.aef49504-3255-4a18-8565-980afd6da26e?api-version=2026-01-20-preview
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.HorizonDb/locations/uksouth/azureAsyncOperation/db37e840-a4f4-44fb-85e8-aa22b45368f4?api-version=2026-01-20-preview&t=639179053254835381&c=MIIHkTCCBnmgAwIBAgIRAIphu0X3wTKY-ML3gzs6k8owDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgRVVTMiBDQSAwMTAeFw0yNjA0MDUxOTUxNDZaFw0yNjEwMDEwMTUxNDZaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnR-Iz8Fgy9ddzo1kN9_c9HX8fqbMo-rawsyhsE9PSveyJv-L6NSkYs-1wxuKxocBLyNq8Jah1OkhbHL2yHbaT2kH5ZLNyn03w4Fn5lmjGi0KRYdPQwRIoK_PTIYI3maaXA7Kya68KMyhJgqlwqg9IsBK3Dq2D3vr1XP-PogUr3cssjfqfW_pVnR8bWGDNVCFKHbZbXMBWTNpAW91fHtf-4ojMqnePnvHVqONRoxeIQxsLtx3bQSh4Hw2QF_n1pMCUJ52n2c3_kjlULgAIesOTCdL9Pqul7Qby0zkLW0k9ppiEtPlfX0NNTyex0tR5-UE6EfjaiZZq9c_3Er-iDFcyQIDAQABo4IEjjCCBIowgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQU3jhSRQ1zlQcx7waACuHPEhCucfswHwYDVR0jBBgwFoAU_Ow-26p8H4IeBbihBvlD5wKzCrkwggGuBgNVHR8EggGlMIIBoTBooGagZIZiaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzMvY3VycmVudC5jcmwwaqBooGaGZGh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzMvY3VycmVudC5jcmwwWaBXoFWGU2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NybHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS8zL2N1cnJlbnQuY3JsMG6gbKBqhmhodHRwOi8vY2NtZWVhc3R1czJwa2kuZWFzdHVzMi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVlYXN0dXMyaWNhMDEvMy9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAnTNmUYMgtA5djeWjFRnP8bzb2RSij05KzI6-zmrz8PwFhloqF_K-ppJyIpYnHi-6ahqLnr9NDS-inELxBS21PcqBnDx4YKiKbvb4iFBRzM1_p-Qs_Ohg8kxB7_s3yJJ42MBeISb04d8hwwG0Hzy6JDsvrcnavrUJxzl7SoGQI3cdVs3L3rOxBKrmixXdFJBIOLZeN8ZRU9cs7iMLzt3XqSfAQv2DpEbhLst8W5F29nJyo_XsgU4CHTh6VDbniACMzAYRvF-MXIf2gLnjEuX4FhnaYly_84KVjx8sr1f0nqFtfDL6X6yYAtrzSZb5lv2fBipHiLwLRt3loXadj5jPy&s=GvoPETB3ANh9YK33MS55mmjUjADRZ9QCKExkYuW5omxvPojo8N8YxDcWYDgVf5ueE7O3lBea3GTdyiuk_pmyIK7-HVd0ZsSpWFSymOzrI0hTpMnPnlqlLgRE5UGOb5oscT818I7LSbWw7ME8I8xyHm3oMeB6HZZ5Gx8pZ1ceAzs_X2qAqkAX49WZOlxxBzxJZ0FDB-Awi90SWBu5WKHIAXS1YAYcPexskgVv4KU3m11BBtj219JgKgK3qP40hbCkLdW8ZENHDPGqjgNbLAlezaQXBNsnp_Qar_mZw2jBUywmLcXiGWU3ixi7Zg_585_Mn8AMpw1tY_Oz6qWMxN38bA&h=jq0ckmq3OTfZqQxZLB9E7_5Lk06cWIfRtr8h0T6eVLo
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Wed, 24 Jun 2026 13:42:04 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.HorizonDb/locations/uksouth/operationResults/db37e840-a4f4-44fb-85e8-aa22b45368f4?api-version=2026-01-20-preview&t=639179053254835381&c=MIIHkTCCBnmgAwIBAgIRAIphu0X3wTKY-ML3gzs6k8owDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgRVVTMiBDQSAwMTAeFw0yNjA0MDUxOTUxNDZaFw0yNjEwMDEwMTUxNDZaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnR-Iz8Fgy9ddzo1kN9_c9HX8fqbMo-rawsyhsE9PSveyJv-L6NSkYs-1wxuKxocBLyNq8Jah1OkhbHL2yHbaT2kH5ZLNyn03w4Fn5lmjGi0KRYdPQwRIoK_PTIYI3maaXA7Kya68KMyhJgqlwqg9IsBK3Dq2D3vr1XP-PogUr3cssjfqfW_pVnR8bWGDNVCFKHbZbXMBWTNpAW91fHtf-4ojMqnePnvHVqONRoxeIQxsLtx3bQSh4Hw2QF_n1pMCUJ52n2c3_kjlULgAIesOTCdL9Pqul7Qby0zkLW0k9ppiEtPlfX0NNTyex0tR5-UE6EfjaiZZq9c_3Er-iDFcyQIDAQABo4IEjjCCBIowgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQU3jhSRQ1zlQcx7waACuHPEhCucfswHwYDVR0jBBgwFoAU_Ow-26p8H4IeBbihBvlD5wKzCrkwggGuBgNVHR8EggGlMIIBoTBooGagZIZiaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzMvY3VycmVudC5jcmwwaqBooGaGZGh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzMvY3VycmVudC5jcmwwWaBXoFWGU2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NybHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS8zL2N1cnJlbnQuY3JsMG6gbKBqhmhodHRwOi8vY2NtZWVhc3R1czJwa2kuZWFzdHVzMi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVlYXN0dXMyaWNhMDEvMy9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAnTNmUYMgtA5djeWjFRnP8bzb2RSij05KzI6-zmrz8PwFhloqF_K-ppJyIpYnHi-6ahqLnr9NDS-inELxBS21PcqBnDx4YKiKbvb4iFBRzM1_p-Qs_Ohg8kxB7_s3yJJ42MBeISb04d8hwwG0Hzy6JDsvrcnavrUJxzl7SoGQI3cdVs3L3rOxBKrmixXdFJBIOLZeN8ZRU9cs7iMLzt3XqSfAQv2DpEbhLst8W5F29nJyo_XsgU4CHTh6VDbniACMzAYRvF-MXIf2gLnjEuX4FhnaYly_84KVjx8sr1f0nqFtfDL6X6yYAtrzSZb5lv2fBipHiLwLRt3loXadj5jPy&s=Pa6Y5raG5oEiXz3tSx8D6ohCJa0pyJhUqyD34pbNNttjy1d59yvgAnVlPpWcuUKbvqKif9oZ0UnhOkTl7CYrsI0tsC_Km9XyLQ3BGLZYqQ2sh2H2lr5nc69hGRSp1y_RUwZd5SQeRTLnk6KzrT8cHqkA7boavGSoluHsMQv7rm9IfLAHsGhA4Z4pCTd5Ax2axscA2lZ2nOHmvBYIz5-RKQoP0GCyrEFZNl9JEnk95v9vZYhtPqgDAyxx6LuuLp-RxKa4erVdCDlkpzRlMjE-h5bj93CjXSTtmsLW-O3stDAqW58fOLD0s1agwlsIsn7mUMOq2AxWuXb5vDvDBNDsrw&h=x0UyH6LpPFprxfXRTdjdlIrV0P9rey2KvHOEo9--R1w
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f91ea4c1-3a04-4ea9-87a6-1c146cca75ee/uksouth/9a85164a-1d7e-4783-ab85-64e415e2ebd9
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '11999'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 2E9CB5C59BF5485D9C36BA12284A541C Ref B: AMS231022012045 Ref C: 2026-06-24T13:42:05Z'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-endpoint-connection reject
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id --description
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002/privateEndpointConnections/cli-pe-000005.aef49504-3255-4a18-8565-980afd6da26e?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"properties":{"privateEndpoint":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.Network/privateEndpoints/cli-pe-000005"},"privateLinkServiceConnectionState":{"status":"Approved","description":"Approved.","actionsRequired":"None"},"groupIds":["DefaultPool"],"provisioningState":"Updating"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002/privateEndpointConnections/cli-pe-000005.aef49504-3255-4a18-8565-980afd6da26e","name":"cli-pe-000005.aef49504-3255-4a18-8565-980afd6da26e","type":"Microsoft.HorizonDb/clusters/privateEndpointConnections"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '704'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:42:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f91ea4c1-3a04-4ea9-87a6-1c146cca75ee/uksouth/25b05b4e-50c4-4031-b837-bf135af41d41
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16498'
+      x-msedge-ref:
+      - 'Ref A: FF07C5DB74914395B082B21D626BDD95 Ref B: AMS231020512035 Ref C: 2026-06-24T13:42:16Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-endpoint-connection reject
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id --description
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002/privateEndpointConnections/cli-pe-000005.aef49504-3255-4a18-8565-980afd6da26e?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"properties":{"privateEndpoint":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.Network/privateEndpoints/cli-pe-000005"},"privateLinkServiceConnectionState":{"status":"Rejected","description":"Rejected.","actionsRequired":"None"},"groupIds":["DefaultPool"],"provisioningState":"Succeeded"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002/privateEndpointConnections/cli-pe-000005.aef49504-3255-4a18-8565-980afd6da26e","name":"cli-pe-000005.aef49504-3255-4a18-8565-980afd6da26e","type":"Microsoft.HorizonDb/clusters/privateEndpointConnections"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '705'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:42:26 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f91ea4c1-3a04-4ea9-87a6-1c146cca75ee/uksouth/82020964-4cbe-45a4-b0b3-4e33c7ff45e2
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: A11242583226489CBBD047BC58A339E3 Ref B: DUB601080509042 Ref C: 2026-06-24T13:42:27Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-endpoint-connection list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002/privateEndpointConnections?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"value":[{"properties":{"privateEndpoint":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.Network/privateEndpoints/cli-pe-000005"},"privateLinkServiceConnectionState":{"status":"Rejected","description":"Rejected.","actionsRequired":"None"},"groupIds":["DefaultPool"],"provisioningState":"Succeeded"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002/privateEndpointConnections/cli-pe-000005.aef49504-3255-4a18-8565-980afd6da26e","name":"cli-pe-000005.aef49504-3255-4a18-8565-980afd6da26e","type":"Microsoft.HorizonDb/clusters/privateEndpointConnections"}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '717'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:42:27 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f91ea4c1-3a04-4ea9-87a6-1c146cca75ee/uksouth/d405b4e2-35a5-4126-976e-33d979b1a644
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 08FE9E83AA544B44B35B182D5F4C0E1D Ref B: AMS231020614017 Ref C: 2026-06-24T13:42:27Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-endpoint-connection delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --id -y
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002/privateEndpointConnections/cli-pe-000005.aef49504-3255-4a18-8565-980afd6da26e?api-version=2026-01-20-preview
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.HorizonDb/locations/uksouth/azureAsyncOperation/5fb88c4b-c55f-4ffc-b6d3-dfb7d2c19c79?api-version=2026-01-20-preview&t=639179053488040052&c=MIIHkTCCBnmgAwIBAgIRAIphu0X3wTKY-ML3gzs6k8owDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgRVVTMiBDQSAwMTAeFw0yNjA0MDUxOTUxNDZaFw0yNjEwMDEwMTUxNDZaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnR-Iz8Fgy9ddzo1kN9_c9HX8fqbMo-rawsyhsE9PSveyJv-L6NSkYs-1wxuKxocBLyNq8Jah1OkhbHL2yHbaT2kH5ZLNyn03w4Fn5lmjGi0KRYdPQwRIoK_PTIYI3maaXA7Kya68KMyhJgqlwqg9IsBK3Dq2D3vr1XP-PogUr3cssjfqfW_pVnR8bWGDNVCFKHbZbXMBWTNpAW91fHtf-4ojMqnePnvHVqONRoxeIQxsLtx3bQSh4Hw2QF_n1pMCUJ52n2c3_kjlULgAIesOTCdL9Pqul7Qby0zkLW0k9ppiEtPlfX0NNTyex0tR5-UE6EfjaiZZq9c_3Er-iDFcyQIDAQABo4IEjjCCBIowgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQU3jhSRQ1zlQcx7waACuHPEhCucfswHwYDVR0jBBgwFoAU_Ow-26p8H4IeBbihBvlD5wKzCrkwggGuBgNVHR8EggGlMIIBoTBooGagZIZiaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzMvY3VycmVudC5jcmwwaqBooGaGZGh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzMvY3VycmVudC5jcmwwWaBXoFWGU2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NybHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS8zL2N1cnJlbnQuY3JsMG6gbKBqhmhodHRwOi8vY2NtZWVhc3R1czJwa2kuZWFzdHVzMi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVlYXN0dXMyaWNhMDEvMy9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAnTNmUYMgtA5djeWjFRnP8bzb2RSij05KzI6-zmrz8PwFhloqF_K-ppJyIpYnHi-6ahqLnr9NDS-inELxBS21PcqBnDx4YKiKbvb4iFBRzM1_p-Qs_Ohg8kxB7_s3yJJ42MBeISb04d8hwwG0Hzy6JDsvrcnavrUJxzl7SoGQI3cdVs3L3rOxBKrmixXdFJBIOLZeN8ZRU9cs7iMLzt3XqSfAQv2DpEbhLst8W5F29nJyo_XsgU4CHTh6VDbniACMzAYRvF-MXIf2gLnjEuX4FhnaYly_84KVjx8sr1f0nqFtfDL6X6yYAtrzSZb5lv2fBipHiLwLRt3loXadj5jPy&s=GPM21F3b7E19Aj9RE3PWZKt7UcsSTSq-HVuvGMQBU6wKzVYo_-fOqvKudWFFq9BRMcyZqK3qmgbXDb3bGoMcIBxcKo1ffoKW5HEa8NH8bfDVYNx3Y7rMo1-_rZRgRS8Eq0MlSbER9fF7Hsr1geFmlwC8rRFXRzKDQqa0CZB3qMmHdIRfG_RnCFsMBgvu4Z5iTi25F5n9XHcVG7oDMn2O2qJDY67Y5YsYpwpNX0NBhjBZbeCqhoV81QIaD2u9-avXFkU6zYO9itDT9lsW76pEG_j3y2VWipnrFKX4AiCvTzYLpNKgCj-XLINCd0r6FqhbvCN-l49hn0aHbOylN2SCmw&h=XVcM5VKRytCwnERy8u2I8pGeBBOkZMnoVHfMx5PKdMg
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Wed, 24 Jun 2026 13:42:28 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.HorizonDb/locations/uksouth/operationResults/5fb88c4b-c55f-4ffc-b6d3-dfb7d2c19c79?api-version=2026-01-20-preview&t=639179053488040052&c=MIIHkTCCBnmgAwIBAgIRAIphu0X3wTKY-ML3gzs6k8owDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgRVVTMiBDQSAwMTAeFw0yNjA0MDUxOTUxNDZaFw0yNjEwMDEwMTUxNDZaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnR-Iz8Fgy9ddzo1kN9_c9HX8fqbMo-rawsyhsE9PSveyJv-L6NSkYs-1wxuKxocBLyNq8Jah1OkhbHL2yHbaT2kH5ZLNyn03w4Fn5lmjGi0KRYdPQwRIoK_PTIYI3maaXA7Kya68KMyhJgqlwqg9IsBK3Dq2D3vr1XP-PogUr3cssjfqfW_pVnR8bWGDNVCFKHbZbXMBWTNpAW91fHtf-4ojMqnePnvHVqONRoxeIQxsLtx3bQSh4Hw2QF_n1pMCUJ52n2c3_kjlULgAIesOTCdL9Pqul7Qby0zkLW0k9ppiEtPlfX0NNTyex0tR5-UE6EfjaiZZq9c_3Er-iDFcyQIDAQABo4IEjjCCBIowgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQU3jhSRQ1zlQcx7waACuHPEhCucfswHwYDVR0jBBgwFoAU_Ow-26p8H4IeBbihBvlD5wKzCrkwggGuBgNVHR8EggGlMIIBoTBooGagZIZiaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzMvY3VycmVudC5jcmwwaqBooGaGZGh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzMvY3VycmVudC5jcmwwWaBXoFWGU2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NybHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS8zL2N1cnJlbnQuY3JsMG6gbKBqhmhodHRwOi8vY2NtZWVhc3R1czJwa2kuZWFzdHVzMi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVlYXN0dXMyaWNhMDEvMy9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAnTNmUYMgtA5djeWjFRnP8bzb2RSij05KzI6-zmrz8PwFhloqF_K-ppJyIpYnHi-6ahqLnr9NDS-inELxBS21PcqBnDx4YKiKbvb4iFBRzM1_p-Qs_Ohg8kxB7_s3yJJ42MBeISb04d8hwwG0Hzy6JDsvrcnavrUJxzl7SoGQI3cdVs3L3rOxBKrmixXdFJBIOLZeN8ZRU9cs7iMLzt3XqSfAQv2DpEbhLst8W5F29nJyo_XsgU4CHTh6VDbniACMzAYRvF-MXIf2gLnjEuX4FhnaYly_84KVjx8sr1f0nqFtfDL6X6yYAtrzSZb5lv2fBipHiLwLRt3loXadj5jPy&s=YeaiwdsQF2MABYPks0BkkJIjI2D82c9IT38jpI4Nikf5HRrdwNR8YPq41y10VOr86Dyc9AMYWFyLJ-4vVKY_k8nCWjBYyYDJtJSbeq8L7MkruKbiiP1C7XZBLcERSQxcgvZop10rdro0jmyl7mQSGeMR8PL695-_yIG344Usn0U6Tx-5gkHDmWRkRwi2LWvv5Mn51eAMAgaGIhepdLeUxPOu82Pm9nXFxjzzKU1VW8piWqIHbvmDISoor5cGmNwPKLpxfD1YthgS62RCaLAf5OdjR1zvJA4YtH52irxc6ucIr8MQDjRIhQBRIaJTPNCa2hS0NQWnQQb5xY81YT7f8Q&h=QdE03P-7RONmv-muxk6oS_tN3BJkCfydIwfsNsyPQP0
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f91ea4c1-3a04-4ea9-87a6-1c146cca75ee/uksouth/5c359fac-6829-42db-a287-b25dedd153fa
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '799'
+      x-ms-ratelimit-remaining-subscription-global-deletes:
+      - '11999'
+      x-msedge-ref:
+      - 'Ref A: ADBFE05F58D24105B67B522B5E85C1E9 Ref B: AMS231022012033 Ref C: 2026-06-24T13:42:28Z'
+    status:
+      code: 202
+      message: Accepted
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_private_link_resource_horizondb_cluster.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_private_link_resource_horizondb_cluster.yaml
@@ -1,0 +1,801 @@
+interactions:
+- request:
+    body: '{"location": "westus2", "properties": {"createMode": "Default", "version":
+      "17", "administratorLogin": "admin123", "administratorLoginPassword": "aBcD1234!@#$",
+      "vCores": 2, "replicaCount": 1, "network": {"publicNetworkAccess": "Enabled"},
+      "highAvailability": {"mode": "Disabled"}, "aiModelManagement": 1}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '306'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - --method --headers --url --body
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"properties":{"createMode":"Default","version":"17","zonePlacementPolicy":"BestEffort","replicaCount":null,"vCores":2,"provisioningState":"Provisioning"},"location":"westus2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.HorizonDb/locations/westus2/azureAsyncOperation/925a48df-96ec-4f83-864d-217314f88a29?api-version=2026-01-20-preview&t=639179022613798303&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=GcmY9SYerlqnHM6RJTDb57WzMnAMcBVAV4o9N2Hc2HZSGFmOePNAjaFu6emdmyMeHtjNDl-q7S-i14qAzggSupkCCA2jdR8nz7pQsArgKUeEUJW9fObPifn8N-UMFUmJhDLDr7afn-JdWeVTqDbpnh81AVgYzCu3EEFgH9KD180ypy-n6QTRYkrtbH40c587CbC3azij02uo-Yl5dyKcJ5w0DVEW1WWeCT09LnE67a8PwDxMFzWFXNWoY7bZ7dFzYgw0_Rrk-yFz0i1gacs-NJQG7LVap17oJf5WzqsApOKQdEPvopV8CvTbUFBbICe5BrV4No_I1Sds2OOKpr9mvw&h=XgIMH2_QAE2YZ_3XSDSTETsVD3uui5nYrRim09hYUvU
+      cache-control:
+      - no-cache
+      content-length:
+      - '383'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 12:51:01 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.HorizonDb/locations/westus2/operationResults/925a48df-96ec-4f83-864d-217314f88a29?api-version=2026-01-20-preview&t=639179022613798303&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=fT7fOy5wJNfQOQv1ipB-GrEHEL5d2AxsXF0yGZ3vPdULGBEAMtaQJbiRApgQagZJLMvSZnQmrECOk9BPP7ga7bbgfuWSARFFoI8XzYZeFyRjVEdaJ6x0_5iz7RoqSwkE0NKKkcWWAQDcgtdJieYHQaFcDLQbum3Asa1SMj84ihu3T-GuXt2RoB9XuCIqvBzTo67_GaNINqu9GbuqJpaAHf0Cb7UZXwFt3aQtNy1morXA-IJWd4PqKnjhujJxOO3nlaeQP0TfoL7rVUlvPzAk3BCE1lqJIcacn9cv0hbotYOHmitNvl9klr4VJOeifQyjlsr9zyt1KkbMKwWD4dpaQw&h=LUFHYGNpP8KxGXTvjcDy5af1OeEFRG_l3vhbgfsAOds
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f91ea4c1-3a04-4ea9-87a6-1c146cca75ee/westus2/e0b28682-c3f3-4833-a031-f9bf233ea494
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '11999'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: C3E1341023BB4101B07B26CB8DE25E10 Ref B: AMS231020512035 Ref C: 2026-06-24T12:51:00Z'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --method --url
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.ae982c353db8.westus2.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.ae982c353db8.ro.westus2.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"westus2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 12:51:11 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 36C7440C963C4948A19166E81B54DB3D Ref B: AMS231020512011 Ref C: 2026-06-24T12:51:12Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --method --url
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.ae982c353db8.westus2.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.ae982c353db8.ro.westus2.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"westus2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 12:52:12 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 1AE9FFF7B1AF4650BE591FA145216EBA Ref B: AMS231020512023 Ref C: 2026-06-24T12:52:13Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --method --url
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.ae982c353db8.westus2.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.ae982c353db8.ro.westus2.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"westus2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 12:53:14 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 392DD06A7F204D4D868E8A8A05BCDB62 Ref B: AMS231020615037 Ref C: 2026-06-24T12:53:14Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --method --url
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.ae982c353db8.westus2.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.ae982c353db8.ro.westus2.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"westus2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 12:54:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: F37C7A6F1CB841E0ACA72E782F62CB92 Ref B: DUB601080511040 Ref C: 2026-06-24T12:54:15Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --method --url
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.ae982c353db8.westus2.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.ae982c353db8.ro.westus2.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"westus2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 12:55:16 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 395959F7FA5A47EEAC08E3CDFBF4297F Ref B: AMS231022012019 Ref C: 2026-06-24T12:55:16Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --method --url
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.ae982c353db8.westus2.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.ae982c353db8.ro.westus2.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"westus2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 12:56:17 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 9AA4FB7481BA431C90C41731C6F7DC02 Ref B: AMS231032607019 Ref C: 2026-06-24T12:56:17Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --method --url
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.ae982c353db8.westus2.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.ae982c353db8.ro.westus2.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"westus2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 12:57:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 92AD3AC2F73A4C3092EF7F4FDB75B246 Ref B: AMS231020615025 Ref C: 2026-06-24T12:57:18Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --method --url
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.ae982c353db8.westus2.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.ae982c353db8.ro.westus2.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"westus2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 12:58:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: F6F1EF282A184B55AEC4E3B905297E18 Ref B: AMS231032609045 Ref C: 2026-06-24T12:58:19Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --method --url
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.ae982c353db8.westus2.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.ae982c353db8.ro.westus2.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"westus2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 12:59:20 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: B543C0D559954F3F8733F810F3208B1D Ref B: AMS231022012017 Ref C: 2026-06-24T12:59:20Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --method --url
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.ae982c353db8.westus2.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.ae982c353db8.ro.westus2.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"westus2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:00:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: E8774738580249959662A4B9A2A5A15E Ref B: AMS231032607017 Ref C: 2026-06-24T13:00:21Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --method --url
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.ae982c353db8.westus2.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.ae982c353db8.ro.westus2.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"westus2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:01:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 2C0CBB37BB2A40D291E183B32BCD690B Ref B: AMS231032607019 Ref C: 2026-06-24T13:01:22Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --method --url
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.ae982c353db8.westus2.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.ae982c353db8.ro.westus2.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"westus2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:02:24 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: BE2C798C2F1A4A5EBED1BDE3595B55FA Ref B: AMS231020512019 Ref C: 2026-06-24T13:02:24Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --method --url
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.ae982c353db8.westus2.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.ae982c353db8.ro.westus2.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"westus2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:03:25 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: DDC3A9CC40554F018959C128E80C601E Ref B: AMS231020512049 Ref C: 2026-06-24T13:03:25Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --method --url
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.ae982c353db8.westus2.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":1,"vCores":2,"readonlyEndpoint":"clitest000002.ae982c353db8.ro.westus2.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"westus2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:04:26 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 0ADAB30DBBDC43C78991CE293CB9FC43 Ref B: AMS231032608019 Ref C: 2026-06-24T13:04:26Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --method --url
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.ae982c353db8.westus2.horizondb.azure.com","version":"17","state":"Succeeded","zonePlacementPolicy":"BestEffort","replicaCount":1,"vCores":2,"readonlyEndpoint":"clitest000002.ae982c353db8.ro.westus2.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled","parameterGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/parameterGroups/default_pg17","syncStatus":"InSync"}},"location":"westus2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '784'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:05:28 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 0786EE60DB2C428E965EA0ECC9A3F662 Ref B: AMS231020614053 Ref C: 2026-06-24T13:05:28Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-link-resource list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --type
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002/privateLinkResources?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"value":[{"properties":{"groupId":"DefaultPool","requiredMembers":["rw","ro"],"requiredZoneNames":["privatelink.horizondb.azure.com"]},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002/privateLinkResources/DefaultPool","name":"DefaultPool","type":"Microsoft.HorizonDb/clusters/privateLinkResources"}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '397'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 24 Jun 2026 13:05:50 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f91ea4c1-3a04-4ea9-87a6-1c146cca75ee/westus2/86e98c2e-339e-44a0-9736-21186306ad88
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: D04CE6BF5DC24CEC957DC1A3A4306302 Ref B: DUB601080512025 Ref C: 2026-06-24T13:05:50Z'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_private_link_resource_horizondb_cluster.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_private_link_resource_horizondb_cluster.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"location": "westus2", "properties": {"createMode": "Default", "version":
+    body: '{"location": "uksouth", "properties": {"createMode": "Default", "version":
       "17", "administratorLogin": "admin123", "administratorLoginPassword": "aBcD1234!@#$",
       "vCores": 2, "replicaCount": 1, "network": {"publicNetworkAccess": "Enabled"},
       "highAvailability": {"mode": "Disabled"}, "aiModelManagement": 1}}'
@@ -25,10 +25,10 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
   response:
     body:
-      string: '{"properties":{"createMode":"Default","version":"17","zonePlacementPolicy":"BestEffort","replicaCount":null,"vCores":2,"provisioningState":"Provisioning"},"location":"westus2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+      string: '{"properties":{"createMode":"Default","version":"17","zonePlacementPolicy":"BestEffort","replicaCount":null,"vCores":2,"provisioningState":"Provisioning"},"location":"uksouth","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.HorizonDb/locations/westus2/azureAsyncOperation/925a48df-96ec-4f83-864d-217314f88a29?api-version=2026-01-20-preview&t=639179022613798303&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=GcmY9SYerlqnHM6RJTDb57WzMnAMcBVAV4o9N2Hc2HZSGFmOePNAjaFu6emdmyMeHtjNDl-q7S-i14qAzggSupkCCA2jdR8nz7pQsArgKUeEUJW9fObPifn8N-UMFUmJhDLDr7afn-JdWeVTqDbpnh81AVgYzCu3EEFgH9KD180ypy-n6QTRYkrtbH40c587CbC3azij02uo-Yl5dyKcJ5w0DVEW1WWeCT09LnE67a8PwDxMFzWFXNWoY7bZ7dFzYgw0_Rrk-yFz0i1gacs-NJQG7LVap17oJf5WzqsApOKQdEPvopV8CvTbUFBbICe5BrV4No_I1Sds2OOKpr9mvw&h=XgIMH2_QAE2YZ_3XSDSTETsVD3uui5nYrRim09hYUvU
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.HorizonDb/locations/uksouth/azureAsyncOperation/b535dd42-29e4-4ceb-8309-e4e3dc339b6c?api-version=2026-01-20-preview&t=639179039305289626&c=MIIHkTCCBnmgAwIBAgIRAIphu0X3wTKY-ML3gzs6k8owDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgRVVTMiBDQSAwMTAeFw0yNjA0MDUxOTUxNDZaFw0yNjEwMDEwMTUxNDZaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnR-Iz8Fgy9ddzo1kN9_c9HX8fqbMo-rawsyhsE9PSveyJv-L6NSkYs-1wxuKxocBLyNq8Jah1OkhbHL2yHbaT2kH5ZLNyn03w4Fn5lmjGi0KRYdPQwRIoK_PTIYI3maaXA7Kya68KMyhJgqlwqg9IsBK3Dq2D3vr1XP-PogUr3cssjfqfW_pVnR8bWGDNVCFKHbZbXMBWTNpAW91fHtf-4ojMqnePnvHVqONRoxeIQxsLtx3bQSh4Hw2QF_n1pMCUJ52n2c3_kjlULgAIesOTCdL9Pqul7Qby0zkLW0k9ppiEtPlfX0NNTyex0tR5-UE6EfjaiZZq9c_3Er-iDFcyQIDAQABo4IEjjCCBIowgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQU3jhSRQ1zlQcx7waACuHPEhCucfswHwYDVR0jBBgwFoAU_Ow-26p8H4IeBbihBvlD5wKzCrkwggGuBgNVHR8EggGlMIIBoTBooGagZIZiaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzMvY3VycmVudC5jcmwwaqBooGaGZGh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzMvY3VycmVudC5jcmwwWaBXoFWGU2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NybHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS8zL2N1cnJlbnQuY3JsMG6gbKBqhmhodHRwOi8vY2NtZWVhc3R1czJwa2kuZWFzdHVzMi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVlYXN0dXMyaWNhMDEvMy9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAnTNmUYMgtA5djeWjFRnP8bzb2RSij05KzI6-zmrz8PwFhloqF_K-ppJyIpYnHi-6ahqLnr9NDS-inELxBS21PcqBnDx4YKiKbvb4iFBRzM1_p-Qs_Ohg8kxB7_s3yJJ42MBeISb04d8hwwG0Hzy6JDsvrcnavrUJxzl7SoGQI3cdVs3L3rOxBKrmixXdFJBIOLZeN8ZRU9cs7iMLzt3XqSfAQv2DpEbhLst8W5F29nJyo_XsgU4CHTh6VDbniACMzAYRvF-MXIf2gLnjEuX4FhnaYly_84KVjx8sr1f0nqFtfDL6X6yYAtrzSZb5lv2fBipHiLwLRt3loXadj5jPy&s=OcR_lXbEIQEPvtj9HeghzFvvxnWpQIUmphN5QlZDgr_tfl1JVZzw4nTeCrm6qnTOkCuuuNAGiIyUxXGkIGCOFpnRSrfdfwCqPapiY_PB_zo_J5DhVFS8RgEXaUSBE7jTWJkjPK8ijHORRm2ye5VtMjyWTM04a9xcRChi-ItuY3EYgVJZQjlqdWjGHqsLfLhxq29uQNzATe5ogYTA_AJUerAn9_E3iTn4jBdw6IKXM5W3r50Am122IlyB-5NVfAVUiVk96DSwvaaAj_MPX7FF7CpEzDDFdgnG5Bz8u2nXiSvAWf7hOTATRaU3fJ6oZXbEAzx2RQ3NErMPruSRb9strg&h=BTGcmChuzT0UAhZMEGxes-kGgxSyOh9gcjyJt81hXQM
       cache-control:
       - no-cache
       content-length:
@@ -36,11 +36,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 24 Jun 2026 12:51:01 GMT
+      - Wed, 24 Jun 2026 13:18:50 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.HorizonDb/locations/westus2/operationResults/925a48df-96ec-4f83-864d-217314f88a29?api-version=2026-01-20-preview&t=639179022613798303&c=MIIHlDCCBnygAwIBAgIQAcfN_Jd6ViGd1-EkFH97aDANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDQwOTA0MzUxMFoXDTI2MTAwNDEwMzUxMFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC9nzXnnnT0V5cDY5fHgY6fvt0f5K67TLY5rf3kXsgNDiGJL9Ub1_cJuWgTTjGYmxaPP6HFz_YOLdMBGPkVhZavejw0qLifjw8nEBivhzrnSlLVzv8ThjIxvzYq7Pixu564lZgpE4tktNQwXrbdQ8_M_ltt8Ia4jO8Wc47QJt-BIUGY10RRyuDzAEGrQRCDbQB1Kyo6IjF95ihEDSUcGthqOIsbqMERKgZokdpO3a8ikGNKVtOb3zrePXR71iCDdkdamGIsPVfGxaBtUDO5vqdKugYbOQDFCYaQdk7x3VINyRpvZXpU4-B41mD-vXX5Rm_X9BL0jN1rjSRIFvfK3YkxAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRktXyyceQOrjzGGHfthVAJlrP3gjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzcyL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNzIvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS83Mi9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBx5I6Sofmi5yGOz0alPqrZuIh1Qv1Gc7iCefJl7OITobABfs9PqLqAUqQ0NZt02K2ag8zFQWRLn3xJESxYpGcBV7meAUTJOJhRHdvwqFTOMyPwYKbVpl-gdceRQV0J4MdXD1EG8ZfrQqJh4yTpH9fs1bJNlNwJZx_jinURgGNM3AvMcEe8RipqTE4QFDEFqJqWftJzvHLBetVu8Z6AGm5099Z3hgXzQkneb6E4dITNtuFdibgZ_w2TYC64wJ1VSMZoWDioo50604N9fZooi7RvEeWH1iooHPyFIUtevrquxTYiMdLAwbW0FzEjba2h2TLxHn3wd3uzwLiJoLGRIzBT&s=fT7fOy5wJNfQOQv1ipB-GrEHEL5d2AxsXF0yGZ3vPdULGBEAMtaQJbiRApgQagZJLMvSZnQmrECOk9BPP7ga7bbgfuWSARFFoI8XzYZeFyRjVEdaJ6x0_5iz7RoqSwkE0NKKkcWWAQDcgtdJieYHQaFcDLQbum3Asa1SMj84ihu3T-GuXt2RoB9XuCIqvBzTo67_GaNINqu9GbuqJpaAHf0Cb7UZXwFt3aQtNy1morXA-IJWd4PqKnjhujJxOO3nlaeQP0TfoL7rVUlvPzAk3BCE1lqJIcacn9cv0hbotYOHmitNvl9klr4VJOeifQyjlsr9zyt1KkbMKwWD4dpaQw&h=LUFHYGNpP8KxGXTvjcDy5af1OeEFRG_l3vhbgfsAOds
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.HorizonDb/locations/uksouth/operationResults/b535dd42-29e4-4ceb-8309-e4e3dc339b6c?api-version=2026-01-20-preview&t=639179039305289626&c=MIIHkTCCBnmgAwIBAgIRAIphu0X3wTKY-ML3gzs6k8owDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgRVVTMiBDQSAwMTAeFw0yNjA0MDUxOTUxNDZaFw0yNjEwMDEwMTUxNDZaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnR-Iz8Fgy9ddzo1kN9_c9HX8fqbMo-rawsyhsE9PSveyJv-L6NSkYs-1wxuKxocBLyNq8Jah1OkhbHL2yHbaT2kH5ZLNyn03w4Fn5lmjGi0KRYdPQwRIoK_PTIYI3maaXA7Kya68KMyhJgqlwqg9IsBK3Dq2D3vr1XP-PogUr3cssjfqfW_pVnR8bWGDNVCFKHbZbXMBWTNpAW91fHtf-4ojMqnePnvHVqONRoxeIQxsLtx3bQSh4Hw2QF_n1pMCUJ52n2c3_kjlULgAIesOTCdL9Pqul7Qby0zkLW0k9ppiEtPlfX0NNTyex0tR5-UE6EfjaiZZq9c_3Er-iDFcyQIDAQABo4IEjjCCBIowgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQU3jhSRQ1zlQcx7waACuHPEhCucfswHwYDVR0jBBgwFoAU_Ow-26p8H4IeBbihBvlD5wKzCrkwggGuBgNVHR8EggGlMIIBoTBooGagZIZiaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzMvY3VycmVudC5jcmwwaqBooGaGZGh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzMvY3VycmVudC5jcmwwWaBXoFWGU2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NybHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS8zL2N1cnJlbnQuY3JsMG6gbKBqhmhodHRwOi8vY2NtZWVhc3R1czJwa2kuZWFzdHVzMi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVlYXN0dXMyaWNhMDEvMy9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAnTNmUYMgtA5djeWjFRnP8bzb2RSij05KzI6-zmrz8PwFhloqF_K-ppJyIpYnHi-6ahqLnr9NDS-inELxBS21PcqBnDx4YKiKbvb4iFBRzM1_p-Qs_Ohg8kxB7_s3yJJ42MBeISb04d8hwwG0Hzy6JDsvrcnavrUJxzl7SoGQI3cdVs3L3rOxBKrmixXdFJBIOLZeN8ZRU9cs7iMLzt3XqSfAQv2DpEbhLst8W5F29nJyo_XsgU4CHTh6VDbniACMzAYRvF-MXIf2gLnjEuX4FhnaYly_84KVjx8sr1f0nqFtfDL6X6yYAtrzSZb5lv2fBipHiLwLRt3loXadj5jPy&s=Dh0-1jVKsgzNo7sy8gP94o9XpmcXMxHd9vTcplPNkVx6eIHTghe9wtlqF0YaMNsuLfvPWjaNrQdx6n-YYODlf3aUY5bH4u1P-2cHRQq67LvldNa-AWuwsb5RCkMCXAMwV2iuDeILKz0lGlUPunvkfmyrpQ922KKH0BQU0tP-5Vt4CSAv1x5PsYtxAgbxyhGpbKth8UjVJ9qnWh1wU0TSkQvgPN2Ytbo-6rCpkrM2h14wgEMpts0ZafDEeLjflQlO2AQwyt1PhKqKBaqQX7XMcEr2R5Ufj1Y60UB-3WHnkZhxt9GN058dKfB0xd53BF16ObDQVGezgKye-HyAjm7xAQ&h=tg-3tiEyP4mulGUacaU3H-08cLHngvmHgqxArvyoXOQ
       pragma:
       - no-cache
       strict-transport-security:
@@ -50,13 +50,13 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f91ea4c1-3a04-4ea9-87a6-1c146cca75ee/westus2/e0b28682-c3f3-4833-a031-f9bf233ea494
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f91ea4c1-3a04-4ea9-87a6-1c146cca75ee/uksouth/9bb0e878-bb67-414f-972c-09c7ab244955
       x-ms-ratelimit-remaining-subscription-global-writes:
       - '11999'
       x-ms-ratelimit-remaining-subscription-writes:
       - '799'
       x-msedge-ref:
-      - 'Ref A: C3E1341023BB4101B07B26CB8DE25E10 Ref B: AMS231020512035 Ref C: 2026-06-24T12:51:00Z'
+      - 'Ref A: DBAAF2F3FF894280878DEFE80F5DE509 Ref B: AMS231022012047 Ref C: 2026-06-24T13:18:50Z'
     status:
       code: 201
       message: Created
@@ -79,7 +79,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
   response:
     body:
-      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.ae982c353db8.westus2.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.ae982c353db8.ro.westus2.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"westus2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.e942cca99994.uksouth.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.e942cca99994.ro.uksouth.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"uksouth","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
     headers:
       cache-control:
       - no-cache
@@ -88,7 +88,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 24 Jun 2026 12:51:11 GMT
+      - Wed, 24 Jun 2026 13:19:00 GMT
       expires:
       - '-1'
       pragma:
@@ -102,7 +102,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 36C7440C963C4948A19166E81B54DB3D Ref B: AMS231020512011 Ref C: 2026-06-24T12:51:12Z'
+      - 'Ref A: 682E47609E774968874D3C17F9071E61 Ref B: AMS231022012033 Ref C: 2026-06-24T13:19:01Z'
     status:
       code: 200
       message: OK
@@ -125,7 +125,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
   response:
     body:
-      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.ae982c353db8.westus2.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.ae982c353db8.ro.westus2.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"westus2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.e942cca99994.uksouth.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.e942cca99994.ro.uksouth.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"uksouth","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
     headers:
       cache-control:
       - no-cache
@@ -134,7 +134,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 24 Jun 2026 12:52:12 GMT
+      - Wed, 24 Jun 2026 13:20:01 GMT
       expires:
       - '-1'
       pragma:
@@ -148,7 +148,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 1AE9FFF7B1AF4650BE591FA145216EBA Ref B: AMS231020512023 Ref C: 2026-06-24T12:52:13Z'
+      - 'Ref A: 2DE19A4A3E984A5EB6CEDDA013D4C7AC Ref B: DUB601080514042 Ref C: 2026-06-24T13:20:01Z'
     status:
       code: 200
       message: OK
@@ -171,7 +171,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
   response:
     body:
-      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.ae982c353db8.westus2.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.ae982c353db8.ro.westus2.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"westus2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.e942cca99994.uksouth.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.e942cca99994.ro.uksouth.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"uksouth","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
     headers:
       cache-control:
       - no-cache
@@ -180,7 +180,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 24 Jun 2026 12:53:14 GMT
+      - Wed, 24 Jun 2026 13:21:03 GMT
       expires:
       - '-1'
       pragma:
@@ -194,7 +194,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 392DD06A7F204D4D868E8A8A05BCDB62 Ref B: AMS231020615037 Ref C: 2026-06-24T12:53:14Z'
+      - 'Ref A: 3B82A1A71130416C94E13BB57D97AEF3 Ref B: AMS231020512049 Ref C: 2026-06-24T13:21:03Z'
     status:
       code: 200
       message: OK
@@ -217,7 +217,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
   response:
     body:
-      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.ae982c353db8.westus2.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.ae982c353db8.ro.westus2.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"westus2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.e942cca99994.uksouth.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.e942cca99994.ro.uksouth.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"uksouth","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
     headers:
       cache-control:
       - no-cache
@@ -226,7 +226,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 24 Jun 2026 12:54:15 GMT
+      - Wed, 24 Jun 2026 13:22:04 GMT
       expires:
       - '-1'
       pragma:
@@ -240,7 +240,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: F37C7A6F1CB841E0ACA72E782F62CB92 Ref B: DUB601080511040 Ref C: 2026-06-24T12:54:15Z'
+      - 'Ref A: A7DECAE849B94348A55B36304E834FF3 Ref B: AMS231020512039 Ref C: 2026-06-24T13:22:04Z'
     status:
       code: 200
       message: OK
@@ -263,7 +263,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
   response:
     body:
-      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.ae982c353db8.westus2.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.ae982c353db8.ro.westus2.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"westus2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.e942cca99994.uksouth.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.e942cca99994.ro.uksouth.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"uksouth","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
     headers:
       cache-control:
       - no-cache
@@ -272,7 +272,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 24 Jun 2026 12:55:16 GMT
+      - Wed, 24 Jun 2026 13:23:05 GMT
       expires:
       - '-1'
       pragma:
@@ -286,7 +286,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 395959F7FA5A47EEAC08E3CDFBF4297F Ref B: AMS231022012019 Ref C: 2026-06-24T12:55:16Z'
+      - 'Ref A: 2ADB25EBDC24493284D5A38C14A3093A Ref B: AMS231020512047 Ref C: 2026-06-24T13:23:05Z'
     status:
       code: 200
       message: OK
@@ -309,7 +309,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
   response:
     body:
-      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.ae982c353db8.westus2.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.ae982c353db8.ro.westus2.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"westus2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.e942cca99994.uksouth.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.e942cca99994.ro.uksouth.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"uksouth","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
     headers:
       cache-control:
       - no-cache
@@ -318,7 +318,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 24 Jun 2026 12:56:17 GMT
+      - Wed, 24 Jun 2026 13:24:05 GMT
       expires:
       - '-1'
       pragma:
@@ -332,7 +332,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 9AA4FB7481BA431C90C41731C6F7DC02 Ref B: AMS231032607019 Ref C: 2026-06-24T12:56:17Z'
+      - 'Ref A: 7AA979C5AABC4B0584A1CADF602277E8 Ref B: DUB601080510042 Ref C: 2026-06-24T13:24:06Z'
     status:
       code: 200
       message: OK
@@ -355,7 +355,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
   response:
     body:
-      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.ae982c353db8.westus2.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.ae982c353db8.ro.westus2.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"westus2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.e942cca99994.uksouth.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.e942cca99994.ro.uksouth.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"uksouth","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
     headers:
       cache-control:
       - no-cache
@@ -364,7 +364,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 24 Jun 2026 12:57:19 GMT
+      - Wed, 24 Jun 2026 13:25:06 GMT
       expires:
       - '-1'
       pragma:
@@ -378,7 +378,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 92AD3AC2F73A4C3092EF7F4FDB75B246 Ref B: AMS231020615025 Ref C: 2026-06-24T12:57:18Z'
+      - 'Ref A: FF1C9FE722D745F192686BACF0AC144D Ref B: AMS231022012009 Ref C: 2026-06-24T13:25:06Z'
     status:
       code: 200
       message: OK
@@ -401,7 +401,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
   response:
     body:
-      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.ae982c353db8.westus2.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.ae982c353db8.ro.westus2.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"westus2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.e942cca99994.uksouth.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.e942cca99994.ro.uksouth.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"uksouth","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
     headers:
       cache-control:
       - no-cache
@@ -410,7 +410,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 24 Jun 2026 12:58:19 GMT
+      - Wed, 24 Jun 2026 13:26:07 GMT
       expires:
       - '-1'
       pragma:
@@ -424,7 +424,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: F6F1EF282A184B55AEC4E3B905297E18 Ref B: AMS231032609045 Ref C: 2026-06-24T12:58:19Z'
+      - 'Ref A: C43E895397254AD5BDBCCEC313C68B2C Ref B: DUB601080510042 Ref C: 2026-06-24T13:26:07Z'
     status:
       code: 200
       message: OK
@@ -447,7 +447,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
   response:
     body:
-      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.ae982c353db8.westus2.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.ae982c353db8.ro.westus2.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"westus2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.e942cca99994.uksouth.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.e942cca99994.ro.uksouth.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"uksouth","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
     headers:
       cache-control:
       - no-cache
@@ -456,7 +456,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 24 Jun 2026 12:59:20 GMT
+      - Wed, 24 Jun 2026 13:27:08 GMT
       expires:
       - '-1'
       pragma:
@@ -470,7 +470,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: B543C0D559954F3F8733F810F3208B1D Ref B: AMS231022012017 Ref C: 2026-06-24T12:59:20Z'
+      - 'Ref A: 327213B3AF554402AF3F8315BDEF30F4 Ref B: AMS231020512011 Ref C: 2026-06-24T13:27:08Z'
     status:
       code: 200
       message: OK
@@ -493,7 +493,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
   response:
     body:
-      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.ae982c353db8.westus2.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.ae982c353db8.ro.westus2.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"westus2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.e942cca99994.uksouth.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.e942cca99994.ro.uksouth.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"uksouth","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
     headers:
       cache-control:
       - no-cache
@@ -502,7 +502,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 24 Jun 2026 13:00:22 GMT
+      - Wed, 24 Jun 2026 13:28:08 GMT
       expires:
       - '-1'
       pragma:
@@ -516,7 +516,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: E8774738580249959662A4B9A2A5A15E Ref B: AMS231032607017 Ref C: 2026-06-24T13:00:21Z'
+      - 'Ref A: DDAC531396BE4EA089F103BCBAA41DAC Ref B: AMS231020615027 Ref C: 2026-06-24T13:28:09Z'
     status:
       code: 200
       message: OK
@@ -539,191 +539,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
   response:
     body:
-      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.ae982c353db8.westus2.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.ae982c353db8.ro.westus2.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"westus2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '594'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 24 Jun 2026 13:01:22 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-cache:
-      - CONFIG_NOCACHE
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-global-reads:
-      - '16499'
-      x-msedge-ref:
-      - 'Ref A: 2C0CBB37BB2A40D291E183B32BCD690B Ref B: AMS231032607019 Ref C: 2026-06-24T13:01:22Z'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - rest
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --method --url
-      User-Agent:
-      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
-  response:
-    body:
-      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.ae982c353db8.westus2.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.ae982c353db8.ro.westus2.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"westus2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '594'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 24 Jun 2026 13:02:24 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-cache:
-      - CONFIG_NOCACHE
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-global-reads:
-      - '16499'
-      x-msedge-ref:
-      - 'Ref A: BE2C798C2F1A4A5EBED1BDE3595B55FA Ref B: AMS231020512019 Ref C: 2026-06-24T13:02:24Z'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - rest
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --method --url
-      User-Agent:
-      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
-  response:
-    body:
-      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.ae982c353db8.westus2.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":0,"vCores":2,"readonlyEndpoint":"clitest000002.ae982c353db8.ro.westus2.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"westus2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '594'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 24 Jun 2026 13:03:25 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-cache:
-      - CONFIG_NOCACHE
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-global-reads:
-      - '16499'
-      x-msedge-ref:
-      - 'Ref A: DDC3A9CC40554F018959C128E80C601E Ref B: AMS231020512049 Ref C: 2026-06-24T13:03:25Z'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - rest
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --method --url
-      User-Agent:
-      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
-  response:
-    body:
-      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.ae982c353db8.westus2.horizondb.azure.com","version":"17","state":"Provisioning","zonePlacementPolicy":"BestEffort","replicaCount":1,"vCores":2,"readonlyEndpoint":"clitest000002.ae982c353db8.ro.westus2.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled"},"location":"westus2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '594'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 24 Jun 2026 13:04:26 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-cache:
-      - CONFIG_NOCACHE
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-global-reads:
-      - '16499'
-      x-msedge-ref:
-      - 'Ref A: 0ADAB30DBBDC43C78991CE293CB9FC43 Ref B: AMS231032608019 Ref C: 2026-06-24T13:04:26Z'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - rest
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --method --url
-      User-Agent:
-      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_hdb000001/providers/Microsoft.HorizonDB/clusters/clitest000002?api-version=2026-01-20-preview
-  response:
-    body:
-      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.ae982c353db8.westus2.horizondb.azure.com","version":"17","state":"Succeeded","zonePlacementPolicy":"BestEffort","replicaCount":1,"vCores":2,"readonlyEndpoint":"clitest000002.ae982c353db8.ro.westus2.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled","parameterGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/parameterGroups/default_pg17","syncStatus":"InSync"}},"location":"westus2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
+      string: '{"properties":{"createMode":"Default","fullyQualifiedDomainName":"clitest000002.e942cca99994.uksouth.horizondb.azure.com","version":"17","state":"Succeeded","zonePlacementPolicy":"BestEffort","replicaCount":1,"vCores":2,"readonlyEndpoint":"clitest000002.e942cca99994.ro.uksouth.horizondb.azure.com","privateEndpointConnections":[],"aiModelManagement":"Disabled","parameterGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/parameterGroups/default_pg17","syncStatus":"InSync"}},"location":"uksouth","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_hdb000001/providers/Microsoft.HorizonDb/clusters/clitest000002","name":"clitest000002","type":"Microsoft.HorizonDb/clusters"}'
     headers:
       cache-control:
       - no-cache
@@ -732,7 +548,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 24 Jun 2026 13:05:28 GMT
+      - Wed, 24 Jun 2026 13:29:10 GMT
       expires:
       - '-1'
       pragma:
@@ -746,7 +562,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 0786EE60DB2C428E965EA0ECC9A3F662 Ref B: AMS231020614053 Ref C: 2026-06-24T13:05:28Z'
+      - 'Ref A: 576067049153471FBDF5F591B4CDD7B0 Ref B: DUB601080512060 Ref C: 2026-06-24T13:29:10Z'
     status:
       code: 200
       message: OK
@@ -778,7 +594,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 24 Jun 2026 13:05:50 GMT
+      - Wed, 24 Jun 2026 13:29:12 GMT
       expires:
       - '-1'
       pragma:
@@ -790,11 +606,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f91ea4c1-3a04-4ea9-87a6-1c146cca75ee/westus2/86e98c2e-339e-44a0-9736-21186306ad88
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=f91ea4c1-3a04-4ea9-87a6-1c146cca75ee/uksouth/381c3016-2d83-4844-bfe2-5bd2b46306e8
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: D04CE6BF5DC24CEC957DC1A3A4306302 Ref B: DUB601080512025 Ref C: 2026-06-24T13:05:50Z'
+      - 'Ref A: 43ED8577733F4FD7969F0865C50DE83F Ref B: AMS231020615047 Ref C: 2026-06-24T13:29:12Z'
     status:
       code: 200
       message: OK

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_private_endpoint_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_private_endpoint_commands.py
@@ -5235,12 +5235,14 @@ class NetworkPrivateLinkHorizonDBScenarioTest(ScenarioTest):
         state = self.get_provisioning_state_for_horizondb_cluster()
         print(state)
         while state not in ["Succeeded", "Ready"]:
-            if state in ["Provisioning", "Updating", "Accepted", None]:
-                print("instance not yet created. waiting for 1 more min...")
-                time.sleep(60)
-            elif count == 15:
+            if state in ["Failed", "Canceled"]:
+                print("creation failed!")
+                self.assertTrue(False)
+            if count == 15:
                 print("TimeOut after waiting for 15 mins!")
                 self.assertTrue(False)
+            print("instance not yet created. waiting for 1 more min...")
+            time.sleep(60)
             count += 1
             state = self.get_provisioning_state_for_horizondb_cluster()
         print("Cluster creation succeeded!")

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_private_endpoint_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_private_endpoint_commands.py
@@ -5101,13 +5101,12 @@ class NetworkPrivateLinkMongoClustersTest(ScenarioTest):
 
 class NetworkPrivateLinkHorizonDBScenarioTest(ScenarioTest):
 
-    @live_only()
-    @ResourceGroupPreparer(name_prefix='cli_test_hdb', random_name_length=18, location='eastus2euap')
+    @ResourceGroupPreparer(name_prefix='cli_test_hdb', random_name_length=18, location='westus2')
     def test_private_link_resource_horizondb_cluster(self, resource_group):
         self.kwargs.update({
             'cluster_name': self.create_random_name(prefix='clitest', length=15),
             'sub': self.get_subscription_id(),
-            'location': 'eastus2euap',
+            'location': 'westus2',
             'api_version': '2026-01-20-preview',
             'resource_type': 'Microsoft.HorizonDB/clusters',
             'headers': '{\\"Content-Type\\":\\"application/json\\"}',
@@ -5125,7 +5124,7 @@ class NetworkPrivateLinkHorizonDBScenarioTest(ScenarioTest):
                  checks=[self.check('length(@)', 1)])
 
     @live_only()
-    @ResourceGroupPreparer(name_prefix='cli_test_hdb', random_name_length=18, location='eastus2euap')
+    @ResourceGroupPreparer(name_prefix='cli_test_hdb', random_name_length=18, location='westus2')
     def test_private_endpoint_connection_horizondb_cluster(self, resource_group):
         from azure.mgmt.core.tools import resource_id
 
@@ -5142,7 +5141,7 @@ class NetworkPrivateLinkHorizonDBScenarioTest(ScenarioTest):
         self.kwargs.update({
             'cluster_name': resource_name,
             'target_resource_id': target_resource_id,
-            'location': 'eastus2euap',
+            'location': 'westus2',
             'resource_type': 'Microsoft.HorizonDB/clusters',
             'vnet': self.create_random_name('cli-vnet-', 24),
             'subnet': self.create_random_name('cli-subnet-', 24),
@@ -5208,7 +5207,7 @@ class NetworkPrivateLinkHorizonDBScenarioTest(ScenarioTest):
         self.cmd('az network private-endpoint-connection delete --id {pec_id} -y')
 
     def _get_horizondb_cluster_body(self):
-        return ('{\\"location\\": \\"eastus2euap\\", '
+        return ('{\\"location\\": \\"westus2\\", '
                 '\\"properties\\": {'
                 '\\"createMode\\": \\"Default\\", '
                 '\\"version\\": \\"17\\", '
@@ -5227,7 +5226,8 @@ class NetworkPrivateLinkHorizonDBScenarioTest(ScenarioTest):
                             'providers/Microsoft.HorizonDB/clusters/{cluster_name}?api-version={api_version}"'
                             ).get_output_in_json()
 
-        return response['properties']['provisioningState']
+        properties = response.get('properties') or {}
+        return properties.get('provisioningState') or properties.get('state') or response.get('status')
 
     def check_provisioning_state_for_horizondb_cluster(self):
         time.sleep(10)
@@ -5235,8 +5235,8 @@ class NetworkPrivateLinkHorizonDBScenarioTest(ScenarioTest):
         print("checking status of creation...........")
         state = self.get_provisioning_state_for_horizondb_cluster()
         print(state)
-        while state != "Succeeded":
-            if state in ["Provisioning", "Updating"]:
+        while state not in ["Succeeded", "Ready"]:
+            if state in ["Provisioning", "Updating", "Accepted", None]:
                 print("instance not yet created. waiting for 1 more min...")
                 time.sleep(60)
             elif count == 15:

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_private_endpoint_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_private_endpoint_commands.py
@@ -5101,12 +5101,12 @@ class NetworkPrivateLinkMongoClustersTest(ScenarioTest):
 
 class NetworkPrivateLinkHorizonDBScenarioTest(ScenarioTest):
 
-    @ResourceGroupPreparer(name_prefix='cli_test_hdb', random_name_length=18, location='westus2')
+    @ResourceGroupPreparer(name_prefix='cli_test_hdb', random_name_length=18, location='uksouth')
     def test_private_link_resource_horizondb_cluster(self, resource_group):
         self.kwargs.update({
             'cluster_name': self.create_random_name(prefix='clitest', length=15),
             'sub': self.get_subscription_id(),
-            'location': 'westus2',
+            'location': 'uksouth',
             'api_version': '2026-01-20-preview',
             'resource_type': 'Microsoft.HorizonDB/clusters',
             'headers': '{\\"Content-Type\\":\\"application/json\\"}',
@@ -5123,8 +5123,7 @@ class NetworkPrivateLinkHorizonDBScenarioTest(ScenarioTest):
                  '--type {resource_type}',
                  checks=[self.check('length(@)', 1)])
 
-    @live_only()
-    @ResourceGroupPreparer(name_prefix='cli_test_hdb', random_name_length=18, location='westus2')
+    @ResourceGroupPreparer(name_prefix='cli_test_hdb', random_name_length=18, location='uksouth')
     def test_private_endpoint_connection_horizondb_cluster(self, resource_group):
         from azure.mgmt.core.tools import resource_id
 
@@ -5141,7 +5140,7 @@ class NetworkPrivateLinkHorizonDBScenarioTest(ScenarioTest):
         self.kwargs.update({
             'cluster_name': resource_name,
             'target_resource_id': target_resource_id,
-            'location': 'westus2',
+            'location': 'uksouth',
             'resource_type': 'Microsoft.HorizonDB/clusters',
             'vnet': self.create_random_name('cli-vnet-', 24),
             'subnet': self.create_random_name('cli-subnet-', 24),
@@ -5207,7 +5206,7 @@ class NetworkPrivateLinkHorizonDBScenarioTest(ScenarioTest):
         self.cmd('az network private-endpoint-connection delete --id {pec_id} -y')
 
     def _get_horizondb_cluster_body(self):
-        return ('{\\"location\\": \\"westus2\\", '
+        return ('{\\"location\\": \\"uksouth\\", '
                 '\\"properties\\": {'
                 '\\"createMode\\": \\"Default\\", '
                 '\\"version\\": \\"17\\", '

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_private_endpoint_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_private_endpoint_commands.py
@@ -5099,6 +5099,154 @@ class NetworkPrivateLinkMongoClustersTest(ScenarioTest):
         print("creation succeeded!")
 
 
+class NetworkPrivateLinkHorizonDBScenarioTest(ScenarioTest):
+
+    @live_only()
+    @ResourceGroupPreparer(name_prefix='cli_test_hdb', random_name_length=18, location='eastus2euap')
+    def test_private_link_resource_horizondb_cluster(self, resource_group):
+        self.kwargs.update({
+            'cluster_name': self.create_random_name(prefix='clitest', length=15),
+            'sub': self.get_subscription_id(),
+            'location': 'eastus2euap',
+            'api_version': '2026-01-20-preview',
+            'resource_type': 'Microsoft.HorizonDB/clusters',
+            'headers': '{\\"Content-Type\\":\\"application/json\\"}',
+            'body': self._get_horizondb_cluster_body()
+        })
+
+        self.cmd('az rest --method "PUT" --headers "{headers}" '
+                 '--url "https://management.azure.com/subscriptions/{sub}/resourcegroups/{rg}/'
+                 'providers/Microsoft.HorizonDB/clusters/{cluster_name}?api-version={api_version}" '
+                 '--body "{body}"')
+        self.check_provisioning_state_for_horizondb_cluster()
+
+        self.cmd('az network private-link-resource list --name {cluster_name} --resource-group {rg} '
+                 '--type {resource_type}',
+                 checks=[self.check('length(@)', 1)])
+
+    @live_only()
+    @ResourceGroupPreparer(name_prefix='cli_test_hdb', random_name_length=18, location='eastus2euap')
+    def test_private_endpoint_connection_horizondb_cluster(self, resource_group):
+        from azure.mgmt.core.tools import resource_id
+
+        namespace = 'Microsoft.HorizonDB'
+        instance_type = 'clusters'
+        resource_name = self.create_random_name(prefix='clitest', length=15)
+        target_resource_id = resource_id(
+            subscription=self.get_subscription_id(),
+            resource_group=resource_group,
+            namespace=namespace,
+            type=instance_type,
+            name=resource_name,
+        )
+        self.kwargs.update({
+            'cluster_name': resource_name,
+            'target_resource_id': target_resource_id,
+            'location': 'eastus2euap',
+            'resource_type': 'Microsoft.HorizonDB/clusters',
+            'vnet': self.create_random_name('cli-vnet-', 24),
+            'subnet': self.create_random_name('cli-subnet-', 24),
+            'pe': self.create_random_name('cli-pe-', 24),
+            'pe_connection': self.create_random_name('cli-pec-', 24),
+            'sub': self.get_subscription_id(),
+            'api_version': '2026-01-20-preview',
+            'headers': '{\\"Content-Type\\":\\"application/json\\"}',
+            'body': self._get_horizondb_cluster_body()
+        })
+
+        self.cmd('az network vnet create -n {vnet} -g {rg} -l {location} --subnet-name {subnet}',
+                 checks=self.check('length(newVNet.subnets)', 1))
+        self.cmd('az network vnet subnet update -n {subnet} --vnet-name {vnet} -g {rg} '
+                 '--disable-private-endpoint-network-policies true',
+                 checks=self.check('privateEndpointNetworkPolicies', 'Disabled'))
+
+        self.cmd('az rest --method "PUT" --headers "{headers}" '
+                 '--url "https://management.azure.com/subscriptions/{sub}/resourcegroups/{rg}/'
+                 'providers/Microsoft.HorizonDB/clusters/{cluster_name}?api-version={api_version}" '
+                 '--body "{body}"')
+        self.check_provisioning_state_for_horizondb_cluster()
+
+        target_private_link_resource = self.cmd(
+            'az network private-link-resource list --id {target_resource_id}').get_output_in_json()
+        self.kwargs.update({
+            'group_id': target_private_link_resource[0]['properties']['groupId']
+        })
+
+        pe = self.cmd(
+            'az network private-endpoint create -g {rg} -n {pe} --vnet-name {vnet} --subnet {subnet} '
+            '--connection-name {pe_connection} --private-connection-resource-id {target_resource_id} '
+            '--group-id {group_id} --manual-request').get_output_in_json()
+        self.kwargs['pe_id'] = pe['id']
+
+        list_private_endpoint_conn = self.cmd(
+            'az network private-endpoint-connection list --id {target_resource_id}').get_output_in_json()
+        self.kwargs.update({
+            'pec_id': list_private_endpoint_conn[0]['id'],
+            'pec_name': list_private_endpoint_conn[0]['name']
+        })
+
+        self.cmd('az network private-endpoint-connection show --id {pec_id}',
+                 checks=self.check('id', '{pec_id}'))
+        self.cmd('az network private-endpoint-connection show --resource-name {cluster_name} -n {pec_name} '
+                 '-g {rg} --type {resource_type}',
+                 checks=self.check('properties.privateLinkServiceConnectionState.status', 'Pending'))
+
+        self.kwargs.update({
+            'approval_desc': 'Approved.',
+            'rejection_desc': 'Rejected.'
+        })
+        self.cmd(
+            'az network private-endpoint-connection approve --resource-name {cluster_name} --resource-group {rg} '
+            '--name {pec_name} --type {resource_type} --description "{approval_desc}"',
+            checks=[self.check('properties.privateLinkServiceConnectionState.status', 'Approved')])
+        self.cmd('az network private-endpoint-connection reject --id {pec_id} '
+                 '--description "{rejection_desc}"',
+                 checks=[self.check('properties.privateLinkServiceConnectionState.status', 'Rejected')])
+        self.cmd('az network private-endpoint-connection list --id {target_resource_id}',
+                 checks=[self.check('length(@)', 1)])
+
+        self.cmd('az network private-endpoint-connection delete --id {pec_id} -y')
+
+    def _get_horizondb_cluster_body(self):
+        return ('{\\"location\\": \\"eastus2euap\\", '
+                '\\"properties\\": {'
+                '\\"createMode\\": \\"Default\\", '
+                '\\"version\\": \\"17\\", '
+                '\\"administratorLogin\\": \\"admin123\\", '
+                '\\"administratorLoginPassword\\": \\"aBcD1234!@#$\\", '
+                '\\"vCores\\": 2, '
+                '\\"replicaCount\\": 1, '
+                '\\"network\\": {\\"publicNetworkAccess\\": \\"Enabled\\"}, '
+                '\\"highAvailability\\": {\\"mode\\": \\"Disabled\\"}, '
+                '\\"aiModelManagement\\": 1'
+                '}}')
+
+    def get_provisioning_state_for_horizondb_cluster(self):
+        response = self.cmd('az rest --method "GET" '
+                            '--url "https://management.azure.com/subscriptions/{sub}/resourcegroups/{rg}/'
+                            'providers/Microsoft.HorizonDB/clusters/{cluster_name}?api-version={api_version}"'
+                            ).get_output_in_json()
+
+        return response['properties']['provisioningState']
+
+    def check_provisioning_state_for_horizondb_cluster(self):
+        time.sleep(10)
+        count = 0
+        print("checking status of creation...........")
+        state = self.get_provisioning_state_for_horizondb_cluster()
+        print(state)
+        while state != "Succeeded":
+            if state in ["Provisioning", "Updating"]:
+                print("instance not yet created. waiting for 1 more min...")
+                time.sleep(60)
+            elif count == 15:
+                print("TimeOut after waiting for 15 mins!")
+                self.assertTrue(False)
+            count += 1
+            state = self.get_provisioning_state_for_horizondb_cluster()
+        print("Cluster creation succeeded!")
+
+
 class NetworkPrivateLinkPostgreSQLFlexibleServerScenarioTest(ScenarioTest):
 
     @ResourceGroupPreparer(name_prefix='cli_test_fspg', random_name_length=18, location='eastus2euap')


### PR DESCRIPTION
**Related command**

`az network private-link-resource`  
`az network private-endpoint-connection`

**Description**

Onboard HorizonDB clusters to the generic Azure CLI Private Link commands by registering `Microsoft.HorizonDB/clusters` with API version `2026-01-20-preview`.

This enables:

- `az network private-link-resource list --id <horizondb-cluster-id>`
- `az network private-endpoint-connection list/show/approve/reject/delete --id <horizondb-private-endpoint-connection-id>`

The change uses the existing generic provider map and does not add a HorizonDB-specific command group.

**Testing Guide**

- `python -m py_compile src\azure-cli\azure\cli\command_modules\network\private_link_resource_and_endpoint_connections\custom.py src\azure-cli\azure\cli\command_modules\network\tests\latest\test_private_endpoint_commands.py`
- `azdev test test_private_link_resource_horizondb_cluster test_private_endpoint_connection_horizondb_cluster --live --series`
  - Passed in `uksouth`
- `azdev test test_private_link_resource_horizondb_cluster test_private_endpoint_connection_horizondb_cluster --series`
  - Passed playback: `2 passed in 21.52s`

**History Notes**

[Network] `az network private-link-resource`, `az network private-endpoint-connection`: Add support for HorizonDB clusters

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
