### PR TITLE
{Cosmos DB} Reclaim the documentdb command namespace

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/__init__.py
@@ -3,17 +3,9 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from knack.events import EVENT_INVOKER_PRE_PARSE_ARGS
-
 from azure.cli.core import AzCommandsLoader
 
 from azure.cli.command_modules.cosmosdb._help import helps  # pylint: disable=unused-import
-
-
-def _documentdb_deprecate(_, args):
-    if args[0] == 'documentdb':
-        from azure.cli.core.util import CLIError
-        raise CLIError('All documentdb commands have been renamed to cosmosdb')
 
 
 class CosmosDbCommandsLoader(AzCommandsLoader):
@@ -26,8 +18,6 @@ class CosmosDbCommandsLoader(AzCommandsLoader):
         cosmosdb_custom = CliCommandType(
             operations_tmpl='azure.cli.command_modules.cosmosdb.custom#{}',
             client_factory=cf_cosmosdb_document)
-
-        cli_ctx.register_event(EVENT_INVOKER_PRE_PARSE_ARGS, _documentdb_deprecate)
 
         super().__init__(cli_ctx=cli_ctx,
                          resource_type=ResourceType.MGMT_COSMOSDB,


### PR DESCRIPTION
### Summary

Reclaim the `documentdb` command namespace by removing the `_documentdb_deprecate` guard from the cosmosdb command module (`src/azure-cli/azure/cli/command_modules/cosmosdb/__init__.py`).

### Background

`Microsoft.DocumentDB` was the original resource provider name for what is now Cosmos DB. Years ago the CLI renamed `az documentdb` to `az cosmosdb` and added a guard that raises `All documentdb commands have been renamed to cosmosdb` on every `az documentdb ...` invocation (registered on `EVENT_INVOKER_PRE_PARSE_ARGS`, before argument parsing).

That guidance is now stale. The `documentdb` namespace is required for the new **DocumentDB (Microsoft.DocumentDB/mongoClusters)** service. Because the guard fires before parsing, even a brand-new provider of `az documentdb` commands is rejected until it is removed.

### Change

- Remove the `_documentdb_deprecate` function.
- Remove its `cli_ctx.register_event(EVENT_INVOKER_PRE_PARSE_ARGS, ...)` registration.
- Remove the now-unused `from knack.events import EVENT_INVOKER_PRE_PARSE_ARGS` import.

### Impact

- `az documentdb` is no longer blocked (the namespace is free for the new service).
- `az cosmosdb` is unaffected — verified `az cosmosdb` still loads and `az cosmosdb create` works end-to-end.
- No tests referenced the guard; the guard was the only usage in the repo.

/cc @necusjz

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>