### PR TITLE
[Network] `az network nat gateway`: Add `--nat64` to enable/disable NAT64 on StandardV2 NAT gateway

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/nat/gateway/_create.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/nat/gateway/_create.py
@@ -142,12 +142,6 @@ class Create(AAZCommand):
             help="Whether Nat64 is enabled for the NAT gateway resource.",
             enum={"Disabled": "Disabled", "Enabled": "Enabled", "None": "None"},
         )
-        _args_schema.service_gateway = AAZObjectArg(
-            options=["--service-gateway"],
-            arg_group="Properties",
-            help="Reference to an existing service gateway.",
-        )
-        cls._build_args_common_sub_resource_create(_args_schema.service_gateway)
         return cls._args_schema
 
     _args_common_sub_resource_create = None
@@ -288,7 +282,6 @@ class Create(AAZCommand):
                 properties.set_prop("publicIpAddressesV6", AAZListType, ".pip_addrs_v6")
                 properties.set_prop("publicIpPrefixes", AAZListType, ".pip_prefixes")
                 properties.set_prop("publicIpPrefixesV6", AAZListType, ".pip_prefs_v6")
-                _CreateHelper._build_schema_common_sub_resource_create(properties.set_prop("serviceGateway", AAZObjectType, ".service_gateway"))
                 _CreateHelper._build_schema_common_sub_resource_create(properties.set_prop("sourceVirtualNetwork", AAZObjectType, ".source_vnet"))
 
             public_ip_addresses = _builder.get(".properties.publicIpAddresses")

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/nat/gateway/_create.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/nat/gateway/_create.py
@@ -22,9 +22,9 @@ class Create(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2024-07-01",
+        "version": "2025-07-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/natgateways/{}", "2024-07-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/natgateways/{}", "2025-07-01"],
         ]
     }
 
@@ -83,7 +83,7 @@ class Create(AAZCommand):
             options=["--source-vnet"],
             help="A reference to the source virtual network using this nat gateway resource.",
         )
-        cls._build_args_sub_resource_create(_args_schema.source_vnet)
+        cls._build_args_common_sub_resource_create(_args_schema.source_vnet)
         _args_schema.sku = AAZStrArg(
             options=["--sku"],
             help="Name of Nat Gateway SKU.",
@@ -110,7 +110,7 @@ class Create(AAZCommand):
 
         pip_addrs_v6 = cls._args_schema.pip_addrs_v6
         pip_addrs_v6.Element = AAZObjectArg()
-        cls._build_args_sub_resource_create(pip_addrs_v6.Element)
+        cls._build_args_common_sub_resource_create(pip_addrs_v6.Element)
 
         pip_prefixes = cls._args_schema.pip_prefixes
         pip_prefixes.Element = AAZObjectArg()
@@ -123,7 +123,7 @@ class Create(AAZCommand):
 
         pip_prefs_v6 = cls._args_schema.pip_prefs_v6
         pip_prefs_v6.Element = AAZObjectArg()
-        cls._build_args_sub_resource_create(pip_prefs_v6.Element)
+        cls._build_args_common_sub_resource_create(pip_prefs_v6.Element)
 
         tags = cls._args_schema.tags
         tags.Element = AAZStrArg()
@@ -132,25 +132,41 @@ class Create(AAZCommand):
         zone.Element = AAZStrArg()
 
         # define Arg Group "Parameters"
+
+        # define Arg Group "Properties"
+
+        _args_schema = cls._args_schema
+        _args_schema.nat64 = AAZStrArg(
+            options=["--nat64"],
+            arg_group="Properties",
+            help="Whether Nat64 is enabled for the NAT gateway resource.",
+            enum={"Disabled": "Disabled", "Enabled": "Enabled", "None": "None"},
+        )
+        _args_schema.service_gateway = AAZObjectArg(
+            options=["--service-gateway"],
+            arg_group="Properties",
+            help="Reference to an existing service gateway.",
+        )
+        cls._build_args_common_sub_resource_create(_args_schema.service_gateway)
         return cls._args_schema
 
-    _args_sub_resource_create = None
+    _args_common_sub_resource_create = None
 
     @classmethod
-    def _build_args_sub_resource_create(cls, _schema):
-        if cls._args_sub_resource_create is not None:
-            _schema.id = cls._args_sub_resource_create.id
+    def _build_args_common_sub_resource_create(cls, _schema):
+        if cls._args_common_sub_resource_create is not None:
+            _schema.id = cls._args_common_sub_resource_create.id
             return
 
-        cls._args_sub_resource_create = AAZObjectArg()
+        cls._args_common_sub_resource_create = AAZObjectArg()
 
-        sub_resource_create = cls._args_sub_resource_create
-        sub_resource_create.id = AAZStrArg(
+        common_sub_resource_create = cls._args_common_sub_resource_create
+        common_sub_resource_create.id = AAZStrArg(
             options=["id"],
             help="Resource ID.",
         )
 
-        _schema.id = cls._args_sub_resource_create.id
+        _schema.id = cls._args_common_sub_resource_create.id
 
     def _execute_operations(self):
         self.pre_operations()
@@ -233,7 +249,7 @@ class Create(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2024-07-01",
+                    "api-version", "2025-07-01",
                     required=True,
                 ),
             }
@@ -267,11 +283,13 @@ class Create(AAZCommand):
             properties = _builder.get(".properties")
             if properties is not None:
                 properties.set_prop("idleTimeoutInMinutes", AAZIntType, ".idle_timeout")
+                properties.set_prop("nat64", AAZStrType, ".nat64")
                 properties.set_prop("publicIpAddresses", AAZListType, ".pip_addresses")
                 properties.set_prop("publicIpAddressesV6", AAZListType, ".pip_addrs_v6")
                 properties.set_prop("publicIpPrefixes", AAZListType, ".pip_prefixes")
                 properties.set_prop("publicIpPrefixesV6", AAZListType, ".pip_prefs_v6")
-                _CreateHelper._build_schema_sub_resource_create(properties.set_prop("sourceVirtualNetwork", AAZObjectType, ".source_vnet"))
+                _CreateHelper._build_schema_common_sub_resource_create(properties.set_prop("serviceGateway", AAZObjectType, ".service_gateway"))
+                _CreateHelper._build_schema_common_sub_resource_create(properties.set_prop("sourceVirtualNetwork", AAZObjectType, ".source_vnet"))
 
             public_ip_addresses = _builder.get(".properties.publicIpAddresses")
             if public_ip_addresses is not None:
@@ -283,7 +301,7 @@ class Create(AAZCommand):
 
             public_ip_addresses_v6 = _builder.get(".properties.publicIpAddressesV6")
             if public_ip_addresses_v6 is not None:
-                _CreateHelper._build_schema_sub_resource_create(public_ip_addresses_v6.set_elements(AAZObjectType, "."))
+                _CreateHelper._build_schema_common_sub_resource_create(public_ip_addresses_v6.set_elements(AAZObjectType, "."))
 
             public_ip_prefixes = _builder.get(".properties.publicIpPrefixes")
             if public_ip_prefixes is not None:
@@ -295,7 +313,7 @@ class Create(AAZCommand):
 
             public_ip_prefixes_v6 = _builder.get(".properties.publicIpPrefixesV6")
             if public_ip_prefixes_v6 is not None:
-                _CreateHelper._build_schema_sub_resource_create(public_ip_prefixes_v6.set_elements(AAZObjectType, "."))
+                _CreateHelper._build_schema_common_sub_resource_create(public_ip_prefixes_v6.set_elements(AAZObjectType, "."))
 
             sku = _builder.get(".sku")
             if sku is not None:
@@ -351,6 +369,7 @@ class Create(AAZCommand):
             properties.idle_timeout_in_minutes = AAZIntType(
                 serialized_name="idleTimeoutInMinutes",
             )
+            properties.nat64 = AAZStrType()
             properties.provisioning_state = AAZStrType(
                 serialized_name="provisioningState",
                 flags={"read_only": True},
@@ -371,33 +390,37 @@ class Create(AAZCommand):
                 serialized_name="resourceGuid",
                 flags={"read_only": True},
             )
+            properties.service_gateway = AAZObjectType(
+                serialized_name="serviceGateway",
+            )
+            _CreateHelper._build_schema_common_sub_resource_read(properties.service_gateway)
             properties.source_virtual_network = AAZObjectType(
                 serialized_name="sourceVirtualNetwork",
             )
-            _CreateHelper._build_schema_sub_resource_read(properties.source_virtual_network)
+            _CreateHelper._build_schema_common_sub_resource_read(properties.source_virtual_network)
             properties.subnets = AAZListType(
                 flags={"read_only": True},
             )
 
             public_ip_addresses = cls._schema_on_200_201.properties.public_ip_addresses
             public_ip_addresses.Element = AAZObjectType()
-            _CreateHelper._build_schema_sub_resource_read(public_ip_addresses.Element)
+            _CreateHelper._build_schema_common_sub_resource_read(public_ip_addresses.Element)
 
             public_ip_addresses_v6 = cls._schema_on_200_201.properties.public_ip_addresses_v6
             public_ip_addresses_v6.Element = AAZObjectType()
-            _CreateHelper._build_schema_sub_resource_read(public_ip_addresses_v6.Element)
+            _CreateHelper._build_schema_common_sub_resource_read(public_ip_addresses_v6.Element)
 
             public_ip_prefixes = cls._schema_on_200_201.properties.public_ip_prefixes
             public_ip_prefixes.Element = AAZObjectType()
-            _CreateHelper._build_schema_sub_resource_read(public_ip_prefixes.Element)
+            _CreateHelper._build_schema_common_sub_resource_read(public_ip_prefixes.Element)
 
             public_ip_prefixes_v6 = cls._schema_on_200_201.properties.public_ip_prefixes_v6
             public_ip_prefixes_v6.Element = AAZObjectType()
-            _CreateHelper._build_schema_sub_resource_read(public_ip_prefixes_v6.Element)
+            _CreateHelper._build_schema_common_sub_resource_read(public_ip_prefixes_v6.Element)
 
             subnets = cls._schema_on_200_201.properties.subnets
             subnets.Element = AAZObjectType()
-            _CreateHelper._build_schema_sub_resource_read(subnets.Element)
+            _CreateHelper._build_schema_common_sub_resource_read(subnets.Element)
 
             sku = cls._schema_on_200_201.sku
             sku.name = AAZStrType()
@@ -415,25 +438,25 @@ class _CreateHelper:
     """Helper class for Create"""
 
     @classmethod
-    def _build_schema_sub_resource_create(cls, _builder):
+    def _build_schema_common_sub_resource_create(cls, _builder):
         if _builder is None:
             return
         _builder.set_prop("id", AAZStrType, ".id")
 
-    _schema_sub_resource_read = None
+    _schema_common_sub_resource_read = None
 
     @classmethod
-    def _build_schema_sub_resource_read(cls, _schema):
-        if cls._schema_sub_resource_read is not None:
-            _schema.id = cls._schema_sub_resource_read.id
+    def _build_schema_common_sub_resource_read(cls, _schema):
+        if cls._schema_common_sub_resource_read is not None:
+            _schema.id = cls._schema_common_sub_resource_read.id
             return
 
-        cls._schema_sub_resource_read = _schema_sub_resource_read = AAZObjectType()
+        cls._schema_common_sub_resource_read = _schema_common_sub_resource_read = AAZObjectType()
 
-        sub_resource_read = _schema_sub_resource_read
-        sub_resource_read.id = AAZStrType()
+        common_sub_resource_read = _schema_common_sub_resource_read
+        common_sub_resource_read.id = AAZStrType()
 
-        _schema.id = cls._schema_sub_resource_read.id
+        _schema.id = cls._schema_common_sub_resource_read.id
 
 
 __all__ = ["Create"]

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/nat/gateway/_delete.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/nat/gateway/_delete.py
@@ -22,9 +22,9 @@ class Delete(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2024-07-01",
+        "version": "2025-07-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/natgateways/{}", "2024-07-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/natgateways/{}", "2025-07-01"],
         ]
     }
 
@@ -142,7 +142,7 @@ class Delete(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2024-07-01",
+                    "api-version", "2025-07-01",
                     required=True,
                 ),
             }

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/nat/gateway/_list.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/nat/gateway/_list.py
@@ -22,10 +22,10 @@ class List(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2024-07-01",
+        "version": "2025-07-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/providers/microsoft.network/natgateways", "2024-07-01"],
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/natgateways", "2024-07-01"],
+            ["mgmt-plane", "/subscriptions/{}/providers/microsoft.network/natgateways", "2025-07-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/natgateways", "2025-07-01"],
         ]
     }
 
@@ -112,7 +112,7 @@ class List(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2024-07-01",
+                    "api-version", "2025-07-01",
                     required=True,
                 ),
             }
@@ -148,7 +148,9 @@ class List(AAZCommand):
             _schema_on_200.next_link = AAZStrType(
                 serialized_name="nextLink",
             )
-            _schema_on_200.value = AAZListType()
+            _schema_on_200.value = AAZListType(
+                flags={"required": True},
+            )
 
             value = cls._schema_on_200.value
             value.Element = AAZObjectType()
@@ -176,6 +178,7 @@ class List(AAZCommand):
             properties.idle_timeout_in_minutes = AAZIntType(
                 serialized_name="idleTimeoutInMinutes",
             )
+            properties.nat64 = AAZStrType()
             properties.provisioning_state = AAZStrType(
                 serialized_name="provisioningState",
                 flags={"read_only": True},
@@ -196,33 +199,37 @@ class List(AAZCommand):
                 serialized_name="resourceGuid",
                 flags={"read_only": True},
             )
+            properties.service_gateway = AAZObjectType(
+                serialized_name="serviceGateway",
+            )
+            _ListHelper._build_schema_common_sub_resource_read(properties.service_gateway)
             properties.source_virtual_network = AAZObjectType(
                 serialized_name="sourceVirtualNetwork",
             )
-            _ListHelper._build_schema_sub_resource_read(properties.source_virtual_network)
+            _ListHelper._build_schema_common_sub_resource_read(properties.source_virtual_network)
             properties.subnets = AAZListType(
                 flags={"read_only": True},
             )
 
             public_ip_addresses = cls._schema_on_200.value.Element.properties.public_ip_addresses
             public_ip_addresses.Element = AAZObjectType()
-            _ListHelper._build_schema_sub_resource_read(public_ip_addresses.Element)
+            _ListHelper._build_schema_common_sub_resource_read(public_ip_addresses.Element)
 
             public_ip_addresses_v6 = cls._schema_on_200.value.Element.properties.public_ip_addresses_v6
             public_ip_addresses_v6.Element = AAZObjectType()
-            _ListHelper._build_schema_sub_resource_read(public_ip_addresses_v6.Element)
+            _ListHelper._build_schema_common_sub_resource_read(public_ip_addresses_v6.Element)
 
             public_ip_prefixes = cls._schema_on_200.value.Element.properties.public_ip_prefixes
             public_ip_prefixes.Element = AAZObjectType()
-            _ListHelper._build_schema_sub_resource_read(public_ip_prefixes.Element)
+            _ListHelper._build_schema_common_sub_resource_read(public_ip_prefixes.Element)
 
             public_ip_prefixes_v6 = cls._schema_on_200.value.Element.properties.public_ip_prefixes_v6
             public_ip_prefixes_v6.Element = AAZObjectType()
-            _ListHelper._build_schema_sub_resource_read(public_ip_prefixes_v6.Element)
+            _ListHelper._build_schema_common_sub_resource_read(public_ip_prefixes_v6.Element)
 
             subnets = cls._schema_on_200.value.Element.properties.subnets
             subnets.Element = AAZObjectType()
-            _ListHelper._build_schema_sub_resource_read(subnets.Element)
+            _ListHelper._build_schema_common_sub_resource_read(subnets.Element)
 
             sku = cls._schema_on_200.value.Element.sku
             sku.name = AAZStrType()
@@ -279,7 +286,7 @@ class List(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2024-07-01",
+                    "api-version", "2025-07-01",
                     required=True,
                 ),
             }
@@ -315,7 +322,9 @@ class List(AAZCommand):
             _schema_on_200.next_link = AAZStrType(
                 serialized_name="nextLink",
             )
-            _schema_on_200.value = AAZListType()
+            _schema_on_200.value = AAZListType(
+                flags={"required": True},
+            )
 
             value = cls._schema_on_200.value
             value.Element = AAZObjectType()
@@ -343,6 +352,7 @@ class List(AAZCommand):
             properties.idle_timeout_in_minutes = AAZIntType(
                 serialized_name="idleTimeoutInMinutes",
             )
+            properties.nat64 = AAZStrType()
             properties.provisioning_state = AAZStrType(
                 serialized_name="provisioningState",
                 flags={"read_only": True},
@@ -363,33 +373,37 @@ class List(AAZCommand):
                 serialized_name="resourceGuid",
                 flags={"read_only": True},
             )
+            properties.service_gateway = AAZObjectType(
+                serialized_name="serviceGateway",
+            )
+            _ListHelper._build_schema_common_sub_resource_read(properties.service_gateway)
             properties.source_virtual_network = AAZObjectType(
                 serialized_name="sourceVirtualNetwork",
             )
-            _ListHelper._build_schema_sub_resource_read(properties.source_virtual_network)
+            _ListHelper._build_schema_common_sub_resource_read(properties.source_virtual_network)
             properties.subnets = AAZListType(
                 flags={"read_only": True},
             )
 
             public_ip_addresses = cls._schema_on_200.value.Element.properties.public_ip_addresses
             public_ip_addresses.Element = AAZObjectType()
-            _ListHelper._build_schema_sub_resource_read(public_ip_addresses.Element)
+            _ListHelper._build_schema_common_sub_resource_read(public_ip_addresses.Element)
 
             public_ip_addresses_v6 = cls._schema_on_200.value.Element.properties.public_ip_addresses_v6
             public_ip_addresses_v6.Element = AAZObjectType()
-            _ListHelper._build_schema_sub_resource_read(public_ip_addresses_v6.Element)
+            _ListHelper._build_schema_common_sub_resource_read(public_ip_addresses_v6.Element)
 
             public_ip_prefixes = cls._schema_on_200.value.Element.properties.public_ip_prefixes
             public_ip_prefixes.Element = AAZObjectType()
-            _ListHelper._build_schema_sub_resource_read(public_ip_prefixes.Element)
+            _ListHelper._build_schema_common_sub_resource_read(public_ip_prefixes.Element)
 
             public_ip_prefixes_v6 = cls._schema_on_200.value.Element.properties.public_ip_prefixes_v6
             public_ip_prefixes_v6.Element = AAZObjectType()
-            _ListHelper._build_schema_sub_resource_read(public_ip_prefixes_v6.Element)
+            _ListHelper._build_schema_common_sub_resource_read(public_ip_prefixes_v6.Element)
 
             subnets = cls._schema_on_200.value.Element.properties.subnets
             subnets.Element = AAZObjectType()
-            _ListHelper._build_schema_sub_resource_read(subnets.Element)
+            _ListHelper._build_schema_common_sub_resource_read(subnets.Element)
 
             sku = cls._schema_on_200.value.Element.sku
             sku.name = AAZStrType()
@@ -406,20 +420,20 @@ class List(AAZCommand):
 class _ListHelper:
     """Helper class for List"""
 
-    _schema_sub_resource_read = None
+    _schema_common_sub_resource_read = None
 
     @classmethod
-    def _build_schema_sub_resource_read(cls, _schema):
-        if cls._schema_sub_resource_read is not None:
-            _schema.id = cls._schema_sub_resource_read.id
+    def _build_schema_common_sub_resource_read(cls, _schema):
+        if cls._schema_common_sub_resource_read is not None:
+            _schema.id = cls._schema_common_sub_resource_read.id
             return
 
-        cls._schema_sub_resource_read = _schema_sub_resource_read = AAZObjectType()
+        cls._schema_common_sub_resource_read = _schema_common_sub_resource_read = AAZObjectType()
 
-        sub_resource_read = _schema_sub_resource_read
-        sub_resource_read.id = AAZStrType()
+        common_sub_resource_read = _schema_common_sub_resource_read
+        common_sub_resource_read.id = AAZStrType()
 
-        _schema.id = cls._schema_sub_resource_read.id
+        _schema.id = cls._schema_common_sub_resource_read.id
 
 
 __all__ = ["List"]

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/nat/gateway/_show.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/nat/gateway/_show.py
@@ -25,9 +25,9 @@ class Show(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2024-07-01",
+        "version": "2025-07-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/natgateways/{}", "2024-07-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/natgateways/{}", "2025-07-01"],
         ]
     }
 
@@ -123,7 +123,7 @@ class Show(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2024-07-01",
+                    "api-version", "2025-07-01",
                     required=True,
                 ),
             }
@@ -178,6 +178,7 @@ class Show(AAZCommand):
             properties.idle_timeout_in_minutes = AAZIntType(
                 serialized_name="idleTimeoutInMinutes",
             )
+            properties.nat64 = AAZStrType()
             properties.provisioning_state = AAZStrType(
                 serialized_name="provisioningState",
                 flags={"read_only": True},
@@ -198,33 +199,37 @@ class Show(AAZCommand):
                 serialized_name="resourceGuid",
                 flags={"read_only": True},
             )
+            properties.service_gateway = AAZObjectType(
+                serialized_name="serviceGateway",
+            )
+            _ShowHelper._build_schema_common_sub_resource_read(properties.service_gateway)
             properties.source_virtual_network = AAZObjectType(
                 serialized_name="sourceVirtualNetwork",
             )
-            _ShowHelper._build_schema_sub_resource_read(properties.source_virtual_network)
+            _ShowHelper._build_schema_common_sub_resource_read(properties.source_virtual_network)
             properties.subnets = AAZListType(
                 flags={"read_only": True},
             )
 
             public_ip_addresses = cls._schema_on_200.properties.public_ip_addresses
             public_ip_addresses.Element = AAZObjectType()
-            _ShowHelper._build_schema_sub_resource_read(public_ip_addresses.Element)
+            _ShowHelper._build_schema_common_sub_resource_read(public_ip_addresses.Element)
 
             public_ip_addresses_v6 = cls._schema_on_200.properties.public_ip_addresses_v6
             public_ip_addresses_v6.Element = AAZObjectType()
-            _ShowHelper._build_schema_sub_resource_read(public_ip_addresses_v6.Element)
+            _ShowHelper._build_schema_common_sub_resource_read(public_ip_addresses_v6.Element)
 
             public_ip_prefixes = cls._schema_on_200.properties.public_ip_prefixes
             public_ip_prefixes.Element = AAZObjectType()
-            _ShowHelper._build_schema_sub_resource_read(public_ip_prefixes.Element)
+            _ShowHelper._build_schema_common_sub_resource_read(public_ip_prefixes.Element)
 
             public_ip_prefixes_v6 = cls._schema_on_200.properties.public_ip_prefixes_v6
             public_ip_prefixes_v6.Element = AAZObjectType()
-            _ShowHelper._build_schema_sub_resource_read(public_ip_prefixes_v6.Element)
+            _ShowHelper._build_schema_common_sub_resource_read(public_ip_prefixes_v6.Element)
 
             subnets = cls._schema_on_200.properties.subnets
             subnets.Element = AAZObjectType()
-            _ShowHelper._build_schema_sub_resource_read(subnets.Element)
+            _ShowHelper._build_schema_common_sub_resource_read(subnets.Element)
 
             sku = cls._schema_on_200.sku
             sku.name = AAZStrType()
@@ -241,20 +246,20 @@ class Show(AAZCommand):
 class _ShowHelper:
     """Helper class for Show"""
 
-    _schema_sub_resource_read = None
+    _schema_common_sub_resource_read = None
 
     @classmethod
-    def _build_schema_sub_resource_read(cls, _schema):
-        if cls._schema_sub_resource_read is not None:
-            _schema.id = cls._schema_sub_resource_read.id
+    def _build_schema_common_sub_resource_read(cls, _schema):
+        if cls._schema_common_sub_resource_read is not None:
+            _schema.id = cls._schema_common_sub_resource_read.id
             return
 
-        cls._schema_sub_resource_read = _schema_sub_resource_read = AAZObjectType()
+        cls._schema_common_sub_resource_read = _schema_common_sub_resource_read = AAZObjectType()
 
-        sub_resource_read = _schema_sub_resource_read
-        sub_resource_read.id = AAZStrType()
+        common_sub_resource_read = _schema_common_sub_resource_read
+        common_sub_resource_read.id = AAZStrType()
 
-        _schema.id = cls._schema_sub_resource_read.id
+        _schema.id = cls._schema_common_sub_resource_read.id
 
 
 __all__ = ["Show"]

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/nat/gateway/_update.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/nat/gateway/_update.py
@@ -22,9 +22,9 @@ class Update(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2024-07-01",
+        "version": "2025-07-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/natgateways/{}", "2024-07-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/natgateways/{}", "2025-07-01"],
         ]
     }
 
@@ -86,7 +86,7 @@ class Update(AAZCommand):
             help="A reference to the source virtual network using this nat gateway resource.",
             nullable=True,
         )
-        cls._build_args_sub_resource_update(_args_schema.source_vnet)
+        cls._build_args_common_sub_resource_update(_args_schema.source_vnet)
         _args_schema.tags = AAZDictArg(
             options=["--tags"],
             help="Space-separated tags: key[=value] [key[=value] ...].",
@@ -109,7 +109,7 @@ class Update(AAZCommand):
         pip_addrs_v6.Element = AAZObjectArg(
             nullable=True,
         )
-        cls._build_args_sub_resource_update(pip_addrs_v6.Element)
+        cls._build_args_common_sub_resource_update(pip_addrs_v6.Element)
 
         pip_prefixes = cls._args_schema.pip_prefixes
         pip_prefixes.Element = AAZObjectArg(
@@ -127,7 +127,7 @@ class Update(AAZCommand):
         pip_prefs_v6.Element = AAZObjectArg(
             nullable=True,
         )
-        cls._build_args_sub_resource_update(pip_prefs_v6.Element)
+        cls._build_args_common_sub_resource_update(pip_prefs_v6.Element)
 
         tags = cls._args_schema.tags
         tags.Element = AAZStrArg(
@@ -135,28 +135,46 @@ class Update(AAZCommand):
         )
 
         # define Arg Group "Parameters"
+
+        # define Arg Group "Properties"
+
+        _args_schema = cls._args_schema
+        _args_schema.nat64 = AAZStrArg(
+            options=["--nat64"],
+            arg_group="Properties",
+            help="Whether Nat64 is enabled for the NAT gateway resource.",
+            nullable=True,
+            enum={"Disabled": "Disabled", "Enabled": "Enabled", "None": "None"},
+        )
+        _args_schema.service_gateway = AAZObjectArg(
+            options=["--service-gateway"],
+            arg_group="Properties",
+            help="Reference to an existing service gateway.",
+            nullable=True,
+        )
+        cls._build_args_common_sub_resource_update(_args_schema.service_gateway)
         return cls._args_schema
 
-    _args_sub_resource_update = None
+    _args_common_sub_resource_update = None
 
     @classmethod
-    def _build_args_sub_resource_update(cls, _schema):
-        if cls._args_sub_resource_update is not None:
-            _schema.id = cls._args_sub_resource_update.id
+    def _build_args_common_sub_resource_update(cls, _schema):
+        if cls._args_common_sub_resource_update is not None:
+            _schema.id = cls._args_common_sub_resource_update.id
             return
 
-        cls._args_sub_resource_update = AAZObjectArg(
+        cls._args_common_sub_resource_update = AAZObjectArg(
             nullable=True,
         )
 
-        sub_resource_update = cls._args_sub_resource_update
-        sub_resource_update.id = AAZStrArg(
+        common_sub_resource_update = cls._args_common_sub_resource_update
+        common_sub_resource_update.id = AAZStrArg(
             options=["id"],
             help="Resource ID.",
             nullable=True,
         )
 
-        _schema.id = cls._args_sub_resource_update.id
+        _schema.id = cls._args_common_sub_resource_update.id
 
     def _execute_operations(self):
         self.pre_operations()
@@ -236,7 +254,7 @@ class Update(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2024-07-01",
+                    "api-version", "2025-07-01",
                     required=True,
                 ),
             }
@@ -267,7 +285,7 @@ class Update(AAZCommand):
                 return cls._schema_on_200
 
             cls._schema_on_200 = AAZObjectType()
-            _UpdateHelper._build_schema_nat_gateway_read(cls._schema_on_200)
+            _UpdateHelper._build_schema_common_nat_gateway_read(cls._schema_on_200)
 
             return cls._schema_on_200
 
@@ -335,7 +353,7 @@ class Update(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2024-07-01",
+                    "api-version", "2025-07-01",
                     required=True,
                 ),
             }
@@ -378,7 +396,7 @@ class Update(AAZCommand):
                 return cls._schema_on_200_201
 
             cls._schema_on_200_201 = AAZObjectType()
-            _UpdateHelper._build_schema_nat_gateway_read(cls._schema_on_200_201)
+            _UpdateHelper._build_schema_common_nat_gateway_read(cls._schema_on_200_201)
 
             return cls._schema_on_200_201
 
@@ -399,11 +417,13 @@ class Update(AAZCommand):
             properties = _builder.get(".properties")
             if properties is not None:
                 properties.set_prop("idleTimeoutInMinutes", AAZIntType, ".idle_timeout")
+                properties.set_prop("nat64", AAZStrType, ".nat64")
                 properties.set_prop("publicIpAddresses", AAZListType, ".pip_addresses")
                 properties.set_prop("publicIpAddressesV6", AAZListType, ".pip_addrs_v6")
                 properties.set_prop("publicIpPrefixes", AAZListType, ".pip_prefixes")
                 properties.set_prop("publicIpPrefixesV6", AAZListType, ".pip_prefs_v6")
-                _UpdateHelper._build_schema_sub_resource_update(properties.set_prop("sourceVirtualNetwork", AAZObjectType, ".source_vnet"))
+                _UpdateHelper._build_schema_common_sub_resource_update(properties.set_prop("serviceGateway", AAZObjectType, ".service_gateway"))
+                _UpdateHelper._build_schema_common_sub_resource_update(properties.set_prop("sourceVirtualNetwork", AAZObjectType, ".source_vnet"))
 
             public_ip_addresses = _builder.get(".properties.publicIpAddresses")
             if public_ip_addresses is not None:
@@ -415,7 +435,7 @@ class Update(AAZCommand):
 
             public_ip_addresses_v6 = _builder.get(".properties.publicIpAddressesV6")
             if public_ip_addresses_v6 is not None:
-                _UpdateHelper._build_schema_sub_resource_update(public_ip_addresses_v6.set_elements(AAZObjectType, "."))
+                _UpdateHelper._build_schema_common_sub_resource_update(public_ip_addresses_v6.set_elements(AAZObjectType, "."))
 
             public_ip_prefixes = _builder.get(".properties.publicIpPrefixes")
             if public_ip_prefixes is not None:
@@ -427,7 +447,7 @@ class Update(AAZCommand):
 
             public_ip_prefixes_v6 = _builder.get(".properties.publicIpPrefixesV6")
             if public_ip_prefixes_v6 is not None:
-                _UpdateHelper._build_schema_sub_resource_update(public_ip_prefixes_v6.set_elements(AAZObjectType, "."))
+                _UpdateHelper._build_schema_common_sub_resource_update(public_ip_prefixes_v6.set_elements(AAZObjectType, "."))
 
             tags = _builder.get(".tags")
             if tags is not None:
@@ -448,52 +468,53 @@ class _UpdateHelper:
     """Helper class for Update"""
 
     @classmethod
-    def _build_schema_sub_resource_update(cls, _builder):
+    def _build_schema_common_sub_resource_update(cls, _builder):
         if _builder is None:
             return
         _builder.set_prop("id", AAZStrType, ".id")
 
-    _schema_nat_gateway_read = None
+    _schema_common_nat_gateway_read = None
 
     @classmethod
-    def _build_schema_nat_gateway_read(cls, _schema):
-        if cls._schema_nat_gateway_read is not None:
-            _schema.etag = cls._schema_nat_gateway_read.etag
-            _schema.id = cls._schema_nat_gateway_read.id
-            _schema.location = cls._schema_nat_gateway_read.location
-            _schema.name = cls._schema_nat_gateway_read.name
-            _schema.properties = cls._schema_nat_gateway_read.properties
-            _schema.sku = cls._schema_nat_gateway_read.sku
-            _schema.tags = cls._schema_nat_gateway_read.tags
-            _schema.type = cls._schema_nat_gateway_read.type
-            _schema.zones = cls._schema_nat_gateway_read.zones
+    def _build_schema_common_nat_gateway_read(cls, _schema):
+        if cls._schema_common_nat_gateway_read is not None:
+            _schema.etag = cls._schema_common_nat_gateway_read.etag
+            _schema.id = cls._schema_common_nat_gateway_read.id
+            _schema.location = cls._schema_common_nat_gateway_read.location
+            _schema.name = cls._schema_common_nat_gateway_read.name
+            _schema.properties = cls._schema_common_nat_gateway_read.properties
+            _schema.sku = cls._schema_common_nat_gateway_read.sku
+            _schema.tags = cls._schema_common_nat_gateway_read.tags
+            _schema.type = cls._schema_common_nat_gateway_read.type
+            _schema.zones = cls._schema_common_nat_gateway_read.zones
             return
 
-        cls._schema_nat_gateway_read = _schema_nat_gateway_read = AAZObjectType()
+        cls._schema_common_nat_gateway_read = _schema_common_nat_gateway_read = AAZObjectType()
 
-        nat_gateway_read = _schema_nat_gateway_read
-        nat_gateway_read.etag = AAZStrType(
+        common_nat_gateway_read = _schema_common_nat_gateway_read
+        common_nat_gateway_read.etag = AAZStrType(
             flags={"read_only": True},
         )
-        nat_gateway_read.id = AAZStrType()
-        nat_gateway_read.location = AAZStrType()
-        nat_gateway_read.name = AAZStrType(
+        common_nat_gateway_read.id = AAZStrType()
+        common_nat_gateway_read.location = AAZStrType()
+        common_nat_gateway_read.name = AAZStrType(
             flags={"read_only": True},
         )
-        nat_gateway_read.properties = AAZObjectType(
+        common_nat_gateway_read.properties = AAZObjectType(
             flags={"client_flatten": True},
         )
-        nat_gateway_read.sku = AAZObjectType()
-        nat_gateway_read.tags = AAZDictType()
-        nat_gateway_read.type = AAZStrType(
+        common_nat_gateway_read.sku = AAZObjectType()
+        common_nat_gateway_read.tags = AAZDictType()
+        common_nat_gateway_read.type = AAZStrType(
             flags={"read_only": True},
         )
-        nat_gateway_read.zones = AAZListType()
+        common_nat_gateway_read.zones = AAZListType()
 
-        properties = _schema_nat_gateway_read.properties
+        properties = _schema_common_nat_gateway_read.properties
         properties.idle_timeout_in_minutes = AAZIntType(
             serialized_name="idleTimeoutInMinutes",
         )
+        properties.nat64 = AAZStrType()
         properties.provisioning_state = AAZStrType(
             serialized_name="provisioningState",
             flags={"read_only": True},
@@ -514,67 +535,71 @@ class _UpdateHelper:
             serialized_name="resourceGuid",
             flags={"read_only": True},
         )
+        properties.service_gateway = AAZObjectType(
+            serialized_name="serviceGateway",
+        )
+        cls._build_schema_common_sub_resource_read(properties.service_gateway)
         properties.source_virtual_network = AAZObjectType(
             serialized_name="sourceVirtualNetwork",
         )
-        cls._build_schema_sub_resource_read(properties.source_virtual_network)
+        cls._build_schema_common_sub_resource_read(properties.source_virtual_network)
         properties.subnets = AAZListType(
             flags={"read_only": True},
         )
 
-        public_ip_addresses = _schema_nat_gateway_read.properties.public_ip_addresses
+        public_ip_addresses = _schema_common_nat_gateway_read.properties.public_ip_addresses
         public_ip_addresses.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(public_ip_addresses.Element)
+        cls._build_schema_common_sub_resource_read(public_ip_addresses.Element)
 
-        public_ip_addresses_v6 = _schema_nat_gateway_read.properties.public_ip_addresses_v6
+        public_ip_addresses_v6 = _schema_common_nat_gateway_read.properties.public_ip_addresses_v6
         public_ip_addresses_v6.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(public_ip_addresses_v6.Element)
+        cls._build_schema_common_sub_resource_read(public_ip_addresses_v6.Element)
 
-        public_ip_prefixes = _schema_nat_gateway_read.properties.public_ip_prefixes
+        public_ip_prefixes = _schema_common_nat_gateway_read.properties.public_ip_prefixes
         public_ip_prefixes.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(public_ip_prefixes.Element)
+        cls._build_schema_common_sub_resource_read(public_ip_prefixes.Element)
 
-        public_ip_prefixes_v6 = _schema_nat_gateway_read.properties.public_ip_prefixes_v6
+        public_ip_prefixes_v6 = _schema_common_nat_gateway_read.properties.public_ip_prefixes_v6
         public_ip_prefixes_v6.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(public_ip_prefixes_v6.Element)
+        cls._build_schema_common_sub_resource_read(public_ip_prefixes_v6.Element)
 
-        subnets = _schema_nat_gateway_read.properties.subnets
+        subnets = _schema_common_nat_gateway_read.properties.subnets
         subnets.Element = AAZObjectType()
-        cls._build_schema_sub_resource_read(subnets.Element)
+        cls._build_schema_common_sub_resource_read(subnets.Element)
 
-        sku = _schema_nat_gateway_read.sku
+        sku = _schema_common_nat_gateway_read.sku
         sku.name = AAZStrType()
 
-        tags = _schema_nat_gateway_read.tags
+        tags = _schema_common_nat_gateway_read.tags
         tags.Element = AAZStrType()
 
-        zones = _schema_nat_gateway_read.zones
+        zones = _schema_common_nat_gateway_read.zones
         zones.Element = AAZStrType()
 
-        _schema.etag = cls._schema_nat_gateway_read.etag
-        _schema.id = cls._schema_nat_gateway_read.id
-        _schema.location = cls._schema_nat_gateway_read.location
-        _schema.name = cls._schema_nat_gateway_read.name
-        _schema.properties = cls._schema_nat_gateway_read.properties
-        _schema.sku = cls._schema_nat_gateway_read.sku
-        _schema.tags = cls._schema_nat_gateway_read.tags
-        _schema.type = cls._schema_nat_gateway_read.type
-        _schema.zones = cls._schema_nat_gateway_read.zones
+        _schema.etag = cls._schema_common_nat_gateway_read.etag
+        _schema.id = cls._schema_common_nat_gateway_read.id
+        _schema.location = cls._schema_common_nat_gateway_read.location
+        _schema.name = cls._schema_common_nat_gateway_read.name
+        _schema.properties = cls._schema_common_nat_gateway_read.properties
+        _schema.sku = cls._schema_common_nat_gateway_read.sku
+        _schema.tags = cls._schema_common_nat_gateway_read.tags
+        _schema.type = cls._schema_common_nat_gateway_read.type
+        _schema.zones = cls._schema_common_nat_gateway_read.zones
 
-    _schema_sub_resource_read = None
+    _schema_common_sub_resource_read = None
 
     @classmethod
-    def _build_schema_sub_resource_read(cls, _schema):
-        if cls._schema_sub_resource_read is not None:
-            _schema.id = cls._schema_sub_resource_read.id
+    def _build_schema_common_sub_resource_read(cls, _schema):
+        if cls._schema_common_sub_resource_read is not None:
+            _schema.id = cls._schema_common_sub_resource_read.id
             return
 
-        cls._schema_sub_resource_read = _schema_sub_resource_read = AAZObjectType()
+        cls._schema_common_sub_resource_read = _schema_common_sub_resource_read = AAZObjectType()
 
-        sub_resource_read = _schema_sub_resource_read
-        sub_resource_read.id = AAZStrType()
+        common_sub_resource_read = _schema_common_sub_resource_read
+        common_sub_resource_read.id = AAZStrType()
 
-        _schema.id = cls._schema_sub_resource_read.id
+        _schema.id = cls._schema_common_sub_resource_read.id
 
 
 __all__ = ["Update"]

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/nat/gateway/_update.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/nat/gateway/_update.py
@@ -146,13 +146,6 @@ class Update(AAZCommand):
             nullable=True,
             enum={"Disabled": "Disabled", "Enabled": "Enabled", "None": "None"},
         )
-        _args_schema.service_gateway = AAZObjectArg(
-            options=["--service-gateway"],
-            arg_group="Properties",
-            help="Reference to an existing service gateway.",
-            nullable=True,
-        )
-        cls._build_args_common_sub_resource_update(_args_schema.service_gateway)
         return cls._args_schema
 
     _args_common_sub_resource_update = None
@@ -422,7 +415,6 @@ class Update(AAZCommand):
                 properties.set_prop("publicIpAddressesV6", AAZListType, ".pip_addrs_v6")
                 properties.set_prop("publicIpPrefixes", AAZListType, ".pip_prefixes")
                 properties.set_prop("publicIpPrefixesV6", AAZListType, ".pip_prefs_v6")
-                _UpdateHelper._build_schema_common_sub_resource_update(properties.set_prop("serviceGateway", AAZObjectType, ".service_gateway"))
                 _UpdateHelper._build_schema_common_sub_resource_update(properties.set_prop("sourceVirtualNetwork", AAZObjectType, ".source_vnet"))
 
             public_ip_addresses = _builder.get(".properties.publicIpAddresses")

--- a/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/nat/gateway/_wait.py
+++ b/src/azure-cli/azure/cli/command_modules/network/aaz/latest/network/nat/gateway/_wait.py
@@ -20,7 +20,7 @@ class Wait(AAZWaitCommand):
 
     _aaz_info = {
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/natgateways/{}", "2024-07-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/natgateways/{}", "2025-07-01"],
         ]
     }
 
@@ -116,7 +116,7 @@ class Wait(AAZWaitCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2024-07-01",
+                    "api-version", "2025-07-01",
                     required=True,
                 ),
             }
@@ -171,6 +171,7 @@ class Wait(AAZWaitCommand):
             properties.idle_timeout_in_minutes = AAZIntType(
                 serialized_name="idleTimeoutInMinutes",
             )
+            properties.nat64 = AAZStrType()
             properties.provisioning_state = AAZStrType(
                 serialized_name="provisioningState",
                 flags={"read_only": True},
@@ -191,33 +192,37 @@ class Wait(AAZWaitCommand):
                 serialized_name="resourceGuid",
                 flags={"read_only": True},
             )
+            properties.service_gateway = AAZObjectType(
+                serialized_name="serviceGateway",
+            )
+            _WaitHelper._build_schema_common_sub_resource_read(properties.service_gateway)
             properties.source_virtual_network = AAZObjectType(
                 serialized_name="sourceVirtualNetwork",
             )
-            _WaitHelper._build_schema_sub_resource_read(properties.source_virtual_network)
+            _WaitHelper._build_schema_common_sub_resource_read(properties.source_virtual_network)
             properties.subnets = AAZListType(
                 flags={"read_only": True},
             )
 
             public_ip_addresses = cls._schema_on_200.properties.public_ip_addresses
             public_ip_addresses.Element = AAZObjectType()
-            _WaitHelper._build_schema_sub_resource_read(public_ip_addresses.Element)
+            _WaitHelper._build_schema_common_sub_resource_read(public_ip_addresses.Element)
 
             public_ip_addresses_v6 = cls._schema_on_200.properties.public_ip_addresses_v6
             public_ip_addresses_v6.Element = AAZObjectType()
-            _WaitHelper._build_schema_sub_resource_read(public_ip_addresses_v6.Element)
+            _WaitHelper._build_schema_common_sub_resource_read(public_ip_addresses_v6.Element)
 
             public_ip_prefixes = cls._schema_on_200.properties.public_ip_prefixes
             public_ip_prefixes.Element = AAZObjectType()
-            _WaitHelper._build_schema_sub_resource_read(public_ip_prefixes.Element)
+            _WaitHelper._build_schema_common_sub_resource_read(public_ip_prefixes.Element)
 
             public_ip_prefixes_v6 = cls._schema_on_200.properties.public_ip_prefixes_v6
             public_ip_prefixes_v6.Element = AAZObjectType()
-            _WaitHelper._build_schema_sub_resource_read(public_ip_prefixes_v6.Element)
+            _WaitHelper._build_schema_common_sub_resource_read(public_ip_prefixes_v6.Element)
 
             subnets = cls._schema_on_200.properties.subnets
             subnets.Element = AAZObjectType()
-            _WaitHelper._build_schema_sub_resource_read(subnets.Element)
+            _WaitHelper._build_schema_common_sub_resource_read(subnets.Element)
 
             sku = cls._schema_on_200.sku
             sku.name = AAZStrType()
@@ -234,20 +239,20 @@ class Wait(AAZWaitCommand):
 class _WaitHelper:
     """Helper class for Wait"""
 
-    _schema_sub_resource_read = None
+    _schema_common_sub_resource_read = None
 
     @classmethod
-    def _build_schema_sub_resource_read(cls, _schema):
-        if cls._schema_sub_resource_read is not None:
-            _schema.id = cls._schema_sub_resource_read.id
+    def _build_schema_common_sub_resource_read(cls, _schema):
+        if cls._schema_common_sub_resource_read is not None:
+            _schema.id = cls._schema_common_sub_resource_read.id
             return
 
-        cls._schema_sub_resource_read = _schema_sub_resource_read = AAZObjectType()
+        cls._schema_common_sub_resource_read = _schema_common_sub_resource_read = AAZObjectType()
 
-        sub_resource_read = _schema_sub_resource_read
-        sub_resource_read.id = AAZStrType()
+        common_sub_resource_read = _schema_common_sub_resource_read
+        common_sub_resource_read.id = AAZStrType()
 
-        _schema.id = cls._schema_sub_resource_read.id
+        _schema.id = cls._schema_common_sub_resource_read.id
 
 
 __all__ = ["Wait"]

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_natgateway_basic.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_natgateway_basic.yaml
@@ -395,7 +395,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ng1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng1","etag":"W/\"bbdfa183-98fa-4869-811c-7382e405a346\"","type":"Microsoft.Network/natGateways","location":"eastus2","tags":{"foo":"bar"},"zones":["2"],"properties":{"provisioningState":"Updating","resourceGuid":"8621b98f-dcb1-428d-a04c-52b4799de3d6","idleTimeoutInMinutes":4,"scope":"Public","privateIPAddresses":[],"privateIPAddressesV6":[],"publicIpAddresses":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pip"}],"publicIpPrefixes":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPPrefixes/prefix"}]},"sku":{"name":"Standard","tier":"Regional"}}'
@@ -554,7 +554,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ng1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng1","etag":"W/\"91ac2cd0-2e17-49c2-94c7-8feea91cad3b\"","type":"Microsoft.Network/natGateways","location":"eastus2","tags":{"foo":"bar"},"zones":["2"],"properties":{"provisioningState":"Succeeded","resourceGuid":"8621b98f-dcb1-428d-a04c-52b4799de3d6","idleTimeoutInMinutes":4,"scope":"Public","privateIPAddresses":[],"privateIPAddressesV6":[],"publicIpAddresses":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pip"}],"publicIpPrefixes":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPPrefixes/prefix"}]},"sku":{"name":"Standard","tier":"Regional"}}'
@@ -604,7 +604,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ng1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng1","etag":"W/\"91ac2cd0-2e17-49c2-94c7-8feea91cad3b\"","type":"Microsoft.Network/natGateways","location":"eastus2","tags":{"foo":"bar"},"zones":["2"],"properties":{"provisioningState":"Succeeded","resourceGuid":"8621b98f-dcb1-428d-a04c-52b4799de3d6","idleTimeoutInMinutes":4,"scope":"Public","privateIPAddresses":[],"privateIPAddressesV6":[],"publicIpAddresses":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pip"}],"publicIpPrefixes":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPPrefixes/prefix"}]},"sku":{"name":"Standard","tier":"Regional"}}'
@@ -662,7 +662,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ng1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng1","etag":"W/\"801eda15-c401-4822-a99b-1e76ea18fd80\"","type":"Microsoft.Network/natGateways","location":"eastus2","tags":{"foo":"bar"},"zones":["2"],"properties":{"provisioningState":"Updating","resourceGuid":"8621b98f-dcb1-428d-a04c-52b4799de3d6","idleTimeoutInMinutes":5,"scope":"Public","privateIPAddresses":[],"privateIPAddressesV6":[],"publicIpAddresses":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pip"}],"publicIpPrefixes":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPPrefixes/prefix"}]},"sku":{"name":"Standard","tier":"Regional"}}'
@@ -768,7 +768,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ng1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng1","etag":"W/\"684f1be0-9635-413a-bce3-8a262accc03c\"","type":"Microsoft.Network/natGateways","location":"eastus2","tags":{"foo":"bar"},"zones":["2"],"properties":{"provisioningState":"Succeeded","resourceGuid":"8621b98f-dcb1-428d-a04c-52b4799de3d6","idleTimeoutInMinutes":5,"scope":"Public","privateIPAddresses":[],"privateIPAddressesV6":[],"publicIpAddresses":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pip"}],"publicIpPrefixes":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPPrefixes/prefix"}]},"sku":{"name":"Standard","tier":"Regional"}}'
@@ -818,7 +818,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways?api-version=2025-07-01
   response:
     body:
       string: '{"value":[{"name":"ng1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng1","etag":"W/\"684f1be0-9635-413a-bce3-8a262accc03c\"","type":"Microsoft.Network/natGateways","location":"eastus2","tags":{"foo":"bar"},"zones":["2"],"properties":{"provisioningState":"Succeeded","resourceGuid":"8621b98f-dcb1-428d-a04c-52b4799de3d6","idleTimeoutInMinutes":5,"scope":"Public","privateIPAddresses":[],"privateIPAddressesV6":[],"publicIpAddresses":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pip"}],"publicIpPrefixes":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPPrefixes/prefix"}]},"sku":{"name":"Standard","tier":"Regional"}}]}'
@@ -868,7 +868,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ng1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng1","etag":"W/\"684f1be0-9635-413a-bce3-8a262accc03c\"","type":"Microsoft.Network/natGateways","location":"eastus2","tags":{"foo":"bar"},"zones":["2"],"properties":{"provisioningState":"Succeeded","resourceGuid":"8621b98f-dcb1-428d-a04c-52b4799de3d6","idleTimeoutInMinutes":5,"scope":"Public","privateIPAddresses":[],"privateIPAddressesV6":[],"publicIpAddresses":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pip"}],"publicIpPrefixes":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPPrefixes/prefix"}]},"sku":{"name":"Standard","tier":"Regional"}}'
@@ -920,7 +920,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng1?api-version=2025-07-01
   response:
     body:
       string: ''
@@ -1080,7 +1080,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways?api-version=2025-07-01
   response:
     body:
       string: '{"value":[]}'
@@ -1176,7 +1176,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ng2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng2","etag":"W/\"4be99a54-3101-46bc-a33e-b6a60be48f8a\"","type":"Microsoft.Network/natGateways","location":"eastus2","zones":["1","2","3"],"properties":{"provisioningState":"Updating","resourceGuid":"3cd18b30-2fef-4ed1-a1d3-9f8847d77467","idleTimeoutInMinutes":4,"scope":"Public","privateIPAddresses":[],"privateIPAddressesV6":[]},"sku":{"name":"StandardV2","tier":"Regional"}}'
@@ -1282,7 +1282,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng2?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ng2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng2","etag":"W/\"3e1e3fdd-2546-4c7c-9247-33605a2d869a\"","type":"Microsoft.Network/natGateways","location":"eastus2","zones":["1","2","3"],"properties":{"provisioningState":"Succeeded","resourceGuid":"3cd18b30-2fef-4ed1-a1d3-9f8847d77467","idleTimeoutInMinutes":4,"scope":"Public","privateIPAddresses":[],"privateIPAddressesV6":[]},"sku":{"name":"StandardV2","tier":"Regional"}}'
@@ -1334,7 +1334,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng2?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng2?api-version=2025-07-01
   response:
     body:
       string: ''

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_natgateway_empty_create.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_natgateway_empty_create.yaml
@@ -20,7 +20,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.73.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ng1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng1","etag":"W/\"64c59881-d5e5-450e-99a0-0df463f7beb6\"","type":"Microsoft.Network/natGateways","location":"eastus2","tags":{"foo":"bar"},"zones":["2"],"properties":{"provisioningState":"Updating","resourceGuid":"085035a4-af71-4949-ab42-d2506d848d40","idleTimeoutInMinutes":4,"type":"Public"},"sku":{"name":"Standard","tier":"Regional"}}'
@@ -126,7 +126,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.73.0 azsdk-python-core/1.31.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng1?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng1?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ng1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng1","etag":"W/\"9faeeed8-1f22-4814-8cd3-860c801cefdd\"","type":"Microsoft.Network/natGateways","location":"eastus2","tags":{"foo":"bar"},"zones":["2"],"properties":{"provisioningState":"Succeeded","resourceGuid":"085035a4-af71-4949-ab42-d2506d848d40","idleTimeoutInMinutes":4,"type":"Public"},"sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_natgateway_nat64.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_natgateway_nat64.yaml
@@ -1,0 +1,712 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network nat gateway create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --sku --nat64
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2024-11-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"product":"azurecli","cause":"automation","test":"test_natgateway_nat64","date":"2026-06-30T03:51:13Z","module":"network"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '361'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 30 Jun 2026 03:51:23 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-msedge-ref:
+      - 'Ref A: 991E36D9C14041229FB87D5B834F302F Ref B: SG2AA1070303031 Ref C: 2026-06-30T03:51:23Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "eastus2", "properties": {"nat64": "Enabled"}, "sku": {"name":
+      "StandardV2"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network nat gateway create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '90'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -n --sku --nat64
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-nat64?api-version=2025-07-01
+  response:
+    body:
+      string: '{"name":"ng-nat64","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-nat64","etag":"W/\"0167e51b-b65c-4b3b-9b81-c2951112eef9\"","type":"Microsoft.Network/natGateways","location":"eastus2","properties":{"provisioningState":"Updating","resourceGuid":"d98863ba-1fc4-45f7-8f4b-6034ca4fdd4b","idleTimeoutInMinutes":4,"scope":"Public","flowlogs":{"logsVersions":{}},"nat64":"Enabled"},"sku":{"name":"StandardV2","tier":"Regional"}}'
+    headers:
+      azure-asyncnotification:
+      - Enabled
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus2/operations/42c11dd4-1c54-410f-b567-08f703cbad13?api-version=2025-07-01&t=639183882855882011&c=MIIHxDCCBqygAwIBAgIRAJbrgketDbWHLEx1EpPCeH4wDQYJKoZIhvcNAQELBQAwNTEzMDEGA1UEAxMqQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgQ1VTIENBIDAxMB4XDTI2MDQwODAwMDQ1MloXDTI2MTAwMzA2MDQ1MlowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDT3FOWry_6qK0dbuwtMK4T4HuDo_lxyL6jb91_Fr1VWY_VRVB7zp7HCgghkwofjjGAbbdIqDseNKJdMcooubZaRzrViDXEgbnaN8vC-4cZ4fjDUhtZh80l4sEyp_iBCPcY7I-xDOLiz7i1vlpvCL7tA0iKHuk6AAPDQk4fPmFWUwUWR3SajkDmuQjTPVWhQyEOJVGJNf6hvyBKFjGuXqSOk8prQb8yn6q8TftPg2b9zjlfxfHQEZqdePVaY7VeW2ljF2sUmWsNvQikg3g_Zh9I6j0tT0DW51c8CoF8PrVglMgLQVrYCdAeE30Fi0vIiXCT0XOP-0RYInckGEJqDB8JAgMBAAGjggTCMIIEvjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQZbVl_wKnmyxn5O2JcAqCDdVaL3zAfBgNVHSMEGDAWgBT85FoKL4UO50S5B3N44NREB6IZETCCAcoGA1UdHwSCAcEwggG9MG-gbaBrhmlodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvY2VudHJhbHVzL2NybHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvNTUvY3VycmVudC5jcmwwcaBvoG2Ga2h0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2NlbnRyYWx1cy9jcmxzL2NjbWVjZW50cmFsdXNwa2kvY2NtZWNlbnRyYWx1c2ljYTAxLzU1L2N1cnJlbnQuY3JsMGCgXqBchlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vY2VudHJhbHVzL2NybHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvNTUvY3VycmVudC5jcmwwdaBzoHGGb2h0dHA6Ly9jY21lY2VudHJhbHVzcGtpLmNlbnRyYWx1cy5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVjZW50cmFsdXNpY2EwMS81NS9jdXJyZW50LmNybDCCAc8GCCsGAQUFBwEBBIIBwTCCAb0wcgYIKwYBBQUHMAKGZmh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZW50cmFsdXMvY2FjZXJ0cy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjB0BggrBgEFBQcwAoZoaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvY2VudHJhbHVzL2NhY2VydHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvY2VydC5jZXIwYwYIKwYBBQUHMAKGV2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9jZW50cmFsdXMvY2FjZXJ0cy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjBsBggrBgEFBQcwAoZgaHR0cDovL2NjbWVjZW50cmFsdXNwa2kuY2VudHJhbHVzLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWNlbnRyYWx1c2ljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCJKCm8sITuRyQTfwfcPh1P_Y_FIoUY5rZqcJP5tAOTOk1M7UmZj3IhXCBuZfq1T1jLPVgMAAzHcyE4XjPrHalXdgSI6SJ0gq8I0X_ncsTkhomAsA5RU_sucWZ9nWgbXX-QDJi_bM0mzxsaKErSi607X1BM3DqI2SNMMgk6r2Ez8s8_vw6HLIGw7rLHx2D1muwevYyZ0dVgJa-VHCrBoSBL_ytZIofR5WUtbICE_9YIipUuxbnIRg9Vo_fv4cLzx0uLFk32vRKMroJ_zkJageE_exU-hNqZc7DSsWkROInmq7mMmyBvpTZB-q5PrEYUJi9zJZserlQTQG1e7u-Z7UEl&s=uP5EVuce9ND3TjWB5eaV4zWlJzgGgJ5Yecop-NuuCMchV2gx1qDOLaKVNEXmOCOrrrtgKIOTqZhAzK2bMzQ4cDCYvyuqHfcon6SYIrQ_-0rgto_oD5_nsxQV4PXV_zm-mA3R7iJirAmIin4b5V3DbULwGl_jvvzYz04YbfKokqBE7sCxqzXkNcc5VampCZl0ktNTQew6Z9ttfAV5JPQVCRLuqxcb08nAglA_LLiwON9Udn7Za3inKqzX0rdfthcl-dXp3U25tYMbSLViCOYSsM39TVSCZ6XQoeLz6B84OP1fgVXuqEUadDZFl_TeqUWqL3LsnoFkgkbLlNqTOwv9yQ&h=_ynrPKcafExNnqfb7ooT3FSo6GTz_sUuvrT-J1YQ6BQ
+      cache-control:
+      - no-cache
+      content-length:
+      - '508'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 30 Jun 2026 03:51:25 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 8b1aee7e-9943-4996-a264-1ef46c9e7eb3
+      x-ms-operation-identifier:
+      - tenantId=544a7a2e-697f-487c-b2b0-a13df7f346b6,objectId=73deb370-6e80-42b7-bab4-943c887d3e3c/eastus2/04ffc1e3-6b88-45cc-ba08-0d96ff8893ce
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '2999'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '199'
+      x-ms-throttle-levels:
+      - operationRatePct=0.1, operationConcurrencyPct=0.3, subscriptionWriteRatePct=0.1,
+        etc
+      x-msedge-ref:
+      - 'Ref A: F16D5DD63300495489120F8DF62C35FB Ref B: SG2AA1040520023 Ref C: 2026-06-30T03:51:24Z'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network nat gateway create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --sku --nat64
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus2/operations/42c11dd4-1c54-410f-b567-08f703cbad13?api-version=2025-07-01&t=639183882855882011&c=MIIHxDCCBqygAwIBAgIRAJbrgketDbWHLEx1EpPCeH4wDQYJKoZIhvcNAQELBQAwNTEzMDEGA1UEAxMqQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgQ1VTIENBIDAxMB4XDTI2MDQwODAwMDQ1MloXDTI2MTAwMzA2MDQ1MlowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDT3FOWry_6qK0dbuwtMK4T4HuDo_lxyL6jb91_Fr1VWY_VRVB7zp7HCgghkwofjjGAbbdIqDseNKJdMcooubZaRzrViDXEgbnaN8vC-4cZ4fjDUhtZh80l4sEyp_iBCPcY7I-xDOLiz7i1vlpvCL7tA0iKHuk6AAPDQk4fPmFWUwUWR3SajkDmuQjTPVWhQyEOJVGJNf6hvyBKFjGuXqSOk8prQb8yn6q8TftPg2b9zjlfxfHQEZqdePVaY7VeW2ljF2sUmWsNvQikg3g_Zh9I6j0tT0DW51c8CoF8PrVglMgLQVrYCdAeE30Fi0vIiXCT0XOP-0RYInckGEJqDB8JAgMBAAGjggTCMIIEvjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQZbVl_wKnmyxn5O2JcAqCDdVaL3zAfBgNVHSMEGDAWgBT85FoKL4UO50S5B3N44NREB6IZETCCAcoGA1UdHwSCAcEwggG9MG-gbaBrhmlodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvY2VudHJhbHVzL2NybHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvNTUvY3VycmVudC5jcmwwcaBvoG2Ga2h0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2NlbnRyYWx1cy9jcmxzL2NjbWVjZW50cmFsdXNwa2kvY2NtZWNlbnRyYWx1c2ljYTAxLzU1L2N1cnJlbnQuY3JsMGCgXqBchlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vY2VudHJhbHVzL2NybHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvNTUvY3VycmVudC5jcmwwdaBzoHGGb2h0dHA6Ly9jY21lY2VudHJhbHVzcGtpLmNlbnRyYWx1cy5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVjZW50cmFsdXNpY2EwMS81NS9jdXJyZW50LmNybDCCAc8GCCsGAQUFBwEBBIIBwTCCAb0wcgYIKwYBBQUHMAKGZmh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZW50cmFsdXMvY2FjZXJ0cy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjB0BggrBgEFBQcwAoZoaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvY2VudHJhbHVzL2NhY2VydHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvY2VydC5jZXIwYwYIKwYBBQUHMAKGV2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9jZW50cmFsdXMvY2FjZXJ0cy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjBsBggrBgEFBQcwAoZgaHR0cDovL2NjbWVjZW50cmFsdXNwa2kuY2VudHJhbHVzLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWNlbnRyYWx1c2ljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCJKCm8sITuRyQTfwfcPh1P_Y_FIoUY5rZqcJP5tAOTOk1M7UmZj3IhXCBuZfq1T1jLPVgMAAzHcyE4XjPrHalXdgSI6SJ0gq8I0X_ncsTkhomAsA5RU_sucWZ9nWgbXX-QDJi_bM0mzxsaKErSi607X1BM3DqI2SNMMgk6r2Ez8s8_vw6HLIGw7rLHx2D1muwevYyZ0dVgJa-VHCrBoSBL_ytZIofR5WUtbICE_9YIipUuxbnIRg9Vo_fv4cLzx0uLFk32vRKMroJ_zkJageE_exU-hNqZc7DSsWkROInmq7mMmyBvpTZB-q5PrEYUJi9zJZserlQTQG1e7u-Z7UEl&s=uP5EVuce9ND3TjWB5eaV4zWlJzgGgJ5Yecop-NuuCMchV2gx1qDOLaKVNEXmOCOrrrtgKIOTqZhAzK2bMzQ4cDCYvyuqHfcon6SYIrQ_-0rgto_oD5_nsxQV4PXV_zm-mA3R7iJirAmIin4b5V3DbULwGl_jvvzYz04YbfKokqBE7sCxqzXkNcc5VampCZl0ktNTQew6Z9ttfAV5JPQVCRLuqxcb08nAglA_LLiwON9Udn7Za3inKqzX0rdfthcl-dXp3U25tYMbSLViCOYSsM39TVSCZ6XQoeLz6B84OP1fgVXuqEUadDZFl_TeqUWqL3LsnoFkgkbLlNqTOwv9yQ&h=_ynrPKcafExNnqfb7ooT3FSo6GTz_sUuvrT-J1YQ6BQ
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 30 Jun 2026 03:51:26 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - ec46721c-c47d-4abb-b6c0-52a86350d19f
+      x-ms-operation-identifier:
+      - tenantId=544a7a2e-697f-487c-b2b0-a13df7f346b6,objectId=73deb370-6e80-42b7-bab4-943c887d3e3c/southeastasia/03ea89be-1521-44d6-94fe-7951599c9eda
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationConcurrencyPct=0.5, etc
+      x-msedge-ref:
+      - 'Ref A: 26702F67F8834B3FA5AD3255AB4F13C1 Ref B: SG2AA1040520029 Ref C: 2026-06-30T03:51:26Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network nat gateway create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --sku --nat64
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-nat64?api-version=2025-07-01
+  response:
+    body:
+      string: '{"name":"ng-nat64","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-nat64","etag":"W/\"7f824735-e4d9-458d-80e4-458477726e1a\"","type":"Microsoft.Network/natGateways","location":"eastus2","properties":{"provisioningState":"Succeeded","resourceGuid":"d98863ba-1fc4-45f7-8f4b-6034ca4fdd4b","idleTimeoutInMinutes":4,"scope":"Public","flowlogs":{"logsVersions":{}},"nat64":"Enabled"},"sku":{"name":"StandardV2","tier":"Regional"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '509'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 30 Jun 2026 03:51:26 GMT
+      etag:
+      - W/"7f824735-e4d9-458d-80e4-458477726e1a"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 0040755b-f7d1-4485-9646-05de08ce9b48
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationRatePct=0.1, operationConcurrencyPct=0.5, etc
+      x-msedge-ref:
+      - 'Ref A: 0F87F916E5BF4932ADC5AC54E40B9576 Ref B: SG2AA1070306054 Ref C: 2026-06-30T03:51:27Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network nat gateway update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --nat64
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-nat64?api-version=2025-07-01
+  response:
+    body:
+      string: '{"name":"ng-nat64","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-nat64","etag":"W/\"7f824735-e4d9-458d-80e4-458477726e1a\"","type":"Microsoft.Network/natGateways","location":"eastus2","properties":{"provisioningState":"Succeeded","resourceGuid":"d98863ba-1fc4-45f7-8f4b-6034ca4fdd4b","idleTimeoutInMinutes":4,"scope":"Public","flowlogs":{"logsVersions":{}},"nat64":"Enabled"},"sku":{"name":"StandardV2","tier":"Regional"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '509'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 30 Jun 2026 03:51:29 GMT
+      etag:
+      - W/"7f824735-e4d9-458d-80e4-458477726e1a"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 126da064-43e2-474d-8dbe-900e098992c3
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationRatePct=0.2, operationConcurrencyPct=0.5, etc
+      x-msedge-ref:
+      - 'Ref A: 925CF8FCA5A54DEBB9B5936DD2279D57 Ref B: SG2AA1040516052 Ref C: 2026-06-30T03:51:29Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-nat64",
+      "location": "eastus2", "properties": {"idleTimeoutInMinutes": 4, "nat64": "Disabled"},
+      "sku": {"name": "StandardV2"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network nat gateway update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '260'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -n --nat64
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-nat64?api-version=2025-07-01
+  response:
+    body:
+      string: '{"name":"ng-nat64","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-nat64","etag":"W/\"6d8519f7-9375-484c-80a9-5442ad07062e\"","type":"Microsoft.Network/natGateways","location":"eastus2","properties":{"provisioningState":"Updating","resourceGuid":"d98863ba-1fc4-45f7-8f4b-6034ca4fdd4b","idleTimeoutInMinutes":4,"scope":"Public","flowlogs":{"logsVersions":{}},"nat64":"Disabled"},"sku":{"name":"StandardV2","tier":"Regional"}}'
+    headers:
+      azure-asyncnotification:
+      - Enabled
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus2/operations/38717da7-0fb9-47f6-bc29-96a6ee089e63?api-version=2025-07-01&t=639183882909050969&c=MIIHxDCCBqygAwIBAgIRAJbrgketDbWHLEx1EpPCeH4wDQYJKoZIhvcNAQELBQAwNTEzMDEGA1UEAxMqQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgQ1VTIENBIDAxMB4XDTI2MDQwODAwMDQ1MloXDTI2MTAwMzA2MDQ1MlowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDT3FOWry_6qK0dbuwtMK4T4HuDo_lxyL6jb91_Fr1VWY_VRVB7zp7HCgghkwofjjGAbbdIqDseNKJdMcooubZaRzrViDXEgbnaN8vC-4cZ4fjDUhtZh80l4sEyp_iBCPcY7I-xDOLiz7i1vlpvCL7tA0iKHuk6AAPDQk4fPmFWUwUWR3SajkDmuQjTPVWhQyEOJVGJNf6hvyBKFjGuXqSOk8prQb8yn6q8TftPg2b9zjlfxfHQEZqdePVaY7VeW2ljF2sUmWsNvQikg3g_Zh9I6j0tT0DW51c8CoF8PrVglMgLQVrYCdAeE30Fi0vIiXCT0XOP-0RYInckGEJqDB8JAgMBAAGjggTCMIIEvjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQZbVl_wKnmyxn5O2JcAqCDdVaL3zAfBgNVHSMEGDAWgBT85FoKL4UO50S5B3N44NREB6IZETCCAcoGA1UdHwSCAcEwggG9MG-gbaBrhmlodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvY2VudHJhbHVzL2NybHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvNTUvY3VycmVudC5jcmwwcaBvoG2Ga2h0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2NlbnRyYWx1cy9jcmxzL2NjbWVjZW50cmFsdXNwa2kvY2NtZWNlbnRyYWx1c2ljYTAxLzU1L2N1cnJlbnQuY3JsMGCgXqBchlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vY2VudHJhbHVzL2NybHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvNTUvY3VycmVudC5jcmwwdaBzoHGGb2h0dHA6Ly9jY21lY2VudHJhbHVzcGtpLmNlbnRyYWx1cy5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVjZW50cmFsdXNpY2EwMS81NS9jdXJyZW50LmNybDCCAc8GCCsGAQUFBwEBBIIBwTCCAb0wcgYIKwYBBQUHMAKGZmh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZW50cmFsdXMvY2FjZXJ0cy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjB0BggrBgEFBQcwAoZoaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvY2VudHJhbHVzL2NhY2VydHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvY2VydC5jZXIwYwYIKwYBBQUHMAKGV2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9jZW50cmFsdXMvY2FjZXJ0cy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjBsBggrBgEFBQcwAoZgaHR0cDovL2NjbWVjZW50cmFsdXNwa2kuY2VudHJhbHVzLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWNlbnRyYWx1c2ljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCJKCm8sITuRyQTfwfcPh1P_Y_FIoUY5rZqcJP5tAOTOk1M7UmZj3IhXCBuZfq1T1jLPVgMAAzHcyE4XjPrHalXdgSI6SJ0gq8I0X_ncsTkhomAsA5RU_sucWZ9nWgbXX-QDJi_bM0mzxsaKErSi607X1BM3DqI2SNMMgk6r2Ez8s8_vw6HLIGw7rLHx2D1muwevYyZ0dVgJa-VHCrBoSBL_ytZIofR5WUtbICE_9YIipUuxbnIRg9Vo_fv4cLzx0uLFk32vRKMroJ_zkJageE_exU-hNqZc7DSsWkROInmq7mMmyBvpTZB-q5PrEYUJi9zJZserlQTQG1e7u-Z7UEl&s=i-qj1sWGDG8sQfRLihoVrcUUMj3Cw5zUajuWNOGVdDmCQg5G6F8vUvK_q2fhPeK0YRt5kf5OnR4bYgr4yuLs_aQ_3aFuKe1N_Hh1lttJ1k5_g6rAtjYcby0XtnfPKmbASFVCn60YOTmR39nN_3_nUknW3gES_BHEE0_TrsLqfFyg96rgx-vPlmtaxLRKSt3x0flEMi6j8uKd6b9JaZJgV8G2YQoRnD9lErFJ1S-J0ByeLglDCO81LaepccQYV6ETf0gJXI3g5XqZHVDXv3zOj3dS0T-DTNSCSDdx76pxwdGc2-WUCi_FzNQIe98gkaOmGu1xDREJrU3oCgIiZ2V-Mw&h=kYO3gQVdsQjRk84Tc95bbR_t1cz8hYVJZcugmWPN6NQ
+      cache-control:
+      - no-cache
+      content-length:
+      - '509'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 30 Jun 2026 03:51:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 9554957a-287e-48af-87bc-9e04183e0a8f
+      x-ms-operation-identifier:
+      - tenantId=544a7a2e-697f-487c-b2b0-a13df7f346b6,objectId=73deb370-6e80-42b7-bab4-943c887d3e3c/eastus2/b9d8a144-e6d0-4b59-9082-9d2a190b1b00
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '2999'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '199'
+      x-ms-throttle-levels:
+      - operationRatePct=0.2, operationConcurrencyPct=0.3, subscriptionWriteRatePct=0.2,
+        etc
+      x-msedge-ref:
+      - 'Ref A: EF96571223874CA687C742B34309F495 Ref B: SG2AA1070306029 Ref C: 2026-06-30T03:51:30Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network nat gateway update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --nat64
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus2/operations/38717da7-0fb9-47f6-bc29-96a6ee089e63?api-version=2025-07-01&t=639183882909050969&c=MIIHxDCCBqygAwIBAgIRAJbrgketDbWHLEx1EpPCeH4wDQYJKoZIhvcNAQELBQAwNTEzMDEGA1UEAxMqQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgQ1VTIENBIDAxMB4XDTI2MDQwODAwMDQ1MloXDTI2MTAwMzA2MDQ1MlowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDT3FOWry_6qK0dbuwtMK4T4HuDo_lxyL6jb91_Fr1VWY_VRVB7zp7HCgghkwofjjGAbbdIqDseNKJdMcooubZaRzrViDXEgbnaN8vC-4cZ4fjDUhtZh80l4sEyp_iBCPcY7I-xDOLiz7i1vlpvCL7tA0iKHuk6AAPDQk4fPmFWUwUWR3SajkDmuQjTPVWhQyEOJVGJNf6hvyBKFjGuXqSOk8prQb8yn6q8TftPg2b9zjlfxfHQEZqdePVaY7VeW2ljF2sUmWsNvQikg3g_Zh9I6j0tT0DW51c8CoF8PrVglMgLQVrYCdAeE30Fi0vIiXCT0XOP-0RYInckGEJqDB8JAgMBAAGjggTCMIIEvjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQZbVl_wKnmyxn5O2JcAqCDdVaL3zAfBgNVHSMEGDAWgBT85FoKL4UO50S5B3N44NREB6IZETCCAcoGA1UdHwSCAcEwggG9MG-gbaBrhmlodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvY2VudHJhbHVzL2NybHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvNTUvY3VycmVudC5jcmwwcaBvoG2Ga2h0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2NlbnRyYWx1cy9jcmxzL2NjbWVjZW50cmFsdXNwa2kvY2NtZWNlbnRyYWx1c2ljYTAxLzU1L2N1cnJlbnQuY3JsMGCgXqBchlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vY2VudHJhbHVzL2NybHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvNTUvY3VycmVudC5jcmwwdaBzoHGGb2h0dHA6Ly9jY21lY2VudHJhbHVzcGtpLmNlbnRyYWx1cy5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVjZW50cmFsdXNpY2EwMS81NS9jdXJyZW50LmNybDCCAc8GCCsGAQUFBwEBBIIBwTCCAb0wcgYIKwYBBQUHMAKGZmh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZW50cmFsdXMvY2FjZXJ0cy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjB0BggrBgEFBQcwAoZoaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvY2VudHJhbHVzL2NhY2VydHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvY2VydC5jZXIwYwYIKwYBBQUHMAKGV2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9jZW50cmFsdXMvY2FjZXJ0cy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjBsBggrBgEFBQcwAoZgaHR0cDovL2NjbWVjZW50cmFsdXNwa2kuY2VudHJhbHVzLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWNlbnRyYWx1c2ljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCJKCm8sITuRyQTfwfcPh1P_Y_FIoUY5rZqcJP5tAOTOk1M7UmZj3IhXCBuZfq1T1jLPVgMAAzHcyE4XjPrHalXdgSI6SJ0gq8I0X_ncsTkhomAsA5RU_sucWZ9nWgbXX-QDJi_bM0mzxsaKErSi607X1BM3DqI2SNMMgk6r2Ez8s8_vw6HLIGw7rLHx2D1muwevYyZ0dVgJa-VHCrBoSBL_ytZIofR5WUtbICE_9YIipUuxbnIRg9Vo_fv4cLzx0uLFk32vRKMroJ_zkJageE_exU-hNqZc7DSsWkROInmq7mMmyBvpTZB-q5PrEYUJi9zJZserlQTQG1e7u-Z7UEl&s=i-qj1sWGDG8sQfRLihoVrcUUMj3Cw5zUajuWNOGVdDmCQg5G6F8vUvK_q2fhPeK0YRt5kf5OnR4bYgr4yuLs_aQ_3aFuKe1N_Hh1lttJ1k5_g6rAtjYcby0XtnfPKmbASFVCn60YOTmR39nN_3_nUknW3gES_BHEE0_TrsLqfFyg96rgx-vPlmtaxLRKSt3x0flEMi6j8uKd6b9JaZJgV8G2YQoRnD9lErFJ1S-J0ByeLglDCO81LaepccQYV6ETf0gJXI3g5XqZHVDXv3zOj3dS0T-DTNSCSDdx76pxwdGc2-WUCi_FzNQIe98gkaOmGu1xDREJrU3oCgIiZ2V-Mw&h=kYO3gQVdsQjRk84Tc95bbR_t1cz8hYVJZcugmWPN6NQ
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 30 Jun 2026 03:51:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - e74d8f6f-14b1-473e-814c-375791bbd892
+      x-ms-operation-identifier:
+      - tenantId=544a7a2e-697f-487c-b2b0-a13df7f346b6,objectId=73deb370-6e80-42b7-bab4-943c887d3e3c/southeastasia/e949c620-1354-46ba-b2bf-b5d5edf826d0
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationConcurrencyPct=0.5, etc
+      x-msedge-ref:
+      - 'Ref A: 67C710BBCE4043C38B21ABEBAE3E6A05 Ref B: SG2AA1040515034 Ref C: 2026-06-30T03:51:31Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network nat gateway update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --nat64
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-nat64?api-version=2025-07-01
+  response:
+    body:
+      string: '{"name":"ng-nat64","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-nat64","etag":"W/\"10b6fe27-0632-4cbd-8c95-ad045838e73c\"","type":"Microsoft.Network/natGateways","location":"eastus2","properties":{"provisioningState":"Succeeded","resourceGuid":"d98863ba-1fc4-45f7-8f4b-6034ca4fdd4b","idleTimeoutInMinutes":4,"scope":"Public","flowlogs":{"logsVersions":{}},"nat64":"Disabled"},"sku":{"name":"StandardV2","tier":"Regional"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '510'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 30 Jun 2026 03:51:32 GMT
+      etag:
+      - W/"10b6fe27-0632-4cbd-8c95-ad045838e73c"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 61bd0562-e241-4db7-8795-cc62129c4ea6
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationRatePct=0.3, operationConcurrencyPct=0.5, subscriptionReadRatePct=0.1,
+        etc
+      x-msedge-ref:
+      - 'Ref A: 41E52EA0B243402A95D46713A66BED2A Ref B: SG2AA1040512052 Ref C: 2026-06-30T03:51:32Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network nat gateway show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-nat64?api-version=2025-07-01
+  response:
+    body:
+      string: '{"name":"ng-nat64","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-nat64","etag":"W/\"10b6fe27-0632-4cbd-8c95-ad045838e73c\"","type":"Microsoft.Network/natGateways","location":"eastus2","properties":{"provisioningState":"Succeeded","resourceGuid":"d98863ba-1fc4-45f7-8f4b-6034ca4fdd4b","idleTimeoutInMinutes":4,"scope":"Public","flowlogs":{"logsVersions":{}},"nat64":"Disabled"},"sku":{"name":"StandardV2","tier":"Regional"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '510'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 30 Jun 2026 03:51:34 GMT
+      etag:
+      - W/"10b6fe27-0632-4cbd-8c95-ad045838e73c"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - d9005d2b-0427-40e5-a8ae-874773edae99
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationRatePct=0.3, operationConcurrencyPct=0.5, subscriptionReadRatePct=0.1,
+        etc
+      x-msedge-ref:
+      - 'Ref A: 33187DD64E9148D58D76C968944CCB12 Ref B: SG2AA1040515040 Ref C: 2026-06-30T03:51:34Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network nat gateway list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways?api-version=2025-07-01
+  response:
+    body:
+      string: '{"value":[{"name":"ng-nat64","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-nat64","etag":"W/\"10b6fe27-0632-4cbd-8c95-ad045838e73c\"","type":"Microsoft.Network/natGateways","location":"eastus2","properties":{"provisioningState":"Succeeded","resourceGuid":"d98863ba-1fc4-45f7-8f4b-6034ca4fdd4b","idleTimeoutInMinutes":4,"scope":"Public","flowlogs":{"logsVersions":{}},"nat64":"Disabled"},"sku":{"name":"StandardV2","tier":"Regional"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '522'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 30 Jun 2026 03:51:36 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 7feb9aa9-cf87-4445-b257-7b43cb14ad87
+      x-ms-original-request-ids:
+      - 552ff3e1-361e-4467-a965-1a7d3db7a41c
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationConcurrencyPct=0.5, subscriptionReadRatePct=0.1, etc
+      x-msedge-ref:
+      - 'Ref A: E8AE44DBF8C14D2099064DAD76C86A00 Ref B: SG2AA1070305025 Ref C: 2026-06-30T03:51:35Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network nat gateway delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-nat64?api-version=2025-07-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncnotification:
+      - Enabled
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus2/operations/be4aaad6-1e53-49c7-af75-e4d5894dd824?api-version=2025-07-01&t=639183882972621882&c=MIIHxDCCBqygAwIBAgIRAJbrgketDbWHLEx1EpPCeH4wDQYJKoZIhvcNAQELBQAwNTEzMDEGA1UEAxMqQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgQ1VTIENBIDAxMB4XDTI2MDQwODAwMDQ1MloXDTI2MTAwMzA2MDQ1MlowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDT3FOWry_6qK0dbuwtMK4T4HuDo_lxyL6jb91_Fr1VWY_VRVB7zp7HCgghkwofjjGAbbdIqDseNKJdMcooubZaRzrViDXEgbnaN8vC-4cZ4fjDUhtZh80l4sEyp_iBCPcY7I-xDOLiz7i1vlpvCL7tA0iKHuk6AAPDQk4fPmFWUwUWR3SajkDmuQjTPVWhQyEOJVGJNf6hvyBKFjGuXqSOk8prQb8yn6q8TftPg2b9zjlfxfHQEZqdePVaY7VeW2ljF2sUmWsNvQikg3g_Zh9I6j0tT0DW51c8CoF8PrVglMgLQVrYCdAeE30Fi0vIiXCT0XOP-0RYInckGEJqDB8JAgMBAAGjggTCMIIEvjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQZbVl_wKnmyxn5O2JcAqCDdVaL3zAfBgNVHSMEGDAWgBT85FoKL4UO50S5B3N44NREB6IZETCCAcoGA1UdHwSCAcEwggG9MG-gbaBrhmlodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvY2VudHJhbHVzL2NybHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvNTUvY3VycmVudC5jcmwwcaBvoG2Ga2h0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2NlbnRyYWx1cy9jcmxzL2NjbWVjZW50cmFsdXNwa2kvY2NtZWNlbnRyYWx1c2ljYTAxLzU1L2N1cnJlbnQuY3JsMGCgXqBchlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vY2VudHJhbHVzL2NybHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvNTUvY3VycmVudC5jcmwwdaBzoHGGb2h0dHA6Ly9jY21lY2VudHJhbHVzcGtpLmNlbnRyYWx1cy5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVjZW50cmFsdXNpY2EwMS81NS9jdXJyZW50LmNybDCCAc8GCCsGAQUFBwEBBIIBwTCCAb0wcgYIKwYBBQUHMAKGZmh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZW50cmFsdXMvY2FjZXJ0cy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjB0BggrBgEFBQcwAoZoaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvY2VudHJhbHVzL2NhY2VydHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvY2VydC5jZXIwYwYIKwYBBQUHMAKGV2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9jZW50cmFsdXMvY2FjZXJ0cy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjBsBggrBgEFBQcwAoZgaHR0cDovL2NjbWVjZW50cmFsdXNwa2kuY2VudHJhbHVzLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWNlbnRyYWx1c2ljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCJKCm8sITuRyQTfwfcPh1P_Y_FIoUY5rZqcJP5tAOTOk1M7UmZj3IhXCBuZfq1T1jLPVgMAAzHcyE4XjPrHalXdgSI6SJ0gq8I0X_ncsTkhomAsA5RU_sucWZ9nWgbXX-QDJi_bM0mzxsaKErSi607X1BM3DqI2SNMMgk6r2Ez8s8_vw6HLIGw7rLHx2D1muwevYyZ0dVgJa-VHCrBoSBL_ytZIofR5WUtbICE_9YIipUuxbnIRg9Vo_fv4cLzx0uLFk32vRKMroJ_zkJageE_exU-hNqZc7DSsWkROInmq7mMmyBvpTZB-q5PrEYUJi9zJZserlQTQG1e7u-Z7UEl&s=cPq8DEqnD29VDW3JyvxWfQuxOtzN9WZvVLKvtpBq_cisF6nxsj4Z8PLRlemksW_iCn5WoFXqDu2W9d4ZPOL2G15VKO6EF9ABW14QIjTGTd2l_iUWwqypytp4Um4H0qvvh_eR4ayZJr4sdURRLQ_rz5D_46HG4VaNxLemEMXTqnn2ScLo1h1vPrCY5APeVOyQytL5jqPB8e5b4bD3T1N1ZgjzBuyJkODvaaWd8Ui5eZTf3CYrC2WyE_6PQZTdIOX_97ARjSFEXQ1HGjStXhfHX7eKJEBETJnUQHyjAI7jdmbrRn9jzjAXZl_JVdeyDIFcSQciIMeHceXH67dmAy5kqg&h=qMq_i82ubj9UAWoiiuX8MBZBUbWilb2ABz6X-jjRpRE
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 30 Jun 2026 03:51:37 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus2/operationResults/be4aaad6-1e53-49c7-af75-e4d5894dd824?api-version=2025-07-01&t=639183882972778136&c=MIIHxDCCBqygAwIBAgIRAJbrgketDbWHLEx1EpPCeH4wDQYJKoZIhvcNAQELBQAwNTEzMDEGA1UEAxMqQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgQ1VTIENBIDAxMB4XDTI2MDQwODAwMDQ1MloXDTI2MTAwMzA2MDQ1MlowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDT3FOWry_6qK0dbuwtMK4T4HuDo_lxyL6jb91_Fr1VWY_VRVB7zp7HCgghkwofjjGAbbdIqDseNKJdMcooubZaRzrViDXEgbnaN8vC-4cZ4fjDUhtZh80l4sEyp_iBCPcY7I-xDOLiz7i1vlpvCL7tA0iKHuk6AAPDQk4fPmFWUwUWR3SajkDmuQjTPVWhQyEOJVGJNf6hvyBKFjGuXqSOk8prQb8yn6q8TftPg2b9zjlfxfHQEZqdePVaY7VeW2ljF2sUmWsNvQikg3g_Zh9I6j0tT0DW51c8CoF8PrVglMgLQVrYCdAeE30Fi0vIiXCT0XOP-0RYInckGEJqDB8JAgMBAAGjggTCMIIEvjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQZbVl_wKnmyxn5O2JcAqCDdVaL3zAfBgNVHSMEGDAWgBT85FoKL4UO50S5B3N44NREB6IZETCCAcoGA1UdHwSCAcEwggG9MG-gbaBrhmlodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvY2VudHJhbHVzL2NybHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvNTUvY3VycmVudC5jcmwwcaBvoG2Ga2h0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2NlbnRyYWx1cy9jcmxzL2NjbWVjZW50cmFsdXNwa2kvY2NtZWNlbnRyYWx1c2ljYTAxLzU1L2N1cnJlbnQuY3JsMGCgXqBchlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vY2VudHJhbHVzL2NybHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvNTUvY3VycmVudC5jcmwwdaBzoHGGb2h0dHA6Ly9jY21lY2VudHJhbHVzcGtpLmNlbnRyYWx1cy5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVjZW50cmFsdXNpY2EwMS81NS9jdXJyZW50LmNybDCCAc8GCCsGAQUFBwEBBIIBwTCCAb0wcgYIKwYBBQUHMAKGZmh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZW50cmFsdXMvY2FjZXJ0cy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjB0BggrBgEFBQcwAoZoaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvY2VudHJhbHVzL2NhY2VydHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvY2VydC5jZXIwYwYIKwYBBQUHMAKGV2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9jZW50cmFsdXMvY2FjZXJ0cy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjBsBggrBgEFBQcwAoZgaHR0cDovL2NjbWVjZW50cmFsdXNwa2kuY2VudHJhbHVzLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWNlbnRyYWx1c2ljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCJKCm8sITuRyQTfwfcPh1P_Y_FIoUY5rZqcJP5tAOTOk1M7UmZj3IhXCBuZfq1T1jLPVgMAAzHcyE4XjPrHalXdgSI6SJ0gq8I0X_ncsTkhomAsA5RU_sucWZ9nWgbXX-QDJi_bM0mzxsaKErSi607X1BM3DqI2SNMMgk6r2Ez8s8_vw6HLIGw7rLHx2D1muwevYyZ0dVgJa-VHCrBoSBL_ytZIofR5WUtbICE_9YIipUuxbnIRg9Vo_fv4cLzx0uLFk32vRKMroJ_zkJageE_exU-hNqZc7DSsWkROInmq7mMmyBvpTZB-q5PrEYUJi9zJZserlQTQG1e7u-Z7UEl&s=0zeDrqrx6lF7fRh3vnaHkLbRHNLhSpdmfy1NxNoQVMqVBMTrDGbnXfEtiDbpoUjar5m_k3G5lcWSonMx0kc4th8b97vAsPwaJujQyWzjA1OLG0KCkIJWDs_MXbC9CEQwiheS1BTH2JPxw4cu4T31bC_dHLgjRUa8CVVgxbwCnbLrhQlHfSHLlzL20GgjhEWc4tgzxnG55mxqY13EVxb67SAtKmml8OBDQqUw7WfyejkHGzxryQPEvJoVHTd_8wSFHoVM_cMbi3ndQurTXKb1OwyvgHGq7JVF_6itGHKtYQjnYgyqvVBKO_td4gL7KKS946gwsnuzE0KGy_ncaakcgA&h=VHsf_eqwLybs2kVPSF59ePgVlHju-z-I_Fm2KVitaS4
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - a6678ca2-bbe0-499e-b0c5-5d7502814f75
+      x-ms-operation-identifier:
+      - tenantId=544a7a2e-697f-487c-b2b0-a13df7f346b6,objectId=73deb370-6e80-42b7-bab4-943c887d3e3c/eastus2/6c9d27ed-c796-476e-a378-61c2cc922e65
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '199'
+      x-ms-ratelimit-remaining-subscription-global-deletes:
+      - '2999'
+      x-ms-throttle-levels:
+      - operationRatePct=0.1, operationConcurrencyPct=0.3, subscriptionWriteRatePct=0.3,
+        etc
+      x-msedge-ref:
+      - 'Ref A: 9E118032DA504CCFBA68803012B46509 Ref B: SG2AA1070306029 Ref C: 2026-06-30T03:51:37Z'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network nat gateway delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus2/operations/be4aaad6-1e53-49c7-af75-e4d5894dd824?api-version=2025-07-01&t=639183882972621882&c=MIIHxDCCBqygAwIBAgIRAJbrgketDbWHLEx1EpPCeH4wDQYJKoZIhvcNAQELBQAwNTEzMDEGA1UEAxMqQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgQ1VTIENBIDAxMB4XDTI2MDQwODAwMDQ1MloXDTI2MTAwMzA2MDQ1MlowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDT3FOWry_6qK0dbuwtMK4T4HuDo_lxyL6jb91_Fr1VWY_VRVB7zp7HCgghkwofjjGAbbdIqDseNKJdMcooubZaRzrViDXEgbnaN8vC-4cZ4fjDUhtZh80l4sEyp_iBCPcY7I-xDOLiz7i1vlpvCL7tA0iKHuk6AAPDQk4fPmFWUwUWR3SajkDmuQjTPVWhQyEOJVGJNf6hvyBKFjGuXqSOk8prQb8yn6q8TftPg2b9zjlfxfHQEZqdePVaY7VeW2ljF2sUmWsNvQikg3g_Zh9I6j0tT0DW51c8CoF8PrVglMgLQVrYCdAeE30Fi0vIiXCT0XOP-0RYInckGEJqDB8JAgMBAAGjggTCMIIEvjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQZbVl_wKnmyxn5O2JcAqCDdVaL3zAfBgNVHSMEGDAWgBT85FoKL4UO50S5B3N44NREB6IZETCCAcoGA1UdHwSCAcEwggG9MG-gbaBrhmlodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvY2VudHJhbHVzL2NybHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvNTUvY3VycmVudC5jcmwwcaBvoG2Ga2h0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2NlbnRyYWx1cy9jcmxzL2NjbWVjZW50cmFsdXNwa2kvY2NtZWNlbnRyYWx1c2ljYTAxLzU1L2N1cnJlbnQuY3JsMGCgXqBchlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vY2VudHJhbHVzL2NybHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvNTUvY3VycmVudC5jcmwwdaBzoHGGb2h0dHA6Ly9jY21lY2VudHJhbHVzcGtpLmNlbnRyYWx1cy5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVjZW50cmFsdXNpY2EwMS81NS9jdXJyZW50LmNybDCCAc8GCCsGAQUFBwEBBIIBwTCCAb0wcgYIKwYBBQUHMAKGZmh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZW50cmFsdXMvY2FjZXJ0cy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjB0BggrBgEFBQcwAoZoaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvY2VudHJhbHVzL2NhY2VydHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvY2VydC5jZXIwYwYIKwYBBQUHMAKGV2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9jZW50cmFsdXMvY2FjZXJ0cy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjBsBggrBgEFBQcwAoZgaHR0cDovL2NjbWVjZW50cmFsdXNwa2kuY2VudHJhbHVzLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWNlbnRyYWx1c2ljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCJKCm8sITuRyQTfwfcPh1P_Y_FIoUY5rZqcJP5tAOTOk1M7UmZj3IhXCBuZfq1T1jLPVgMAAzHcyE4XjPrHalXdgSI6SJ0gq8I0X_ncsTkhomAsA5RU_sucWZ9nWgbXX-QDJi_bM0mzxsaKErSi607X1BM3DqI2SNMMgk6r2Ez8s8_vw6HLIGw7rLHx2D1muwevYyZ0dVgJa-VHCrBoSBL_ytZIofR5WUtbICE_9YIipUuxbnIRg9Vo_fv4cLzx0uLFk32vRKMroJ_zkJageE_exU-hNqZc7DSsWkROInmq7mMmyBvpTZB-q5PrEYUJi9zJZserlQTQG1e7u-Z7UEl&s=cPq8DEqnD29VDW3JyvxWfQuxOtzN9WZvVLKvtpBq_cisF6nxsj4Z8PLRlemksW_iCn5WoFXqDu2W9d4ZPOL2G15VKO6EF9ABW14QIjTGTd2l_iUWwqypytp4Um4H0qvvh_eR4ayZJr4sdURRLQ_rz5D_46HG4VaNxLemEMXTqnn2ScLo1h1vPrCY5APeVOyQytL5jqPB8e5b4bD3T1N1ZgjzBuyJkODvaaWd8Ui5eZTf3CYrC2WyE_6PQZTdIOX_97ARjSFEXQ1HGjStXhfHX7eKJEBETJnUQHyjAI7jdmbrRn9jzjAXZl_JVdeyDIFcSQciIMeHceXH67dmAy5kqg&h=qMq_i82ubj9UAWoiiuX8MBZBUbWilb2ABz6X-jjRpRE
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 30 Jun 2026 03:51:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - ff29d60e-f35a-4c02-8d28-224f19449958
+      x-ms-operation-identifier:
+      - tenantId=544a7a2e-697f-487c-b2b0-a13df7f346b6,objectId=73deb370-6e80-42b7-bab4-943c887d3e3c/malaysiasouth/b86bc4a5-5f63-4612-8d82-c1780fbab98a
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationConcurrencyPct=0.5, subscriptionReadRatePct=0.2, etc
+      x-msedge-ref:
+      - 'Ref A: 908BD99EAC8D4F689077C3BD2C3135C8 Ref B: SG2AA1040512034 Ref C: 2026-06-30T03:51:37Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network nat gateway delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus2/operationResults/be4aaad6-1e53-49c7-af75-e4d5894dd824?api-version=2025-07-01&t=639183882972778136&c=MIIHxDCCBqygAwIBAgIRAJbrgketDbWHLEx1EpPCeH4wDQYJKoZIhvcNAQELBQAwNTEzMDEGA1UEAxMqQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgQ1VTIENBIDAxMB4XDTI2MDQwODAwMDQ1MloXDTI2MTAwMzA2MDQ1MlowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDT3FOWry_6qK0dbuwtMK4T4HuDo_lxyL6jb91_Fr1VWY_VRVB7zp7HCgghkwofjjGAbbdIqDseNKJdMcooubZaRzrViDXEgbnaN8vC-4cZ4fjDUhtZh80l4sEyp_iBCPcY7I-xDOLiz7i1vlpvCL7tA0iKHuk6AAPDQk4fPmFWUwUWR3SajkDmuQjTPVWhQyEOJVGJNf6hvyBKFjGuXqSOk8prQb8yn6q8TftPg2b9zjlfxfHQEZqdePVaY7VeW2ljF2sUmWsNvQikg3g_Zh9I6j0tT0DW51c8CoF8PrVglMgLQVrYCdAeE30Fi0vIiXCT0XOP-0RYInckGEJqDB8JAgMBAAGjggTCMIIEvjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQZbVl_wKnmyxn5O2JcAqCDdVaL3zAfBgNVHSMEGDAWgBT85FoKL4UO50S5B3N44NREB6IZETCCAcoGA1UdHwSCAcEwggG9MG-gbaBrhmlodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvY2VudHJhbHVzL2NybHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvNTUvY3VycmVudC5jcmwwcaBvoG2Ga2h0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2NlbnRyYWx1cy9jcmxzL2NjbWVjZW50cmFsdXNwa2kvY2NtZWNlbnRyYWx1c2ljYTAxLzU1L2N1cnJlbnQuY3JsMGCgXqBchlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vY2VudHJhbHVzL2NybHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvNTUvY3VycmVudC5jcmwwdaBzoHGGb2h0dHA6Ly9jY21lY2VudHJhbHVzcGtpLmNlbnRyYWx1cy5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVjZW50cmFsdXNpY2EwMS81NS9jdXJyZW50LmNybDCCAc8GCCsGAQUFBwEBBIIBwTCCAb0wcgYIKwYBBQUHMAKGZmh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZW50cmFsdXMvY2FjZXJ0cy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjB0BggrBgEFBQcwAoZoaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvY2VudHJhbHVzL2NhY2VydHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvY2VydC5jZXIwYwYIKwYBBQUHMAKGV2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9jZW50cmFsdXMvY2FjZXJ0cy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjBsBggrBgEFBQcwAoZgaHR0cDovL2NjbWVjZW50cmFsdXNwa2kuY2VudHJhbHVzLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWNlbnRyYWx1c2ljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCJKCm8sITuRyQTfwfcPh1P_Y_FIoUY5rZqcJP5tAOTOk1M7UmZj3IhXCBuZfq1T1jLPVgMAAzHcyE4XjPrHalXdgSI6SJ0gq8I0X_ncsTkhomAsA5RU_sucWZ9nWgbXX-QDJi_bM0mzxsaKErSi607X1BM3DqI2SNMMgk6r2Ez8s8_vw6HLIGw7rLHx2D1muwevYyZ0dVgJa-VHCrBoSBL_ytZIofR5WUtbICE_9YIipUuxbnIRg9Vo_fv4cLzx0uLFk32vRKMroJ_zkJageE_exU-hNqZc7DSsWkROInmq7mMmyBvpTZB-q5PrEYUJi9zJZserlQTQG1e7u-Z7UEl&s=0zeDrqrx6lF7fRh3vnaHkLbRHNLhSpdmfy1NxNoQVMqVBMTrDGbnXfEtiDbpoUjar5m_k3G5lcWSonMx0kc4th8b97vAsPwaJujQyWzjA1OLG0KCkIJWDs_MXbC9CEQwiheS1BTH2JPxw4cu4T31bC_dHLgjRUa8CVVgxbwCnbLrhQlHfSHLlzL20GgjhEWc4tgzxnG55mxqY13EVxb67SAtKmml8OBDQqUw7WfyejkHGzxryQPEvJoVHTd_8wSFHoVM_cMbi3ndQurTXKb1OwyvgHGq7JVF_6itGHKtYQjnYgyqvVBKO_td4gL7KKS946gwsnuzE0KGy_ncaakcgA&h=VHsf_eqwLybs2kVPSF59ePgVlHju-z-I_Fm2KVitaS4
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncnotification:
+      - Enabled
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus2/operations/be4aaad6-1e53-49c7-af75-e4d5894dd824?api-version=2025-07-01&t=639183883004063965&c=MIIIJzCCBw-gAwIBAgIRAPkg2z-B9Jm_vrDg-qNrjwswDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgV0NVUyBDQSAwMTAeFw0yNjA0MTAwNjUyMTdaFw0yNjEwMDUxMjUyMTdaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxhFGHIBug-4Pg8y8wrt85aTDI_1ckzX8XYnsk6BmTh36sX4QX-zrgCccWt1yXC8y3lSRvEr66Pgoywj0gN60U0prO-Llj-OOWdlGOnbBFPBaBa2ogrj2ULknxSn8HyrgUsMa3zGCqoR_eDSq7R_O20UZDFBlonw8TSmqdLPA4fe1TarGVXDGoRxYv_BQE0sxI54JmyZ5uATcXoIBRqCEmrRFh6MO0V4rK5-sBO8yodyMdOweERdOFcDfLvM2WCaax5HnsjPSLMYy-XTD01vXM3XkKAJ6K30JxQ4_Wtn1IvN-b0R-eEdUMUdPKhH4RDL_8xL-ALqsnaG0cNZazOQr1QIDAQABo4IFJDCCBSAwgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQUdjmEGeQg6LiPic0f-L1KBD3vO0wwHwYDVR0jBBgwFoAUFNI34PbWfX7djbq6ZasElCXglh0wggH7BgNVHR8EggHyMIIB7jB7oHmgd4Z1aHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3RjZW50cmFsdXMvY3Jscy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxLzI5L2N1cnJlbnQuY3JsMH2ge6B5hndodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0Y2VudHJhbHVzL2NybHMvY2NtZXdlc3RjZW50cmFsdXNwa2kvY2NtZXdlc3RjZW50cmFsdXNpY2EwMS8yOS9jdXJyZW50LmNybDBsoGqgaIZmaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3dlc3RjZW50cmFsdXMvY3Jscy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxLzI5L2N1cnJlbnQuY3JsMIGBoH-gfYZ7aHR0cDovL2NjbWV3ZXN0Y2VudHJhbHVzcGtpLndlc3RjZW50cmFsdXMucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdGNlbnRyYWx1c2ljYTAxLzI5L2N1cnJlbnQuY3JsMIICAAYIKwYBBQUHAQEEggHyMIIB7jB-BggrBgEFBQcwAoZyaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3RjZW50cmFsdXMvY2FjZXJ0cy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxL2NlcnQuY2VyMIGABggrBgEFBQcwAoZ0aHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdGNlbnRyYWx1cy9jYWNlcnRzL2NjbWV3ZXN0Y2VudHJhbHVzcGtpL2NjbWV3ZXN0Y2VudHJhbHVzaWNhMDEvY2VydC5jZXIwbwYIKwYBBQUHMAKGY2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0Y2VudHJhbHVzL2NhY2VydHMvY2NtZXdlc3RjZW50cmFsdXNwa2kvY2NtZXdlc3RjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjB4BggrBgEFBQcwAoZsaHR0cDovL2NjbWV3ZXN0Y2VudHJhbHVzcGtpLndlc3RjZW50cmFsdXMucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdGNlbnRyYWx1c2ljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAwpZthpdA-8D9zmLFa9DswaQjZpHoWrNOxcAkBHpasqPjLn8-Kn0Epr2tRtCqiDWEGx_u3n8ziMDqRxvNKiDUdDWhMl9QuodIY45vNfF6z92zdJEJ0m01EaNwji4O0BNu0Yy7zPa_L79KmbrFPHHQkexKO2qyHqYM0M22afvWFTacEIlhMIcL-Hq6afh-pfO3r2D3ZnFSmrZFt1A8qT0qTCXRaOqAM1Wk35M7k-idK2KawQ4Q9KnP0h62bPPhktf4Hi_Ax5-Ms7zxobTxMvoilvGVHYDeQ2zZDEoMmyNZ1gfzPjnGnV2BbMj3JEHIzWuKuw033HBrOIc8peAt8JKrH&s=cfRpnadkke_29ASP0FNNir9hq5gIyu6mU8qfVBIWtXPtQb7vsfCZFQme7pXqtqGZp_68od_B6afxHSvMlPjnZOxFp04-dznTpQq0rJhYyeY-lnFGz379QlSYq5UELp4pGDjN_eghgQXrcMYH8ACMXSexWvIjz7V46GdKsnQIOTI6D0OLpMuLbJZnfUrQUz00lchuEDbp40OU4gV4rOveWijR6A64nsEURYiwBlu6JScz3i6Vqe74JFzUoJWDN0n-4Cl_-nITm8dWb973FIKcwv_0zcW_PRXo-0yf8JdvPOWy5dPebRLxMT38rBMuaKZ24QnVcATnWUC9-CJiD9PKKg&h=uoMDpfz6t-A4NHIOr0r7N96tjGTabHcdcSN26QbR8zQ
+      cache-control:
+      - no-cache
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 30 Jun 2026 03:51:39 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus2/operationResults/be4aaad6-1e53-49c7-af75-e4d5894dd824?api-version=2025-07-01&t=639183883004063965&c=MIIIJzCCBw-gAwIBAgIRAPkg2z-B9Jm_vrDg-qNrjwswDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UEAxMrQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgV0NVUyBDQSAwMTAeFw0yNjA0MTAwNjUyMTdaFw0yNjEwMDUxMjUyMTdaMEAxPjA8BgNVBAMTNWFzeW5jb3BlcmF0aW9uc2lnbmluZ2NlcnRpZmljYXRlLm1hbmFnZW1lbnQuYXp1cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxhFGHIBug-4Pg8y8wrt85aTDI_1ckzX8XYnsk6BmTh36sX4QX-zrgCccWt1yXC8y3lSRvEr66Pgoywj0gN60U0prO-Llj-OOWdlGOnbBFPBaBa2ogrj2ULknxSn8HyrgUsMa3zGCqoR_eDSq7R_O20UZDFBlonw8TSmqdLPA4fe1TarGVXDGoRxYv_BQE0sxI54JmyZ5uATcXoIBRqCEmrRFh6MO0V4rK5-sBO8yodyMdOweERdOFcDfLvM2WCaax5HnsjPSLMYy-XTD01vXM3XkKAJ6K30JxQ4_Wtn1IvN-b0R-eEdUMUdPKhH4RDL_8xL-ALqsnaG0cNZazOQr1QIDAQABo4IFJDCCBSAwgZ0GA1UdIASBlTCBkjAMBgorBgEEAYI3ewEBMGYGCisGAQQBgjd7AgIwWDBWBggrBgEFBQcCAjBKHkgAMwAzAGUAMAAxADkAMgAxAC0ANABkADYANAAtADQAZgA4AGMALQBhADAANQA1AC0ANQBiAGQAYQBmAGYAZAA1AGUAMwAzAGQwDAYKKwYBBAGCN3sDAjAMBgorBgEEAYI3ewQCMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA4GA1UdDwEB_wQEAwIFoDAdBgNVHQ4EFgQUdjmEGeQg6LiPic0f-L1KBD3vO0wwHwYDVR0jBBgwFoAUFNI34PbWfX7djbq6ZasElCXglh0wggH7BgNVHR8EggHyMIIB7jB7oHmgd4Z1aHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3RjZW50cmFsdXMvY3Jscy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxLzI5L2N1cnJlbnQuY3JsMH2ge6B5hndodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0Y2VudHJhbHVzL2NybHMvY2NtZXdlc3RjZW50cmFsdXNwa2kvY2NtZXdlc3RjZW50cmFsdXNpY2EwMS8yOS9jdXJyZW50LmNybDBsoGqgaIZmaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3dlc3RjZW50cmFsdXMvY3Jscy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxLzI5L2N1cnJlbnQuY3JsMIGBoH-gfYZ7aHR0cDovL2NjbWV3ZXN0Y2VudHJhbHVzcGtpLndlc3RjZW50cmFsdXMucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdGNlbnRyYWx1c2ljYTAxLzI5L2N1cnJlbnQuY3JsMIICAAYIKwYBBQUHAQEEggHyMIIB7jB-BggrBgEFBQcwAoZyaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3RjZW50cmFsdXMvY2FjZXJ0cy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxL2NlcnQuY2VyMIGABggrBgEFBQcwAoZ0aHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdGNlbnRyYWx1cy9jYWNlcnRzL2NjbWV3ZXN0Y2VudHJhbHVzcGtpL2NjbWV3ZXN0Y2VudHJhbHVzaWNhMDEvY2VydC5jZXIwbwYIKwYBBQUHMAKGY2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0Y2VudHJhbHVzL2NhY2VydHMvY2NtZXdlc3RjZW50cmFsdXNwa2kvY2NtZXdlc3RjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjB4BggrBgEFBQcwAoZsaHR0cDovL2NjbWV3ZXN0Y2VudHJhbHVzcGtpLndlc3RjZW50cmFsdXMucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdGNlbnRyYWx1c2ljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQAwpZthpdA-8D9zmLFa9DswaQjZpHoWrNOxcAkBHpasqPjLn8-Kn0Epr2tRtCqiDWEGx_u3n8ziMDqRxvNKiDUdDWhMl9QuodIY45vNfF6z92zdJEJ0m01EaNwji4O0BNu0Yy7zPa_L79KmbrFPHHQkexKO2qyHqYM0M22afvWFTacEIlhMIcL-Hq6afh-pfO3r2D3ZnFSmrZFt1A8qT0qTCXRaOqAM1Wk35M7k-idK2KawQ4Q9KnP0h62bPPhktf4Hi_Ax5-Ms7zxobTxMvoilvGVHYDeQ2zZDEoMmyNZ1gfzPjnGnV2BbMj3JEHIzWuKuw033HBrOIc8peAt8JKrH&s=vrKpneKvThMa4zkE20206dHzMcIQlhwOHo6UMw2tE8fFx2ab-JtYmUQACdp6cXGZGhVJ0C1JnC5X31LSjdgd7WTkP12LBjiJyWKKS4KujNEFOzuQVU-85uN4Jc03VCoEzc_RXhzQbZAbgbuSkZjGiw7UcCPd06Ok9-csPjOSjf_fUYsYXDBwCZrMhgZBP-_7BWncPma_nX-eyQHoU7ClF4tdZmplWAISfvxbdTfJgsurM1R4Swmp9nos9mHGhHrT16NTezPHpgH8tt89G1MeQJ4ga1RL8QvL-bteBAkm0f808sEWIHYaZzdV9aPRApib9FmotvgouGh6Ur1Il_5luw&h=A2Jge--LyYkycxtLVt_OVYfg1A5krQr6S0lWtGqhnEc
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - a6678ca2-bbe0-499e-b0c5-5d7502814f75
+      x-ms-operation-identifier:
+      - tenantId=544a7a2e-697f-487c-b2b0-a13df7f346b6,objectId=73deb370-6e80-42b7-bab4-943c887d3e3c/southeastasia/418a4676-0221-4ba0-a583-9f4179939f90
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '3749'
+      x-ms-throttle-levels:
+      - operationConcurrencyPct=0.5, subscriptionReadRatePct=0.2, etc
+      x-msedge-ref:
+      - 'Ref A: 59F30DC310FF40568049975544580A58 Ref B: SG2AA1040520052 Ref C: 2026-06-30T03:51:40Z'
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_natgateway_pipv6_param_formats.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_natgateway_pipv6_param_formats.yaml
@@ -1075,7 +1075,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-v6-formats?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-v6-formats?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ng-v6-formats","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-v6-formats","etag":"W/\"ab21db54-116a-46de-a704-28c18e1d0728\"","type":"Microsoft.Network/natGateways","location":"eastus2","zones":["1","2","3"],"properties":{"provisioningState":"Updating","resourceGuid":"58447b77-a2db-4c88-b887-6972b899d13d","idleTimeoutInMinutes":4,"scope":"Public","privateIPAddresses":[],"privateIPAddressesV6":[],"publicIpAddresses":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv4"}],"publicIpAddressesV6":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv6-1"}],"publicIpPrefixesV6":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPPrefixes/prefixv6-1"}]},"sku":{"name":"StandardV2","tier":"Regional"}}'
@@ -1181,7 +1181,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-v6-formats?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-v6-formats?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ng-v6-formats","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-v6-formats","etag":"W/\"5de4db4c-7152-4f67-b5fa-a41fe0491487\"","type":"Microsoft.Network/natGateways","location":"eastus2","zones":["1","2","3"],"properties":{"provisioningState":"Succeeded","resourceGuid":"58447b77-a2db-4c88-b887-6972b899d13d","idleTimeoutInMinutes":4,"scope":"Public","privateIPAddresses":[],"privateIPAddressesV6":[],"publicIpAddresses":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv4"}],"publicIpAddressesV6":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv6-1"}],"publicIpPrefixesV6":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPPrefixes/prefixv6-1"}]},"sku":{"name":"StandardV2","tier":"Regional"}}'
@@ -1231,7 +1231,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-v6-formats?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-v6-formats?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ng-v6-formats","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-v6-formats","etag":"W/\"5de4db4c-7152-4f67-b5fa-a41fe0491487\"","type":"Microsoft.Network/natGateways","location":"eastus2","zones":["1","2","3"],"properties":{"provisioningState":"Succeeded","resourceGuid":"58447b77-a2db-4c88-b887-6972b899d13d","idleTimeoutInMinutes":4,"scope":"Public","privateIPAddresses":[],"privateIPAddressesV6":[],"publicIpAddresses":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv4"}],"publicIpAddressesV6":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv6-1"}],"publicIpPrefixesV6":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPPrefixes/prefixv6-1"}]},"sku":{"name":"StandardV2","tier":"Regional"}}'
@@ -1292,7 +1292,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-v6-formats?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-v6-formats?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ng-v6-formats","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-v6-formats","etag":"W/\"8bff6bf1-f89f-4362-b594-2e0179b395ea\"","type":"Microsoft.Network/natGateways","location":"eastus2","zones":["1","2","3"],"properties":{"provisioningState":"Updating","resourceGuid":"58447b77-a2db-4c88-b887-6972b899d13d","idleTimeoutInMinutes":4,"scope":"Public","privateIPAddresses":[],"privateIPAddressesV6":[],"publicIpAddresses":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv4"}],"publicIpAddressesV6":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv6-1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv6-2"}],"publicIpPrefixesV6":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPPrefixes/prefixv6-1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPPrefixes/prefixv6-2"}]},"sku":{"name":"StandardV2","tier":"Regional"}}'
@@ -1398,7 +1398,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-v6-formats?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-v6-formats?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ng-v6-formats","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-v6-formats","etag":"W/\"ed894d0c-d478-47ef-af95-ec735e52293f\"","type":"Microsoft.Network/natGateways","location":"eastus2","zones":["1","2","3"],"properties":{"provisioningState":"Succeeded","resourceGuid":"58447b77-a2db-4c88-b887-6972b899d13d","idleTimeoutInMinutes":4,"scope":"Public","privateIPAddresses":[],"privateIPAddressesV6":[],"publicIpAddresses":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv4"}],"publicIpAddressesV6":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv6-1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv6-2"}],"publicIpPrefixesV6":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPPrefixes/prefixv6-1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPPrefixes/prefixv6-2"}]},"sku":{"name":"StandardV2","tier":"Regional"}}'
@@ -1448,7 +1448,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-v6-formats?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-v6-formats?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ng-v6-formats","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-v6-formats","etag":"W/\"ed894d0c-d478-47ef-af95-ec735e52293f\"","type":"Microsoft.Network/natGateways","location":"eastus2","zones":["1","2","3"],"properties":{"provisioningState":"Succeeded","resourceGuid":"58447b77-a2db-4c88-b887-6972b899d13d","idleTimeoutInMinutes":4,"scope":"Public","privateIPAddresses":[],"privateIPAddressesV6":[],"publicIpAddresses":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv4"}],"publicIpAddressesV6":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv6-1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv6-2"}],"publicIpPrefixesV6":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPPrefixes/prefixv6-1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPPrefixes/prefixv6-2"}]},"sku":{"name":"StandardV2","tier":"Regional"}}'
@@ -1509,7 +1509,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-v6-formats?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-v6-formats?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ng-v6-formats","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-v6-formats","etag":"W/\"ed894d0c-d478-47ef-af95-ec735e52293f\"","type":"Microsoft.Network/natGateways","location":"eastus2","zones":["1","2","3"],"properties":{"provisioningState":"Succeeded","resourceGuid":"58447b77-a2db-4c88-b887-6972b899d13d","idleTimeoutInMinutes":4,"scope":"Public","privateIPAddresses":[],"privateIPAddressesV6":[],"publicIpAddresses":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv4"}],"publicIpAddressesV6":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv6-1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv6-2"}],"publicIpPrefixesV6":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPPrefixes/prefixv6-1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPPrefixes/prefixv6-2"}]},"sku":{"name":"StandardV2","tier":"Regional"}}'
@@ -1615,7 +1615,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-v6-formats?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-v6-formats?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ng-v6-formats","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-v6-formats","etag":"W/\"ed894d0c-d478-47ef-af95-ec735e52293f\"","type":"Microsoft.Network/natGateways","location":"eastus2","zones":["1","2","3"],"properties":{"provisioningState":"Succeeded","resourceGuid":"58447b77-a2db-4c88-b887-6972b899d13d","idleTimeoutInMinutes":4,"scope":"Public","privateIPAddresses":[],"privateIPAddressesV6":[],"publicIpAddresses":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv4"}],"publicIpAddressesV6":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv6-1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv6-2"}],"publicIpPrefixesV6":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPPrefixes/prefixv6-1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPPrefixes/prefixv6-2"}]},"sku":{"name":"StandardV2","tier":"Regional"}}'
@@ -1665,7 +1665,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-v6-formats?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-v6-formats?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ng-v6-formats","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-v6-formats","etag":"W/\"ed894d0c-d478-47ef-af95-ec735e52293f\"","type":"Microsoft.Network/natGateways","location":"eastus2","zones":["1","2","3"],"properties":{"provisioningState":"Succeeded","resourceGuid":"58447b77-a2db-4c88-b887-6972b899d13d","idleTimeoutInMinutes":4,"scope":"Public","privateIPAddresses":[],"privateIPAddressesV6":[],"publicIpAddresses":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv4"}],"publicIpAddressesV6":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv6-1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv6-2"}],"publicIpPrefixesV6":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPPrefixes/prefixv6-1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPPrefixes/prefixv6-2"}]},"sku":{"name":"StandardV2","tier":"Regional"}}'
@@ -1725,7 +1725,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-v6-formats?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-v6-formats?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ng-v6-formats","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-v6-formats","etag":"W/\"3b26f50e-5b11-4b68-a4e3-7e8176f76eb5\"","type":"Microsoft.Network/natGateways","location":"eastus2","zones":["1","2","3"],"properties":{"provisioningState":"Updating","resourceGuid":"58447b77-a2db-4c88-b887-6972b899d13d","idleTimeoutInMinutes":4,"scope":"Public","privateIPAddresses":[],"privateIPAddressesV6":[],"publicIpAddresses":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv4"}],"publicIpAddressesV6":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv6-1"}],"publicIpPrefixesV6":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPPrefixes/prefixv6-1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPPrefixes/prefixv6-2"}]},"sku":{"name":"StandardV2","tier":"Regional"}}'
@@ -1831,7 +1831,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-v6-formats?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-v6-formats?api-version=2025-07-01
   response:
     body:
       string: '{"name":"ng-v6-formats","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-v6-formats","etag":"W/\"3c24d860-3222-4477-852e-fc01f4cd0d7a\"","type":"Microsoft.Network/natGateways","location":"eastus2","zones":["1","2","3"],"properties":{"provisioningState":"Succeeded","resourceGuid":"58447b77-a2db-4c88-b887-6972b899d13d","idleTimeoutInMinutes":4,"scope":"Public","privateIPAddresses":[],"privateIPAddressesV6":[],"publicIpAddresses":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv4"}],"publicIpAddressesV6":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/pipv6-1"}],"publicIpPrefixesV6":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPPrefixes/prefixv6-1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPPrefixes/prefixv6-2"}]},"sku":{"name":"StandardV2","tier":"Regional"}}'
@@ -1883,7 +1883,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.85.0 azsdk-python-core/1.38.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-v6-formats?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/natGateways/ng-v6-formats?api-version=2025-07-01
   response:
     body:
       string: ''

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_subnet_detach_nat_gateway.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_subnet_detach_nat_gateway.yaml
@@ -345,7 +345,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.76.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_detach_nat_gateway_000001/providers/Microsoft.Network/natGateways/test-nat?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_detach_nat_gateway_000001/providers/Microsoft.Network/natGateways/test-nat?api-version=2025-07-01
   response:
     body:
       string: '{"name":"test-nat","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_detach_nat_gateway_000001/providers/Microsoft.Network/natGateways/test-nat","etag":"W/\"30eac9f9-663c-476b-827a-7a1949f552f5\"","type":"Microsoft.Network/natGateways","location":"eastus2","zones":["2"],"properties":{"provisioningState":"Updating","resourceGuid":"1a8845ae-b2f4-45e5-9bf7-a64a768a9b27","idleTimeoutInMinutes":4,"type":"Public","publicIpAddresses":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_detach_nat_gateway_000001/providers/Microsoft.Network/publicIPAddresses/pip"}],"publicIpPrefixes":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_detach_nat_gateway_000001/providers/Microsoft.Network/publicIPPrefixes/prefix"}]},"sku":{"name":"Standard","tier":"Regional"}}'
@@ -504,7 +504,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.76.0 azsdk-python-core/1.35.0 Python/3.12.10 (Windows-11-10.0.26100-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_detach_nat_gateway_000001/providers/Microsoft.Network/natGateways/test-nat?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_detach_nat_gateway_000001/providers/Microsoft.Network/natGateways/test-nat?api-version=2025-07-01
   response:
     body:
       string: '{"name":"test-nat","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_detach_nat_gateway_000001/providers/Microsoft.Network/natGateways/test-nat","etag":"W/\"12aa83f8-3093-46c0-a63e-4967feccfe85\"","type":"Microsoft.Network/natGateways","location":"eastus2","zones":["2"],"properties":{"provisioningState":"Succeeded","resourceGuid":"1a8845ae-b2f4-45e5-9bf7-a64a768a9b27","idleTimeoutInMinutes":4,"type":"Public","publicIpAddresses":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_detach_nat_gateway_000001/providers/Microsoft.Network/publicIPAddresses/pip"}],"publicIpPrefixes":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_subnet_detach_nat_gateway_000001/providers/Microsoft.Network/publicIPPrefixes/prefix"}]},"sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_natgateway_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_natgateway_commands.py
@@ -162,6 +162,40 @@ class NatGatewayScenarioTests(ScenarioTest):
         self.cmd('az network nat gateway delete -g {rg} -n {name}')
 
     @ResourceGroupPreparer(location='eastus2')
+    def test_natgateway_nat64(self, resource_group, resource_group_location):
+        """Test --nat64 (Enabled/Disabled) on StandardV2 NAT gateway create and update."""
+        self.kwargs.update({
+            'name': 'ng-nat64',
+            'location': resource_group_location,
+        })
+
+        # create with --nat64 Enabled
+        self.cmd(
+            'az network nat gateway create -g {rg} -n {name} --sku StandardV2 --nat64 Enabled',
+            checks=[
+                self.check('sku.name', 'StandardV2'),
+                self.check('nat64', 'Enabled'),
+            ]
+        )
+
+        # update --nat64 to Disabled
+        self.cmd(
+            'az network nat gateway update -g {rg} -n {name} --nat64 Disabled',
+            checks=[self.check('nat64', 'Disabled')]
+        )
+
+        self.cmd('az network nat gateway show -g {rg} -n {name}',
+                 checks=self.check('nat64', 'Disabled'))
+
+        self.cmd('az network nat gateway list -g {rg}',
+                 checks=[
+                     self.check('length(@)', 1),
+                     self.check('[0].nat64', 'Disabled'),
+                 ])
+
+        self.cmd('az network nat gateway delete -g {rg} -n {name}')
+
+    @ResourceGroupPreparer(location='eastus2')
     def test_natgateway_empty_create(self, resource_group, resource_group_location):
         self.kwargs.update({
             'name': "ng1",


### PR DESCRIPTION
**Related command**
`az network nat gateway create`
`az network nat gateway update`
`az network nat gateway show`
`az network nat gateway list`

**Description**
Add a new `--nat64` parameter to `az network nat gateway create` and `az network nat gateway update`, allowing customers to enable or disable NAT64 on StandardV2 SKU NAT gateways. Accepted values: `Enabled`, `Disabled`, `None`. The `nat64` property is surfaced in `show`/`list` output.

resolve https://github.com/Azure/azure-cli/issues/33646
aaz https://github.com/Azure/aaz/pull/1038

**Testing Guide**
`azdev test test_natgateway_nat64 --live`

**History Notes**

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
