### PR TITLE
{Packaging} Fix Homebrew test install on older brew by rewriting formula_opt_prefix in test jobs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -683,6 +683,12 @@ jobs:
       # allowed in official Homebrew taps. Remove it so the formula can be installed from
       # this local dev tap. It must remain in the released formula, so we only strip it here.
       sed -i '' '/no_autobump!/d' $(brew --repository)/Library/Taps/dev/homebrew-azure-cli/Formula/azure-cli.rb
+      # TODO(packaging): remove once the macOS CI agent image's Homebrew provides formula_opt_prefix.
+      # The upstream homebrew-core formula calls `formula_opt_prefix("openssl@3")`, a newer
+      # Homebrew DSL helper not available on the older Homebrew on the macOS CI agent image
+      # (NoMethodError). Rewrite it to the backward-compatible `Formula["openssl@3"].opt_prefix`
+      # form for the local test install only; the generated/submitted formula stays upstream-faithful.
+      sed -E -i '' 's/formula_opt_prefix\(?[[:space:]]*"([^"]+)"[[:space:]]*\)?/Formula["\1"].opt_prefix/g' $(brew --repository)/Library/Taps/dev/homebrew-azure-cli/Formula/azure-cli.rb
       brew install --build-from-source dev/homebrew-azure-cli/azure-cli
       
       echo == Az Version ==

--- a/scripts/release/homebrew/test_homebrew_package.sh
+++ b/scripts/release/homebrew/test_homebrew_package.sh
@@ -8,6 +8,12 @@ echo == Remove pre-installed azure-cli ==
 brew uninstall azure-cli
 
 echo == Install azure-cli.rb formula ==
+# TODO(packaging): remove once the macOS CI agent image's Homebrew provides formula_opt_prefix.
+# The upstream homebrew-core formula calls `formula_opt_prefix("openssl@3")`, a newer
+# Homebrew DSL helper not available on the older Homebrew on the macOS CI agent image
+# (NoMethodError). Rewrite it to the backward-compatible `Formula["openssl@3"].opt_prefix`
+# form for the local test install only; the generated/submitted formula stays upstream-faithful.
+sed -E -i '' 's/formula_opt_prefix\(?[[:space:]]*"([^"]+)"[[:space:]]*\)?/Formula["\1"].opt_prefix/g' $SYSTEM_ARTIFACTSDIRECTORY/homebrew/azure-cli.rb
 brew install --build-from-source $SYSTEM_ARTIFACTSDIRECTORY/homebrew/azure-cli.rb
 
 AZ_BASE=/usr/local/Cellar/azure-cli/$CLI_VERSION/libexec


### PR DESCRIPTION
## Root cause

The upstream homebrew-core `azure-cli.rb` `def install` now calls `formula_opt_prefix("openssl@3")`, a new Homebrew DSL helper (brew `utils/path.rb`). That helper is missing on the older Homebrew preinstalled on the `macOS-14` CI agent image, so `brew install` fails with a `NoMethodError`. This was first observed in the batched/nightly CI failure around 2026-06-23.

## Fix

Patch the formula only in the macOS test jobs, right before `brew install`, rewriting the call to the backward-compatible `Formula["openssl@3"].opt_prefix` form — mirroring the existing `no_autobump!` sed convention. The generated/submitted homebrew-core formula is intentionally left upstream-faithful (no change to `formula_generate.py`).

Changed files:
- `azure-pipelines.yml` (job `TestHomebrewFormula`)
- `scripts/release/homebrew/test_homebrew_package.sh`

## Note

`TestHomebrewPackage` is currently `condition: false` (disabled), so only `TestHomebrewFormula` actively exercises this fix; the shell-script change is preventative for when that job is re-enabled.

## Cleanup

A `TODO(packaging)` marker was added above each shim so it can be removed once the agent image's Homebrew ships `formula_opt_prefix`.

## HISTORY.rst

Intentionally skipped — this is an internal CI/packaging change with no customer-facing behavior.
