### PR TITLE
{CI} resourceManagement.yml sync: replace squad labels/reviewers/mentionees and route to squad teams

### DIFF
--- a/tools/Github/ParseSquadMappingList.ps1
+++ b/tools/Github/ParseSquadMappingList.ps1
@@ -235,6 +235,55 @@ function GetLabelsFromConditions {
     return $labels
 }
 
+function IsSquadValue {
+    [CmdletBinding()]
+    param(
+        [string] $Value
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Value)) {
+        return $false
+    }
+
+    return $Value.Trim() -match '^(Azure/)?act-[a-z0-9-]+-squad$'
+}
+
+function ToSquadLabel {
+    [CmdletBinding()]
+    param(
+        [string] $Squad
+    )
+
+    if ($Squad -match '^Azure/(act-[a-z0-9-]+-squad)$') {
+        return $Matches[1]
+    }
+
+    return $Squad
+}
+
+function NormalizeSquadTeamForms {
+    [CmdletBinding()]
+    param(
+        [string[]] $Lines
+    )
+
+    $result = [string[]]::new($Lines.Length)
+    for ($i = 0; $i -lt $Lines.Length; $i++) {
+        $line = $Lines[$i]
+
+        if ($line -match '^(\s*)reviewer:\s*(act-[a-z0-9-]+-squad)\s*$') {
+            $line = "$($Matches[1])reviewer: Azure/$($Matches[2])"
+        }
+        elseif ($line -match '^(\s*)-\s+(act-[a-z0-9-]+-squad)\s*$') {
+            $line = "$($Matches[1])- Azure/$($Matches[2])"
+        }
+
+        $result[$i] = $line
+    }
+
+    return $result
+}
+
 function AddSquadLabelsToYaml {
     [CmdletBinding()]
     param(
@@ -242,182 +291,207 @@ function AddSquadLabelsToYaml {
         [hashtable] $LabelToSquad
     )
 
+    $work = [System.Collections.Generic.List[string]]::new()
+    $work.AddRange($Lines)
+
     $insertions = [System.Collections.Generic.List[object]]::new()
 
-    for ($i = 0; $i -lt $Lines.Count; $i++) {
-        $line = $Lines[$i]
-        if ($line -match '^(\s*)(then|actions):\s*$') {
-            $baseIndentLength = $Matches[1].Length
+    for ($i = 0; $i -lt $work.Count; $i++) {
+        $line = $work[$i]
+        if ($line -notmatch '^(\s*)(then|actions):\s*$') {
+            continue
+        }
+        $baseIndentLength = $Matches[1].Length
 
-            $j = $i + 1
-            while ($j -lt $Lines.Count -and $Lines[$j].Trim().Length -eq 0) {
-                $j++
+        $j = $i + 1
+        while ($j -lt $work.Count -and $work[$j].Trim().Length -eq 0) {
+            $j++
+        }
+        if ($j -ge $work.Count) {
+            continue
+        }
+
+        $listLine = $work[$j]
+        $listIndentLength = GetIndentLength -Line $listLine
+        if ($listIndentLength -lt $baseIndentLength -or -not ($listLine -match '^\s*-\s+')) {
+            continue
+        }
+
+        $k = $j
+        while ($k -lt $work.Count) {
+            $lineAtK = $work[$k]
+            if ($lineAtK.Trim().Length -ne 0 -and (GetIndentLength -Line $lineAtK) -lt $baseIndentLength) {
+                break
             }
-            if ($j -ge $Lines.Count) {
+            # Also break if we hit a `description:` at the same level as `then:`
+            if ($lineAtK -match '^\s*description:' -and (GetIndentLength -Line $lineAtK) -eq $baseIndentLength) {
+                break
+            }
+            $k++
+        }
+
+        $componentLabels = [System.Collections.Generic.List[string]]::new()
+        $addLabelSquadLines = [System.Collections.Generic.List[int]]::new()
+        $lastAddLabelLine = -1
+        $reviewerSquadLines = [System.Collections.Generic.List[int]]::new()
+        $lastReviewerLine = -1
+        $mentioneeSquadLines = [System.Collections.Generic.List[int]]::new()
+        $lastMentionLine = -1
+        $mentionItemIndent = -1
+        $hasMentionees = $false
+
+        for ($b = $j; $b -lt $k; $b++) {
+            $lineAtB = $work[$b]
+            $indentAtB = GetIndentLength -Line $lineAtB
+
+            if ($lineAtB -match '^\s*-\s+addLabel:\s*$' -and $indentAtB -eq $listIndentLength) {
+                for ($c = $b + 1; $c -lt $k; $c++) {
+                    $lineAtC = $work[$c]
+                    if ($lineAtC -match '^\s*-\s+' -and (GetIndentLength -Line $lineAtC) -eq $listIndentLength) {
+                        break
+                    }
+                    $labelValue = TryParseLabelValue -Line $lineAtC
+                    if ($null -ne $labelValue) {
+                        $lastAddLabelLine = $c
+                        if (IsSquadValue -Value $labelValue) {
+                            $addLabelSquadLines.Add($c)
+                        } elseif (-not [string]::IsNullOrWhiteSpace($labelValue) -and -not $componentLabels.Contains($labelValue)) {
+                            $componentLabels.Add($labelValue)
+                        }
+                        break
+                    }
+                }
                 continue
             }
 
-            $listLine = $Lines[$j]
-            $listIndentLength = GetIndentLength -Line $listLine
-            if ($listIndentLength -lt $baseIndentLength -or -not ($listLine -match '^\s*-\s+')) {
+            if ($lineAtB -match '^\s*-\s+requestReview:\s*$' -and $indentAtB -eq $listIndentLength) {
+                for ($c = $b + 1; $c -lt $k; $c++) {
+                    $lineAtC = $work[$c]
+                    if ($lineAtC -match '^\s*-\s+' -and (GetIndentLength -Line $lineAtC) -eq $listIndentLength) {
+                        break
+                    }
+                    if ($lineAtC -match '^\s*reviewer:\s*(.+?)\s*$') {
+                        $reviewerValue = $Matches[1].Trim()
+                        if (($reviewerValue.StartsWith("'") -and $reviewerValue.EndsWith("'")) -or ($reviewerValue.StartsWith('"') -and $reviewerValue.EndsWith('"'))) {
+                            $reviewerValue = $reviewerValue.Substring(1, $reviewerValue.Length - 2).Trim()
+                        }
+                        $lastReviewerLine = $c
+                        if (IsSquadValue -Value $reviewerValue) {
+                            $reviewerSquadLines.Add($c)
+                        }
+                        break
+                    }
+                }
                 continue
             }
 
-            $k = $j
-            while ($k -lt $Lines.Count) {
-                $lineAtK = $Lines[$k]
-                if ($lineAtK.Trim().Length -ne 0 -and (GetIndentLength -Line $lineAtK) -lt $baseIndentLength) {
-                    break
-                }
-                # Also break if we hit a `description:` at the same level as `then:`
-                if ($lineAtK -match '^\s*description:' -and (GetIndentLength -Line $lineAtK) -eq $baseIndentLength) {
-                    break
-                }
-                $k++
-            }
-
-            $labelsPresent = @{}
-            $lastAddLabelEnd = -1
-            for ($b = $j; $b -lt $k; $b++) {
-                $lineAtB = $Lines[$b]
-                if ($lineAtB -match '^\s*-\s+addLabel:\s*$' -and (GetIndentLength -Line $lineAtB) -eq $listIndentLength) {
-                    $labelValue = $null
-                    for ($c = $b + 1; $c -lt $k; $c++) {
-                        $lineAtC = $Lines[$c]
-                        if ($lineAtC -match '^\s*-\s+' -and (GetIndentLength -Line $lineAtC) -eq $listIndentLength) {
-                            break
-                        }
-                        $labelValue = TryParseLabelValue -Line $lineAtC
-                        if ($null -ne $labelValue) {
-                            $lastAddLabelEnd = $c
-                            break
+            if ($lineAtB -match '^\s*-\s+mentionUsers:\s*$' -and $indentAtB -eq $listIndentLength) {
+                $hasMentionees = $true
+                for ($c = $b + 1; $c -lt $k; $c++) {
+                    $lineAtC = $work[$c]
+                    $indentAtC = GetIndentLength -Line $lineAtC
+                    if ($lineAtC.Trim().Length -ne 0 -and $indentAtC -le $listIndentLength -and $lineAtC -match '^\s*-\s+') {
+                        break
+                    }
+                    if ($lineAtC -match '^\s*-\s+(\S+)\s*$') {
+                        if ($mentionItemIndent -lt 0) { $mentionItemIndent = $indentAtC }
+                        $lastMentionLine = $c
+                        if (IsSquadValue -Value $Matches[1]) {
+                            $mentioneeSquadLines.Add($c)
                         }
                     }
-                    if (![string]::IsNullOrWhiteSpace($labelValue)) {
-                        $labelsPresent[$labelValue] = $true
-                    }
                 }
+                continue
             }
+        }
 
-            $labelsFromConditions = GetLabelsFromConditions -Lines $Lines -ThenLineIndex $i -BaseIndentLength $baseIndentLength
-            foreach ($condLabel in $labelsFromConditions) {
-                if (-not [string]::IsNullOrWhiteSpace($condLabel)) {
-                    $labelsPresent[$condLabel] = $true
+        $labelsFromConditions = GetLabelsFromConditions -Lines $Lines -ThenLineIndex $i -BaseIndentLength $baseIndentLength
+        foreach ($condLabel in $labelsFromConditions) {
+            if (-not [string]::IsNullOrWhiteSpace($condLabel) -and -not (IsSquadValue -Value $condLabel) -and -not $componentLabels.Contains($condLabel)) {
+                $componentLabels.Add($condLabel)
+            }
+        }
+
+        $targets = [System.Collections.Generic.List[string]]::new()
+        foreach ($componentLabel in $componentLabels) {
+            if ($LabelToSquad.ContainsKey($componentLabel)) {
+                $squad = $LabelToSquad[$componentLabel]
+                if (-not [string]::IsNullOrWhiteSpace($squad) -and -not $targets.Contains($squad)) {
+                    $targets.Add($squad)
                 }
             }
+        }
 
-            $labelsToAdd = [System.Collections.Generic.List[string]]::new()
-            $sortedLabels = $labelsPresent.Keys | Sort-Object -CaseSensitive
-            foreach ($label in $sortedLabels) {
-                if ($LabelToSquad.ContainsKey($label)) {
-                    $squadLabel = $LabelToSquad[$label]
-                    if (-not $labelsPresent.ContainsKey($squadLabel) -and -not $labelsToAdd.Contains($squadLabel)) {
-                        $labelsToAdd.Add($squadLabel)
-                    }
-                }
+        if ($targets.Count -eq 0) {
+            continue
+        }
+
+        $isPR = $false
+        for ($p = $i - 1; $p -ge 0; $p--) {
+            if ($Lines[$p] -match '^\s*description:') { break }
+            if ($Lines[$p] -match 'payloadType:\s*Pull_Request') { $isPR = $true; break }
+        }
+
+        $labelExtraLines = [System.Collections.Generic.List[string]]::new()
+        for ($t = 0; $t -lt $targets.Count; $t++) {
+            $squadLabel = ToSquadLabel -Squad $targets[$t]
+            if ($t -lt $addLabelSquadLines.Count) {
+                $lineIndex = $addLabelSquadLines[$t]
+                $indent = " " * (GetIndentLength -Line $work[$lineIndex])
+                $work[$lineIndex] = "${indent}label: $squadLabel"
+            } elseif ($lastAddLabelLine -ge 0) {
+                $labelExtraLines.Add((" " * $listIndentLength) + "- addLabel:")
+                $labelExtraLines.Add((" " * $listIndentLength) + "    label: $squadLabel")
             }
+        }
+        if ($labelExtraLines.Count -gt 0) {
+            $insertions.Add([PSCustomObject]@{ Index = $lastAddLabelLine + 1; Lines = $labelExtraLines })
+        }
 
-            if ($labelsToAdd.Count -gt 0) {
-                if ($lastAddLabelEnd -ge 0) {
-                    $insertLines = [System.Collections.Generic.List[string]]::new()
-                    foreach ($squadLabel in $labelsToAdd) {
-                        $insertLines.Add((" " * $listIndentLength) + "- addLabel:")
-                        $insertLines.Add((" " * $listIndentLength) + "    label: $squadLabel")
-                    }
-                    $insertions.Add([PSCustomObject]@{ Index = $lastAddLabelEnd + 1; Lines = $insertLines })
-                }
-
-                $isPR = $false
-                    for ($p = $i - 1; $p -ge 0; $p--) {
-                        if ($Lines[$p] -match '^\s*description:') { break }
-                        if ($Lines[$p] -match 'payloadType:\s*Pull_Request') { $isPR = $true; break }
-                    }
-                    if ($isPR) {
-                        $lastReviewEnd = -1
-                        $reviewIndent = $listIndentLength + 4
-                        $existingReviewers = @{}
-                        for ($b = $j; $b -lt $k; $b++) {
-                            if ($Lines[$b] -match '^\s*-\s+requestReview:\s*$' -and (GetIndentLength -Line $Lines[$b]) -eq $listIndentLength) {
-                                for ($c = $b + 1; $c -lt $k; $c++) {
-                                    if ($Lines[$c] -match '^\s*-\s+' -and (GetIndentLength -Line $Lines[$c]) -eq $listIndentLength) { break }
-                                    if ($Lines[$c] -match '^\s*reviewer:\s*(\S+)\s*$') {
-                                        $existingReviewers[$Matches[1]] = $true
-                                        $lastReviewEnd = $c
-                                    }
-                                }
-                            }
-                        }
-                        if ($lastReviewEnd -lt 0) {
-                            $lastReviewEnd = $lastAddLabelEnd
-                        }
-                        if ($lastReviewEnd -ge 0) {
-                            $reviewInsertLines = [System.Collections.Generic.List[string]]::new()
-                            foreach ($squadLabel in $labelsToAdd) {
-                                if (-not $existingReviewers.ContainsKey($squadLabel)) {
-                                    $reviewInsertLines.Add((" " * $listIndentLength) + "- requestReview:")
-                                    $reviewInsertLines.Add((" " * $reviewIndent) + "reviewer: $squadLabel")
-                                }
-                            }
-                            if ($reviewInsertLines.Count -gt 0) {
-                                $insertions.Add([PSCustomObject]@{ Index = $lastReviewEnd + 1; Lines = $reviewInsertLines })
-                            }
-                        }
-                    }
-
-                $mentionUsersIndex = -1
-                $mentioneesIndent = -1
-                $mentionItemIndent = -1
-                $existingMentions = @{}
-                $lastMentionEnd = -1
-                for ($b = $j; $b -lt $k; $b++) {
-                    $lineAtB = $Lines[$b]
-                    $indentAtB = GetIndentLength -Line $lineAtB
-                    if ($lineAtB -match '^\s*-\s+mentionUsers:\s*$' -and $indentAtB -eq $listIndentLength) {
-                        $mentionUsersIndex = $b
-                        continue
-                    }
-                    if ($mentionUsersIndex -ge 0) {
-                        if ($lineAtB.Trim().Length -ne 0 -and $indentAtB -le $listIndentLength -and $lineAtB -match '^\s*-\s+') { break }
-                        if ($lineAtB -match '^\s*mentionees:\s*$') { $mentioneesIndent = $indentAtB; continue }
-                        if ($lineAtB -match '^\s*-\s+(\S+)\s*$') {
-                            if ($mentionItemIndent -lt 0) { $mentionItemIndent = $indentAtB }
-                            $existingMention = $Matches[1]
-                            $existingMentions[$existingMention] = $true
-                            $existingMentions[(NormalizeMentioneeValue -Mentionee $existingMention)] = $true
-                            $lastMentionEnd = $b
-                        }
-                    }
-                }
-
-                if ($mentionUsersIndex -ge 0 -and $lastMentionEnd -ge 0) {
-                    if ($mentionItemIndent -lt 0) { $mentionItemIndent = ($mentioneesIndent -gt 0) ? $mentioneesIndent : ($listIndentLength + 4) }
-                    $mentionInsertLines = [System.Collections.Generic.List[string]]::new()
-                    foreach ($squadLabel in $labelsToAdd) {
-                        $mentioneeValue = NormalizeMentioneeValue -Mentionee $squadLabel
-                        if (-not $existingMentions.ContainsKey($mentioneeValue)) {
-                            $mentionInsertLines.Add((" " * $mentionItemIndent) + "- $mentioneeValue")
-                        }
-                    }
-                    if ($mentionInsertLines.Count -gt 0) {
-                        $insertions.Add([PSCustomObject]@{ Index = $lastMentionEnd + 1; Lines = $mentionInsertLines })
-                    }
-                }
+        $reviewerAnchor = if ($lastReviewerLine -ge 0) { $lastReviewerLine } else { $lastAddLabelLine }
+        $reviewerExtraLines = [System.Collections.Generic.List[string]]::new()
+        for ($t = 0; $t -lt $targets.Count; $t++) {
+            $reviewerTeam = NormalizeMentioneeValue -Mentionee $targets[$t]
+            if ($t -lt $reviewerSquadLines.Count) {
+                $lineIndex = $reviewerSquadLines[$t]
+                $indent = " " * (GetIndentLength -Line $work[$lineIndex])
+                $work[$lineIndex] = "${indent}reviewer: $reviewerTeam"
+            } elseif ($isPR -and $reviewerAnchor -ge 0) {
+                $reviewerExtraLines.Add((" " * $listIndentLength) + "- requestReview:")
+                $reviewerExtraLines.Add((" " * ($listIndentLength + 4)) + "reviewer: $reviewerTeam")
             }
+        }
+        if ($reviewerExtraLines.Count -gt 0) {
+            $insertions.Add([PSCustomObject]@{ Index = $reviewerAnchor + 1; Lines = $reviewerExtraLines })
+        }
+
+        $mentionIndent = if ($mentionItemIndent -ge 0) { $mentionItemIndent } else { $listIndentLength + 4 }
+        $mentionExtraLines = [System.Collections.Generic.List[string]]::new()
+        for ($t = 0; $t -lt $targets.Count; $t++) {
+            $mentionTeam = NormalizeMentioneeValue -Mentionee $targets[$t]
+            if ($t -lt $mentioneeSquadLines.Count) {
+                $lineIndex = $mentioneeSquadLines[$t]
+                $indent = " " * (GetIndentLength -Line $work[$lineIndex])
+                $work[$lineIndex] = "${indent}- $mentionTeam"
+            } elseif ($hasMentionees -and $lastMentionLine -ge 0) {
+                $mentionExtraLines.Add((" " * $mentionIndent) + "- $mentionTeam")
+            }
+        }
+        if ($mentionExtraLines.Count -gt 0) {
+            $insertions.Add([PSCustomObject]@{ Index = $lastMentionLine + 1; Lines = $mentionExtraLines })
         }
     }
 
     if ($insertions.Count -eq 0) {
-        return $Lines
+        return $work.ToArray()
     }
 
     $sortedInsertions = $insertions | Sort-Object Index -Descending
-    $lineList = [System.Collections.Generic.List[string]]::new()
-    $lineList.AddRange($Lines)
     foreach ($insertion in $sortedInsertions) {
-        $lineList.InsertRange($insertion.Index, $insertion.Lines)
+        $work.InsertRange($insertion.Index, $insertion.Lines)
     }
 
-    return $lineList.ToArray()
+    return $work.ToArray()
 }
 
 $labelToSquad = GetSquadMappingFromWiki -AccessToken $AccessToken
@@ -434,6 +508,7 @@ if ($yamlContent.Contains("`r`n")) {
 $endsWithNewline = $yamlContent.EndsWith("`n")
 $yamlLines = [regex]::Split($yamlContent, "\r?\n", [System.Text.RegularExpressions.RegexOptions]::None)
 $updatedLines = AddSquadLabelsToYaml -Lines $yamlLines -LabelToSquad $labelToSquad
+$updatedLines = NormalizeSquadTeamForms -Lines $updatedLines
 $updatedContent = [string]::Join($lineEnding, $updatedLines)
 if (-not $endsWithNewline -and $updatedContent.EndsWith($lineEnding)) {
     $updatedContent = $updatedContent.Substring(0, $updatedContent.Length - $lineEnding.Length)


### PR DESCRIPTION
**Related command**

This is a CI/automation tooling change (no `az` command surface). It updates the script that syncs the ADO Wiki *Squad Mapping* table into `.github/policies/resourceManagement.yml`.

**Description**

Updates `tools/Github/ParseSquadMappingList.ps1` so squad routing is written correctly and deterministically:

- Existing squad references (labels, reviewers, mentionees) are now replaced in place so a rule routes to the currently-mapped squad instead of accumulating stale ones. Re-running the sync no longer grows the file or leaves duplicate squads behind.
- `mentionees` and `reviewer` values are emitted in GitHub team form (`Azure/act-*-squad`) so they can actually be @mentioned and assigned. `addLabel` and `hasLabel` deliberately stay in bare label form (`act-*-squad`), since those require a label, not a team.
- A new `NormalizeSquadTeamForms` pass normalizes squad reviewers/mentionees to team form everywhere including the hand-written auto-assign rules that are keyed on a squad label and are therefore not driven by the wiki mapping.

**Testing Guide**

Ran the script locally against the live ADO Wiki and audited the generated `resourceManagement.yml`:

```powershell
$token = az account get-access-token --resource {resource-id} --query accessToken -o tsv
pwsh -NoProfile -File tools/Github/ParseSquadMappingList.ps1 -AccessToken $token
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
