### PR TITLE
[POSTGRESQL] `az postgres flexible-server backup create`: Fix duplicate auto-generated backup names after deletions

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/postgresql/commands/backup_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/postgresql/commands/backup_commands.py
@@ -21,10 +21,11 @@ def _generate_backup_name(client, resource_group_name, server_name):
     on_demand_count = sum(1 for name in existing_names if name.startswith(_BACKUP_NAME_PREFIX))
 
     date_str = datetime.utcnow().strftime("%m%d%Y")
-    backup_name = f"{_BACKUP_NAME_PREFIX}-{date_str}-{on_demand_count + 1}"
-
-    if backup_name in existing_names:
-        backup_name = f"{_BACKUP_NAME_PREFIX}-{date_str}-{on_demand_count + 2}"
+    suffix = on_demand_count + 1
+    backup_name = f"{_BACKUP_NAME_PREFIX}-{date_str}-{suffix}"
+    while backup_name in existing_names:
+        suffix += 1
+        backup_name = f"{_BACKUP_NAME_PREFIX}-{date_str}-{suffix}"
 
     return backup_name
 


### PR DESCRIPTION
**Related command**
az postgres flexible-server backup create

**Description**<!--Mandatory-->
Fix duplicate auto-generated backup names after deletions

**Testing Guide**
Manual testing

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[POSTGRESQL] `az postgres flexible-server backup create`: Fix duplicate auto-generated backup names after deletions

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
