### PR TITLE
[App Service] `az webapp deploy`: Fix deployment-id attribution

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -9897,11 +9897,14 @@ def _check_runtimestatus_with_deploymentstatusapi(cmd, resource_group_name, name
         response_body = _check_zip_deployment_status(cmd, resource_group_name, name, deployment_status_url,
                                                      slot, timeout, deploy_params=deploy_params)
     else:
-        # get the deployment id
-        # once deploymentstatus/latest is available, we can use it to track the deployment
-        deployment_id = _get_latest_deployment_id(cmd, resource_group_name,
-                                                  name, deployment_status_url, slot,
-                                                  deploy_params=deploy_params)
+        # Prefer the request-specific id from the publish response; fall back to /latest.
+        deployment_id = None
+        if deploy_params is not None:
+            deployment_id = deploy_params._deployment_id  # pylint: disable=protected-access
+        if deployment_id is None:
+            deployment_id = _get_latest_deployment_id(cmd, resource_group_name,
+                                                      name, deployment_status_url, slot,
+                                                      deploy_params=deploy_params)
         if deployment_id is None:
             logger.warning("Failed to enable tracking runtime status for this deployment. "
                            "Resuming without tracking status.")
@@ -11149,6 +11152,7 @@ class OneDeployParams:
         # host_name_ssl_states on each access (trivial iteration).
         self._cached_scm_headers = None
         self._cached_site = None
+        self._deployment_id = None
 # pylint: enable=too-many-instance-attributes,too-few-public-methods
 
 
@@ -11560,6 +11564,9 @@ def _make_onedeploy_request(params):
         else:
             response = send_raw_request(params.cmd.cli_ctx, "PUT", deploy_url, body=body)
         poll_async_deployment_for_debugging = False
+
+    # Pin THIS request's deployment id from the publish response; avoids the racy /latest lookup.
+    params._deployment_id = response.headers.get('SCM-DEPLOYMENT-ID')  # pylint: disable=protected-access
 
     # check the status of deployment
     # pylint: disable=too-many-nested-blocks

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_deployment_context_engine.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_deployment_context_engine.py
@@ -25,6 +25,7 @@ from azure.cli.command_modules.appservice._deployment_context_engine import (
     EnrichedDeploymentError,
     _determine_deployment_type,
 )
+from azure.cli.command_modules.appservice import custom
 
 
 def _make_mock_params(**overrides):
@@ -448,6 +449,50 @@ class TestExtractStatusCode(unittest.TestCase):
     # --- Edge case: 200-range should NOT be extracted ---
     def test_200_not_extracted(self):
         self.assertIsNone(extract_status_code_from_message("Status Code: 200"))
+
+
+# ---------------------------------------------------------------------------
+# Deployment-id attribution: prefer the request-specific SCM-DEPLOYMENT-ID
+# (captured on OneDeployParams) over the global /api/deployments/latest lookup.
+# ---------------------------------------------------------------------------
+def _make_deploy_params(deployment_id):
+    params = MagicMock()
+    params._deployment_id = deployment_id
+    return params
+
+
+class TestDeploymentIdSelection(unittest.TestCase):
+
+    @patch.object(custom, '_poll_deployment_runtime_status', return_value={'status': 'RuntimeSuccessful'})
+    @patch.object(custom, '_build_deploymentstatus_url', return_value='https://scm/deploymentstatus/x')
+    @patch.object(custom, '_get_latest_deployment_id')
+    @patch.object(custom, '_get_or_fetch_is_linux_webapp', return_value=True)
+    def test_uses_request_specific_id_when_present(self, _linux, mock_latest, mock_build_url, _poll):
+        deploy_params = _make_deploy_params('scm-id-123')
+
+        result = custom._check_runtimestatus_with_deploymentstatusapi(
+            MagicMock(), 'rg', 'app', None,
+            'https://scm/api/deployments/latest', False, None,
+            deploy_params=deploy_params)
+
+        mock_latest.assert_not_called()
+        self.assertEqual(mock_build_url.call_args[0][4], 'scm-id-123')
+        self.assertEqual(result, {'status': 'RuntimeSuccessful'})
+
+    @patch.object(custom, '_poll_deployment_runtime_status', return_value={'status': 'RuntimeSuccessful'})
+    @patch.object(custom, '_build_deploymentstatus_url', return_value='https://scm/deploymentstatus/x')
+    @patch.object(custom, '_get_latest_deployment_id', return_value='latest-id-999')
+    @patch.object(custom, '_get_or_fetch_is_linux_webapp', return_value=True)
+    def test_falls_back_to_latest_when_id_absent(self, _linux, mock_latest, mock_build_url, _poll):
+        deploy_params = _make_deploy_params(None)
+
+        custom._check_runtimestatus_with_deploymentstatusapi(
+            MagicMock(), 'rg', 'app', None,
+            'https://scm/api/deployments/latest', False, None,
+            deploy_params=deploy_params)
+
+        mock_latest.assert_called_once()
+        self.assertEqual(mock_build_url.call_args[0][4], 'latest-id-999')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Related command**
az webapp deploy

**Description**

The runtime-status tracker now identifies its own deployment using the  SCM-DEPLOYMENT-ID  header returned by the publish ( /api/publish ) response,  instead of polling the global  /api/deployments/latest  pointer.

The build server normally serializes deployments and rejects a concurrent one with "Another deployment is in progress" — but if two requests arrive before the first acquires its lock, both slip through and run together. In that race, the CLI's old /api/deployments/latest lookup made both runs report the same deployment id. Capturing each publish response's request-specific  SCM-DEPLOYMENT-ID  fixes this, so every invocation reports the deployment its  own POST created.

**Testing Guide**
Before the Change:
<img width="1900" height="708" alt="image" src="https://github.com/user-attachments/assets/0407558c-3ece-4c3e-9ed7-df459e05c5e4" />

<img width="1897" height="762" alt="image" src="https://github.com/user-attachments/assets/69d1f0a9-e221-4b2c-b205-d00fecc777ce" />

Both deployments when triggered around the same time returned same deployment ID

<img width="527" height="96" alt="image" src="https://github.com/user-attachments/assets/a89719bb-f668-4bcc-95f1-2b00827110e0" />

But the actual deployment IDs are different


After the Change:

<img width="1886" height="957" alt="image" src="https://github.com/user-attachments/assets/3b18532e-626d-475e-8418-04becdc76b93" />

<img width="1912" height="888" alt="image" src="https://github.com/user-attachments/assets/573c807d-5fc8-486e-bef7-5384a153d309" />

<img width="575" height="66" alt="image" src="https://github.com/user-attachments/assets/c5b93b9c-7a1f-44f6-8e1b-3bb8de0f9315" />

The cli displayed correct deployment ID and logs


Tests:
Added  TestDeploymentIdSelection  in  test_deployment_context_engine.py  (offline, mocked):

 • uses the request-specific id when present (skips  /latest )
 • falls back to  /latest  when the header is absent

<img width="1898" height="323" alt="image" src="https://github.com/user-attachments/assets/fc91ec14-e6f1-4da7-95bd-219438c23513" />


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
