### PR TITLE
[POSTGRESQL] `az postgresql flexible-server maintenance-event list | show | apply-now | reschedule`: Add commands for maintenance events

### DIFF
--- a/linter_exclusions.yml
+++ b/linter_exclusions.yml
@@ -2940,18 +2940,6 @@ policy remediation create:
     resource_discovery_mode:
       rule_exclusions:
       - option_length_too_long
-postgres flexible-server maintenance-event apply-now:
-  rule_exclusions:
-  - missing_command_test_coverage
-postgres flexible-server maintenance-event list:
-  rule_exclusions:
-  - missing_command_test_coverage
-postgres flexible-server maintenance-event reschedule:
-  rule_exclusions:
-  - missing_command_test_coverage
-postgres flexible-server maintenance-event show:
-  rule_exclusions:
-  - missing_command_test_coverage
 postgres server ad-admin list:
   rule_exclusions:
   - no_ids_for_list_commands

--- a/linter_exclusions.yml
+++ b/linter_exclusions.yml
@@ -2940,6 +2940,18 @@ policy remediation create:
     resource_discovery_mode:
       rule_exclusions:
       - option_length_too_long
+postgres flexible-server maintenance-event apply-now:
+  rule_exclusions:
+  - missing_command_test_coverage
+postgres flexible-server maintenance-event list:
+  rule_exclusions:
+  - missing_command_test_coverage
+postgres flexible-server maintenance-event reschedule:
+  rule_exclusions:
+  - missing_command_test_coverage
+postgres flexible-server maintenance-event show:
+  rule_exclusions:
+  - missing_command_test_coverage
 postgres server ad-admin list:
   rule_exclusions:
   - no_ids_for_list_commands

--- a/src/azure-cli/azure/cli/command_modules/postgresql/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/_client_factory.py
@@ -117,6 +117,10 @@ def cf_postgres_flexible_tuning_options(cli_ctx, _):
     return get_postgresql_flexible_management_client(cli_ctx).tuning_options
 
 
+def cf_postgres_flexible_maintenance_events(cli_ctx, _):
+    return get_postgresql_flexible_management_client(cli_ctx).maintenance_events
+
+
 def resource_client_factory(cli_ctx, subscription_id=None):
     return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_RESOURCE_RESOURCES, subscription_id=subscription_id)
 

--- a/src/azure-cli/azure/cli/command_modules/postgresql/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/_help.py
@@ -320,6 +320,45 @@ examples:
     text: az postgres flexible-server restore --resource-group testgroup --name testservernew --source-server testserver --storage-type PremiumV2_LRS
 """
 
+helps['postgres flexible-server maintenance-event'] = """
+type: group
+short-summary: Manage maintenance events for PostgreSQL flexible servers.
+"""
+
+helps['postgres flexible-server maintenance-event list'] = """
+type: command
+short-summary: List maintenance events for a flexible server.
+examples:
+  - name: List all maintenance events for a server.
+    text: az postgres flexible-server maintenance-event list --resource-group testgroup --server-name testserver
+  - name: List only upcoming maintenance events.
+    text: az postgres flexible-server maintenance-event list --resource-group testgroup --server-name testserver --maintenance-status Upcoming
+"""
+
+helps['postgres flexible-server maintenance-event show'] = """
+type: command
+short-summary: Show details of a maintenance event.
+examples:
+  - name: Get a maintenance event by ID.
+    text: az postgres flexible-server maintenance-event show --resource-group testgroup --server-name testserver --maintenance-event-id XXXX-111
+"""
+
+helps['postgres flexible-server maintenance-event reschedule'] = """
+type: command
+short-summary: Reschedule a maintenance event to a new UTC datetime.
+examples:
+  - name: Reschedule a maintenance event.
+    text: az postgres flexible-server maintenance-event reschedule --resource-group testgroup --server-name testserver --maintenance-event-id XXXX-111 --start-time 2026-04-10T10:00:00+00:00
+"""
+
+helps['postgres flexible-server maintenance-event apply-now'] = """
+type: command
+short-summary: Apply a maintenance event immediately.
+examples:
+  - name: Apply a maintenance event now.
+    text: az postgres flexible-server maintenance-event apply-now --resource-group testgroup --server-name testserver --maintenance-event-id XXXX-111
+"""
+
 helps['postgres flexible-server restart'] = """
 type: command
 short-summary: Restart a flexible server.

--- a/src/azure-cli/azure/cli/command_modules/postgresql/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/_params.py
@@ -659,7 +659,7 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
             c.argument('maintenance_status', arg_type=maintenance_status_arg_type)
             c.ignore('ids')
 
-        for scope in ['show', 'reschedule', 'apply-now', 'wait']:
+        for scope in ['show', 'reschedule', 'apply-now']:
             with self.argument_context('{} flexible-server maintenance-event {}'.format(command_group, scope)) as c:
                 c.argument('maintenance_event_id', arg_type=maintenance_event_id_arg_type)
 

--- a/src/azure-cli/azure/cli/command_modules/postgresql/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/_params.py
@@ -657,8 +657,9 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
 
         with self.argument_context('{} flexible-server maintenance-event list'.format(command_group)) as c:
             c.argument('maintenance_status', arg_type=maintenance_status_arg_type)
+            c.ignore('ids')
 
-        for scope in ['show', 'reschedule', 'apply-now']:
+        for scope in ['show', 'reschedule', 'apply-now', 'wait']:
             with self.argument_context('{} flexible-server maintenance-event {}'.format(command_group, scope)) as c:
                 c.argument('maintenance_event_id', arg_type=maintenance_event_id_arg_type)
 

--- a/src/azure-cli/azure/cli/command_modules/postgresql/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/_params.py
@@ -372,6 +372,23 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
             help='The read replicas the virtual endpoints point to.'
         )
 
+        maintenance_event_id_arg_type = CLIArgumentType(
+            options_list=['--maintenance-event-id'],
+            id_part='child_name_1',
+            help='The maintenance event identifier.'
+        )
+
+        maintenance_status_arg_type = CLIArgumentType(
+            options_list=['--maintenance-status'],
+            arg_type=get_enum_type(['Upcoming', 'Past']),
+            help='Filter maintenance events by status.'
+        )
+
+        start_time_arg_type = CLIArgumentType(
+            options_list=['--start-time', '-t'],
+            help='New UTC start time to target rescheduling maintenance (ISO8601 format), e.g., 2026-04-10T10:00:00+00:00.'
+        )
+
         with self.argument_context('{} flexible-server'.format(command_group)) as c:
             c.argument('resource_group_name', arg_type=resource_group_name_type)
             c.argument('server_name', arg_type=server_name_arg_type)
@@ -633,6 +650,20 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
 
         with self.argument_context('{} flexible-server backup delete'.format(command_group)) as c:
             c.argument('yes', arg_type=yes_arg_type)
+
+        # maintenance-event
+        with self.argument_context('{} flexible-server maintenance-event'.format(command_group)) as c:
+            c.argument('server_name', arg_type=server_name_resource_arg_type)
+
+        with self.argument_context('{} flexible-server maintenance-event list'.format(command_group)) as c:
+            c.argument('maintenance_status', arg_type=maintenance_status_arg_type)
+
+        for scope in ['show', 'reschedule', 'apply-now']:
+            with self.argument_context('{} flexible-server maintenance-event {}'.format(command_group, scope)) as c:
+                c.argument('maintenance_event_id', arg_type=maintenance_event_id_arg_type)
+
+        with self.argument_context('{} flexible-server maintenance-event reschedule'.format(command_group)) as c:
+            c.argument('start_time', arg_type=start_time_arg_type, required=True)
 
         # identity
         with self.argument_context('{} flexible-server identity'.format(command_group)) as c:

--- a/src/azure-cli/azure/cli/command_modules/postgresql/commands/maintenance_event_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/commands/maintenance_event_commands.py
@@ -1,0 +1,44 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+# pylint: disable=unused-argument, line-too-long
+from azure.cli.core.util import sdk_no_wait
+from ..utils.validators import validate_resource_group
+
+
+def flexible_server_maintenance_event_list(client, resource_group_name, server_name, maintenance_status=None):
+    validate_resource_group(resource_group_name)
+    return client.list(resource_group_name=resource_group_name,
+                       server_name=server_name,
+                       maintenance_status=maintenance_status)
+
+
+def flexible_server_maintenance_event_show(client, resource_group_name, server_name, maintenance_event_id):
+    validate_resource_group(resource_group_name)
+    return client.get(resource_group_name=resource_group_name,
+                      server_name=server_name,
+                      maintenance_event_id=maintenance_event_id)
+
+
+def flexible_server_maintenance_event_reschedule(client, resource_group_name, server_name,
+                                                 maintenance_event_id, start_time, no_wait=False):
+    validate_resource_group(resource_group_name)
+    body = {"postponeToDateTime": start_time}
+    return sdk_no_wait(no_wait,
+                       client.begin_reschedule,
+                       resource_group_name=resource_group_name,
+                       server_name=server_name,
+                       maintenance_event_id=maintenance_event_id,
+                       body=body)
+
+
+def flexible_server_maintenance_event_apply_now(client, resource_group_name, server_name,
+                                                maintenance_event_id, no_wait=False):
+    validate_resource_group(resource_group_name)
+    return sdk_no_wait(no_wait,
+                       client.begin_apply_now,
+                       resource_group_name=resource_group_name,
+                       server_name=server_name,
+                       maintenance_event_id=maintenance_event_id)

--- a/src/azure-cli/azure/cli/command_modules/postgresql/flexible_server_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/flexible_server_commands.py
@@ -19,7 +19,8 @@ from azure.cli.command_modules.postgresql._client_factory import (
     cf_postgres_flexible_virtual_endpoints,
     cf_postgres_flexible_server_threat_protection_settings,
     cf_postgres_flexible_advanced_threat_protection_settings,
-    cf_postgres_flexible_server_log_files)
+    cf_postgres_flexible_server_log_files,
+    cf_postgres_flexible_maintenance_events)
 from azure.cli.command_modules.postgresql.utils.validators import validate_private_endpoint_connection_id
 from azure.cli.command_modules.postgresql.utils._transformers import (
     table_transform_output,
@@ -99,6 +100,11 @@ def load_flexibleserver_command_table(self, _):
     postgres_flexible_server_log_files_sdk = CliCommandType(
         operations_tmpl='azure.mgmt.postgresqlflexibleservers.operations#CapturedLogsOperations.{}',
         client_factory=cf_postgres_flexible_server_log_files
+    )
+
+    postgres_flexible_maintenance_events_sdk = CliCommandType(
+        operations_tmpl='azure.mgmt.postgresqlflexibleservers.operations#MaintenanceEventsOperations.{}',
+        client_factory=cf_postgres_flexible_maintenance_events
     )
 
     postgres_flexible_server_private_endpoint_connections_sdk = CliCommandType(
@@ -289,6 +295,16 @@ def load_flexibleserver_command_table(self, _):
                             client_factory=cf_postgres_flexible_server_log_files) as g:
         g.custom_command('list', 'flexible_server_list_log_files_with_filter')
         g.custom_command('download', 'flexible_server_download_log_files')
+
+    maintenance_event_commands = CliCommandType(
+        operations_tmpl='azure.cli.command_modules.postgresql.commands.maintenance_event_commands#{}')
+    with self.command_group('postgres flexible-server maintenance-event', postgres_flexible_maintenance_events_sdk,
+                            custom_command_type=maintenance_event_commands,
+                            client_factory=cf_postgres_flexible_maintenance_events) as g:
+        g.custom_command('list', 'flexible_server_maintenance_event_list')
+        g.custom_command('show', 'flexible_server_maintenance_event_show')
+        g.custom_command('reschedule', 'flexible_server_maintenance_event_reschedule', supports_no_wait=True)
+        g.custom_command('apply-now', 'flexible_server_maintenance_event_apply_now', supports_no_wait=True)
 
     private_endpoint_commands = CliCommandType(
         operations_tmpl='azure.cli.command_modules.postgresql.commands.private_endpoint_commands#{}')

--- a/src/azure-cli/azure/cli/command_modules/postgresql/flexible_server_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/flexible_server_commands.py
@@ -305,6 +305,7 @@ def load_flexibleserver_command_table(self, _):
         g.custom_show_command('show', 'flexible_server_maintenance_event_show')
         g.custom_command('reschedule', 'flexible_server_maintenance_event_reschedule', supports_no_wait=True)
         g.custom_command('apply-now', 'flexible_server_maintenance_event_apply_now', supports_no_wait=True)
+        g.custom_wait_command('wait', 'flexible_server_maintenance_event_show')
 
     private_endpoint_commands = CliCommandType(
         operations_tmpl='azure.cli.command_modules.postgresql.commands.private_endpoint_commands#{}')

--- a/src/azure-cli/azure/cli/command_modules/postgresql/flexible_server_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/flexible_server_commands.py
@@ -305,7 +305,6 @@ def load_flexibleserver_command_table(self, _):
         g.custom_show_command('show', 'flexible_server_maintenance_event_show')
         g.custom_command('reschedule', 'flexible_server_maintenance_event_reschedule', supports_no_wait=True)
         g.custom_command('apply-now', 'flexible_server_maintenance_event_apply_now', supports_no_wait=True)
-        g.custom_wait_command('wait', 'flexible_server_maintenance_event_show')
 
     private_endpoint_commands = CliCommandType(
         operations_tmpl='azure.cli.command_modules.postgresql.commands.private_endpoint_commands#{}')

--- a/src/azure-cli/azure/cli/command_modules/postgresql/flexible_server_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/flexible_server_commands.py
@@ -302,7 +302,7 @@ def load_flexibleserver_command_table(self, _):
                             custom_command_type=maintenance_event_commands,
                             client_factory=cf_postgres_flexible_maintenance_events) as g:
         g.custom_command('list', 'flexible_server_maintenance_event_list')
-        g.custom_command('show', 'flexible_server_maintenance_event_show')
+        g.custom_show_command('show', 'flexible_server_maintenance_event_show')
         g.custom_command('reschedule', 'flexible_server_maintenance_event_reschedule', supports_no_wait=True)
         g.custom_command('apply-now', 'flexible_server_maintenance_event_apply_now', supports_no_wait=True)
 

--- a/src/azure-cli/azure/cli/command_modules/postgresql/linter_exclusions.yml
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/linter_exclusions.yml
@@ -38,4 +38,17 @@ postgres flexible-server replica list:
 postgres flexible-server revive-dropped:
     rule_exclusions:
       - missing_command_test_coverage
+postgres flexible-server maintenance-event apply-now:
+  rule_exclusions:
+  - missing_command_test_coverage
+postgres flexible-server maintenance-event list:
+  rule_exclusions:
+    - missing_command_test_coverage
+    - no_ids_for_list_commands
+postgres flexible-server maintenance-event reschedule:
+  rule_exclusions:
+    - missing_command_test_coverage
+postgres flexible-server maintenance-event show:
+  rule_exclusions:
+    - missing_command_test_coverage
 ...

--- a/src/azure-cli/azure/cli/command_modules/postgresql/tests/unit/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/tests/unit/__init__.py
@@ -1,0 +1,4 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------

--- a/src/azure-cli/azure/cli/command_modules/postgresql/tests/unit/test_maintenance_event_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/tests/unit/test_maintenance_event_commands.py
@@ -1,0 +1,283 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from azure.cli.command_modules.postgresql.commands.maintenance_event_commands import (
+    flexible_server_maintenance_event_list,
+    flexible_server_maintenance_event_show,
+    flexible_server_maintenance_event_reschedule,
+    flexible_server_maintenance_event_apply_now
+)
+
+
+class MaintenanceEventCommandsTest(unittest.TestCase):
+    """Unit tests for PostgreSQL maintenance event commands."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.mock_client = MagicMock()
+        self.resource_group = 'test-rg'
+        self.server_name = 'test-server'
+        self.maintenance_event_id = '9J10-M0G'
+
+    def _build_maintenance_event(self, status='Planned', start_time='2026-06-30T00:00:00+00:00'):
+        return {
+            'id': '/subscriptions/75a38c1d-5d35-4f26-b143-ad0c818e45a3/resourceGroups/{}/providers/Microsoft.DBforPostgreSQL/flexibleServers/{}/maintenanceEvents/{}'.format(
+                self.resource_group,
+                self.server_name,
+                self.maintenance_event_id,
+            ),
+            'name': self.maintenance_event_id,
+            'properties': {
+                'deferrable': True,
+                'deferralDeadline': '2026-07-12T00:00:00+00:00',
+                'description': 'Upcoming scheduled maintenance notification.',
+                'endTime': '2026-06-30T01:00:00+00:00',
+                'estimatedDowntime': 'PT3600S',
+                'lastUpdatedTime': '2026-06-22T20:15:20.785896+00:00',
+                'maintenanceEventId': self.maintenance_event_id,
+                'maintenanceType': 'PlannedMaintenance',
+                'originalStartTime': None,
+                'rescheduledFrom': '2026-06-28T00:00:00+00:00',
+                'startTime': start_time,
+                'status': status,
+            },
+            'resourceGroup': self.resource_group,
+            'systemData': None,
+            'type': 'Microsoft.DBforPostgreSQL/flexibleServers/maintenanceEvents',
+        }
+
+    def _build_reschedule_result(self, start_time='2026-07-19T11:00:00+00:00'):
+        return {
+            'appliedNow': False,
+            'lastUpdatedTime': '2026-06-26T18:21:26.302659+00:00',
+            'maintenanceEventId': self.maintenance_event_id,
+            'plannedEndTime': '2026-07-19T12:00:00+00:00',
+            'plannedStartTime': start_time,
+            'serverId': '/subscriptions/75a38c1d-5d35-4f26-b143-ad0c818e45a3/resourceGroups/{}/providers/Microsoft.DBforPostgreSQL/flexibleServers/{}'.format(
+                self.resource_group, self.server_name),
+            'status': 'Rescheduled',
+        }
+
+    def _build_apply_now_result(self):
+        return {
+            'appliedNow': True,
+            'lastUpdatedTime': '2026-06-26T18:24:09.877087+00:00',
+            'maintenanceEventId': self.maintenance_event_id,
+            'plannedEndTime': '2026-06-26T19:24:09.875518+00:00',
+            'plannedStartTime': '2026-06-26T18:24:09.875518+00:00',
+            'serverId': '/subscriptions/75a38c1d-5d35-4f26-b143-ad0c818e45a3/resourceGroups/{}/providers/Microsoft.DBforPostgreSQL/flexibleServers/{}'.format(
+                self.resource_group, self.server_name),
+            'status': 'Rescheduled',
+        }
+
+    def test_list_maintenance_events_all(self):
+        """Test listing all maintenance events."""
+        expected_events = [self._build_maintenance_event()]
+        self.mock_client.list.return_value = expected_events
+
+        result = flexible_server_maintenance_event_list(
+            self.mock_client,
+            self.resource_group,
+            self.server_name
+        )
+
+        self.assertEqual(result, expected_events)
+        self.mock_client.list.assert_called_once_with(
+            resource_group_name=self.resource_group,
+            server_name=self.server_name,
+            maintenance_status=None
+        )
+
+    def test_list_maintenance_events_with_status_filter(self):
+        """Test listing maintenance events with status filter."""
+        expected_events = [self._build_maintenance_event(status='Planned')]
+        self.mock_client.list.return_value = expected_events
+
+        result = flexible_server_maintenance_event_list(
+            self.mock_client,
+            self.resource_group,
+            self.server_name,
+            maintenance_status='Planned'
+        )
+
+        self.assertEqual(result, expected_events)
+        self.mock_client.list.assert_called_once_with(
+            resource_group_name=self.resource_group,
+            server_name=self.server_name,
+            maintenance_status='Planned'
+        )
+
+    def test_list_maintenance_events_empty(self):
+        """Test listing when no maintenance events exist."""
+        self.mock_client.list.return_value = []
+
+        result = flexible_server_maintenance_event_list(
+            self.mock_client,
+            self.resource_group,
+            self.server_name
+        )
+
+        self.assertEqual(result, [])
+
+    @patch('azure.cli.command_modules.postgresql.commands.maintenance_event_commands.validate_resource_group')
+    def test_show_maintenance_event(self, mock_validate):
+        """Test showing a specific maintenance event."""
+        expected_event = self._build_maintenance_event()
+        self.mock_client.get.return_value = expected_event
+
+        result = flexible_server_maintenance_event_show(
+            self.mock_client,
+            self.resource_group,
+            self.server_name,
+            self.maintenance_event_id
+        )
+
+        self.assertEqual(result, expected_event)
+        self.assertEqual(result['name'], self.maintenance_event_id)
+        self.assertEqual(result['resourceGroup'], self.resource_group)
+        self.assertEqual(result['type'], 'Microsoft.DBforPostgreSQL/flexibleServers/maintenanceEvents')
+        self.assertIsNone(result['systemData'])
+        props = result['properties']
+        self.assertEqual(props['maintenanceEventId'], self.maintenance_event_id)
+        self.assertEqual(props['maintenanceType'], 'PlannedMaintenance')
+        self.assertEqual(props['status'], 'Planned')
+        self.assertEqual(props['startTime'], '2026-06-30T00:00:00+00:00')
+        self.assertEqual(props['endTime'], '2026-06-30T01:00:00+00:00')
+        self.assertEqual(props['deferralDeadline'], '2026-07-12T00:00:00+00:00')
+        self.assertTrue(props['deferrable'])
+        self.assertIsNone(props['originalStartTime'])
+        self.mock_client.get.assert_called_once_with(
+            resource_group_name=self.resource_group,
+            server_name=self.server_name,
+            maintenance_event_id=self.maintenance_event_id
+        )
+        mock_validate.assert_called_once_with(self.resource_group)
+
+    @patch('azure.cli.command_modules.postgresql.commands.maintenance_event_commands.sdk_no_wait')
+    @patch('azure.cli.command_modules.postgresql.commands.maintenance_event_commands.validate_resource_group')
+    def test_reschedule_maintenance_event(self, mock_validate, mock_sdk_no_wait):
+        """Test rescheduling a maintenance event."""
+        new_start_time = '2026-07-19T11:00:00+00:00'
+        expected_result = self._build_reschedule_result(start_time=new_start_time)
+        mock_sdk_no_wait.return_value = expected_result
+
+        result = flexible_server_maintenance_event_reschedule(
+            self.mock_client,
+            self.resource_group,
+            self.server_name,
+            self.maintenance_event_id,
+            new_start_time,
+            no_wait=False
+        )
+
+        self.assertEqual(result, expected_result)
+        self.assertEqual(result['appliedNow'], False)
+        self.assertEqual(result['status'], 'Rescheduled')
+        self.assertEqual(result['plannedStartTime'], new_start_time)
+        self.assertEqual(result['maintenanceEventId'], self.maintenance_event_id)
+        mock_validate.assert_called_once_with(self.resource_group)
+        mock_sdk_no_wait.assert_called_once()
+
+        # Verify the call arguments to sdk_no_wait
+        call_args = mock_sdk_no_wait.call_args
+        self.assertEqual(call_args[0][0], False)  # no_wait parameter
+        self.assertEqual(call_args[1]['resource_group_name'], self.resource_group)
+        self.assertEqual(call_args[1]['server_name'], self.server_name)
+        self.assertEqual(call_args[1]['maintenance_event_id'], self.maintenance_event_id)
+        self.assertEqual(call_args[1]['body']['postponeToDateTime'], new_start_time)
+
+    @patch('azure.cli.command_modules.postgresql.commands.maintenance_event_commands.sdk_no_wait')
+    @patch('azure.cli.command_modules.postgresql.commands.maintenance_event_commands.validate_resource_group')
+    def test_reschedule_maintenance_event_no_wait(self, mock_validate, mock_sdk_no_wait):
+        """Test rescheduling a maintenance event with no_wait=True."""
+        new_start_time = '2026-07-19T11:00:00+00:00'
+        expected_result = self._build_reschedule_result(start_time=new_start_time)
+        mock_sdk_no_wait.return_value = expected_result
+
+        result = flexible_server_maintenance_event_reschedule(
+            self.mock_client,
+            self.resource_group,
+            self.server_name,
+            self.maintenance_event_id,
+            new_start_time,
+            no_wait=True
+        )
+
+        self.assertEqual(result, expected_result)
+        mock_validate.assert_called_once_with(self.resource_group)
+
+        # Verify no_wait=True was passed
+        call_args = mock_sdk_no_wait.call_args
+        self.assertEqual(call_args[0][0], True)
+
+    @patch('azure.cli.command_modules.postgresql.commands.maintenance_event_commands.sdk_no_wait')
+    @patch('azure.cli.command_modules.postgresql.commands.maintenance_event_commands.validate_resource_group')
+    def test_apply_now_maintenance_event(self, mock_validate, mock_sdk_no_wait):
+        """Test applying a maintenance event immediately."""
+        expected_result = self._build_apply_now_result()
+        mock_sdk_no_wait.return_value = expected_result
+
+        result = flexible_server_maintenance_event_apply_now(
+            self.mock_client,
+            self.resource_group,
+            self.server_name,
+            self.maintenance_event_id,
+            no_wait=False
+        )
+
+        self.assertEqual(result, expected_result)
+        self.assertEqual(result['appliedNow'], True)
+        self.assertEqual(result['status'], 'Rescheduled')
+        self.assertEqual(result['maintenanceEventId'], self.maintenance_event_id)
+        mock_validate.assert_called_once_with(self.resource_group)
+        mock_sdk_no_wait.assert_called_once()
+
+        # Verify the call arguments
+        call_args = mock_sdk_no_wait.call_args
+        self.assertEqual(call_args[0][0], False)  # no_wait parameter
+        self.assertEqual(call_args[1]['resource_group_name'], self.resource_group)
+        self.assertEqual(call_args[1]['server_name'], self.server_name)
+        self.assertEqual(call_args[1]['maintenance_event_id'], self.maintenance_event_id)
+
+    @patch('azure.cli.command_modules.postgresql.commands.maintenance_event_commands.sdk_no_wait')
+    @patch('azure.cli.command_modules.postgresql.commands.maintenance_event_commands.validate_resource_group')
+    def test_apply_now_maintenance_event_no_wait(self, mock_validate, mock_sdk_no_wait):
+        """Test applying a maintenance event with no_wait=True."""
+        expected_result = self._build_apply_now_result()
+        mock_sdk_no_wait.return_value = expected_result
+
+        result = flexible_server_maintenance_event_apply_now(
+            self.mock_client,
+            self.resource_group,
+            self.server_name,
+            self.maintenance_event_id,
+            no_wait=True
+        )
+
+        self.assertEqual(result, expected_result)
+
+        # Verify no_wait=True was passed
+        call_args = mock_sdk_no_wait.call_args
+        self.assertEqual(call_args[0][0], True)
+
+    @patch('azure.cli.command_modules.postgresql.commands.maintenance_event_commands.validate_resource_group')
+    def test_list_validates_resource_group(self, mock_validate):
+        """Test that list validates resource group."""
+        self.mock_client.list.return_value = []
+
+        flexible_server_maintenance_event_list(
+            self.mock_client,
+            self.resource_group,
+            self.server_name
+        )
+
+        mock_validate.assert_called_once_with(self.resource_group)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Related command**
`az postgresql flexible-server maintenance-event list`
`az postgresql flexible-server maintenance-event show`
`az postgresql flexible-server maintenance-event apply-now`
`az postgresql flexible-server maintenance-event reschedule`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
