### PR TITLE
{CI} Bump azdev pin to 0.2.12 for editable installs with --no-build-isolation

### DIFF
--- a/.azure-pipelines/templates/azdev_setup.yml
+++ b/.azure-pipelines/templates/azdev_setup.yml
@@ -19,12 +19,14 @@ steps:
       # 82 removes pkg_resources) so `azdev setup` builds under a supported
       # setuptools regardless of what the agent image ships.
       python -m pip install -U pip "setuptools<81"
-      # azdev 0.2.11b1 decouples extension metadata generation from wheel==0.30.0
-      # (see Azure/azure-cli-extensions#7740). It is not on PyPI yet, so install it
-      # pinned to the azure-cli-dev-tools#549 merge commit (0.2.11b1) for a
-      # reproducible build. Switch this to `pip install --upgrade "azdev==0.2.11b1"`
-      # once the pre-release is published to PyPI.
-      pip install --upgrade "git+https://github.com/Azure/azure-cli-dev-tools.git@49390f30c6a822620d2fbdf88889c4445d22666f#egg=azdev"
+      # Pin azdev to azure-cli-dev-tools commit 644d296 (0.2.12). This bundles:
+      # decouple extension metadata from wheel==0.30.0 (#549), quote paths in
+      # editable installs (#551), and --no-build-isolation for editable installs
+      # (#552) so extensions whose setup.py imports azure (e.g. confcom) build
+      # against the environment instead of an isolated PEP 517 env under
+      # setuptools>=79. It is not on PyPI yet; switch this to
+      # `pip install --upgrade "azdev==0.2.12"` once published to PyPI.
+      pip install --upgrade "git+https://github.com/Azure/azure-cli-dev-tools.git@644d296d9ca9b322b438d5ca21141b247258d0e5#egg=azdev"
       azdev --version
 
       if [ -z "$CLI_EXT_REPO_PATH" ]; then


### PR DESCRIPTION
### Description

The Codegen Coverage job has been failing since we unpinned `wheel`/`setuptools`. With setuptools 80, `azdev extension add "*"` builds each extension in an isolated PEP 517 environment, so extensions whose `setup.py` imports `azure` at build time (e.g. confcom) fail with `ModuleNotFoundError: No module named 'azure'`.

azure-cli-dev-tools 0.2.12 adds `--no-build-isolation` to azdev's editable installs, so the build runs against the environment where `azure-cli-core` is already installed. This bumps the pin from 0.2.11b1 (`49390f3`) to 0.2.12 (`644d296`).

### Testing

Installed azdev from the pinned commit and reproduced the pipeline steps locally:
- `azdev setup -c azure-cli -r azure-cli-extensions`,  all CLI packages install editable.
- `azdev extension add confcom`, succeeds on setuptools 79.x (previously failed with the isolated-build error).

azure-cli-extensions already pins the same commit. Once azdev 0.2.11/12 is published to PyPI the pin can switch to `azdev==0.2.11/12`.