### PR TITLE
{CI} Switch docs reference trigger to tag trigger

### DIFF
--- a/.azure-pipelines/trigger-reference-docs-ci.yml
+++ b/.azure-pipelines/trigger-reference-docs-ci.yml
@@ -2,10 +2,11 @@ name: Azure CLI Trigger Reference Docs CI
 
 trigger:
   branches:
+    exclude:
+    - '*'
+  tags:
     include:
-    - release
-    - release-lts-*
-    - test-release-*
+    - azure-cli-*
 
 pr: none
 
@@ -19,7 +20,6 @@ variables:
 jobs:
 - job: TriggerReferenceDocsCI
   displayName: 'Queue Microsoft Learn Docs Reference CI'
-  condition: or(eq(variables['Build.SourceBranchName'], 'release'), startsWith(variables['Build.SourceBranchName'], 'release-lts-'), startsWith(variables['Build.SourceBranchName'], 'test-release-'))
   pool:
     name: ${{ variables.ubuntu_pool }}
   steps:
@@ -35,7 +35,28 @@ jobs:
         $project = $env:AdoProject
         $thisRepoLink = $env:ThisRepoLink
         $thisRunLink = $env:ThisRunLink
-        $triggerBranch = $env:ReleaseBranch
+        $tagName = $env:TagName
+
+        # Resolve the release's target_commitish ('release' = latest, 'release-lts-<ver>' = LTS) to pick
+        # the matching docs pipeline. Never guess: retry transient errors, but a 404 (tag with no Release)
+        # or exhausted retries fail the job so a release is never queued against the wrong pipeline.
+        $triggerBranch = $null
+        for ($attempt = 1; $attempt -le 3; $attempt++) {
+            $resp = Invoke-WebRequest -Uri "https://api.github.com/repos/Azure/azure-cli/releases/tags/$tagName" -Headers @{ 'User-Agent' = 'azure-cli-ado' } -SkipHttpErrorCheck
+            if ($resp.StatusCode -ge 200 -and $resp.StatusCode -lt 300) {
+                $triggerBranch = ($resp.Content | ConvertFrom-Json).target_commitish
+                break
+            }
+            if ($resp.StatusCode -eq 404) {
+                throw "Tag '$tagName' has no GitHub Release (404); aborting without queuing."
+            }
+            Write-Host "Release lookup attempt $attempt got HTTP $($resp.StatusCode), retrying..."
+            Start-Sleep -Seconds 10
+        }
+        if (-not $triggerBranch) {
+            throw "Could not resolve target_commitish for tag '$tagName' after retries; aborting."
+        }
+
         $definitionId = $triggerBranch -like 'release-lts-*' ? $env:AdoLtsPipelineId : $env:AdoLatestPipelineId
         $variables = @("triggerBranch=$triggerBranch", "triggerFromRepo=$thisRepoLink", "triggerByPipeline=$thisRunLink")
 
@@ -53,6 +74,6 @@ jobs:
       AdoProject: $(ADO_DocsReference_Project)
       AdoLatestPipelineId: $(ADO_DocsReference_Latest_Pipeline_ID)
       AdoLtsPipelineId: $(ADO_DocsReference_LTS_Pipeline_ID)
-      ReleaseBranch: $(Build.SourceBranchName)
+      TagName: $(Build.SourceBranchName)
       ThisRepoLink: $(Build.Repository.Uri)
       ThisRunLink: $(System.CollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)


### PR DESCRIPTION
## Summary

Switch the docs reference CI trigger pipeline from a **branch** CI trigger to a **tag** trigger, and derive latest-vs-LTS by looking up the release's `target_commitish`.

## Why — a branch trigger can't fire on release

The previous version triggered on pushes to `release` / `release-lts-*`. But the azure-cli release process **does not push a commit onto the `release` branch** at release time:

- It fast-forwards `main` *onto* `release` (`git merge --no-edit --ff-only release`, then pushes **`main`**) — that updates `main`, not `release`.
- The actual publish step creates a GitHub Release via the API:
  ```
  POST /repos/Azure/azure-cli/releases
  { "tag_name": "azure-cli-<ver>", "target_commitish": "release" | "release-lts-<ver>", ... }
  ```
  which **creates a Release + tag** — it pushes no commit to `release`.

So `release` gets no new commit during a release; the only thing that actually happens is a **tag/Release being created**. A branch CI trigger therefore never fires. (This is also why the old GitHub Action listened on `release: [released]`, not on a branch push.)

## How — trigger on the release tag, resolve latest/LTS by lookup

- Trigger on tags matching `azure-cli-*` (the tag the release process creates).
- A tag doesn't carry `target_commitish`, and latest/LTS tags are both `azure-cli-x.y.z` (indistinguishable by name). So the script looks up the GitHub Release for the tag and reads `target_commitish` (`release` → latest, `release-lts-<ver>` → LTS) — the same signal the old Action used.
- If no GitHub Release exists for the tag (HTTP 404), the job fails immediately without queuing — the pipeline must never guess latest vs LTS. Transient errors (5xx / network) are retried up to 3 times with a 10-second interval; exhausted retries also fail the job.

## What — behavior after this change

- On each release (a `azure-cli-<version>` Release/tag is created), the pipeline fires, resolves latest vs LTS via `target_commitish`, and queues the matching docs reference CI (`ADO_DocsReference_Latest_Pipeline_ID` / `ADO_DocsReference_LTS_Pipeline_ID`).
- Timing matches the old `release: [released]` Action — both originate from the same "create release tag" step; the difference is seconds, negligible.
- The old GitHub Action can then be retired.

## Prerequisite

The tag points at the HEAD of `release` / `release-lts-*`, and ADO evaluates the **tag commit's** YAML, so this file must exist on those branches:

- `release`: comes for free on the next release cut (it's cut from `dev`).
- `release-lts-2.66` (and future LTS branches): cherry-pick this file once; future LTS branches cut from `dev` will already include it.
