### PR TITLE
{Misc} Modify CODEOWNERS to replace individual owners with squad teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,77 +1,77 @@
 # See for instructions on this file https://help.github.com/articles/about-codeowners/
 
-*help.py @necusjz @DanielMicrosoft @yonzhan
-*help.yaml @necusjz @DanielMicrosoft @yonzhan
-*help.yml @necusjz @DanielMicrosoft @yonzhan
+*help.py @Azure/act-quality-productivity-squad
+*help.yaml @Azure/act-quality-productivity-squad
+*help.yml @Azure/act-quality-productivity-squad
 
-/linter_exclusions.yml @naga-nandyala @yonzhan @wangzelin007 @a0x1ab
+/linter_exclusions.yml @Azure/act-platform-engineering-squad @Azure/act-experience-enablement-squad
 
-/doc/ @necusjz @DanielMicrosoft @yonzhan
-/tools/ @naga-nandyala @yonzhan @wangzelin007 @a0x1ab @VeryEarly @Pan-Qi @jsntcy @YangAn-microsoft
-/tools/aaz-flow @a0x1ab @necusjz @VeryEarly @Pan-Qi @jsntcy @YangAn-microsoft
-/scripts/ @naga-nandyala @yonzhan @wangzelin007 @a0x1ab @VeryEarly @Pan-Qi @jsntcy @YangAn-microsoft
-/scripts/live_test @naga-nandyala @yonzhan @wangzelin007
-/src/azure-cli-testsdk/ @necusjz @DanielMicrosoft @yonzhan
+/doc/ @Azure/act-quality-productivity-squad
+/tools/ @Azure/act-platform-engineering-squad @Azure/act-experience-enablement-squad @Azure/act-codegen-extensibility-squad
+/tools/aaz-flow @Azure/act-experience-enablement-squad @Azure/act-codegen-extensibility-squad
+/scripts/ @Azure/act-platform-engineering-squad @Azure/act-experience-enablement-squad @Azure/act-codegen-extensibility-squad
+/scripts/live_test @Azure/act-platform-engineering-squad
+/src/azure-cli-testsdk/ @Azure/act-quality-productivity-squad
 
-/src/azure-cli-core/ @necusjz @DanielMicrosoft @yonzhan @Azure/act-identity-squad @jsntcy @YangAn-microsoft @VeryEarly @Pan-Qi
+/src/azure-cli-core/ @Azure/act-codegen-extensibility-squad @Azure/act-quality-productivity-squad @Azure/act-platform-engineering-squad @Azure/act-identity-squad
 /src/azure-cli-core/azure/cli/core/_profile.py @Azure/act-identity-squad
 /src/azure-cli-core/azure/cli/core/auth/ @Azure/act-identity-squad
 /src/azure-cli-core/azure/cli/core/cloud.py @Azure/act-identity-squad
-/src/azure-cli-core/azure/cli/core/extension/ @VeryEarly @Pan-Qi @jsntcy @necusjz @YangAn-microsoft
-/src/azure-cli-core/azure/cli/core/style.py @NoriZC @yanzhudd @teresaritorto
-/src/azure-cli-core/azure/cli/core/aaz/ @VeryEarly @Pan-Qi @jsntcy @necusjz @YangAn-microsoft
+/src/azure-cli-core/azure/cli/core/extension/ @Azure/act-codegen-extensibility-squad
+/src/azure-cli-core/azure/cli/core/style.py @Azure/act-observability-squad
+/src/azure-cli-core/azure/cli/core/aaz/ @Azure/act-codegen-extensibility-squad
 
-/src/azure-cli/ @necusjz @DanielMicrosoft @yonzhan @jsntcy @YangAn-microsoft @VeryEarly @Pan-Qi
+/src/azure-cli/ @Azure/act-codegen-extensibility-squad @Azure/act-quality-productivity-squad @Azure/act-platform-engineering-squad
 
-/src/azure-cli-core/setup.py @necusjz @DanielMicrosoft @yonzhan @Azure/act-identity-squad @jsntcy @YangAn-microsoft @VeryEarly @Pan-Qi
-/src/azure-cli/setup.py @Azure/act-identity-squad @jsntcy @YangAn-microsoft @VeryEarly @Pan-Qi
-/src/azure-cli/requirements.*.txt @necusjz @DanielMicrosoft @yonzhan @Azure/act-identity-squad @jsntcy @YangAn-microsoft @VeryEarly @Pan-Qi
+/src/azure-cli-core/setup.py @Azure/act-codegen-extensibility-squad @Azure/act-quality-productivity-squad @Azure/act-platform-engineering-squad @Azure/act-identity-squad
+/src/azure-cli/setup.py @Azure/act-identity-squad @Azure/act-codegen-extensibility-squad
+/src/azure-cli/requirements.*.txt @Azure/act-codegen-extensibility-squad @Azure/act-quality-productivity-squad @Azure/act-platform-engineering-squad @Azure/act-identity-squad
 
-/src/azure-cli/azure/cli/command_modules/acr/ @NoriZC @yanzhudd @teresaritorto @northtyphoon @rosanch
-/src/azure-cli/azure/cli/command_modules/acs/ @NoriZC @yanzhudd @teresaritorto @fumingzhang @elvazhu521
-/src/azure-cli/azure/cli/command_modules/advisor/ @VeryEarly @Pan-Qi @jsntcy @Prasanna-Padmanabhan
-/src/azure-cli/azure/cli/command_modules/apim/ @NoriZC @yanzhudd @teresaritorto @kevinhillinger @jonlester
-/src/azure-cli/azure/cli/command_modules/appconfig/ @VeryEarly @Pan-Qi @jsntcy @ChristineWanjau @albertofori @avanigupta @mrm9084
-/src/azure-cli/azure/cli/command_modules/appservice/ @NoriZC @yanzhudd @teresaritorto @panchagnula
-/src/azure-cli/azure/cli/command_modules/aro/ @VeryEarly @Pan-Qi @jsntcy @bennerv @hawkowl @jewzaam @rogbas @necusjz
-/src/azure-cli/azure/cli/command_modules/backup/ @NoriZC @yanzhudd @teresaritorto @dragonfly91 @akshayneema
-/src/azure-cli/azure/cli/command_modules/batch/ @NoriZC @yanzhudd @teresaritorto @cRui861 @wanghoppe @dpwatrous @wiboris
-/src/azure-cli/azure/cli/command_modules/batchai/ @VeryEarly @Pan-Qi @jsntcy @AlexanderYukhanov
-/src/azure-cli/azure/cli/command_modules/botservice/ @jsntcy @jiaxuwu2021 @luhan2017 @wangzelin007 @a0x1ab @coopercox-ms
-/src/azure-cli/azure/cli/command_modules/cdn/ @necusjz @DanielMicrosoft @yonzhan @t-bzhan
+/src/azure-cli/azure/cli/command_modules/acr/ @Azure/act-observability-squad @northtyphoon @rosanch
+/src/azure-cli/azure/cli/command_modules/acs/ @Azure/act-observability-squad @fumingzhang @elvazhu521
+/src/azure-cli/azure/cli/command_modules/advisor/ @Azure/act-codegen-extensibility-squad @Prasanna-Padmanabhan
+/src/azure-cli/azure/cli/command_modules/apim/ @Azure/act-observability-squad @kevinhillinger @jonlester
+/src/azure-cli/azure/cli/command_modules/appconfig/ @Azure/act-codegen-extensibility-squad @ChristineWanjau @albertofori @avanigupta @mrm9084
+/src/azure-cli/azure/cli/command_modules/appservice/ @Azure/act-observability-squad @panchagnula
+/src/azure-cli/azure/cli/command_modules/aro/ @Azure/act-codegen-extensibility-squad @bennerv @hawkowl @jewzaam @rogbas
+/src/azure-cli/azure/cli/command_modules/backup/ @Azure/act-observability-squad @dragonfly91 @akshayneema
+/src/azure-cli/azure/cli/command_modules/batch/ @Azure/act-observability-squad @cRui861 @wanghoppe @dpwatrous @wiboris
+/src/azure-cli/azure/cli/command_modules/batchai/ @Azure/act-codegen-extensibility-squad @AlexanderYukhanov
+/src/azure-cli/azure/cli/command_modules/botservice/ @Azure/act-experience-enablement-squad @jiaxuwu2021 @luhan2017
+/src/azure-cli/azure/cli/command_modules/cdn/ @Azure/act-quality-productivity-squad @t-bzhan
 /src/azure-cli/azure/cli/command_modules/cloud/ @Azure/act-identity-squad
-/src/azure-cli/azure/cli/command_modules/consumption/ @VeryEarly @Pan-Qi @jsntcy @sandeepnl
-/src/azure-cli/azure/cli/command_modules/container/ @NoriZC @yanzhudd @teresaritorto @joseph-porter
-/src/azure-cli/azure/cli/command_modules/cosmosdb/ @VeryEarly @Pan-Qi @jsntcy @dmakwana @kristynhamasaki @YangAn-microsoft
-/src/azure-cli/azure/cli/command_modules/databoxedge/ @VeryEarly @Pan-Qi @jsntcy @YangAn-microsoft
-/src/azure-cli/azure/cli/command_modules/dls/ @VeryEarly @Pan-Qi @jsntcy @akharit @rahuldutta90 @YangAn-microsoft
-/src/azure-cli/azure/cli/command_modules/dms/ @VeryEarly @Pan-Qi @jsntcy @temandr @binuj @YangAn-microsoft
-/src/azure-cli/azure/cli/command_modules/eventgrid/ @NoriZC @yanzhudd @teresaritorto @VidyaKukke
-/src/azure-cli/azure/cli/command_modules/eventhubs/ @NoriZC @yanzhudd @teresaritorto @v-ajnava
-/src/azure-cli/azure/cli/command_modules/extension/ @VeryEarly @Pan-Qi @jsntcy @YangAn-microsoft
-/src/azure-cli/azure/cli/command_modules/feedback/ @VeryEarly @Pan-Qi @jsntcy
-/src/azure-cli/azure/cli/command_modules/hdinsight/ @VeryEarly @Pan-Qi @jsntcy @aim-for-better
+/src/azure-cli/azure/cli/command_modules/consumption/ @Azure/act-codegen-extensibility-squad @sandeepnl
+/src/azure-cli/azure/cli/command_modules/container/ @Azure/act-observability-squad @joseph-porter
+/src/azure-cli/azure/cli/command_modules/cosmosdb/ @Azure/act-codegen-extensibility-squad @dmakwana @kristynhamasaki
+/src/azure-cli/azure/cli/command_modules/databoxedge/ @Azure/act-codegen-extensibility-squad
+/src/azure-cli/azure/cli/command_modules/dls/ @Azure/act-codegen-extensibility-squad @akharit @rahuldutta90
+/src/azure-cli/azure/cli/command_modules/dms/ @Azure/act-codegen-extensibility-squad @temandr @binuj
+/src/azure-cli/azure/cli/command_modules/eventgrid/ @Azure/act-observability-squad @VidyaKukke
+/src/azure-cli/azure/cli/command_modules/eventhubs/ @Azure/act-observability-squad @v-ajnava
+/src/azure-cli/azure/cli/command_modules/extension/ @Azure/act-codegen-extensibility-squad
+/src/azure-cli/azure/cli/command_modules/feedback/ @Azure/act-codegen-extensibility-squad
+/src/azure-cli/azure/cli/command_modules/hdinsight/ @Azure/act-codegen-extensibility-squad @aim-for-better
 /src/azure-cli/azure/cli/command_modules/identity/ @Azure/act-identity-squad
-/src/azure-cli/azure/cli/command_modules/iot/ @NoriZC @yanzhudd @teresaritorto @digimaun
+/src/azure-cli/azure/cli/command_modules/iot/ @Azure/act-observability-squad @digimaun
 /src/azure-cli/azure/cli/command_modules/keyvault/ @Azure/act-identity-squad
-/src/azure-cli/azure/cli/command_modules/monitor/ @NoriZC @yanzhudd @teresaritorto
-/src/azure-cli/azure/cli/command_modules/mysql/ @VeryEarly @Pan-Qi @jsntcy @honghr @YangAn-microsoft
-/src/azure-cli/azure/cli/command_modules/natgateway/ @necusjz @DanielMicrosoft @yonzhan @khannarheams
-/src/azure-cli/azure/cli/command_modules/network/ @necusjz @DanielMicrosoft @yonzhan
+/src/azure-cli/azure/cli/command_modules/monitor/ @Azure/act-observability-squad
+/src/azure-cli/azure/cli/command_modules/mysql/ @Azure/act-codegen-extensibility-squad @honghr
+/src/azure-cli/azure/cli/command_modules/natgateway/ @Azure/act-quality-productivity-squad @khannarheams
+/src/azure-cli/azure/cli/command_modules/network/ @Azure/act-quality-productivity-squad
 /src/azure-cli/azure/cli/command_modules/policyinsights/ @Azure/act-identity-squad @cheggert
-/src/azure-cli/azure/cli/command_modules/postgresql/ @VeryEarly @Pan-Qi @jsntcy @arde0708 @YangAn-microsoft
-/src/azure-cli/azure/cli/command_modules/privatedns/ @necusjz @DanielMicrosoft @yonzhan
+/src/azure-cli/azure/cli/command_modules/postgresql/ @Azure/act-codegen-extensibility-squad @arde0708
+/src/azure-cli/azure/cli/command_modules/privatedns/ @Azure/act-quality-productivity-squad
 /src/azure-cli/azure/cli/command_modules/profile/ @Azure/act-identity-squad
-/src/azure-cli/azure/cli/command_modules/rdbms/ @VeryEarly @Pan-Qi @jsntcy @arde0708 @alanenriqueo @YangAn-microsoft
+/src/azure-cli/azure/cli/command_modules/rdbms/ @Azure/act-codegen-extensibility-squad @arde0708 @alanenriqueo
 /src/azure-cli/azure/cli/command_modules/resource/ @Azure/act-identity-squad
 /src/azure-cli/azure/cli/command_modules/role/ @Azure/act-identity-squad
-/src/azure-cli/azure/cli/command_modules/search/ @VeryEarly @Pan-Qi @jsntcy @huangbolun
-/src/azure-cli/azure/cli/command_modules/servicebus/ @NoriZC @yanzhudd @teresaritorto @v-ajnava
-/src/azure-cli/azure/cli/command_modules/serviceconnector/ @VeryEarly @Pan-Qi @jsntcy @yungezz @houk-ms @xfz11
-/src/azure-cli/azure/cli/command_modules/servicefabric/ @NoriZC @yanzhudd @teresaritorto @QingChenmsft
-/src/azure-cli/azure/cli/command_modules/sql/ @VeryEarly @Pan-Qi @jsntcy @jaredmoo @YangAn-microsoft
-/src/azure-cli/azure/cli/command_modules/storage/ @VeryEarly @Pan-Qi @jsntcy @YangAn-microsoft
-/src/azure-cli/azure/cli/command_modules/synapse/ @jsntcy @idear1203 @zesluo @wangzelin007 @a0x1ab @coopercox-ms
-/src/azure-cli/azure/cli/command_modules/util/ @naga-nandyala @yonzhan @wangzelin007
-/src/azure-cli/azure/cli/command_modules/vm/ @NoriZC @yanzhudd @teresaritorto @Drewm3 @TravisCragg-MSFT @nikhilpatel909 @sandeepraichura @hilaryw29 @GabstaMSFT @ramankumarlive @ushnaarshadkhan
-/src/azure-cli/azure/cli/command_modules/containerapp/ @NoriZC @yanzhudd @teresaritorto @ruslany @sanchitmehta @ebencarek @JennyLawrance @howang-ms @vinisoto @chinadragon0515 @vturecek @torosent @pagariyaalok @Juliehzl @jijohn14 @Greedygre @ShichaoQiu
+/src/azure-cli/azure/cli/command_modules/search/ @Azure/act-codegen-extensibility-squad @huangbolun
+/src/azure-cli/azure/cli/command_modules/servicebus/ @Azure/act-observability-squad @v-ajnava
+/src/azure-cli/azure/cli/command_modules/serviceconnector/ @Azure/act-codegen-extensibility-squad @yungezz @houk-ms @xfz11
+/src/azure-cli/azure/cli/command_modules/servicefabric/ @Azure/act-observability-squad @QingChenmsft
+/src/azure-cli/azure/cli/command_modules/sql/ @Azure/act-codegen-extensibility-squad @jaredmoo
+/src/azure-cli/azure/cli/command_modules/storage/ @Azure/act-codegen-extensibility-squad
+/src/azure-cli/azure/cli/command_modules/synapse/ @Azure/act-experience-enablement-squad @idear1203 @zesluo
+/src/azure-cli/azure/cli/command_modules/util/ @Azure/act-platform-engineering-squad
+/src/azure-cli/azure/cli/command_modules/vm/ @Azure/act-observability-squad @Drewm3 @TravisCragg-MSFT @nikhilpatel909 @sandeepraichura @hilaryw29 @GabstaMSFT @ramankumarlive @ushnaarshadkhan
+/src/azure-cli/azure/cli/command_modules/containerapp/ @Azure/act-observability-squad @ruslany @sanchitmehta @ebencarek @JennyLawrance @howang-ms @vinisoto @chinadragon0515 @vturecek @torosent @pagariyaalok @Juliehzl @jijohn14 @Greedygre @ShichaoQiu


### PR DESCRIPTION
**Related command**
N/A

**Description**
Rewrites `.github/CODEOWNERS` to assign ownership to ACT squad teams instead of listing individuals. For each line, where at least two members of the same team are present, the individuals are replaced with the team handle (`@Azure/act-*-squad`) and those members are removed; remaining non-team individuals and pre-existing team handles are preserved. Team membership was resolved live from GitHub.

**Testing Guide**
Tested in https://github.com/Azure/azure-cli/pull/33665 that the change still aligns with how we want to do PR reviews

**History Notes**
N/A